### PR TITLE
refactor: separate validation methods and fix classification ordering

### DIFF
--- a/pkg/util/url/url.go
+++ b/pkg/util/url/url.go
@@ -241,7 +241,7 @@ func PrepareURLValue(myURL string) (string, error) {
 	return preparedURL, nil
 }
 
-func Validate(myURL string, isInternal bool, data *report.Detection) (*ValidationResult, error) {
+func ValidateFormat(myURL string, data *report.Detection) (*ValidationResult, error) {
 	ValidationResult := ValidationResult{
 		State:  Invalid,
 		Reason: "uncertain", // default
@@ -274,6 +274,11 @@ func Validate(myURL string, isInternal bool, data *report.Detection) (*Validatio
 		return &ValidationResult, nil
 	}
 
+	if parsedURL.Host[0:1] == "." {
+		ValidationResult.Reason = "tld_error"
+		return &ValidationResult, nil
+	}
+
 	if net.ParseIP(parsedURL.Host) != nil {
 		ValidationResult.Reason = "ip_address_error"
 		return &ValidationResult, nil
@@ -300,9 +305,19 @@ func Validate(myURL string, isInternal bool, data *report.Detection) (*Validatio
 		return &ValidationResult, nil
 	}
 
-	if parsedURL.Host == "" || parsedURL.Host[0:1] == "." {
-		ValidationResult.Reason = "tld_error"
-		return &ValidationResult, nil
+	ValidationResult.State = Potential
+	return &ValidationResult, nil
+}
+
+func ValidateInternal(myURL string) (*ValidationResult, error) {
+	ValidationResult := ValidationResult{
+		State:  Invalid,
+		Reason: "uncertain", // default
+	}
+
+	parsedURL, err := url.Parse(myURL)
+	if err != nil {
+		return nil, err
 	}
 
 	parsedDomain, err := publicsuffix.ParseFromListWithOptions(
@@ -314,81 +329,103 @@ func Validate(myURL string, isInternal bool, data *report.Detection) (*Validatio
 		return nil, err
 	}
 
-	if !isInternal {
-		if parsedDomain.TLD == "" || isBlocklisted(parsedDomain.TLD) {
-			ValidationResult.Reason = "tld_error"
-			return &ValidationResult, nil
-		}
-
-		// todo: :invalid, :domain_not_reachable
-
-		if domainIsExcluded(parsedURL.Host) {
-			ValidationResult.Reason = "excluded_domains_error"
-			return &ValidationResult, nil
-		}
-	}
-
 	if subdomainIsNotAllowed(parsedDomain.TRD) {
-		if isInternal {
-			ValidationResult.Reason = "internal_domain_subdomain_error"
-		} else {
-			ValidationResult.Reason = "subdomain_error"
-		}
+		ValidationResult.Reason = "internal_domain_subdomain_error"
 		return &ValidationResult, nil
 	}
 
 	if pathError(parsedURL.Path) {
-		if isInternal {
-			ValidationResult.Reason = "internal_domain_errors_in_path"
-		} else {
-			ValidationResult.Reason = "errors_in_path"
-		}
+		ValidationResult.Reason = "internal_domain_errors_in_path"
 		return &ValidationResult, nil
 	}
 
 	if pathContainsAPIorAuth(parsedURL.Path) {
 		ValidationResult.State = Valid
-		if isInternal {
-			ValidationResult.Reason = "internal_domain_path_contains_api_or_auth"
-		} else {
-			ValidationResult.Reason = "path_contains_api_or_auth"
-		}
+		ValidationResult.Reason = "internal_domain_path_contains_api_or_auth"
+
 		return &ValidationResult, nil
 	}
 
-	if isInternal {
-		if parsedDomain.TRD == "" {
-			ValidationResult.Reason = "internal_domain_but_no_subdomain"
-			return &ValidationResult, nil
-		}
-
-		if strings.Contains(parsedURL.Host, "*") {
-			ValidationResult.Reason = "internal_domain_and_subdomain_with_wildcard"
-			ValidationResult.State = Potential
-			return &ValidationResult, nil
-		}
-
-		ValidationResult.Reason = "internal_domain_and_subdomain"
-		ValidationResult.State = Valid
+	if parsedDomain.TRD == "" {
+		ValidationResult.Reason = "internal_domain_but_no_subdomain"
 		return &ValidationResult, nil
-	} else {
-		if parsedDomain.TRD == "" {
+	}
+
+	if strings.Contains(parsedURL.Host, "*") {
+		ValidationResult.State = Potential
+		ValidationResult.Reason = "internal_domain_and_subdomain_with_wildcard"
+		return &ValidationResult, nil
+	}
+
+	ValidationResult.State = Valid
+	ValidationResult.Reason = "internal_domain_and_subdomain"
+	return &ValidationResult, nil
+}
+
+func Validate(myURL string) (*ValidationResult, error) {
+	ValidationResult := ValidationResult{
+		State:  Invalid,
+		Reason: "uncertain", // default
+	}
+
+	parsedURL, err := url.Parse(myURL)
+	if err != nil {
+		return nil, err
+	}
+
+	parsedDomain, err := publicsuffix.ParseFromListWithOptions(
+		publicsuffix.DefaultList,
+		parsedURL.Host,
+		&publicsuffix.FindOptions{IgnorePrivate: true, DefaultRule: nil},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if parsedDomain.TLD == "" || isBlocklisted(parsedDomain.TLD) {
+		ValidationResult.Reason = "tld_error"
+		return &ValidationResult, nil
+	}
+
+	// todo: :invalid, :domain_not_reachable
+
+	if domainIsExcluded(parsedURL.Host) {
+		ValidationResult.Reason = "excluded_domains_error"
+		return &ValidationResult, nil
+	}
+
+	if subdomainIsNotAllowed(parsedDomain.TRD) {
+		ValidationResult.Reason = "subdomain_error"
+		return &ValidationResult, nil
+	}
+
+	if pathError(parsedURL.Path) {
+		ValidationResult.Reason = "errors_in_path"
+		return &ValidationResult, nil
+	}
+
+	if pathContainsAPIorAuth(parsedURL.Path) {
+		ValidationResult.State = Valid
+		ValidationResult.Reason = "path_contains_api_or_auth"
+		return &ValidationResult, nil
+	}
+
+	if parsedDomain.TRD == "" {
+		ValidationResult.State = Potential
+		ValidationResult.Reason = "no_subdomain"
+		return &ValidationResult, nil
+	}
+
+	if strings.Contains(parsedDomain.TRD, "api") {
+		if strings.Contains(parsedURL.Host, "*") {
 			ValidationResult.State = Potential
-			ValidationResult.Reason = "no_subdomain"
+			ValidationResult.Reason = "subdomain_contains_api_with_wildcard"
 			return &ValidationResult, nil
 		}
 
-		if strings.Contains(parsedDomain.TRD, "api") {
-			if strings.Contains(parsedURL.Host, "*") {
-				ValidationResult.State = Potential
-				ValidationResult.Reason = "subdomain_contains_api_with_wildcard"
-				return &ValidationResult, nil
-			}
-
-			ValidationResult.State = Valid
-			ValidationResult.Reason = "subdomain_contains_api"
-			return &ValidationResult, nil
-		}
+		ValidationResult.State = Valid
+		ValidationResult.Reason = "subdomain_contains_api"
+		return &ValidationResult, nil
 	}
 
 	ValidationResult.State = Potential // uncertain

--- a/pkg/util/url/url_test.go
+++ b/pkg/util/url/url_test.go
@@ -16,7 +16,6 @@ type MatchTestCase struct {
 	DetectionURL string
 	RecipeURL    string
 	Want         string
-	Skip         bool
 }
 
 func TestMatch(t *testing.T) {
@@ -26,184 +25,155 @@ func TestMatch(t *testing.T) {
 			RecipeURL:    "https://api.bearer.com",
 			DetectionURL: "https://api.bearer.com",
 			Want:         "https://api.bearer.com",
-			Skip:         false,
 		},
 		{
 			Name:         "when the urls are just domains and don't match",
 			RecipeURL:    "https://api.bearer.com",
 			DetectionURL: "https://docs.bearer.com",
 			Want:         "",
-			Skip:         false,
 		},
 		{
 			Name:         "when the detection url has a subdomain prefix",
 			RecipeURL:    "https://api.bearer.com",
 			DetectionURL: "https://test.api.bearer.com",
 			Want:         "https://test.api.bearer.com",
-			Skip:         false,
 		},
 		{
 			Name:         "when the detection url has a non-subdomain prefix",
 			RecipeURL:    "https://api.bearer.com",
 			DetectionURL: "https://testapi.bearer.com",
 			Want:         "",
-			Skip:         false,
 		},
 		{
 			Name:         "when the url has a subdomain prefix",
 			RecipeURL:    "https://test.api.bearer.com",
 			DetectionURL: "https://api.bearer.com",
 			Want:         "",
-			Skip:         false,
 		},
 		{
 			Name:         "when the detection url contains a wildcard for an entire domain segment",
 			RecipeURL:    "https://s3.eu.amazonaws.com",
 			DetectionURL: "https://s3.*.amazonaws.com",
 			Want:         "https://s3.*.amazonaws.com",
-			Skip:         false,
 		},
 		{
 			Name:         "when the detection url contains a wildcard for the tld",
 			RecipeURL:    "https://api.bearer.com",
 			DetectionURL: "https://api.bearer.*",
 			Want:         "",
-			Skip:         false,
 		},
 		{
 			Name:         "when the detection url contains a wildcard for the sld",
 			RecipeURL:    "https://api.bearer.com",
 			DetectionURL: "https://api.*.com",
 			Want:         "",
-			Skip:         false,
 		},
 		{
 			Name:         "when the detection url contains a wildcard for part of a domain segment",
 			RecipeURL:    "https://s3.eu-west.amazonaws.com",
 			DetectionURL: "https://s3.eu-*.amazonaws.com",
 			Want:         "",
-			Skip:         false,
 		},
 		{
 			Name:         "when the url contains a wildcard for an entire domain segment",
 			RecipeURL:    "https://s3.*.amazonaws.com",
 			DetectionURL: "https://s3.eu.amazonaws.com",
 			Want:         "https://s3.eu.amazonaws.com",
-			Skip:         false,
 		},
 		{
 			Name:         "when the url contains a wildcard for part of a domain segment",
 			RecipeURL:    "https://s3.eu-*.amazonaws.com",
 			DetectionURL: "https://s3.eu-west.amazonaws.com",
 			Want:         "https://s3.eu-west.amazonaws.com",
-			Skip:         false,
 		},
 		{
 			Name:         "when the url contains a wildcard matching across detection url segments",
 			RecipeURL:    "https://api.*.amazonaws.com",
 			DetectionURL: "https://api.s3.eu-west.amazonaws.com",
 			Want:         "https://api.s3.eu-west.amazonaws.com",
-			Skip:         false,
 		},
 		{
 			Name:         "when the urls include a path and match exactly",
 			RecipeURL:    "https://api.bearer.com/path",
 			DetectionURL: "https://api.bearer.com/path",
 			Want:         "https://api.bearer.com/path",
-			Skip:         false,
 		},
 		{
 			Name:         "when the urls include a path and the path doesn't match",
 			RecipeURL:    "https://api.bearer.com/path",
 			DetectionURL: "https://api.bearer.com/otherpath",
 			Want:         "",
-			Skip:         false,
 		},
 		{
 			Name:         "when the urls match but the url has a trailing slash",
 			RecipeURL:    "https://api.bearer.com/path/",
 			DetectionURL: "https://api.bearer.com/path",
 			Want:         "https://api.bearer.com/path",
-			Skip:         false,
 		},
 		{
 			Name:         "when the urls match but the detection url has a trailing slash",
 			RecipeURL:    "https://api.bearer.com/path",
 			DetectionURL: "https://api.bearer.com/path/",
 			Want:         "https://api.bearer.com/path",
-			Skip:         false,
 		},
 		{
 			Name:         "when the detection url has a path segment suffix",
 			RecipeURL:    "https://api.bearer.com/path",
 			DetectionURL: "https://api.bearer.com/path/other",
 			Want:         "https://api.bearer.com/path",
-			Skip:         false,
 		},
 		{
 			Name:         "when the url has a path segment suffix",
 			RecipeURL:    "https://api.bearer.com/path/other",
 			DetectionURL: "https://api.bearer.com/path",
 			Want:         "",
-			Skip:         false,
 		},
 		{
 			Name:         "when the detection url has a non-segment path suffix",
 			RecipeURL:    "https://api.bearer.com/path",
 			DetectionURL: "https://api.bearer.com/pathother",
 			Want:         "",
-			Skip:         false,
 		},
 		{
 			Name:         "when the detection url contains a wildcard for an entire path segment",
 			RecipeURL:    "https://bearer.com/api/v2",
 			DetectionURL: "https://bearer.com/api/*",
 			Want:         "https://bearer.com/api/*",
-			Skip:         false,
 		},
 		{
 			Name:         "when the detection url contains a wildcard for part of a path segment",
 			RecipeURL:    "https://bearer.com/api/v2",
 			DetectionURL: "https://bearer.com/api/v*",
 			Want:         "",
-			Skip:         false,
 		},
 		{
 			Name:         "when the url contains a wildcard for an entire path segment",
 			RecipeURL:    "https://bearer.com/api/*",
 			DetectionURL: "https://bearer.com/api/v2",
 			Want:         "https://bearer.com/api/v2",
-			Skip:         false,
 		},
 		{
 			Name:         "when the url contains a wildcard for part of a path segment",
 			RecipeURL:    "https://bearer.com/api/v*",
 			DetectionURL: "https://bearer.com/api/v2",
 			Want:         "https://bearer.com/api/v2",
-			Skip:         false,
 		},
 		{
 			Name:         "when the url contains a wildcard matching multiple path segments",
 			RecipeURL:    "https://bearer.com/*/api",
 			DetectionURL: "https://bearer.com/eu/west/api/fred",
 			Want:         "https://bearer.com/eu/west/api",
-			Skip:         false,
 		},
 		{
 			Name:         "when the urls match exactly except the scheme",
 			RecipeURL:    "http://api.bearer.com",
 			DetectionURL: "https://api.bearer.com",
 			Want:         "https://api.bearer.com",
-			Skip:         false,
 		},
 	}
 
 	for _, testCase := range tests {
 		t.Run(testCase.Name, func(t *testing.T) {
-			if testCase.Skip {
-				t.Skip("interfaces not implemented")
-			}
-
 			regexpMatcher, _ := url.PrepareRegexpMatcher(testCase.RecipeURL)
 			output, err := url.Match(
 				testCase.DetectionURL,
@@ -287,18 +257,16 @@ func TestPrepareURLValue(t *testing.T) {
 	}
 }
 
-func TestValidate(t *testing.T) {
+func TestValidateFormat(t *testing.T) {
 	tests := []struct {
-		Name       string
-		URL        string
-		Data       *report.Detection
-		isInternal bool
-		Want       *url.ValidationResult
+		Name string
+		URL  string
+		Data *report.Detection
+		Want *url.ValidationResult
 	}{
 		{
-			Name:       "when a detection is from a potential detector",
-			URL:        "https://eu.example.com/path/*",
-			isInternal: false,
+			Name: "when a detection is from a potential detector",
+			URL:  "https://eu.example.com/path/*",
 			Data: &report.Detection{
 				DetectorType: detectors.DetectorEnvFile,
 			},
@@ -308,9 +276,8 @@ func TestValidate(t *testing.T) {
 			},
 		},
 		{
-			Name:       "when a detection is included inside a vendor folder - case 1",
-			URL:        "https://eu.example.com/path/*",
-			isInternal: false,
+			Name: "when a detection is included inside a vendor folder - case 1",
+			URL:  "https://eu.example.com/path/*",
 			Data: &report.Detection{
 				Source: source.Source{
 					Filename: "foo/vendor/symfony/symfony/src/Symfony/Component/Validator/Mapping/MemberMetadata.php",
@@ -322,9 +289,8 @@ func TestValidate(t *testing.T) {
 			},
 		},
 		{
-			Name:       "when a detection is included inside a vendor folder - case 2",
-			URL:        "https://eu.example.com/path/*",
-			isInternal: false,
+			Name: "when a detection is included inside a vendor folder - case 2",
+			URL:  "https://eu.example.com/path/*",
 			Data: &report.Detection{
 				Source: source.Source{
 					Filename: "rancher-powerdns4/vendor/github.com/prasmussen/gandi-api/client/client.go",
@@ -336,39 +302,35 @@ func TestValidate(t *testing.T) {
 			},
 		},
 		{
-			Name:       "when there's not data to make a strong decision",
-			URL:        "https://eu.example.com/path/*",
-			isInternal: false,
-			Data:       &report.Detection{},
+			Name: "when there's not data to make a strong decision",
+			URL:  "https://eu.example.com/path/*",
+			Data: &report.Detection{},
 			Want: &url.ValidationResult{
 				State:  url.Potential,
 				Reason: "uncertain",
 			},
 		},
 		{
-			Name:       "when the URL is blank",
-			URL:        "",
-			isInternal: false,
-			Data:       &report.Detection{},
+			Name: "when the URL is blank",
+			URL:  "",
+			Data: &report.Detection{},
 			Want: &url.ValidationResult{
 				State:  url.Invalid,
 				Reason: "blank_url",
 			},
 		},
 		{
-			Name:       "when an IP address is given",
-			URL:        "https://127.0.0.1",
-			isInternal: false,
-			Data:       &report.Detection{},
+			Name: "when an IP address is given",
+			URL:  "https://127.0.0.1",
+			Data: &report.Detection{},
 			Want: &url.ValidationResult{
 				State:  url.Invalid,
 				Reason: "ip_address_error",
 			},
 		},
 		{
-			Name:       "when a dependency file is provided",
-			URL:        "https://eu.example.com/path/*",
-			isInternal: false,
+			Name: "when a dependency file is provided",
+			URL:  "https://eu.example.com/path/*",
 			Data: &report.Detection{
 				Source: source.Source{
 					Filename: "Gemfile.lock",
@@ -380,9 +342,8 @@ func TestValidate(t *testing.T) {
 			},
 		},
 		{
-			Name:       "when markup is detected with a simple detector type",
-			URL:        "https://eu.example.com/path/*",
-			isInternal: false,
+			Name: "when markup is detected with a simple detector type",
+			URL:  "https://eu.example.com/path/*",
 			Data: &report.Detection{
 				DetectorType: detectors.DetectorSimple,
 				Source: source.Source{
@@ -395,9 +356,8 @@ func TestValidate(t *testing.T) {
 			},
 		},
 		{
-			Name:       "when the filename isn't accepted",
-			URL:        "https://eu.example.com/path/*",
-			isInternal: false,
+			Name: "when the filename isn't accepted",
+			URL:  "https://eu.example.com/path/*",
 			Data: &report.Detection{
 				Source: source.Source{
 					Filename: "config/translations/en.js",
@@ -409,171 +369,18 @@ func TestValidate(t *testing.T) {
 			},
 		},
 		{
-			Name:       "internal domain with restricted subdomain",
-			URL:        "https://cdn.mish-company.com",
-			isInternal: true,
-			Data:       &report.Detection{},
-			Want: &url.ValidationResult{
-				State:  url.Invalid,
-				Reason: "internal_domain_subdomain_error",
-			},
-		},
-		{
-			Name:       "internal domain with no subdomain",
-			URL:        "https://mish-company.com",
-			isInternal: true,
-			Data:       &report.Detection{},
-			Want: &url.ValidationResult{
-				State:  url.Invalid,
-				Reason: "internal_domain_but_no_subdomain",
-			},
-		},
-		{
-			Name:       "internal domain with invalid chars in path",
-			URL:        "https://eu.mish-company.com/%20",
-			isInternal: true,
-			Data:       &report.Detection{},
-			Want: &url.ValidationResult{
-				State:  url.Invalid,
-				Reason: "internal_domain_errors_in_path",
-			},
-		},
-		{
-			Name:       "internal domain with file extension in path",
-			URL:        "https://eu.mish-company.com/photo.jpeg",
-			isInternal: true,
-			Data:       &report.Detection{},
-			Want: &url.ValidationResult{
-				State:  url.Invalid,
-				Reason: "internal_domain_errors_in_path",
-			},
-		},
-		{
-			Name:       "internal domain with 'api' in path",
-			URL:        "https://eu.mish-company.com/api/v2/shipment?debug=true",
-			isInternal: true,
-			Data:       &report.Detection{},
-			Want: &url.ValidationResult{
-				State:  url.Valid,
-				Reason: "internal_domain_path_contains_api_or_auth",
-			},
-		},
-		{
-			Name:       "internal domain with a wildcard",
-			URL:        "https://cdn*.mish-company.com/",
-			isInternal: true,
-			Data:       &report.Detection{},
-			Want: &url.ValidationResult{
-				State:  url.Potential,
-				Reason: "internal_domain_and_subdomain_with_wildcard",
-			},
-		},
-		{
-			Name:       "missing TLD",
-			URL:        "https://.",
-			isInternal: false,
-			Data:       &report.Detection{},
+			Name: "missing TLD",
+			URL:  "https://.",
+			Data: &report.Detection{},
 			Want: &url.ValidationResult{
 				State:  url.Invalid,
 				Reason: "tld_error",
 			},
 		},
 		{
-			Name:       "TLD is not allowed",
-			URL:        "https://example.id",
-			isInternal: false,
-			Data:       &report.Detection{},
-			Want: &url.ValidationResult{
-				State:  url.Invalid,
-				Reason: "tld_error",
-			},
-		},
-		// todo: unreachable domain
-		// {
-		// 	Name:                   "unreachable domain",
-		// 	URL:                    "https://example.id",
-		// 	isInternal: false,
-		// 	Data:                   &report.Detection{},
-		// 	Want: &url.ValidationResult{
-		// 		State:  url.Invalid,
-		// 		Reason: "domain_not_reachable",
-		// 	},
-		// },
-		{
-			Name:       "blacklisted domain",
-			URL:        "https://github.com",
-			isInternal: false,
-			Data:       &report.Detection{},
-			Want: &url.ValidationResult{
-				State:  url.Invalid,
-				Reason: "excluded_domains_error",
-			},
-		},
-		{
-			Name:       "blacklisted subdomain",
-			URL:        "https://wiki.example.com",
-			isInternal: false,
-			Data:       &report.Detection{},
-			Want: &url.ValidationResult{
-				State:  url.Invalid,
-				Reason: "subdomain_error",
-			},
-		},
-		{
-			Name:       "path with invalid characters",
-			URL:        "https://eu.example.com/%20",
-			isInternal: false,
-			Data:       &report.Detection{},
-			Want: &url.ValidationResult{
-				State:  url.Invalid,
-				Reason: "errors_in_path",
-			},
-		},
-		{
-			Name:       "path contains 'api'",
-			URL:        "https://eu.example.com/api/v2",
-			isInternal: false,
-			Data:       &report.Detection{},
-			Want: &url.ValidationResult{
-				State:  url.Valid,
-				Reason: "path_contains_api_or_auth",
-			},
-		},
-		{
-			Name:       "subdomain not provided",
-			URL:        "https://example.com",
-			isInternal: false,
-			Data:       &report.Detection{},
-			Want: &url.ValidationResult{
-				State:  url.Potential,
-				Reason: "no_subdomain",
-			},
-		},
-		{
-			Name:       "subdomain contains 'api'",
-			URL:        "https://api.example.com",
-			isInternal: false,
-			Data:       &report.Detection{},
-			Want: &url.ValidationResult{
-				State:  url.Valid,
-				Reason: "subdomain_contains_api",
-			},
-		},
-		{
-			Name:       "subdomain contains a wildcard",
-			URL:        "https://api.*.example.com",
-			isInternal: false,
-			Data:       &report.Detection{},
-			Want: &url.ValidationResult{
-				State:  url.Potential,
-				Reason: "subdomain_contains_api_with_wildcard",
-			},
-		},
-		{
-			Name:       "domain is empty",
-			URL:        "/nothing",
-			isInternal: false,
-			Data:       &report.Detection{},
+			Name: "domain is empty",
+			URL:  "/nothing",
+			Data: &report.Detection{},
 			Want: &url.ValidationResult{
 				State:  url.Invalid,
 				Reason: "no_host_error",
@@ -583,7 +390,173 @@ func TestValidate(t *testing.T) {
 
 	for _, testCase := range tests {
 		t.Run(testCase.Name, func(t *testing.T) {
-			output, err := url.Validate(testCase.URL, testCase.isInternal, testCase.Data)
+			output, err := url.ValidateFormat(testCase.URL, testCase.Data)
+			if err != nil {
+
+				if !assert.Equal(t, err.Error(), testCase.Want) {
+					t.Errorf("ValidateFormat returned unexpected error %s", err)
+				}
+			}
+
+			assert.Equal(t, testCase.Want, output)
+		})
+	}
+}
+
+func TestValidateInternal(t *testing.T) {
+	tests := []struct {
+		Name string
+		URL  string
+		Want *url.ValidationResult
+	}{
+		{
+			Name: "internal domain with restricted subdomain",
+			URL:  "https://cdn.mish-company.com",
+			Want: &url.ValidationResult{
+				State:  url.Invalid,
+				Reason: "internal_domain_subdomain_error",
+			},
+		},
+		{
+			Name: "internal domain with no subdomain",
+			URL:  "https://mish-company.com",
+			Want: &url.ValidationResult{
+				State:  url.Invalid,
+				Reason: "internal_domain_but_no_subdomain",
+			},
+		},
+		{
+			Name: "internal domain with invalid chars in path",
+			URL:  "https://eu.mish-company.com/%20",
+			Want: &url.ValidationResult{
+				State:  url.Invalid,
+				Reason: "internal_domain_errors_in_path",
+			},
+		},
+		{
+			Name: "internal domain with file extension in path",
+			URL:  "https://eu.mish-company.com/photo.jpeg",
+			Want: &url.ValidationResult{
+				State:  url.Invalid,
+				Reason: "internal_domain_errors_in_path",
+			},
+		},
+		{
+			Name: "internal domain with 'api' in path",
+			URL:  "https://eu.mish-company.com/api/v2/shipment?debug=true",
+			Want: &url.ValidationResult{
+				State:  url.Valid,
+				Reason: "internal_domain_path_contains_api_or_auth",
+			},
+		},
+		{
+			Name: "internal domain with a wildcard",
+			URL:  "https://cdn*.mish-company.com/",
+			Want: &url.ValidationResult{
+				State:  url.Potential,
+				Reason: "internal_domain_and_subdomain_with_wildcard",
+			},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.Name, func(t *testing.T) {
+			output, err := url.ValidateInternal(testCase.URL)
+			if err != nil {
+
+				if !assert.Equal(t, err.Error(), testCase.Want) {
+					t.Errorf("ValidateInternal returned unexpected error %s", err)
+				}
+			}
+
+			assert.Equal(t, testCase.Want, output)
+		})
+	}
+}
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		Name string
+		URL  string
+		Want *url.ValidationResult
+	}{
+		{
+			Name: "TLD is not allowed",
+			URL:  "https://example.id",
+			Want: &url.ValidationResult{
+				State:  url.Invalid,
+				Reason: "tld_error",
+			},
+		},
+		// todo: unreachable domain
+		// {
+		// 	Name:                   "unreachable domain",
+		// 	URL:                    "https://example.id",
+		// 	Want: &url.ValidationResult{
+		// 		State:  url.Invalid,
+		// 		Reason: "domain_not_reachable",
+		// 	},
+		// },
+		{
+			Name: "blacklisted domain",
+			URL:  "https://github.com",
+			Want: &url.ValidationResult{
+				State:  url.Invalid,
+				Reason: "excluded_domains_error",
+			},
+		},
+		{
+			Name: "blacklisted subdomain",
+			URL:  "https://wiki.example.com",
+			Want: &url.ValidationResult{
+				State:  url.Invalid,
+				Reason: "subdomain_error",
+			},
+		},
+		{
+			Name: "path with invalid characters",
+			URL:  "https://eu.example.com/%20",
+			Want: &url.ValidationResult{
+				State:  url.Invalid,
+				Reason: "errors_in_path",
+			},
+		},
+		{
+			Name: "path contains 'api'",
+			URL:  "https://eu.example.com/api/v2",
+			Want: &url.ValidationResult{
+				State:  url.Valid,
+				Reason: "path_contains_api_or_auth",
+			},
+		},
+		{
+			Name: "subdomain not provided",
+			URL:  "https://example.com",
+			Want: &url.ValidationResult{
+				State:  url.Potential,
+				Reason: "no_subdomain",
+			},
+		},
+		{
+			Name: "subdomain contains 'api'",
+			URL:  "https://api.example.com",
+			Want: &url.ValidationResult{
+				State:  url.Valid,
+				Reason: "subdomain_contains_api",
+			},
+		},
+		{
+			Name: "subdomain contains a wildcard",
+			URL:  "https://api.*.example.com",
+			Want: &url.ValidationResult{
+				State:  url.Potential,
+				Reason: "subdomain_contains_api_with_wildcard",
+			},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.Name, func(t *testing.T) {
+			output, err := url.Validate(testCase.URL)
 			if err != nil {
 
 				if !assert.Equal(t, err.Error(), testCase.Want) {


### PR DESCRIPTION
## Description
Refactor URL classification - including separating big `Validate` URL utility function into separate functions - to bring order of classification checks in line with Miro diagram here: https://miro.com/app/board/uXjVObtsAQk=/

Splitting the `Validate` function also (I hope) makes the code easier to read and a bit more maintainable

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
