### PR TITLE
Allow numbers to be used as header/query values in Node client

### DIFF
--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -86,7 +86,7 @@ class BearerClient {
       throw new InvalidRequestOptions()
     }
 
-    const preheaders: { [key: string]: string } = {
+    const preheaders: BearerHeaders = {
       Authorization: this.bearerApiKey,
       'User-Agent': 'Bearer.sh',
       'Bearer-Auth-Id': this.authId!,
@@ -144,10 +144,12 @@ class BearerClient {
  * Types
  */
 
+type BearerHeaders = Record<string, string | number | undefined>
 type BearerRequestMethod = AxiosRequestConfig['method']
+
 interface BearerRequestParameters {
-  headers?: { [key: string]: string }
-  query?: string | { [key: string]: string }
+  headers?: BearerHeaders
+  query?: string | Record<string, string | number>
   body?: any
 }
 


### PR DESCRIPTION
<!-- Feel free to remove any section you don't need -->

## 🐻 What your PR is doing?

Changes the typing in the NodeJS Client package to allow numbers to be used as header/query param values

## 📦 Package concerned

- @bearer/node

## ✅ Checklist

- [ ] Tests were added (if necessary)
- [x] I used conventional commits
