### PR TITLE
Prepare detected url before classifying

### DIFF
--- a/pkg/classification/interfaces/interfaces.go
+++ b/pkg/classification/interfaces/interfaces.go
@@ -98,8 +98,10 @@ func (classifier *Classifier) Classify(data report.Detection) (*ClassifiedInterf
 		return nil, errors.New("detection is not an interface")
 	}
 
-	// detected url, with unknown parts replaced with * wildcards
-	value := detectedInterface.Value.ToString()
+	value, err := url.PrepareURLValue(detectedInterface.Value.ToString())
+	if err != nil {
+		return nil, err
+	}
 	recipeMatch, err := classifier.FindMatchingRecipeUrl(value)
 	if err != nil {
 		return nil, err

--- a/pkg/classification/interfaces/interfaces_test.go
+++ b/pkg/classification/interfaces/interfaces_test.go
@@ -97,8 +97,7 @@ func TestInterface(t *testing.T) {
 				},
 			},
 			Want: &interfaces.Classification{
-				// todo: we should expect https:// here
-				URL:         "googleapis.com/auth/spreadsheets",
+				URL:         "https://googleapis.com/auth/spreadsheets",
 				RecipeName:  "Google Spreadsheets",
 				RecipeMatch: true,
 				Decision: interfaces.ClassificationDecision{


### PR DESCRIPTION
## Description
Prepare the detected URL before classification to ensure that it will be well handled by the URL and domain parsers

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [x] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
