### PR TITLE
feat(webhook): allow alias as key handler

### DIFF
--- a/packages/express/src/index.test.ts
+++ b/packages/express/src/index.test.ts
@@ -53,6 +53,18 @@ describe('Bearer middleware', () => {
         expect(mock.mock.calls[0][0].title).toBe('Sponge bob is the king')
       })
 
+      it('with alias - calls handler with req object', async () => {
+        await request(app)
+          .post('/whatever/webhooks')
+          .set('BEARER-INTEGRATION-HANDLER', 'whatever')
+          .set('BEARER-INTEGRATION-ALIAS', SUCCESS_HANDLER)
+
+        const mock = webHookHandlers[SUCCESS_HANDLER] as jest.Mock
+        // request is passed down
+        expect(mock.mock.calls[0][0]).toBeInstanceOf(IncomingMessage)
+        expect(mock.mock.calls[0][0].title).toBe('Sponge bob is the king')
+      })
+
       it('returns correct success payload', async () => {
         const response = await request(app)
           .post('/whatever/webhooks')

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -81,17 +81,20 @@ export type TWebhookOptions = {
  * Middlwares
  */
 const INTEGRATION_HANDLER = 'bearer-integration-handler'
+const ALIAS_HANDLER = 'bearer-integration-alias'
 const BEARER_SHA = 'bearer-sha'
 const FUNCTION_DURATION_HEADER = 'X-BEARER-WEBHOOK-HANDLER-DURATION'
 
 function ensureHandlerExists(handlers: TWebhookHandlers) {
   return (req: Request & Partial<TWithHandlerReq>, res: Response, next: NextFunction) => {
     const integrationHandler = req.headers[INTEGRATION_HANDLER] as string
-    if (!handlers[integrationHandler]) {
+    const aliasHandler = req.headers[ALIAS_HANDLER] as string
+    const handler = handlers[integrationHandler] || handlers[aliasHandler]
+    if (!handler) {
       res.status(422)
       next(new WebhookMissingHandler(`Integration handler not found: ${integrationHandler}`))
     } else {
-      req.bearerHandler = handlers[integrationHandler]
+      req.bearerHandler = handler
       req.bearerHandlerName = integrationHandler
       next()
     }


### PR DESCRIPTION
<!-- Feel free to remove any section you don't need -->

## 🐻 What your PR is doing?

<!--  Describe briefly what your Pull Request is doing -->

allow webhook to have alias as key

## 📦 Package concerned

- @bearer/express

<!--
  Uncomment the ones concerned
- @bearer/cli
- @bearer/core
- create-bearer
- @bearer/functions
- @bearer/legacy-cli
- @bearer/js
- @bearer/openapi-generator
- @bearer/react
- @bearer/transpiler
- @bearer/tslint-config
- @bearer/types
- @bearer/ui
- none
- all
 -->



## 🛠 How to test it

<!-- Provide any helpful information to help reviewer test you changes -->

## ✅ Checklist

- [x] Tests were added (if necessary)
- [x] I used conventional commits
