### PR TITLE
feat(x-ray) separate env variables init from the override functions

### DIFF
--- a/packages/functions/src/functions/fetch.ts
+++ b/packages/functions/src/functions/fetch.ts
@@ -1,6 +1,6 @@
 import debug from '@bearer/logger'
 import http from 'http'
-import { captureHttps } from '@bearer/x-ray'
+import { captureHttps, setupFunctionIdentifiers } from '@bearer/x-ray'
 
 import * as d from '../declaration'
 import { eventAsActionParams, BACKEND_ONLY_ERROR } from './utils'
@@ -32,8 +32,7 @@ export abstract class FetchData<ReturnedData = any, TError = any, AuthContext = 
 
       const updatedEvent = Object.assign({}, event)
       updatedEvent.context.integrationUuid = event.context.buid
-
-      captureHttps(http, updatedEvent)
+      setupFunctionIdentifiers(updatedEvent)
 
       const functionEvent: d.TFetchActionEvent = {
         ...eventAsActionParams(event),
@@ -55,6 +54,7 @@ export abstract class FetchData<ReturnedData = any, TError = any, AuthContext = 
   }
 
   static init() {
+    captureHttps(http)
     return FetchData.call(this as any)
   }
 }

--- a/packages/x-ray/__test__/helpers/utils.ts
+++ b/packages/x-ray/__test__/helpers/utils.ts
@@ -49,17 +49,30 @@ export const httpClient = {
   }
 }
 
-export const expectedResponse = {
-  message: {
-    clientId: '132464737464748494404949984847474848',
-    integrationUuid: 'scenarioUuid',
-    intentName: 'MyHandler',
-    method: 'GET',
-    path: 'www.google.com',
-    pathname: '/',
-    responseStatus: 200,
-    responseStatusMesage: 'OK',
-    stage: 'test'
-  },
-  timestamp: expect.any(Number)
+export const expectedResponse = (
+  opts = { clientId: '132464737464748494404949984847474848', integrationUuid: 'scenarioUuid' }
+) => {
+  return {
+    message: {
+      clientId: opts.clientId,
+      integrationUuid: opts.integrationUuid,
+      intentName: 'MyHandler',
+      method: 'GET',
+      path: 'www.google.com',
+      pathname: '/',
+      responseStatus: 200,
+      responseStatusMesage: 'OK',
+      stage: 'test'
+    },
+    timestamp: expect.any(Number)
+  }
+}
+
+export const event = function() {
+  return {
+    context: {
+      clientId: 'myClientId',
+      integrationUuid: 'myIntegrationUuid'
+    }
+  }
 }

--- a/packages/x-ray/__test__/http-overrides.test.ts
+++ b/packages/x-ray/__test__/http-overrides.test.ts
@@ -28,7 +28,7 @@ describe('override http', () => {
       })
     })
 
-    expect(sendToCloudwatchGroup).toHaveBeenCalledWith(expectedResponse)
+    expect(sendToCloudwatchGroup).toHaveBeenCalledWith(expectedResponse())
   })
 
   it('overrides the get method', () => {
@@ -51,7 +51,7 @@ describe('override http', () => {
       })
     })
 
-    expect(sendToCloudwatchGroup).toHaveBeenCalledWith(expectedResponse)
+    expect(sendToCloudwatchGroup).toHaveBeenCalledWith(expectedResponse())
   })
 
   it('skips the shim when calling AWS infra', async () => {

--- a/packages/x-ray/__test__/index.test.ts
+++ b/packages/x-ray/__test__/index.test.ts
@@ -1,0 +1,56 @@
+import { captureHttps, setupFunctionIdentifiers } from '../src/index'
+import { sendToCloudwatchGroup } from '../src/cloud-watch-logs'
+import { httpClient, expectedResponse, event } from './helpers/utils'
+import http from 'http'
+
+jest.mock('../src/constants')
+jest.mock('../src/cloud-watch-logs')
+
+describe('captureHttp', () => {
+  it('captures https without identifiers', async () => {
+    captureHttps(httpClient)
+    expect((httpClient as any)._request).toBeDefined()
+    await new Promise((res, _rej) => {
+      httpClient.request('http://www.google.com/', (data: http.IncomingMessage) => {
+        res(data)
+        data.resume()
+      })
+    })
+
+    expect(sendToCloudwatchGroup).toHaveBeenCalledWith(
+      expectedResponse({ clientId: undefined, integrationUuid: undefined } as any)
+    )
+    expect(process.env.clientId).toEqual(undefined)
+    expect(process.env.scenarioUuid).toEqual(undefined)
+  })
+
+  it('captures https with identifiers', async () => {
+    const functionEvent = event()
+    captureHttps(httpClient)
+    setupFunctionIdentifiers(functionEvent)
+    await new Promise((res, _rej) => {
+      httpClient.request('http://www.google.com/', (data: http.IncomingMessage) => {
+        res(data)
+        data.resume()
+      })
+    })
+
+    expect(sendToCloudwatchGroup).toHaveBeenCalledWith(
+      expectedResponse({
+        clientId: functionEvent.context.clientId,
+        integrationUuid: functionEvent.context.integrationUuid
+      } as any)
+    )
+    expect(process.env.clientId).toEqual(functionEvent.context.clientId)
+    expect(process.env.scenarioUuid).toEqual(functionEvent.context.integrationUuid)
+  })
+})
+
+describe('setupFunctionIdentifiers', () => {
+  it('setup all function identifiers', () => {
+    const functionEvent = event()
+    setupFunctionIdentifiers(functionEvent)
+    expect(process.env.clientId).toEqual(functionEvent.context.clientId)
+    expect(process.env.scenarioUuid).toEqual(functionEvent.context.integrationUuid)
+  })
+})

--- a/packages/x-ray/src/index.ts
+++ b/packages/x-ray/src/index.ts
@@ -1,13 +1,8 @@
 import logger from './logger'
 import { overrideRequestMethod, overrideGetMethod } from './http-overrides'
 
-export const captureHttps = (module: any, event: any) => {
-  const context = event.context || {}
-  const { clientId, integrationUuid } = context
-  logger(`Ìnject ${clientId} and ${integrationUuid}`)
-  process.env.clientId = clientId
-  process.env.scenarioUuid = integrationUuid
-
+export const captureHttps = function(module: any) {
+  logger('%j', { message: 'Override request and get methods', application: 'x-ray' })
   if (module._request && module._get) {
     // This because the cold lambda start
     // Avoid overriding methods for next calls
@@ -16,4 +11,12 @@ export const captureHttps = (module: any, event: any) => {
 
   overrideRequestMethod(module)
   overrideGetMethod(module)
+}
+
+export const setupFunctionIdentifiers = function(event: any) {
+  const context = event.context || {}
+  const { clientId, integrationUuid } = context
+  logger('%j', { message: `Ìnject ${clientId} and ${integrationUuid}`, application: 'x-ray' })
+  process.env.clientId = clientId
+  process.env.scenarioUuid = integrationUuid
 }


### PR DESCRIPTION
<!-- Feel free to remove any section you don't need -->

## 🐻 What your PR is doing?

Separate the function override from the env variable functions, so that, we can override http(s) outside the handler and ensure that the override is done during the warming phase and not during the first execution.

## 📦 Package concerned

<!--
  Uncomment the ones concerned
- @bearer/x-ray
- @bearer/functions
 -->

## 🛠 How to test it

Deploy the new next release and do some calls to test

## ✅ Checklist

- [x] Tests were added (if necessary)
- [x] I used conventional commits
