### PR TITLE
Improvements to proxy support in node client

### DIFF
--- a/packages/node/src/client.test.ts
+++ b/packages/node/src/client.test.ts
@@ -2,8 +2,8 @@ import nock from 'nock'
 
 import clientFactory, { Bearer } from './client'
 const apiKey = 'spongeBobApiKey'
-
-const distantApi = jest.fn(() => ({ ok: 'ok' }))
+const okResponse = { ok: 'ok' }
+const distantApi = jest.fn(() => okResponse)
 
 describe('Bearer client', () => {
   const client = clientFactory(apiKey)
@@ -35,7 +35,7 @@ You'll find you API key at this location: https://app.bearer.sh/keys`
       const { data } = await client.invoke('12345-integration-name', 'functionName')
 
       expect(distantApi).toHaveBeenCalled()
-      expect(data).toEqual({ ok: 'ok' })
+      expect(data).toEqual(okResponse)
     })
   })
 
@@ -57,7 +57,7 @@ You'll find you API key at this location: https://app.bearer.sh/keys`
       const { data } = await api.post('/test', { query: { sponge: 'bob' } })
 
       expect(distantApi).toHaveBeenCalled()
-      expect(data).toEqual({ ok: 'ok' })
+      expect(data).toEqual(okResponse)
     })
 
     it('allows to make authenticated API calls', async () => {
@@ -73,14 +73,32 @@ You'll find you API key at this location: https://app.bearer.sh/keys`
         .query({ sponge: 'bob' })
         .reply(200, distantApi)
 
-      const { data } = await api.auth({ authId }).post('/test', { query: { sponge: 'bob' } })
+      const { data } = await api.auth(authId).post('/test', { query: { sponge: 'bob' } })
 
       expect(distantApi).toHaveBeenCalled()
-      expect(data).toEqual({ ok: 'ok' })
+      expect(data).toEqual(okResponse)
     })
 
     it('has an alias function "authenticate"', async () => {
       expect(api.authenticate).toEqual(api.auth)
+    })
+
+    it('sends any configured setup id in a Bearer-Setup-Id header', async () => {
+      const setupId = 'test-setup-id'
+
+      nock('https://int.bearer.sh', {
+        reqheaders: {
+          authorization: apiKey,
+          'Bearer-Setup-Id': setupId
+        }
+      })
+        .get(`/api/v4/functions/backend/${integrationName}/bearer-proxy/test`)
+        .reply(200, distantApi)
+
+      const { data } = await api.setup(setupId).get('/test')
+
+      expect(distantApi).toHaveBeenCalled()
+      expect(data).toEqual(okResponse)
     })
   })
 })

--- a/packages/node/src/client.test.ts
+++ b/packages/node/src/client.test.ts
@@ -8,6 +8,10 @@ const distantApi = jest.fn(() => okResponse)
 describe('Bearer client', () => {
   const client = clientFactory(apiKey)
 
+  beforeEach(() => {
+    distantApi.mockClear()
+  })
+
   it('returns a client instance', () => {
     expect(client).toBeInstanceOf(Bearer)
   })
@@ -23,7 +27,6 @@ You'll find you API key at this location: https://app.bearer.sh/keys`
 
   describe('#invoke', () => {
     it('send request to the function', async () => {
-      distantApi.mockClear()
       nock('https://int.bearer.sh', {
         reqheaders: {
           authorization: apiKey
@@ -42,63 +45,121 @@ You'll find you API key at this location: https://app.bearer.sh/keys`
   describe('#integration', () => {
     const integrationName = '12345'
     const api = client.integration(integrationName)
+    const query = { sponge: 'bob' }
+    const headers = {}
+    const body = '{"body":"data"}'
+
+    interface IMockRequestParams {
+      method: string
+      extraHeaders?: Record<string, string>
+      body?: any
+    }
+
+    const mockRequest = ({ method, extraHeaders = {}, body }: IMockRequestParams) => {
+      nock('https://int.bearer.sh', {
+        reqheaders: {
+          authorization: apiKey,
+          ...headers,
+          ...extraHeaders
+        }
+      })
+        .intercept(`/api/v4/functions/backend/${integrationName}/bearer-proxy/test`, method, body)
+        .once()
+        .query(query)
+        .reply(200, distantApi)
+    }
 
     it('performs correct API calls', async () => {
-      distantApi.mockClear()
-      nock('https://int.bearer.sh', {
-        reqheaders: {
-          authorization: apiKey
-        }
-      })
-        .post(`/api/v4/functions/backend/${integrationName}/bearer-proxy/test`)
-        .query({ sponge: 'bob' })
-        .reply(200, distantApi)
+      mockRequest({ body, method: 'POST' })
 
-      const { data } = await api.post('/test', { query: { sponge: 'bob' } })
+      const { data } = await api.post('/test', { headers, query, body })
 
       expect(distantApi).toHaveBeenCalled()
       expect(data).toEqual(okResponse)
     })
 
-    it('allows to make authenticated API calls', async () => {
-      const authId = 'abcde12345...'
-      distantApi.mockClear()
-      nock('https://int.bearer.sh', {
-        reqheaders: {
-          authorization: apiKey,
-          'Bearer-Auth-Id': authId
-        }
+    describe('#request', () => {
+      it('supports GET requests', async () => {
+        mockRequest({ method: 'GET' })
+
+        const { data } = await api.request('GET', '/test', { headers, query })
+
+        expect(distantApi).toHaveBeenCalled()
+        expect(data).toEqual(okResponse)
       })
-        .post(`/api/v4/functions/backend/${integrationName}/bearer-proxy/test`)
-        .query({ sponge: 'bob' })
-        .reply(200, distantApi)
 
-      const { data } = await api.auth(authId).post('/test', { query: { sponge: 'bob' } })
+      it('supports HEAD requests', async () => {
+        mockRequest({ method: 'HEAD' })
 
-      expect(distantApi).toHaveBeenCalled()
-      expect(data).toEqual(okResponse)
+        const { data } = await api.request('HEAD', '/test', { headers, query })
+
+        expect(distantApi).toHaveBeenCalled()
+        expect(data).toEqual(okResponse)
+      })
+
+      it('supports POST requests', async () => {
+        mockRequest({ body, method: 'POST' })
+
+        const { data } = await api.request('POST', '/test', { headers, query, body })
+
+        expect(distantApi).toHaveBeenCalled()
+        expect(data).toEqual(okResponse)
+      })
+
+      it('supports PUT requests', async () => {
+        mockRequest({ body, method: 'PUT' })
+
+        const { data } = await api.request('PUT', '/test', { headers, query, body })
+
+        expect(distantApi).toHaveBeenCalled()
+        expect(data).toEqual(okResponse)
+      })
+
+      it('supports PATCH requests', async () => {
+        mockRequest({ body, method: 'PATCH' })
+
+        const { data } = await api.request('PATCH', '/test', { headers, query, body })
+
+        expect(distantApi).toHaveBeenCalled()
+        expect(data).toEqual(okResponse)
+      })
+
+      it('supports DELETE requests', async () => {
+        mockRequest({ body, method: 'DELETE' })
+
+        const { data } = await api.request('DELETE', '/test', { headers, query, body })
+
+        expect(distantApi).toHaveBeenCalled()
+        expect(data).toEqual(okResponse)
+      })
     })
 
-    it('has an alias function "authenticate"', async () => {
-      expect(api.authenticate).toEqual(api.auth)
+    describe('#auth', () => {
+      it('sends any configured auth id in a Bearer-Auth-Id header', async () => {
+        const authId = 'abcde12345...'
+        mockRequest({ method: 'POST', extraHeaders: { 'Bearer-Auth-Id': authId } })
+
+        const { data } = await api.auth(authId).post('/test', { query })
+
+        expect(distantApi).toHaveBeenCalled()
+        expect(data).toEqual(okResponse)
+      })
+
+      it('has an alias function "authenticate"', async () => {
+        expect(api.authenticate).toEqual(api.auth)
+      })
     })
 
-    it('sends any configured setup id in a Bearer-Setup-Id header', async () => {
-      const setupId = 'test-setup-id'
+    describe('#setup', () => {
+      it('sends any configured setup id in a Bearer-Setup-Id header', async () => {
+        const setupId = 'test-setup-id'
+        mockRequest({ method: 'GET', extraHeaders: { 'Bearer-Setup-Id': setupId } })
 
-      nock('https://int.bearer.sh', {
-        reqheaders: {
-          authorization: apiKey,
-          'Bearer-Setup-Id': setupId
-        }
+        const { data } = await api.setup(setupId).get('/test', { query })
+
+        expect(distantApi).toHaveBeenCalled()
+        expect(data).toEqual(okResponse)
       })
-        .get(`/api/v4/functions/backend/${integrationName}/bearer-proxy/test`)
-        .reply(200, distantApi)
-
-      const { data } = await api.setup(setupId).get('/test')
-
-      expect(distantApi).toHaveBeenCalled()
-      expect(data).toEqual(okResponse)
     })
   })
 })

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -176,12 +176,12 @@ in the form "{ headers: { "Foo": "bar" }, body: "My body" }"`)
  * Exports
  */
 
-export default (apiKey: string | undefined): Bearer => {
+export default (apiKey: string | undefined, options?: BearerClientOptions): Bearer => {
   if (!apiKey) {
     throw new InvalidAPIKey(apiKey)
   }
 
-  return new Bearer(apiKey)
+  return new Bearer(apiKey, options)
 }
 
 export { Bearer }

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -38,8 +38,12 @@ class BearerClient {
     readonly authId?: string
   ) {}
 
-  public auth = ({ setupId, authId }: { setupId?: string; authId?: string }) => {
-    return new BearerClient(this.integrationId, this.options, this.bearerApiKey, setupId, authId)
+  public auth = (authId: string) => {
+    return new BearerClient(this.integrationId, this.options, this.bearerApiKey, this.setupId, authId)
+  }
+
+  public setup = (setupId: string) => {
+    return new BearerClient(this.integrationId, this.options, this.bearerApiKey, setupId, this.authId)
   }
 
   public authenticate = this.auth // Alias

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -53,30 +53,30 @@ class BearerClient {
    */
 
   public get = (endpoint: string, parameters?: BearerRequestParameters, options?: any) => {
-    return this.makeRequest('GET', endpoint, parameters, options)
+    return this.request('GET', endpoint, parameters, options)
   }
 
   public head = (endpoint: string, parameters?: BearerRequestParameters, options?: any) => {
-    return this.makeRequest('HEAD', endpoint, parameters, options)
+    return this.request('HEAD', endpoint, parameters, options)
   }
 
   public post = (endpoint: string, parameters?: BearerRequestParameters, options?: any) => {
-    return this.makeRequest('POST', endpoint, parameters, options)
+    return this.request('POST', endpoint, parameters, options)
   }
 
   public put = (endpoint: string, parameters?: BearerRequestParameters, options?: any) => {
-    return this.makeRequest('PUT', endpoint, parameters, options)
+    return this.request('PUT', endpoint, parameters, options)
   }
 
   public delete = (endpoint: string, parameters?: BearerRequestParameters, options?: any) => {
-    return this.makeRequest('DELETE', endpoint, parameters, options)
+    return this.request('DELETE', endpoint, parameters, options)
   }
 
   public patch = (endpoint: string, parameters?: BearerRequestParameters, options?: any) => {
-    return this.makeRequest('PATCH', endpoint, parameters, options)
+    return this.request('PATCH', endpoint, parameters, options)
   }
 
-  protected makeRequest = (
+  public request = (
     method: BearerRequestMethod,
     endpoint: string,
     parameters?: BearerRequestParameters,


### PR DESCRIPTION
## 🐻 What your PR is doing?

Makes the following changes to the NodeJS client:

- Replaces `.auth({ setupId: ..., authId: ... })` with `.auth(...)` and `.setup(...)`
- Adds `.request` function. This makes it easier to use the API if you have the method in a variable.
- Support passing client options when using the client factory function. This makes it easier to use the client in the staging environment

## 📦 Package concerned

- @bearer/node


## ✅ Checklist

- [x] Tests were added (if necessary)
- [x] I used conventional commits
