### PR TITLE
fix(cli): use refresh token for every dev portal request

### DIFF
--- a/packages/cli/src/commands/integrations/create.ts
+++ b/packages/cli/src/commands/integrations/create.ts
@@ -4,7 +4,6 @@ import * as suggest from 'inquirer-prompt-suggest'
 
 import BaseCommand from '../../base-command'
 import CreateIntegration from '../../actions/createIntegration'
-import { ensureFreshToken } from '../../utils/decorators'
 
 export default class IntegrationsCreate extends BaseCommand {
   static description = 'create a new Integration'
@@ -16,7 +15,6 @@ export default class IntegrationsCreate extends BaseCommand {
     skipLink: flags.boolean({ char: 'l' })
   }
 
-  @ensureFreshToken()
   async run() {
     const {
       flags: { name, description, skipLink }

--- a/packages/cli/src/commands/integrations/index.ts
+++ b/packages/cli/src/commands/integrations/index.ts
@@ -1,5 +1,4 @@
 import BaseCommand from '../../base-command'
-import { ensureFreshToken } from '../../utils/decorators'
 
 export default class IntegrationsList extends BaseCommand {
   static description = 'list deployed integrations'
@@ -10,7 +9,6 @@ export default class IntegrationsList extends BaseCommand {
 
   static args = []
 
-  @ensureFreshToken()
   async run() {
     try {
       const { data } = await this.devPortalClient.request<{ integrations: Integration[] }>({

--- a/packages/cli/src/utils/decorators.ts
+++ b/packages/cli/src/utils/decorators.ts
@@ -117,34 +117,6 @@ export async function withFreshToken(command: TCommand) {
   }
 }
 
-export function ensureFreshToken() {
-  return function(_target: any, _propertyKey: string | symbol, descriptor: PropertyDescriptor) {
-    const originalMethod = descriptor.value
-    descriptor.value = async function(this: TCommand) {
-      const { expires_at, refresh_token } = (await this.bearerConfig.getToken()) || {
-        expires_at: null,
-        refresh_token: null
-      }
-      if (expires_at && refresh_token) {
-        try {
-          if (expires_at < Date.now()) {
-            cliUx.action.start('Refreshing token')
-            await refreshMyToken(this, refresh_token)
-            cliUx.action.stop()
-          }
-        } catch (error) {
-          cliUx.action.stop(`Failed`)
-          this.error(error.message)
-        }
-      } else {
-        await promptToLogin(this)
-      }
-      return await originalMethod.apply(this, arguments)
-    }
-    return descriptor
-  }
-}
-
 // tslint:disable-next-line variable-name
 async function refreshMyToken(command: TCommand, refresh_token: string): Promise<boolean | Error> {
   // TODO: rework refresh mechanism

--- a/packages/cli/src/utils/decorators.ts
+++ b/packages/cli/src/utils/decorators.ts
@@ -95,6 +95,28 @@ export function RequireLinkedIntegration(prompt = true) {
   }
 }
 
+export async function withFreshToken(command: TCommand) {
+  const { expires_at, refresh_token } = (await command.bearerConfig.getToken()) || {
+    expires_at: null,
+    refresh_token: null
+  }
+
+  if (expires_at && refresh_token) {
+    try {
+      if (expires_at < Date.now()) {
+        cliUx.action.start('Refreshing token')
+        await refreshMyToken(command, refresh_token)
+        cliUx.action.stop()
+      }
+    } catch (error) {
+      cliUx.action.stop(`Failed`)
+      command.error(error.message)
+    }
+  } else {
+    await promptToLogin(command)
+  }
+}
+
 export function ensureFreshToken() {
   return function(_target: any, _propertyKey: string | symbol, descriptor: PropertyDescriptor) {
     const originalMethod = descriptor.value

--- a/packages/cli/src/utils/decorators.ts
+++ b/packages/cli/src/utils/decorators.ts
@@ -1,13 +1,8 @@
-import axios from 'axios'
-import cliUx from 'cli-ux'
 import * as inquirer from 'inquirer'
 import Command from '../base-command'
 
 import Link from '../actions/link'
 import Create from '../actions/createIntegration'
-import { promptToLogin } from '../actions/login'
-
-import { LOGIN_CLIENT_ID } from './constants'
 
 type Constructor<T> = new (...args: any[]) => T
 type TCommand = InstanceType<Constructor<Command>>
@@ -93,38 +88,4 @@ export function RequireLinkedIntegration(prompt = true) {
     }
     return descriptor
   }
-}
-
-export async function withFreshToken(command: TCommand) {
-  const { expires_at, refresh_token } = (await command.bearerConfig.getToken()) || {
-    expires_at: null,
-    refresh_token: null
-  }
-
-  if (expires_at && refresh_token) {
-    try {
-      if (expires_at < Date.now()) {
-        cliUx.action.start('Refreshing token')
-        await refreshMyToken(command, refresh_token)
-        cliUx.action.stop()
-      }
-    } catch (error) {
-      cliUx.action.stop(`Failed`)
-      command.error(error.message)
-    }
-  } else {
-    await promptToLogin(command)
-  }
-}
-
-// tslint:disable-next-line variable-name
-async function refreshMyToken(command: TCommand, refresh_token: string): Promise<boolean | Error> {
-  // TODO: rework refresh mechanism
-  const response = await axios.post(`${command.constants.LoginDomain}/oauth/token`, {
-    refresh_token,
-    grant_type: 'refresh_token',
-    client_id: LOGIN_CLIENT_ID
-  })
-  await command.bearerConfig.storeToken({ ...response.data, refresh_token })
-  return true
 }

--- a/packages/cli/src/utils/devPortal.ts
+++ b/packages/cli/src/utils/devPortal.ts
@@ -1,6 +1,9 @@
+import cliUx from 'cli-ux'
 import axios, { AxiosInstance } from 'axios'
+
 import BaseCommand from '../base-command'
-import { withFreshToken } from './decorators'
+import { promptToLogin } from '../actions/login'
+import { LOGIN_CLIENT_ID } from './constants'
 
 export class Client {
   private instance: AxiosInstance
@@ -34,4 +37,38 @@ export class Client {
 
 export const devPortalClient = (command: BaseCommand) => {
   return new Client(command)
+}
+
+export async function withFreshToken(command: BaseCommand) {
+  const { expires_at, refresh_token } = (await command.bearerConfig.getToken()) || {
+    expires_at: null,
+    refresh_token: null
+  }
+
+  if (expires_at && refresh_token) {
+    try {
+      if (expires_at < Date.now()) {
+        cliUx.action.start('Refreshing token')
+        await refreshMyToken(command, refresh_token)
+        cliUx.action.stop()
+      }
+    } catch (error) {
+      cliUx.action.stop(`Failed`)
+      command.error(error.message)
+    }
+  } else {
+    await promptToLogin(command)
+  }
+}
+
+// tslint:disable-next-line variable-name
+async function refreshMyToken(command: BaseCommand, refresh_token: string): Promise<boolean | Error> {
+  // TODO: rework refresh mechanism
+  const response = await axios.post(`${command.constants.LoginDomain}/oauth/token`, {
+    refresh_token,
+    grant_type: 'refresh_token',
+    client_id: LOGIN_CLIENT_ID
+  })
+  await command.bearerConfig.storeToken({ ...response.data, refresh_token })
+  return true
 }

--- a/packages/cli/src/utils/devPortal.ts
+++ b/packages/cli/src/utils/devPortal.ts
@@ -1,36 +1,37 @@
-import axios from 'axios'
+import axios, { AxiosInstance } from 'axios'
 import BaseCommand from '../base-command'
-import { promptToLogin } from '../actions/login'
+import { withFreshToken } from './decorators'
 
-export const devPortalClient = (command: BaseCommand) => {
-  const instance = axios.create({
-    baseURL: command.constants.DeveloperPortalAPIUrl
-  })
-  instance.interceptors.response.use(
-    r => r,
-    error => {
-      if (error.response && error.response.status) {
-        command.error('Unauthorized action, please run bearer login first')
+export class Client {
+  private instance: AxiosInstance
+  constructor(private readonly command: BaseCommand) {
+    this.instance = axios.create({
+      baseURL: command.constants.DeveloperPortalAPIUrl
+    })
+    this.instance.interceptors.response.use(
+      r => r,
+      error => {
+        if (error.response && error.response.status) {
+          command.error('Unauthorized action, please run bearer login first')
+        }
+        return Promise.reject(error)
       }
-      return Promise.reject(error)
-    }
-  )
-  async function requestFunction<DataReturned>(data: { query: string; variables?: any }) {
-    let token = await command.bearerConfig.getToken()
-    if (!token) {
-      command.debug('no token found, trying to log you in')
-      await promptToLogin(command)
-      token = await command.bearerConfig.getToken()
-    }
+    )
+  }
 
-    return await instance.post<{ data?: DataReturned; errors?: any }>('', data, {
+  async request<DataReturned>(data: { query: string; variables?: any }) {
+    await withFreshToken(this.command)
+
+    const token = await this.command.bearerConfig.getToken()
+
+    return await this.instance.post<{ data?: DataReturned; errors?: any }>('', data, {
       headers: {
         Authorization: `Bearer ${token!.access_token}`
       }
     })
   }
+}
 
-  return {
-    request: requestFunction
-  }
+export const devPortalClient = (command: BaseCommand) => {
+  return new Client(command)
 }

--- a/packages/cli/test/utils/devPortal.test.ts
+++ b/packages/cli/test/utils/devPortal.test.ts
@@ -1,4 +1,8 @@
-import { devPortalClient } from '../../src/utils/devPortal'
+import { devPortalClient, withFreshToken } from '../../src/utils/devPortal'
+
+jest.mock('../../src/actions/login')
+
+import { promptToLogin } from '../../src/actions/login'
 
 describe('devPortalClient', () => {
   it('export a factory and expect a command as argument', () => {
@@ -8,5 +12,43 @@ describe('devPortalClient', () => {
   it('creates an instance with a request async method', () => {
     const instance = devPortalClient({ constants: { DeveloperPortalAPIUrl: 'http://test.bearer.sh' } } as any)
     expect(instance.request).toHaveLength(1)
+  })
+})
+
+describe('withFreshToken', () => {
+  describe('when token is still valid', () => {
+    it('does nothing', async () => {
+      const command = {
+        bearerConfig: {
+          getToken: jest.fn(() => ({
+            expires_at: Date.now() + 2000,
+            refresh_token: 'a token'
+          }))
+        }
+      }
+      await withFreshToken(command as any)
+    })
+  })
+
+  describe('when token does not exists (never logged in)', () => {
+    it('prompt to log in', async () => {
+      const command = {
+        bearerConfig: {
+          getToken: jest.fn()
+        },
+        colors: {
+          bold: jest.fn()
+        },
+        log: jest.fn()
+      }
+
+      await withFreshToken(command as any)
+
+      expect(promptToLogin).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('when token is outdated', () => {
+    it('refresh the token', () => {})
   })
 })

--- a/packages/cli/test/utils/devPortal.test.ts
+++ b/packages/cli/test/utils/devPortal.test.ts
@@ -1,35 +1,12 @@
 import { devPortalClient } from '../../src/utils/devPortal'
-import * as nock from 'nock'
 
 describe('devPortalClient', () => {
-  it('export a facotry and expect a command as argument', () => {
+  it('export a factory and expect a command as argument', () => {
     expect(devPortalClient).toHaveLength(1)
   })
 
   it('creates an instance with a request async method', () => {
     const instance = devPortalClient({ constants: { DeveloperPortalAPIUrl: 'http://test.bearer.sh' } } as any)
     expect(instance.request).toHaveLength(1)
-  })
-
-  describe('instance', () => {
-    function setup({ token }: { token?: { access_token: string } }) {
-      const command = {
-        constants: { DeveloperPortalAPIUrl: 'http://test.bearer.sh' },
-        bearerConfig: { getToken: jest.fn(() => token) }
-      } as any
-      const instance = devPortalClient(command)
-      return instance
-    }
-
-    it('throws error no token present', async () => {
-      nock('http://test.bearer.sh', { reqheaders: { authorization: 'Bearer valid_token' } })
-        .post('/', { query: 'somehting' })
-        .reply(200, 'OK')
-      const instance = setup({ token: { access_token: 'valid_token' } })
-
-      const { data } = await instance.request({ query: 'somehting' })
-
-      expect(data).toEqual('OK')
-    })
   })
 })

--- a/packages/functions/src/functions/fetch.ts
+++ b/packages/functions/src/functions/fetch.ts
@@ -1,4 +1,5 @@
 import debug from '@bearer/logger'
+import http from 'http'
 import { captureHttps, setupFunctionIdentifiers } from '@bearer/x-ray'
 
 import * as d from '../declaration'
@@ -53,7 +54,7 @@ export abstract class FetchData<ReturnedData = any, TError = any, AuthContext = 
   }
 
   static init() {
-    captureHttps()
+    captureHttps(http)
     return FetchData.call(this as any)
   }
 }

--- a/packages/functions/src/functions/fetch.ts
+++ b/packages/functions/src/functions/fetch.ts
@@ -1,5 +1,4 @@
 import debug from '@bearer/logger'
-import http from 'http'
 import { captureHttps, setupFunctionIdentifiers } from '@bearer/x-ray'
 
 import * as d from '../declaration'
@@ -54,7 +53,7 @@ export abstract class FetchData<ReturnedData = any, TError = any, AuthContext = 
   }
 
   static init() {
-    captureHttps(http)
+    captureHttps()
     return FetchData.call(this as any)
   }
 }


### PR DESCRIPTION
<!-- Feel free to remove any section you don't need -->

## 🐻 What your PR is doing?

<!--  Describe briefly what your Pull Request is doing -->

wrap devportal request so that we refresh the token if it is  outdated


## 📦 Package concerned
- @bearer/cli
<!--
  Uncomment the ones concerned
- @bearer/cli
- @bearer/core
- create-bearer
- @bearer/functions
- @bearer/legacy-cli
- @bearer/js
- @bearer/openapi-generator
- @bearer/react
- @bearer/transpiler
- @bearer/tslint-config
- @bearer/types
- @bearer/ui
- none
- all
 -->


## ✅ Checklist

- [ ] Tests were added (if necessary) (no I'm a badass)
- [x] I used conventional commits
