### PR TITLE
Handle case where correlation ids are undefined

### DIFF
--- a/packages/functions/src/functions/fetch.ts
+++ b/packages/functions/src/functions/fetch.ts
@@ -60,14 +60,20 @@ const setupFunctionIdentifiers = function(event: d.TLambdaEvent<d.TAuthContext>)
   const context = event.context || {}
   const { clientId, integrationUuid, internalCorrelationId, organizationIdentifier, userCorrelationId } = context
   logger('%j', {
-    message: `Injecting ${JSON.stringify({ clientId, integrationUuid, organizationIdentifier })} `,
+    message: `Injecting ${JSON.stringify({
+      clientId,
+      integrationUuid,
+      internalCorrelationId,
+      organizationIdentifier,
+      userCorrelationId
+    })} `,
     application: 'x-ray'
   })
   process.env.clientId = organizationIdentifier || clientId
   process.env.environmentId = clientId
-  process.env.internalCorrelationId = internalCorrelationId
+  process.env.internalCorrelationId = internalCorrelationId || ''
   process.env.scenarioUuid = integrationUuid
-  process.env.userCorrelationId = userCorrelationId
+  process.env.userCorrelationId = userCorrelationId || ''
 }
 
 export class FetchActionExecutionError extends Error {}


### PR DESCRIPTION

## 🐻 What your PR is doing?

We were passing the string 'undefined' to XRay for the correlation ids because the environment variables are string values. We now pass an empty string in this case.

## 📦 Package concerned

- @bearer/functions

## ✅ Checklist

- [x] Tests were added (if necessary)
- [x] I used conventional commits
