### PR TITLE
Debug Flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ curio scan ./curio-ci-test/Pipfile.lock
 ### Scan Flags
 
 - `--skip-path` specify the comma separated files and directories to skip (supports \* syntax), eg. --skip-path users/\*.go,users/admin.sql
-- `--debug` enable debug logs (default 0)
+- `--debug` enable debug logs
 
 ### Worker Flags
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ curio scan ./curio-ci-test/Pipfile.lock
 ### Scan Flags
 
 - `--skip-path` specify the comma separated files and directories to skip (supports \* syntax), eg. --skip-path users/\*.go,users/admin.sql
+- `--debug` enable debug logs (default 0)
 
 ### Worker Flags
 

--- a/pkg/commands/process/balancer/process.go
+++ b/pkg/commands/process/balancer/process.go
@@ -44,8 +44,13 @@ func (process *Process) StartProcess(task *workertype.ProcessRequest) error {
 		log.Fatal().Msgf("failed to get current command executable %e", err)
 	}
 
+	debugArgument := "0"
+	if process.config.Scan.Debug {
+		debugArgument = "1"
+	}
+
 	log.Debug().Msgf("spawning on port %s", port)
-	cmd := exec.Command(currentCommand, "processing-worker", "--port", port)
+	cmd := exec.Command(currentCommand, "processing-worker", "--port="+port, "--debug="+debugArgument)
 	cmd.Dir, err = os.Getwd()
 	if err != nil {
 		log.Fatal().Err(fmt.Errorf("couldn't determine current working dir %w", err)).Send()

--- a/pkg/commands/process/balancer/process.go
+++ b/pkg/commands/process/balancer/process.go
@@ -44,13 +44,13 @@ func (process *Process) StartProcess(task *workertype.ProcessRequest) error {
 		log.Fatal().Msgf("failed to get current command executable %e", err)
 	}
 
-	debugArgument := "0"
+	args := []string{"processing-worker", "--port=" + port}
 	if process.config.Scan.Debug {
-		debugArgument = "1"
+		args = append(args, "--debug")
 	}
 
 	log.Debug().Msgf("spawning on port %s", port)
-	cmd := exec.Command(currentCommand, "processing-worker", "--port="+port, "--debug="+debugArgument)
+	cmd := exec.Command(currentCommand, args...)
 	cmd.Dir, err = os.Getwd()
 	if err != nil {
 		log.Fatal().Err(fmt.Errorf("couldn't determine current working dir %w", err)).Send()

--- a/pkg/flag/scan_flags.go
+++ b/pkg/flag/scan_flags.go
@@ -5,7 +5,7 @@ var (
 		Name:       "skip-path",
 		ConfigName: "scan.skip-path",
 		Value:      []string{},
-		Usage:      "specify the comma separated files and directories to skip (supports * syntax), eg. --skip users/*.go,users/admin.sql",
+		Usage:      "specify the comma separated files and directories to skip (supports * syntax), eg. --skip-path users/*.go,users/admin.sql",
 	}
 	DebugFlag = Flag{
 		Name:       "debug",

--- a/pkg/flag/scan_flags.go
+++ b/pkg/flag/scan_flags.go
@@ -7,20 +7,29 @@ var (
 		Value:      []string{},
 		Usage:      "specify the comma separated files and directories to skip (supports * syntax), eg. --skip users/*.go,users/admin.sql",
 	}
+	DebugFlag = Flag{
+		Name:       "debug",
+		ConfigName: "scan.debug",
+		Value:      false,
+		Usage:      "enable debug logs",
+	}
 )
 
 type ScanFlagGroup struct {
 	SkipPathFlag *Flag
+	DebugFlag    *Flag
 }
 
 type ScanOptions struct {
 	Target   string
 	SkipPath []string
+	Debug    bool
 }
 
 func NewScanFlagGroup() *ScanFlagGroup {
 	return &ScanFlagGroup{
 		SkipPathFlag: &SkipPathFlag,
+		DebugFlag:    &DebugFlag,
 	}
 }
 
@@ -29,7 +38,10 @@ func (f *ScanFlagGroup) Name() string {
 }
 
 func (f *ScanFlagGroup) Flags() []*Flag {
-	return []*Flag{f.SkipPathFlag}
+	return []*Flag{
+		f.SkipPathFlag,
+		f.DebugFlag,
+	}
 }
 
 func (f *ScanFlagGroup) ToOptions(args []string) (ScanOptions, error) {
@@ -40,6 +52,7 @@ func (f *ScanFlagGroup) ToOptions(args []string) (ScanOptions, error) {
 
 	return ScanOptions{
 		SkipPath: getStringSlice(f.SkipPathFlag),
+		Debug:    getBool(f.DebugFlag),
 		Target:   target,
 	}, nil
 }

--- a/pkg/report/output/ouput.go
+++ b/pkg/report/output/ouput.go
@@ -3,12 +3,12 @@ package output
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/bearer/curio/pkg/types"
+	"github.com/bearer/curio/pkg/util/output"
 
-	// "github.com/rs/zerolog/log"
+	"github.com/rs/zerolog/log"
 	"github.com/wlredeye/jsonlines"
 )
 
@@ -24,13 +24,14 @@ func ReportJSON(report types.Report) error {
 		return fmt.Errorf("failed to decode report: %w", err)
 	}
 
-	log.Printf("got %d detections", len(detections))
+	log.Debug().Msgf("got %d detections", len(detections))
 
 	jsonBytes, err := json.MarshalIndent(&detections, "", "\t")
 	if err != nil {
 		return fmt.Errorf("failed to json marshal detections: %w", err)
 	}
 
-	log.Print(string(jsonBytes))
+	output.DefaultLogger().Msg(string(jsonBytes))
+
 	return nil
 }

--- a/pkg/util/output/output.go
+++ b/pkg/util/output/output.go
@@ -1,0 +1,32 @@
+package output
+
+import (
+	"os"
+
+	"github.com/bearer/curio/pkg/flag"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+func DefaultLogger() *zerolog.Event {
+	logger := log.Output(zerolog.ConsoleWriter{
+		Out:     os.Stdout,
+		NoColor: true,
+		FormatTimestamp: func(i interface{}) string {
+			return ""
+		},
+		FormatLevel: func(i interface{}) string {
+			return ""
+		},
+	})
+
+	return logger.Info()
+}
+
+func Setup(options flag.Options) {
+	if options.Debug {
+		zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	} else {
+		zerolog.SetGlobalLevel(zerolog.InfoLevel)
+	}
+}


### PR DESCRIPTION
## Description
Add support for debug flag `--debug` to enable debug, by default it is false and sets up log level to `info` for both processing worker and main process.
It also adds a default logger as an util for writing clean logs to cli (the ones without timestamp and that are not json serliazed).

This pr doesn't handle passing down all configuration flags and options to processing worker.
If the need for it arises it should be handled in separate ticket.

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [x] I've updated or added documentation if required.
- [x] I've included usage information in the description if CLI behavior was updated or added.
