### PR TITLE
fix: handle correct hostnam

### DIFF
--- a/packages/x-ray/__test__/__snapshots__/http-overrides.test.ts.snap
+++ b/packages/x-ray/__test__/__snapshots__/http-overrides.test.ts.snap
@@ -32,6 +32,7 @@ Array [
         "body": "",
         "hash": null,
         "headers": Object {},
+        "host": "bearer.sh",
         "hostname": "bearer.sh",
         "href": "https://bearer.sh/path?ok=false",
         "method": "get",
@@ -94,6 +95,7 @@ Array [
         "headers": Object {
           "useragent": "Bearer",
         },
+        "host": "bearer.sh:443",
         "hostname": "bearer.sh",
         "href": undefined,
         "method": "get",
@@ -103,7 +105,7 @@ Array [
         "protocol": "http",
         "query": undefined,
         "search": undefined,
-        "url": "http//bearer.sh/postPath?postQuery=sponge",
+        "url": "http://bearer.sh/postPath?postQuery=sponge",
       },
       "response": Object {
         "body": "{\\"great\\":\\"sponge bob is the king of posts\\"}",
@@ -154,6 +156,7 @@ Array [
         "headers": Object {
           "useragent": "Bearer",
         },
+        "host": "bearer.sh:443",
         "hostname": "bearer.sh",
         "href": undefined,
         "method": "get",
@@ -163,7 +166,7 @@ Array [
         "protocol": "https",
         "query": undefined,
         "search": undefined,
-        "url": "https//bearer.sh/postPath?postQuery=sponge",
+        "url": "https://bearer.sh/postPath?postQuery=sponge",
       },
       "response": Object {
         "body": "{\\"great\\":\\"sponge bob is the king\\"}",

--- a/packages/x-ray/__test__/__snapshots__/http-overrides.test.ts.snap
+++ b/packages/x-ray/__test__/__snapshots__/http-overrides.test.ts.snap
@@ -32,7 +32,6 @@ Array [
         "body": "",
         "hash": null,
         "headers": Object {},
-        "host": "bearer.sh",
         "hostname": "bearer.sh",
         "href": "https://bearer.sh/path?ok=false",
         "method": "get",
@@ -95,17 +94,16 @@ Array [
         "headers": Object {
           "useragent": "Bearer",
         },
-        "host": "bearer.sh:443",
         "hostname": "bearer.sh",
         "href": undefined,
         "method": "get",
         "path": "/postPath?postQuery=sponge",
         "pathname": undefined,
         "port": 443,
-        "protocol": undefined,
+        "protocol": "http",
         "query": undefined,
         "search": undefined,
-        "url": "undefined//bearer.sh:443/postPath?postQuery=sponge",
+        "url": "http//bearer.sh/postPath?postQuery=sponge",
       },
       "response": Object {
         "body": "{\\"great\\":\\"sponge bob is the king of posts\\"}",
@@ -113,6 +111,66 @@ Array [
           "content-type": "application/json",
         },
         "status": 204,
+      },
+    },
+    "payloadType": "EXTERNAL_CALL",
+    "service": "function",
+    "tid": "aws_trace",
+  },
+]
+`;
+
+exports[`overrideRequestMethod https request when hostname attribute is passed logs the same way 1`] = `
+Array [
+  "%j",
+  Object {
+    "message": Object {
+      "clientId": "a-client-id",
+      "integrationUuid": "custom0buid",
+      "intentName": undefined,
+      "method": "get",
+      "path": "bearer.sh",
+      "pathname": undefined,
+      "stage": undefined,
+      "tid": "aws_trace",
+      "type": "externalCall",
+    },
+    "timestamp": 5,
+  },
+]
+`;
+
+exports[`overrideRequestMethod https request when hostname attribute is passed logs the same way 2`] = `
+Array [
+  "%j",
+  Object {
+    "buid": "custom0buid",
+    "payload": Object {
+      "duration": 0,
+      "request": Object {
+        "auth": undefined,
+        "body": "{\\"todo\\":\\"Buy the milk\\"}",
+        "hash": undefined,
+        "headers": Object {
+          "useragent": "Bearer",
+        },
+        "hostname": "bearer.sh",
+        "href": undefined,
+        "method": "get",
+        "path": "/postPath?postQuery=sponge",
+        "pathname": undefined,
+        "port": 443,
+        "protocol": "https",
+        "query": undefined,
+        "search": undefined,
+        "url": "https//bearer.sh/postPath?postQuery=sponge",
+      },
+      "response": Object {
+        "body": "{\\"great\\":\\"sponge bob is the king\\"}",
+        "headers": Object {
+          "content-type": "application/json",
+        },
+        "status": 201,
       },
     },
     "payloadType": "EXTERNAL_CALL",

--- a/packages/x-ray/src/http-overrides.ts
+++ b/packages/x-ray/src/http-overrides.ts
@@ -49,16 +49,18 @@ export const overrideRequestMethod = (
     const url: string | urlParser.UrlWithParsedQuery = args[0]
 
     let parsedUrl: urlParser.UrlWithParsedQuery
-
+    let builtUrl: string = ''
     if (typeof url === 'string') {
       parsedUrl = urlParser.parse(url, true)
+      builtUrl = url
     } else {
       parsedUrl = url
       // http accepts either host or hostname
       parsedUrl.protocol = parsedUrl.protocol || 'http'
       parsedUrl.hostname = parsedUrl.hostname || parsedUrl.host
     }
-    const { port, path, protocol, auth, hostname, hash, search, query, pathname, href } = parsedUrl
+    const { port, path, protocol, auth, hostname, hash, search, query, pathname, href, host } = parsedUrl
+
     info.request = {
       ...info.request,
       port,
@@ -71,7 +73,8 @@ export const overrideRequestMethod = (
       query,
       pathname,
       href,
-      url: `${protocol}//${hostname}${path}`
+      host,
+      url: builtUrl || `${protocol}://${hostname}${path}`
     }
     const requestData: string[] = []
     const requestStart = Date.now()

--- a/packages/x-ray/src/http-overrides.ts
+++ b/packages/x-ray/src/http-overrides.ts
@@ -54,13 +54,15 @@ export const overrideRequestMethod = (
       parsedUrl = urlParser.parse(url, true)
     } else {
       parsedUrl = url
+      // http accepts either host or hostname
+      parsedUrl.protocol = parsedUrl.protocol || 'http'
+      parsedUrl.hostname = parsedUrl.hostname || parsedUrl.host
     }
-    const { port, path, host, protocol, auth, hostname, hash, search, query, pathname, href } = parsedUrl
+    const { port, path, protocol, auth, hostname, hash, search, query, pathname, href } = parsedUrl
     info.request = {
       ...info.request,
       port,
       path,
-      host,
       protocol,
       auth,
       hostname,
@@ -69,7 +71,7 @@ export const overrideRequestMethod = (
       query,
       pathname,
       href,
-      url: `${protocol}//${host || hostname}${path}`
+      url: `${protocol}//${hostname}${path}`
     }
     const requestData: string[] = []
     const requestStart = Date.now()


### PR DESCRIPTION
<!-- Feel free to remove any section you don't need -->

## 🐻 What your PR is doing?

<!--  Describe briefly what your Pull Request is doing -->

-  handle missing hostname option

http args allow either host or hostname as argument

## 📦 Package concerned
- @bearer/x-ray
<!--
  Uncomment the ones concerned
- @bearer/cli
- @bearer/core
- create-bearer
- @bearer/functions
- @bearer/legacy-cli
- @bearer/js
- @bearer/openapi-generator
- @bearer/react
- @bearer/transpiler
- @bearer/tslint-config
- @bearer/types
- @bearer/ui
- none
- all
 -->
## ✅ Checklist

- [x] Tests were added (if necessary)
- [x] I used conventional commits
