### PR TITLE
fix(cli): allow nested files

### DIFF
--- a/packages/cli/src/commands/build/functions.ts
+++ b/packages/cli/src/commands/build/functions.ts
@@ -64,7 +64,7 @@ export default class BuildFunctions extends BaseCommand {
     return new Promise<string[]>(async (resolve, reject) => {
       try {
         // generate bundle
-        const files = await globby([`${entriesPath}/*.ts`])
+        const files = await globby([`${entriesPath}/**/*.ts`])
 
         if (!files.length) {
           return reject(new Error('No func to transpile'))
@@ -77,6 +77,10 @@ export default class BuildFunctions extends BaseCommand {
             compilerOptions: { ...compilerOptions, module: ts.ModuleKind.ES2015 }
           })
           const newFile = path.join(this.locator.buildFunctionsDir, file.replace(entriesPath, '').replace(/ts$/, 'js'))
+          const dir = path.dirname(newFile)
+          if (!fs.pathExistsSync(dir)) {
+            fs.mkdirpSync(dir)
+          }
           fs.writeFileSync(newFile, outputText, {
             encoding: 'utf8'
           })


### PR DESCRIPTION
this allow user to split functions logic to different files

<!-- Feel free to remove any section you don't need -->

## 🐻 What your PR is doing?

<!--  Describe briefly what your Pull Request is doing -->

- allow functions to be organized into nested folders

it allows this

```
├── functions
│   ├── client.ts
│   ├── proxy.d.ts
│   ├── proxy.ts
│   ├── retrieveSetup.ts
│   └── validators
│       └── custom.ts
└── package.json
``` 
## 📦 Package concerned
- @bearer/cli
<!--
  Uncomment the ones concerned
- @bearer/cli
- @bearer/core
- create-bearer
- @bearer/functions
- @bearer/legacy-cli
- @bearer/js
- @bearer/openapi-generator
- @bearer/react
- @bearer/transpiler
- @bearer/tslint-config
- @bearer/types
- @bearer/ui
- none
- all
 -->


## 🛠 How to test it

<!-- Provide any helpful information to help reviewer test you changes -->

- link to an integration that have nested files into functions folder

## ✅ Checklist

- [ ] Tests were added (if necessary)
- [x] I used conventional commits
