### PR TITLE
feat(node): raise error if apiKey is not provided

### DIFF
--- a/packages/node/src/client.test.ts
+++ b/packages/node/src/client.test.ts
@@ -12,6 +12,15 @@ describe('Bearer client', () => {
     expect(client).toBeInstanceOf(BearerClient)
   })
 
+  it('throws an error if the token is not correct', () => {
+    expect(() => {
+      new BearerClient(undefined as any)
+    }).toThrowError(
+      `Invalid Bearer API key provided.  Value: undefined
+You'll find you API key at this location: https://app.bearer.sh`
+    )
+  })
+
   describe('#invoke', () => {
     it('send request to the function', async () => {
       distantApi.mockClear()

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -13,6 +13,9 @@ export class BearerClient<T = string> {
   protected client: AxiosInstance
 
   constructor(protected readonly token: string, clientOptions: Partial<TClientOptions> = {}) {
+    if (!token) {
+      throw new InvalidAPIKey(token)
+    }
     this.options = { ...BearerClient.defaultOptions, ...clientOptions }
 
     this.client = axios.create({
@@ -44,4 +47,11 @@ export class IntegrationClient<T = string> {
 
 export default (token: string): BearerClient => {
   return new BearerClient(token)
+}
+
+class InvalidAPIKey extends Error {
+  constructor(token: any) {
+    super(`Invalid Bearer API key provided.  Value: ${token}
+You'll find you API key at this location: https://app.bearer.sh`)
+  }
 }


### PR DESCRIPTION
<!-- Feel free to remove any section you don't need -->

## 🐻 What your PR is doing?

<!--  Describe briefly what your Pull Request is doing -->

- raise an error if the bearer API key provided is falsy

## 📦 Package concerned
- @bearer/node
<!--
  Uncomment the ones concerned
- @bearer/cli
- @bearer/core
- create-bearer
- @bearer/functions
- @bearer/legacy-cli
- @bearer/js
- @bearer/openapi-generator
- @bearer/react
- @bearer/transpiler
- @bearer/tslint-config
- @bearer/types
- @bearer/ui
- none
- all
 -->

## 🛠 How to test it

<!-- Provide any helpful information to help reviewer test you changes -->

- create a new instance of the bearer note client with a falsy value
```ts
import client from '@bearer/node'
const instance = client(undefined)
```

- it should raise an error

## ✅ Checklist

- [x] Tests were added (if necessary)
- [x] I used conventional commits
