### PR TITLE
fix(security): remove buffer warnings

### DIFF
--- a/packages/security/src/index.ts
+++ b/packages/security/src/index.ts
@@ -23,9 +23,9 @@ export default class Cipher {
 
   decrypt = (encryptedMessage: string) => {
     const textParts = encryptedMessage.split(':')
-    const iv = new Buffer(textParts.shift()!, 'hex')
-    const encryptedText = new Buffer(textParts.join(':'), 'hex')
-    const decipher = crypto.createDecipheriv('aes-256-cbc', new Buffer(this.key), iv)
+    const iv = Buffer.from(textParts.shift()!, 'hex')
+    const encryptedText = Buffer.from(textParts.join(':'), 'hex')
+    const decipher = crypto.createDecipheriv('aes-256-cbc', Buffer.from(this.key), iv)
     const decrypted = decipher.update(encryptedText)
 
     return Buffer.concat([decrypted, decipher.final()]).toString()
@@ -34,7 +34,7 @@ export default class Cipher {
   digest = (message: string) => {
     return crypto
       .createHmac(this.config.digestAlgo, this.key)
-      .update(new Buffer(message, this.config.encoding))
+      .update(Buffer.from(message, this.config.encoding))
       .digest('hex')
   }
 }


### PR DESCRIPTION
<!-- Feel free to remove any section you don't need -->

## 🐻 What your PR is doing?

<!--  Describe briefly what your Pull Request is doing -->

- fix warnings
```
@bearer/security: (node:130) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
```

## 📦 Package concerned
- @bearer/security
<!--
  Uncomment the ones concerned
- @bearer/cli
- @bearer/core
- create-bearer
- @bearer/functions
- @bearer/legacy-cli
- @bearer/js
- @bearer/openapi-generator
- @bearer/react
- @bearer/transpiler
- @bearer/tslint-config
- @bearer/types
- @bearer/ui
- none
- all
 -->

## ✅ Checklist

- [x] Tests were added (if necessary)
- [x] I used conventional commits
