### PR TITLE
fix(cli): add setup argument option

### DIFF
--- a/packages/cli/src/commands/setup/auth.ts
+++ b/packages/cli/src/commands/setup/auth.ts
@@ -30,7 +30,7 @@ const enum keys {
 }
 export default class SetupAuth extends BaseCommand {
   static description = `setup API credentials for local development.
-If you would like to bypass prompt, you can either:
+If you would like to bypass the prompt, you can either:
 \t* pass credentials as argument (see description later)
 \t* use environment variables
 see examples`

--- a/packages/cli/src/commands/setup/auth.ts
+++ b/packages/cli/src/commands/setup/auth.ts
@@ -17,13 +17,49 @@ import { BEARER_AUTH_PORT, SUCCESS_LOGIN_PAGE } from '../../utils/constants'
 import { askForString, askForPassword } from '../../utils/prompts'
 
 type Event = 'success' | 'error'
-
+const SEPARATOR = ':'
+const COMMAND = `bearer setup:auth`
+const enum keys {
+  BEARER_AUTH_CLIENT_ID = 'BEARER_AUTH_CLIENT_ID',
+  BEARER_AUTH_CLIENT_SECRET = 'BEARER_AUTH_CLIENT_SECRET',
+  BEARER_AUTH_CONSUMER_KEY = 'BEARER_AUTH_CONSUMER_KEY',
+  BEARER_AUTH_CONSUMER_SECRET = 'BEARER_AUTH_CONSUMER_SECRET',
+  BEARER_AUTH_USERNAME = 'BEARER_AUTH_USERNAME',
+  BEARER_AUTH_PASSWORD = 'BEARER_AUTH_PASSWORD',
+  BEARER_AUTH_APIKEY = 'BEARER_AUTH_APIKEY'
+}
 export default class SetupAuth extends BaseCommand {
-  static description = 'setup API credentials for local development'
+  static description = `setup API credentials for local development.
+If you would like to bypass prompt, you can either:
+\t* pass credentials as argument (see description later)
+\t* use environment variables
+see examples`
 
   static flags = {
     ...BaseCommand.flags
   }
+
+  static examples = [
+    `With argument`,
+    `\t${COMMAND} CLIENT_ID${SEPARATOR}CLIENT_SECRET`,
+    `\t${COMMAND} CONSUMER_KEY${SEPARATOR}CONSUMER_SECRET`,
+    `\t${COMMAND} USERNAME${SEPARATOR}PASSWORD`,
+    `\t${COMMAND} APIKEY`,
+    `With environment variables`,
+    `\t${keys.BEARER_AUTH_CLIENT_ID}=CLIENT_ID ${keys.BEARER_AUTH_CLIENT_SECRET}=CLIENT_SECRET ${COMMAND}`,
+    `\t${keys.BEARER_AUTH_CONSUMER_KEY}=CONSUMER_KEY ${keys.BEARER_AUTH_CONSUMER_SECRET}=CONSUMER_SECRET ${COMMAND}`,
+    `\t${keys.BEARER_AUTH_USERNAME}=USERNAME ${keys.BEARER_AUTH_CONSUMER_SECRET}=PASSWORD ${COMMAND}`,
+    `\t${keys.BEARER_AUTH_APIKEY}=APIKEY ${COMMAND}`
+  ]
+
+  static args = [
+    {
+      name: 'credentials',
+      description: `Provide inline credentials`,
+      required: false,
+      default: ''
+    }
+  ]
 
   _server?: http.Server
   _verifier!: string
@@ -38,6 +74,7 @@ export default class SetupAuth extends BaseCommand {
 
   @RequireIntegrationFolder()
   async run() {
+    const { args } = this.parse(SetupAuth)
     const config: TConfig = JSON.parse(
       fs.readFileSync(this.locator.authConfigPath, {
         encoding: 'utf8'
@@ -46,20 +83,34 @@ export default class SetupAuth extends BaseCommand {
     const { authType } = config
     switch (authType) {
       case Authentications.OAuth2: {
-        const { BEARER_AUTH_CLIENT_ID, BEARER_AUTH_CLIENT_SECRET } = process.env
-        const clientID = BEARER_AUTH_CLIENT_ID || (await askForString('Client ID', { type: 'password' }))
-        const clientSecret = BEARER_AUTH_CLIENT_SECRET || (await askForString('Client secret', { type: 'password' }))
-        const newConfig = { ...config, clientID, clientSecret }
+        const [idArg, secretArg] = args.credentials.split(SEPARATOR)
+        const {
+          [keys.BEARER_AUTH_CLIENT_ID]: id = idArg,
+          [keys.BEARER_AUTH_CLIENT_SECRET]: secret = secretArg
+        } = process.env
+        const clientID = id || (await askForString('Client ID', { type: 'password' }))
+        const clientSecret = secret || (await askForString('Client secret', { type: 'password' }))
+
         this.debug('Your credentials:\n%j', { ...config, clientID, clientSecret: clientSecret.replace(/./g, '*') })
+
+        const newConfig = { ...config, clientID, clientSecret }
         const token = await this.fetchAuthToken(newConfig as configs.TOAuth2Config)
         const setup = JSON.parse(Buffer.from(token, 'base64').toString('ascii')) as contexts.OAuth2
         await this.persistSetup(setup)
         break
       }
       case Authentications.OAuth1: {
-        const consumerKey = process.env.BEARER_AUTH_CONSUMER_KEY || (await askForString('Consumer key'))
-        const consumerSecret = process.env.BEARER_AUTH_CONSUMER_SECRET || (await askForPassword('Consumer secret'))
+        const [keyArg, secretArg] = args.credentials.split(SEPARATOR)
+        const {
+          [keys.BEARER_AUTH_CONSUMER_KEY]: key = keyArg,
+          [keys.BEARER_AUTH_CONSUMER_SECRET]: secret = secretArg
+        } = process.env
+
+        const consumerKey = key || (await askForString('Consumer key'))
+        const consumerSecret = secret || (await askForPassword('Consumer secret'))
+
         this.debug('Your credentials:\n%j', { consumerKey, consumerSecret: consumerSecret.replace(/./g, '*') })
+
         const newConfig = { ...config, consumerKey, consumerSecret }
         const token = await this.fetchAuthToken(newConfig as configs.TOAuth1Config)
         const setup = JSON.parse(Buffer.from(token, 'base64').toString('ascii')) as contexts.OAuth1
@@ -69,18 +120,27 @@ export default class SetupAuth extends BaseCommand {
       }
 
       case Authentications.Basic: {
-        const username = await askForString('Username')
-        const password = await askForPassword('Password')
+        const [usernameArg, passwordArg] = args.credentials.split(SEPARATOR)
+        const {
+          [keys.BEARER_AUTH_USERNAME]: basicUsername = usernameArg,
+          [keys.BEARER_AUTH_PASSWORD]: basicPassword = passwordArg
+        } = process.env
+        const username = basicUsername || (await askForString('Username'))
+        const password = basicPassword || (await askForPassword('Password'))
+
         await this.persistSetup({ username, password } as contexts.Basic)
+
         break
       }
       case Authentications.ApiKey: {
-        const apiKey = await askForPassword('API Key')
+        const { [keys.BEARER_AUTH_APIKEY]: key = args.credentials } = process.env
+        const apiKey = key || (await askForPassword('API Key'))
         await this.persistSetup({ apiKey } as contexts.ApiKey)
         break
       }
       case Authentications.Custom:
       case Authentications.NoAuth: {
+        await this.persistSetup({})
         return this.warn(
           `The current authentication type of this integration is not supported by this command: ${authType}`
         )
@@ -93,7 +153,7 @@ export default class SetupAuth extends BaseCommand {
     }
   }
 
-  fetchAuthToken = async (config: configs.TOAuth2Config | configs.TOAuth1Config): Promise<TBase64EncodedString> => {
+  async fetchAuthToken(config: configs.TOAuth2Config | configs.TOAuth1Config): Promise<TBase64EncodedString> {
     return new Promise(async (resolve, reject) => {
       this._server = await this.startServer()
       const redirectLocation = await axios

--- a/packages/cli/test/commands/deploy.test.ts
+++ b/packages/cli/test/commands/deploy.test.ts
@@ -1,3 +1,0 @@
-describe('deploy', () => {
-  it.skip('TODO', () => {})
-})

--- a/packages/cli/test/commands/setup/__snapshots__/auth.test.ts.snap
+++ b/packages/cli/test/commands/setup/__snapshots__/auth.test.ts.snap
@@ -1,0 +1,115 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`setup auth with argument auth type {"auth":"APIKEY","arg":"anApikey","returned":{}} save to local.config.jsonc 1`] = `
+"{
+  \\"setup\\": {
+    \\"auth\\": {
+      \\"apiKey\\": \\"anApikey\\"
+    }
+  }
+}"
+`;
+
+exports[`setup auth with argument auth type {"auth":"BASIC","arg":"aUsername:aPassword","returned":{}} save to local.config.jsonc 1`] = `
+"{
+  \\"setup\\": {
+    \\"auth\\": {
+      \\"username\\": \\"aUsername\\",
+      \\"password\\": \\"aPassword\\"
+    }
+  }
+}"
+`;
+
+exports[`setup auth with argument auth type {"auth":"CUSTOM","arg":"","returned":{}} save to local.config.jsonc 1`] = `
+"{
+  \\"setup\\": {
+    \\"auth\\": {}
+  }
+}"
+`;
+
+exports[`setup auth with argument auth type {"auth":"NONE","arg":"","returned":{}} save to local.config.jsonc 1`] = `
+"{
+  \\"setup\\": {
+    \\"auth\\": {}
+  }
+}"
+`;
+
+exports[`setup auth with argument auth type {"auth":"OAUTH1","arg":"aKey:aConsumerSecret","returned":{"someDataFromOauth1Server":"ok"}} save to local.config.jsonc 1`] = `
+"{
+  \\"setup\\": {
+    \\"auth\\": {
+      \\"someDataFromOauth1Server\\": \\"ok\\"
+    }
+  }
+}"
+`;
+
+exports[`setup auth with argument auth type {"auth":"OAUTH2","arg":"aClientId:aClientSecret","returned":{"someDataFromOauth2Server":"ok"}} save to local.config.jsonc 1`] = `
+"{
+  \\"setup\\": {
+    \\"auth\\": {
+      \\"someDataFromOauth2Server\\": \\"ok\\"
+    }
+  }
+}"
+`;
+
+exports[`setup auth with environment variables {"auth":"APIKEY","env":{"BEARER_AUTH_APIKEY":"anApiKeyFromEnv"},"returned":{}} save to local.config.jsonc 1`] = `
+"{
+  \\"setup\\": {
+    \\"auth\\": {
+      \\"apiKey\\": \\"anApiKeyFromEnv\\"
+    }
+  }
+}"
+`;
+
+exports[`setup auth with environment variables {"auth":"BASIC","env":{"BEARER_AUTH_USERNAME":"userNameFromEnv","BEARER_AUTH_PASSWORD":"passwordFromEnv"},"returned":{}} save to local.config.jsonc 1`] = `
+"{
+  \\"setup\\": {
+    \\"auth\\": {
+      \\"username\\": \\"userNameFromEnv\\",
+      \\"password\\": \\"passwordFromEnv\\"
+    }
+  }
+}"
+`;
+
+exports[`setup auth with environment variables {"auth":"CUSTOM","env":{},"returned":{}} save to local.config.jsonc 1`] = `
+"{
+  \\"setup\\": {
+    \\"auth\\": {}
+  }
+}"
+`;
+
+exports[`setup auth with environment variables {"auth":"NONE","env":{},"returned":{}} save to local.config.jsonc 1`] = `
+"{
+  \\"setup\\": {
+    \\"auth\\": {}
+  }
+}"
+`;
+
+exports[`setup auth with environment variables {"auth":"OAUTH1","env":{"BEARER_AUTH_CONSUMER_KEY":"aKeyFromEnv","BEARER_AUTH_CONSUMER_SECRET":"aSecretFromEnv"},"returned":{"someDataFromOauth1Server":"ok"}} save to local.config.jsonc 1`] = `
+"{
+  \\"setup\\": {
+    \\"auth\\": {
+      \\"someDataFromOauth1Server\\": \\"ok\\"
+    }
+  }
+}"
+`;
+
+exports[`setup auth with environment variables {"auth":"OAUTH2","env":{"BEARER_AUTH_CLIENT_ID":"aClientIdFromEnv","BEARER_AUTH_CLIENT_SECRET":"sSecretFromEmv"},"returned":{"someDataFromOauth2Server":"ok"}} save to local.config.jsonc 1`] = `
+"{
+  \\"setup\\": {
+    \\"auth\\": {
+      \\"someDataFromOauth2Server\\": \\"ok\\"
+    }
+  }
+}"
+`;

--- a/packages/cli/test/commands/setup/auth.test.ts
+++ b/packages/cli/test/commands/setup/auth.test.ts
@@ -1,0 +1,110 @@
+import { Authentications } from '@bearer/types/lib/authentications'
+
+import SetupAuth from '../../../src/commands/setup/auth'
+import { ensureBearerStructure } from '../../helpers/setup'
+import { readFile } from '../../helpers/utils'
+
+jest.mock('open', () => {
+  return () => ({
+    on: jest.fn()
+  })
+})
+
+describe('setup', () => {
+  describe('auth', () => {
+    describe('with argument', () => {
+      describe.each([
+        [{ auth: Authentications.ApiKey, arg: 'anApikey', returned: {} }],
+        [{ auth: Authentications.OAuth1, arg: 'aKey:aConsumerSecret', returned: { someDataFromOauth1Server: 'ok' } }],
+        [
+          { auth: Authentications.OAuth2, arg: 'aClientId:aClientSecret', returned: { someDataFromOauth2Server: 'ok' } }
+        ],
+        [{ auth: Authentications.Basic, arg: 'aUsername:aPassword', returned: {} }],
+        [{ auth: Authentications.Custom, arg: '', returned: {} }],
+        [{ auth: Authentications.NoAuth, arg: '', returned: {} }]
+      ])('auth type %j', (...usecase) => {
+        const [{ returned, auth, arg }] = usecase
+        beforeAll(() => {
+          SetupAuth.prototype.fetchAuthToken = () => {
+            return Promise.resolve(Buffer.from(JSON.stringify(returned)).toString('base64') as any)
+          }
+        })
+
+        test(`save to local.config.jsonc`, async () => {
+          const path = ensureBearerStructure({
+            authConfig: {
+              authType: auth
+            }
+          })
+
+          await SetupAuth.run(['--path', path, arg])
+          expect(readSetup(path)).toMatchSnapshot()
+        })
+      })
+    })
+
+    describe('with environment variables', () => {
+      const OLD_ENV = process.env
+
+      describe.each([
+        [
+          {
+            auth: Authentications.ApiKey,
+            env: { BEARER_AUTH_APIKEY: 'anApiKeyFromEnv' },
+            returned: {}
+          }
+        ],
+        [
+          {
+            auth: Authentications.OAuth1,
+            env: { BEARER_AUTH_CONSUMER_KEY: 'aKeyFromEnv', BEARER_AUTH_CONSUMER_SECRET: 'aSecretFromEnv' },
+            returned: { someDataFromOauth1Server: 'ok' }
+          }
+        ],
+        [
+          {
+            auth: Authentications.OAuth2,
+            env: { BEARER_AUTH_CLIENT_ID: 'aClientIdFromEnv', BEARER_AUTH_CLIENT_SECRET: 'sSecretFromEmv' },
+            returned: { someDataFromOauth2Server: 'ok' }
+          }
+        ],
+        [
+          {
+            auth: Authentications.Basic,
+            env: { BEARER_AUTH_USERNAME: 'userNameFromEnv', BEARER_AUTH_PASSWORD: 'passwordFromEnv' },
+            returned: {}
+          }
+        ],
+        [{ auth: Authentications.Custom, env: {}, returned: {} }],
+        [{ auth: Authentications.NoAuth, env: {}, returned: {} }]
+      ])('%j', (...usecase) => {
+        const [{ returned, env, auth }] = usecase
+        beforeAll(() => {
+          process.env = { ...OLD_ENV, ...env }
+          SetupAuth.prototype.fetchAuthToken = () => {
+            return Promise.resolve(Buffer.from(JSON.stringify(returned)).toString('base64') as any)
+          }
+
+          afterAll(() => {
+            process.env = { ...OLD_ENV }
+          })
+        })
+
+        test(`save to local.config.jsonc`, async () => {
+          const path = ensureBearerStructure({
+            authConfig: {
+              authType: auth
+            }
+          })
+
+          await SetupAuth.run(['--path', path])
+          expect(readSetup(path)).toMatchSnapshot()
+        })
+      })
+    })
+  })
+})
+
+function readSetup(path: string) {
+  return readFile(path, 'local.config.jsonc')
+}

--- a/packages/cli/test/helpers/setup.ts
+++ b/packages/cli/test/helpers/setup.ts
@@ -20,6 +20,7 @@ export function cleanArtifactFolder(name: string) {
 
   return bearerFolder
 }
+
 export function ensureBearerStructure({
   authConfig,
   folderName = 'fakeintegration',


### PR DESCRIPTION
<!-- Feel free to remove any section you don't need -->

## 🐻 What your PR is doing?

<!--  Describe briefly what your Pull Request is doing -->
allow `bearer setup:auth` command to receive either arguments or env variables

## 📦 Package concerned
- @bearer/cli
<!--
  Uncomment the ones concerned

- @bearer/core
- create-bearer
- @bearer/functions
- @bearer/legacy-cli
- @bearer/js
- @bearer/openapi-generator
- @bearer/react
- @bearer/transpiler
- @bearer/tslint-config
- @bearer/types
- @bearer/ui
- none
- all
 -->

## 🖥 Screenshots or screen recording
![carbon (3)](https://user-images.githubusercontent.com/263097/56721555-6d8ef300-6745-11e9-8561-1bfa04e600ff.png)


## 🛠 How to test it

<!-- Provide any helpful information to help reviewer test you changes -->
- link the repo to an integration
- run `yarn bearer setup:auth`
- run `yarn bearer setup:auth apikey`
- run `BEARER_AUTH_APIKEY=apikey yarn bearer setup:auth`

**You'll need to test each authentications**

## ✅ Checklist

- [x] Tests were added (if necessary)
- [x] I used conventional commits
