### PR TITLE
fix: update test to match authType

### DIFF
--- a/packages/cli/test/utils/__snapshots__/generator.test.ts.snap
+++ b/packages/cli/test/utils/__snapshots__/generator.test.ts.snap
@@ -29,8 +29,7 @@ exports[`generators build generates openapi documentation 1`] = `
           {
             \\"name\\": \\"authId\\",
             \\"schema\\": {
-              \\"type\\": \\"string\\",
-              \\"format\\": \\"uuid\\"
+              \\"type\\": \\"string\\"
             },
             \\"in\\": \\"query\\",
             \\"description\\": \\"User Identifier\\",
@@ -137,8 +136,7 @@ exports[`generators build generates openapi documentation 1`] = `
           {
             \\"name\\": \\"authId\\",
             \\"schema\\": {
-              \\"type\\": \\"string\\",
-              \\"format\\": \\"uuid\\"
+              \\"type\\": \\"string\\"
             },
             \\"in\\": \\"query\\",
             \\"description\\": \\"User Identifier\\",

--- a/packages/openapi-generator/__tests__/__snapshots__/converter.test.ts.snap
+++ b/packages/openapi-generator/__tests__/__snapshots__/converter.test.ts.snap
@@ -191,7 +191,7 @@ Object {
 
 exports[`#functionTypeToSchemaConverter converts types to schemas for fetchDataOauth1.ts 1`] = `
 Object {
-  "functionAuthType": "TOAUTH1AuthContext",
+  "functionAuthType": "OAUTH1",
   "requestBody": Object {
     "properties": Object {
       "id": Object {

--- a/packages/openapi-generator/__tests__/__snapshots__/generator.test.ts.snap
+++ b/packages/openapi-generator/__tests__/__snapshots__/generator.test.ts.snap
@@ -229,8 +229,7 @@ exports[`#generator generates the valid openapi 3.0 document 1`] = `
           {
             \\"name\\": \\"authId\\",
             \\"schema\\": {
-              \\"type\\": \\"string\\",
-              \\"format\\": \\"uuid\\"
+              \\"type\\": \\"string\\"
             },
             \\"in\\": \\"query\\",
             \\"description\\": \\"User Identifier\\",
@@ -433,7 +432,17 @@ exports[`#generator generates the valid openapi 3.0 document 1`] = `
     },
     \\"/4l1c3-happy-goats/fetchDataOauth1\\": {
       \\"post\\": {
-        \\"parameters\\": [],
+        \\"parameters\\": [
+          {
+            \\"name\\": \\"authId\\",
+            \\"schema\\": {
+              \\"type\\": \\"string\\"
+            },
+            \\"in\\": \\"query\\",
+            \\"description\\": \\"User Identifier\\",
+            \\"required\\": true
+          }
+        ],
         \\"summary\\": \\"fetchDataOauth1\\",
         \\"requestBody\\": {
           \\"content\\": {
@@ -537,8 +546,7 @@ exports[`#generator generates the valid openapi 3.0 document 1`] = `
           {
             \\"name\\": \\"authId\\",
             \\"schema\\": {
-              \\"type\\": \\"string\\",
-              \\"format\\": \\"uuid\\"
+              \\"type\\": \\"string\\"
             },
             \\"in\\": \\"query\\",
             \\"description\\": \\"User Identifier\\",
@@ -648,8 +656,7 @@ exports[`#generator generates the valid openapi 3.0 document 1`] = `
           {
             \\"name\\": \\"authId\\",
             \\"schema\\": {
-              \\"type\\": \\"string\\",
-              \\"format\\": \\"uuid\\"
+              \\"type\\": \\"string\\"
             },
             \\"in\\": \\"query\\",
             \\"description\\": \\"User Identifier\\",

--- a/packages/openapi-generator/src/index.ts
+++ b/packages/openapi-generator/src/index.ts
@@ -68,11 +68,11 @@ function getFunctionAuthType(sym: ts.Symbol | undefined, node: ts.Node, checker:
     const typ = checker.getTypeOfSymbolAtLocation(sym, node)
     if (typ.aliasTypeArguments) {
       const authType = checker.typeToString(typ.aliasTypeArguments[1])
-      if (/ApiKey/.test(authType)) return 'APIKEY'
-      if (/Basic/.test(authType)) return 'BASIC'
-      if (/OAuth1/.test(authType)) return 'OAUTH1'
-      if (/OAuth2/.test(authType)) return 'OAUTH2'
-      if (/None/.test(authType)) return 'NONE'
+      if (/ApiKey/i.test(authType)) return 'APIKEY'
+      if (/Basic/i.test(authType)) return 'BASIC'
+      if (/OAuth1/i.test(authType)) return 'OAUTH1'
+      if (/OAuth2/i.test(authType)) return 'OAUTH2'
+      if (/None/i.test(authType)) return 'NONE'
       return authType
     }
   }

--- a/packages/openapi-generator/src/openapi-template.ts
+++ b/packages/openapi-generator/src/openapi-template.ts
@@ -19,7 +19,7 @@ type THeader = {
 
 type TParam = {
   name: string
-  schema: { type: string; format: string }
+  schema: { type: string; format?: string }
   in: string
   description: string
   required?: boolean
@@ -73,7 +73,7 @@ function oauthParam(oauth: boolean): TParam | undefined {
   if (oauth) {
     return {
       name: 'authId',
-      schema: { type: 'string', format: 'uuid' },
+      schema: { type: 'string' },
       in: 'query',
       description: 'User Identifier',
       required: true


### PR DESCRIPTION
<!-- Feel free to remove any section you don't need -->

## 🐻 What your PR is doing?

Updates test to match `OAuth` or `OAUTH` in the same way.
Also, updates the type for `authId` as it can be provided by the user and in this case it won't be a `uuid` necessarily.

## 📦 Package concerned

- @bearer/openapi-generator

<!--
  Uncomment the ones concerned
- @bearer/cli
- @bearer/core
- create-bearer
- @bearer/functions
- @bearer/legacy-cli
- @bearer/js

- @bearer/react
- @bearer/transpiler
- @bearer/tslint-config
- @bearer/types
- @bearer/ui
- none
- all
 -->

## ✅ Checklist

- [ ] Tests were added (if necessary)
- [ ] I used conventional commits
