### PR TITLE
fix: freeze inquirer dependency (freeze issue)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,7 +39,7 @@
     "get-port": "^4.2.0",
     "globby": "^8.0.1",
     "ini": "^1.3.5",
-    "inquirer": "^6.2.2",
+    "inquirer": "~6.3.1",
     "inquirer-prompt-suggest": "^0.1.0",
     "jsonc-parser": "^2.1.0",
     "knex": "^0.16.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8839,7 +8839,7 @@ inquirer@^5.2.0:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
-inquirer@^6.2.0, inquirer@^6.2.2:
+inquirer@^6.2.0:
   version "6.2.2"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.2.2.tgz#46941176f65c9eb20804627149b743a218f25406"
   integrity sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==
@@ -8875,6 +8875,25 @@ inquirer@^6.2.1:
     rxjs "^6.1.0"
     string-width "^2.1.0"
     strip-ansi "^5.0.0"
+    through "^2.3.6"
+
+inquirer@~6.3.1:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.3.1.tgz#7a413b5e7950811013a3db491c61d1f3b776e8e7"
+  integrity sha512-MmL624rfkFt4TG9y/Jvmt8vdmOo836U7Y0Hxr2aFk3RelZEGX4Igk0KabWrcaaZaTv9uzglOqWh1Vly+FAWAXA==
+  dependencies:
+    ansi-escapes "^3.2.0"
+    chalk "^2.4.2"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^3.0.3"
+    figures "^2.0.0"
+    lodash "^4.17.11"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rxjs "^6.4.0"
+    string-width "^2.1.0"
+    strip-ansi "^5.1.0"
     through "^2.3.6"
 
 interpret@^1.0.0, interpret@^1.1.0, interpret@^1.2.0:


### PR DESCRIPTION
<!-- Feel free to remove any section you don't need -->

## 🐻 What your PR is doing?

<!--  Describe briefly what your Pull Request is doing -->

- freeze inquirer version: https://github.com/SBoudrias/Inquirer.js/issues/811

## 📦 Package concerned

- @bearer/cli

<!--
  Uncomment the ones concerned
- @bearer/cli
- @bearer/core
- create-bearer
- @bearer/functions
- @bearer/legacy-cli
- @bearer/js
- @bearer/openapi-generator
- @bearer/react
- @bearer/transpiler
- @bearer/tslint-config
- @bearer/types
- @bearer/ui
- none
- all
 -->


## 🛠 How to test it

<!-- Provide any helpful information to help reviewer test you changes -->

- `yarn bearer setup:auth`

## ✅ Checklist

- [ ] Tests were added (if necessary)
- [x] I used conventional commits
