### PR TITLE
fix(js): send clientId as headers

### DIFF
--- a/packages/js/src/lib/integrationClient.ts
+++ b/packages/js/src/lib/integrationClient.ts
@@ -41,7 +41,6 @@ export class IntegrationClient {
       authId: this.authId,
       setupId: this.setupId,
       ...query,
-      clientId: this.bearerInstance.clientId,
       secured: this.bearerInstance.config.secured
     }
     this.logger('json request: path %s', functionName)
@@ -56,7 +55,10 @@ export class IntegrationClient {
         baseURL: `${this.bearerInstance.config.integrationHost}/api/v4/functions/${this.integrationId}`,
         url: functionName,
         params: cleanOptions(queryParams),
-        data: params || {}
+        data: params || {},
+        headers: {
+          ['Bearer-Publishable-Key']: this.bearerInstance.clientId
+        }
       })
       this.logger('successful request %j', payload)
 
@@ -130,7 +132,8 @@ export class IntegrationClient {
 
     const headers: BearerHeaders = {
       'Bearer-Auth-Id': this.authId!,
-      'Bearer-Setup-Id': this.setupId!
+      'Bearer-Setup-Id': this.setupId!,
+      'Bearer-Publishable-Key': this.bearerInstance.clientId
     }
 
     if (parameters && parameters.headers) {
@@ -144,7 +147,7 @@ export class IntegrationClient {
       headers: cleanOptions(headers),
       baseURL: `${this.bearerInstance.config.integrationHost}/api/v4/functions/${this.integrationId}/bearer-proxy`,
       url: endpoint,
-      params: { ...parameters.query, clientId: this.bearerInstance.clientId },
+      params: parameters.query,
       data: parameters && parameters.body
     })
   }


### PR DESCRIPTION
some apis does not like to have unknown query parameters sent

<!-- Feel free to remove any section you don't need -->

## 🐻 What your PR is doing?

<!--  Describe briefly what your Pull Request is doing -->

fix: #733 

## 📦 Package concerned
- @bearer/js
<!--
  Uncomment the ones concerned
- @bearer/cli
- @bearer/core
- create-bearer
- @bearer/functions
- @bearer/legacy-cli
- @bearer/js
- @bearer/openapi-generator
- @bearer/react
- @bearer/transpiler
- @bearer/tslint-config
- @bearer/types
- @bearer/ui
- none
- all
 -->


## 🛠 How to test it

<!-- Provide any helpful information to help reviewer test you changes -->

`yarn test`

## ✅ Checklist

- [x] Tests were added (if necessary)
- [x] I used conventional commits
