### PR TITLE
docs/setup structure and initial docs examples.

### DIFF
--- a/docs/explanations/index.md
+++ b/docs/explanations/index.md
@@ -1,0 +1,10 @@
+---
+title: Concepts
+---
+
+The following articles explain the rationale and implementations behind curio.
+
+- Detection
+- Classification
+- Policies
+- Recipes

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,3 @@
+---
+title: Get Started
+---

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1,0 +1,69 @@
+---
+title: Commands
+---
+
+Curio offers a number of commands to use and customize the CLI to your needs.
+
+- [scan](#scan): Scans a repository, project, or file.
+- [config](#config): Checks the config file for misconfigurations.
+
+In addition to flags available for specific commands, the following flags are globally available for all commands:
+
+- `--config [path]`, `-c [path]` (string): Instructs curio to use the path to a `yaml` config file.
+- `--debug`, `-d`: Places curio in debug mode.
+- `--generate-default-config`: Writes the default config to `curio-default.yaml`.
+- `--quiet`, `-q`: Suppresses progress bar and log output.
+- `--version`, `-v`: Displays the installed version number.
+
+## scan
+
+Scans a repository, project, or file.
+
+```bash
+curio scan [FLAGS] [PATH]
+```
+
+- `PATH` (string) (optional) (default: current working directory)
+  - A path to a directory or file.
+- `FLAGS`
+  - Report flags:
+    - `--format`, `-f` format (json) (default "json")
+  - Scan Flags
+    - `--skip` string specify the path to file containing patterns of files to skip when scanning (in .gitignore fashion)
+  - Worker Flags
+    - `--file-size-max` ignore files with file size larger than this config (default 25000000)
+    - `--files-to-batch` number of files to batch to worker (default 1)
+    - `--memory-max` if memory needed to scan a file surpasses this limit, skip the file (default 800000000)
+    - `--timeout` time allowed to complete scan (default 10m0s)
+    - `--timeout-file-max` maximum timeout assigned to scanning file, this config superseeds timeout-second-per-bytes (default 5m0s)
+    - `--timeout-file-min` minimum timeout assigned to scanning file, this config superseeds timeout-second-per-bytes (default 5s)
+    - `--timeout-file-second-per-bytes` number of file size bytes producing a second of timeout assigned to scanning a file (default 10000)
+    - `--timeout-worker-online` maximum time for worker process to come online (default 1m0s)
+    - `--workers` number of processing workers to spawn (default 1)
+
+### Usage
+
+Below are usage examples for the `scan` command:
+
+```bash
+# Scan a local project
+curio scan /path/to/project
+
+# Scan an individual file
+curio scan /path/to/Pipfile.lock
+
+# Scan the current directory with a custom config file
+curio scan --config /path/to/custom-config.yaml
+```
+
+## config
+
+Checks the curio configuration file for misconfigurations.
+
+```bash
+curio config [FLAGS] [DIR]
+```
+
+- `DIR`
+- `FLAGS`
+  - TODO

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,5 @@
+---
+title: Reference
+---
+
+- [Commands](commands.md)

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,5 +1,0 @@
----
-title: Reference
----
-
-- [Commands](commands.md)


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->
Begins to build out format for documentation. Rather than make the readme the catch-all during development, individual supporting docs can be created 

## How it works:

- `docs/reference`: Core reference examples go here. A starter file for all top-level CLI commands has been added. Future references can include config file formats, policy formats, etc.
- `docs/explanations`: Rational/explanations for how things work, why they work a certain way, etc.

Additional placeholders have been added. Any unknown/uncategorized additions can be created as individual files in the `docs` subfolder.

_All documentation should be written in markdown as `.md` files._

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
