### PR TITLE
feat: allow auth without version

### DIFF
--- a/packages/js/src/lib/bearer.ts
+++ b/packages/js/src/lib/bearer.ts
@@ -68,7 +68,7 @@ export class Bearer {
         clientId: this.clientId
       })
     )
-    const AUTHORIZED_URL = `${this.config.integrationHost}/v2/auth/${integration}?${query}`
+    const AUTHORIZED_URL = `${this.config.integrationHost}/auth/${integration}?${query}`
 
     const promise = new Promise<{ integration: string; authId: string }>((resolve, reject) => {
       Bearer.authorizedListener.clearListeners(authorizeEvent(integration))


### PR DESCRIPTION
<!-- Feel free to remove any section you don't need -->

## 🐻 What your PR is doing?

<!--  Describe briefly what your Pull Request is doing -->

We should allow the authentication flow to be performed without having to specify a version number.

## 📦 Package concerned

- @bearer/js

<!--
  Uncomment the ones concerned
- @bearer/cli
- @bearer/core
- create-bearer
- @bearer/functions
- @bearer/legacy-cli
- @bearer/js
- @bearer/openapi-generator
- @bearer/react
- @bearer/transpiler
- @bearer/tslint-config
- @bearer/types
- @bearer/ui
- none
- all
 -->

## ✅ Checklist

- [ ] Tests were added (if necessary)
- [ ] I used conventional commits
