### PR TITLE
Add report flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ curio scan ./curio-ci-test/Pipfile.lock
 ### Report Flags
 
 - `-f`, `--format` format (json) (default "json")
-- `--report` report what (detectors) (default "detectors")
+- `--report` specify the kind of report (detectors) (default "detectors")
 
 ### Scan Flags
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ curio scan ./curio-ci-test/Pipfile.lock
 ### Report Flags
 
 - `-f`, `--format` format (json) (default "json")
+- `--report` report what (detectors) (default "detectors")
 
 ### Scan Flags
 

--- a/pkg/flag/process_flags.go
+++ b/pkg/flag/process_flags.go
@@ -3,7 +3,7 @@ package flag
 var (
 	PortFlag = Flag{
 		Name:       "port",
-		ConfigName: "port",
+		ConfigName: "process.port",
 		Shorthand:  "p",
 		Value:      "",
 		Usage:      "server listening on what port",

--- a/pkg/flag/report_flags.go
+++ b/pkg/flag/report_flags.go
@@ -26,7 +26,7 @@ var (
 		Name:       "report",
 		ConfigName: "report.report",
 		Value:      ReportDetectors,
-		Usage:      "report what (detectors)",
+		Usage:      "specify the kind of report (detectors)",
 	}
 )
 

--- a/pkg/flag/report_flags.go
+++ b/pkg/flag/report_flags.go
@@ -9,29 +9,41 @@ type Severity int
 var (
 	FormatJSON      = "json"
 	FormatJSONLines = "jsonlines"
+
+	ReportDetectors = "detectors"
+	ReportDataFlow  = "dataflow"
 )
 
 var (
 	FormatFlag = Flag{
 		Name:       "format",
-		ConfigName: "format",
+		ConfigName: "report.format",
 		Shorthand:  "f",
 		Value:      FormatJSON,
 		Usage:      "format (json)",
+	}
+	ReportFlag = Flag{
+		Name:       "report",
+		ConfigName: "report.report",
+		Value:      ReportDetectors,
+		Usage:      "report what (detectors)",
 	}
 )
 
 type ReportFlagGroup struct {
 	Format *Flag
+	Report *Flag
 }
 
 type ReportOptions struct {
 	Format string
+	Report string
 }
 
 func NewReportFlagGroup() *ReportFlagGroup {
 	return &ReportFlagGroup{
 		Format: &FormatFlag,
+		Report: &ReportFlag,
 	}
 }
 
@@ -40,11 +52,12 @@ func (f *ReportFlagGroup) Name() string {
 }
 
 func (f *ReportFlagGroup) Flags() []*Flag {
-	return []*Flag{f.Format}
+	return []*Flag{f.Format, f.Report}
 }
 
 func (f *ReportFlagGroup) ToOptions(out io.Writer) ReportOptions {
 	return ReportOptions{
 		Format: getString(f.Format),
+		Report: getString(f.Report),
 	}
 }


### PR DESCRIPTION
## Description
This pr adds a flag/placeholder for detectors/dataflow/policies called `--report`


## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
