### PR TITLE
fix: look for Bearer API key in ENV vars

### DIFF
--- a/packages/cli/src/utils/devPortal.ts
+++ b/packages/cli/src/utils/devPortal.ts
@@ -16,18 +16,35 @@ export const devPortalClient = (command: BaseCommand) => {
     }
   )
   async function requestFunction<DataReturned>(data: { query: string; variables?: any }) {
+    return await instance.post<{ data?: DataReturned; errors?: any }>('', data, {
+      headers: {
+        Authorization: `Bearer ${access_token}`
+      }
+    })
+  }
+
+  async function access_token() {
     let token = await command.bearerConfig.getToken()
+
+    // If no token is configured, do we have an ENV var
+    // available to access the Bearer API?
+    if (!token && process.env.BEARER_API_KEY) {
+      return process.env.BEARER_API_KEY
+    }
+
+    // No token configured and no API key
+    // Let's ask the user to log in
     if (!token) {
       command.debug('no token found, trying to log you in')
       await promptToLogin(command)
       token = await command.bearerConfig.getToken()
     }
 
-    return await instance.post<{ data?: DataReturned; errors?: any }>('', data, {
-      headers: {
-        Authorization: `Bearer ${token!.access_token}`
-      }
-    })
+    if (token) {
+      return token.access_token
+    }
+
+    return ''
   }
 
   return {


### PR DESCRIPTION
## 🐻 What your PR is doing?

Get API access token from ENV if it is present

Currently we get the API access token via pre-existing config or via browser login. This change means that we can continue to use `bearer push` in our GitHub actions as long as we provide the API access token as a secret ENV var. 

## 📦 Package concerned

<!--
  Uncomment the ones concerned
@bearer/cli
- @bearer/core
- create-bearer
- @bearer/functions
- @bearer/legacy-cli
- @bearer/js
- @bearer/openapi-generator
- @bearer/react
- @bearer/transpiler
- @bearer/tslint-config
- @bearer/types
- @bearer/ui
- none
- all
 -->

## 🖥 Screenshots or screen recording

<!-- record terminal (macOS) https://github.com/asciinema/asciinema -->

<!-- Before your changes -->

**Before**

<!-- After your changes -->

**After**

## 🐺 Links

[RFC to remove Cognito](https://github.com/Bearer/rfcs-internal/pull/21)

## 🛠 How to test it

<!-- Provide any helpful information to help reviewer test you changes -->

## ✅ Checklist

- [ ] Tests were added (if necessary)
- [ ] I used conventional commits
