### PR TITLE
Fix counters issue by providing global organization scope

### DIFF
--- a/packages/x-ray/__test__/index.test.ts
+++ b/packages/x-ray/__test__/index.test.ts
@@ -19,6 +19,7 @@ describe('setupFunctionIdentifiers', () => {
   it('setup all function identifiers', () => {
     const event = {
       context: {
+        organizationIdentifier: 'organizationIdentifier',
         clientId: 'myClientId',
         integrationUuid: 'myIntegrationUuid'
       }
@@ -26,7 +27,23 @@ describe('setupFunctionIdentifiers', () => {
 
     setupFunctionIdentifiers(event)
 
-    expect(process.env.clientId).toEqual('myClientId')
+    expect(process.env.clientId).toEqual('organizationIdentifier')
     expect(process.env.scenarioUuid).toEqual('myIntegrationUuid')
+  })
+
+  describe('when organizationIdentifier is missing in context', () => {
+    it('setup fallbacks to clientId', () => {
+      const event = {
+        context: {
+          clientId: 'myClientId',
+          integrationUuid: 'myIntegrationUuid'
+        }
+      }
+
+      setupFunctionIdentifiers(event)
+
+      expect(process.env.clientId).toEqual('myClientId')
+      expect(process.env.scenarioUuid).toEqual('myIntegrationUuid')
+    })
   })
 })

--- a/packages/x-ray/src/index.ts
+++ b/packages/x-ray/src/index.ts
@@ -25,9 +25,12 @@ export const bearerOverride = () => {
 
 export const setupFunctionIdentifiers = function(event: any) {
   const context = event.context || {}
-  const { clientId, integrationUuid } = context
-  logger('%j', { message: `Ìnject ${clientId} and ${integrationUuid}`, application: 'x-ray' })
-  process.env.clientId = clientId
+  const { clientId, integrationUuid, organizationIdentifier } = context
+  logger('%j', {
+    message: `Injecting ${JSON.stringify({ clientId, integrationUuid, organizationIdentifier })} `,
+    application: 'x-ray'
+  })
+  process.env.clientId = organizationIdentifier || clientId
   process.env.scenarioUuid = integrationUuid
 }
 


### PR DESCRIPTION
# WHAT
- use environmentIdentifier (fallback to clientId) for the external api counters
# WHY
- after releasing environments we have realized that the scopes for the counters are now wrong. We should rely on global organization scope instead of using the clientId (which now has become an environment scope)

- [x] Tests were added (if necessary)
- [x] I used conventional commits
