### PR TITLE
docs: warn developer that bearer is written with ES6

### DIFF
--- a/packages/js/README.md
+++ b/packages/js/README.md
@@ -41,6 +41,8 @@ class MyApp {
 }
 ```
 
+**:warning: `@bearer/js` is written in ES6**. If you want to support older browser (IE11) you'll have to add extra configuration to your bundling system. You'll need to explicitly tell your bundler (ex: webpack) to process and transform bearer's files.
+
 ## Usage
 
 ## Calling any APIs
@@ -63,11 +65,10 @@ slack
 // passing extra arguments
 slack
   .auth(authId)
-  .post('/reminders.add', { text: 'Remind me something', time: 'in 10 seconds'})
+  .post('/reminders.add', { text: 'Remind me something', time: 'in 10 seconds' })
   .then(console.log)
   .catch(console.error)
 ```
-
 
 ### Invoke js
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -16,6 +16,8 @@ Install dependencies
 yarn add @bearer/js @bearer/react
 ```
 
+**:warning: `@bearer/js` and `@bearer/react` are written in ES6**. If you want to support older browser (IE11) you'll have to add extra configuration to your bundling system. You'll need to explicitly tell your bundler (ex: webpack) to process and transform bearer's files.
+
 ## Factory
 
 Factory lets you create components or HOC scoped for an integration. It prevents your to repeat yourself.
@@ -94,7 +96,7 @@ function DisplayComponent(props: TProps) {
   }
 
   const invoke = () => {
-    props.invoke({query: { authId: 'AUTH_ID'}})
+    props.invoke({ query: { authId: 'AUTH_ID' } })
   }
 
   return (


### PR DESCRIPTION
<!-- Feel free to remove any section you don't need -->

## 🐻 What your PR is doing?

<!--  Describe briefly what your Pull Request is doing -->

update documentation so that people know they need to update their bundle config to have bearer writtend with ES5 syntax

## 📦 Package concerned

- @bearer/js
- @bearer/react
<!--
  Uncomment the ones concerned
- @bearer/cli
- @bearer/core
- create-bearer
- @bearer/functions
- @bearer/legacy-cli
- @bearer/js
- @bearer/openapi-generator
- @bearer/react
- @bearer/transpiler
- @bearer/tslint-config
- @bearer/types
- @bearer/ui
- none
- all
 -->
