### PR TITLE
fix(x-ray): fix x-ray logging to many entries in eu-west-1

### DIFF
--- a/packages/x-ray/src/http-overrides.ts
+++ b/packages/x-ray/src/http-overrides.ts
@@ -3,7 +3,7 @@ import { STAGE, _HANDLER } from './constants'
 import url from 'url'
 import uuid = require('uuid')
 
-const EXCLUDED_API = ['logs.eu-west-3.amazonaws.com']
+const EXCLUDED_API = ['logs.eu-west-3.amazonaws.com', 'logs.eu-west-1.amazonaws.com']
 
 export const overrideRequestMethod = (module: any) => {
   // override http.request method


### PR DESCRIPTION
<!-- Feel free to remove any section you don't need -->

## 🐻 What your PR is doing?
Fix eu-west-1 issues with external api counter logging to many requests
<!--  Describe briefly what your Pull Request is doing -->

## 📦 Package concerned
@bearer/x-ray
<!--
  Uncomment the ones concerned
- @bearer/cli
- @bearer/core
- create-bearer
- @bearer/functions
- @bearer/legacy-cli
- @bearer/js
- @bearer/openapi-generator
- @bearer/react
- @bearer/transpiler
- @bearer/tslint-config
- @bearer/types
- @bearer/ui
- none
- all
 -->

## 🖥 Screenshots or screen recording

<!-- record terminal (macOS) https://github.com/asciinema/asciinema -->

<!-- Before your changes -->

**Before**

<!-- After your changes -->

**After**

## 🐺 Links

<!--  Add any useful links, JIRA links, docs etc... -->

## 🛠 How to test it

<!-- Provide any helpful information to help reviewer test you changes -->

## ✅ Checklist

- [x] Tests were added (if necessary)
- [x] I used conventional commits
