### PR TITLE
Support version command

### DIFF
--- a/cmd/curio/build/build.go
+++ b/cmd/curio/build/build.go
@@ -1,0 +1,6 @@
+package build
+
+var (
+	// These should be set via go build -ldflags -X 'xxxx'.
+	Version = "dev"
+)

--- a/cmd/curio/build/build.go
+++ b/cmd/curio/build/build.go
@@ -2,5 +2,6 @@ package build
 
 var (
 	// These should be set via go build -ldflags -X 'xxxx'.
-	Version = "dev"
+	Version   = "dev"
+	CommitSHA = "devSHA"
 )

--- a/cmd/curio/main.go
+++ b/cmd/curio/main.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	version = "dev"
+	Version = "dev"
 )
 
 func main() {
@@ -17,7 +17,7 @@ func main() {
 }
 
 func run() error {
-	app := commands.NewApp(version)
+	app := commands.NewApp(Version)
 	if err := app.Execute(); err != nil {
 		return err
 	}

--- a/cmd/curio/main.go
+++ b/cmd/curio/main.go
@@ -3,11 +3,9 @@ package main
 import (
 	"log"
 
-	"github.com/bearer/curio/pkg/commands"
-)
+	"github.com/bearer/curio/cmd/curio/build"
 
-var (
-	Version = "dev"
+	"github.com/bearer/curio/pkg/commands"
 )
 
 func main() {
@@ -17,7 +15,7 @@ func main() {
 }
 
 func run() error {
-	app := commands.NewApp(Version)
+	app := commands.NewApp(build.Version)
 	if err := app.Execute(); err != nil {
 		return err
 	}

--- a/cmd/curio/main.go
+++ b/cmd/curio/main.go
@@ -15,7 +15,7 @@ func main() {
 }
 
 func run() error {
-	app := commands.NewApp(build.Version)
+	app := commands.NewApp(build.Version, build.CommitSHA)
 	if err := app.Execute(); err != nil {
 		return err
 	}

--- a/goreleaser/darwin.yaml
+++ b/goreleaser/darwin.yaml
@@ -13,6 +13,8 @@ builds:
     goarch:
       - arm64
       - amd64
+    ldflags:
+      - -X github.com/bearer/curio/cmd/curio.Version={{.Version}}
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
 changelog:

--- a/goreleaser/darwin.yaml
+++ b/goreleaser/darwin.yaml
@@ -15,7 +15,8 @@ builds:
       - amd64
     ldflags:
       - -s -w
-      - -X github.com/bearer/curio/cmd/curio/build.Version={{.Version}}
+      - -X "github.com/bearer/curio/cmd/curio/build.Version={{.Version}}"
+      - -X "github.com/bearer/curio/cmd/curio/build.CommitSHA={{.Commit}}"
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
 changelog:

--- a/goreleaser/darwin.yaml
+++ b/goreleaser/darwin.yaml
@@ -15,8 +15,6 @@ builds:
       - amd64
     ldflags:
       - -X github.com/bearer/curio/cmd/curio/build.Version={{.Version}}
-    env:
-      - VERSION="development"
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
 changelog:

--- a/goreleaser/darwin.yaml
+++ b/goreleaser/darwin.yaml
@@ -14,7 +14,9 @@ builds:
       - arm64
       - amd64
     ldflags:
-      - -X github.com/bearer/curio/cmd/curio.Version={{.Version}}
+      - -X github.com/bearer/curio/cmd/curio/build.Version={{.Version}}
+    env:
+      - VERSION="development"
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
 changelog:

--- a/goreleaser/darwin.yaml
+++ b/goreleaser/darwin.yaml
@@ -14,6 +14,7 @@ builds:
       - arm64
       - amd64
     ldflags:
+      - -s -w
       - -X github.com/bearer/curio/cmd/curio/build.Version={{.Version}}
 snapshot:
   name_template: "{{ incpatch .Version }}-next"

--- a/goreleaser/linux.yaml
+++ b/goreleaser/linux.yaml
@@ -15,7 +15,8 @@ builds:
       - amd64
     ldflags:
       - -s -w
-      - -X github.com/bearer/curio/cmd/curio/build.Version={{.Version}}
+      - -X "github.com/bearer/curio/cmd/curio/build.Version={{.Version}}"
+      - -X "github.com/bearer/curio/cmd/curio/build.CommitSHA={{.Commit}}"
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
 changelog:

--- a/goreleaser/linux.yaml
+++ b/goreleaser/linux.yaml
@@ -14,6 +14,7 @@ builds:
       - 386
       - amd64
     ldflags:
+      - -s -w
       - -X github.com/bearer/curio/cmd/curio/build.Version={{.Version}}
 snapshot:
   name_template: "{{ incpatch .Version }}-next"

--- a/goreleaser/linux.yaml
+++ b/goreleaser/linux.yaml
@@ -13,6 +13,8 @@ builds:
     goarch:
       - 386
       - amd64
+    ldflags:
+      - -X github.com/bearer/curio/cmd/curio.Version={{.Version}}
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
 changelog:

--- a/goreleaser/linux.yaml
+++ b/goreleaser/linux.yaml
@@ -14,7 +14,7 @@ builds:
       - 386
       - amd64
     ldflags:
-      - -X github.com/bearer/curio/cmd/curio.Version={{.Version}}
+      - -X github.com/bearer/curio/cmd/curio/build.Version={{.Version}}
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
 changelog:

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -46,13 +46,13 @@ func SetOut(out io.Writer) {
 }
 
 // NewApp is the factory method to return Curio CLI
-func NewApp(version string) *cobra.Command {
+func NewApp(version string, commitSHA string) *cobra.Command {
 	rootCmd := NewRootCommand()
 	rootCmd.AddCommand(
 		NewProcessingServerCommand(),
 		NewScanCommand(),
 		NewConfigCommand(),
-		NewVersionCommand(version),
+		NewVersionCommand(version, commitSHA),
 	)
 
 	return rootCmd
@@ -214,17 +214,15 @@ func NewConfigCommand() *cobra.Command {
 	return cmd
 }
 
-func NewVersionCommand(version string) *cobra.Command {
+func NewVersionCommand(version string, commitSHA string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Print the version",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			output.DefaultLogger().Msgf("curio version: %s", version)
+			output.DefaultLogger().Msgf("curio version: %s\nSHA: %s", version, commitSHA)
 			return nil
 		},
-		SilenceErrors: false,
-		SilenceUsage:  false,
 	}
 	cmd.SetFlagErrorFunc(flagErrorFunc)
 

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -220,7 +220,7 @@ func NewVersionCommand(version string, commitSHA string) *cobra.Command {
 		Short: "Print the version",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			output.DefaultLogger().Msgf("curio version: %s\nSHA: %s", version, commitSHA)
+			output.DefaultLogger().Msgf("curio version: %s\nsha: %s", version, commitSHA)
 			return nil
 		},
 	}

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -52,7 +51,7 @@ func NewApp(version string) *cobra.Command {
 		NewProcessingServerCommand(),
 		NewScanCommand(),
 		NewConfigCommand(),
-		NewVersionCommand(),
+		NewVersionCommand(version),
 	)
 
 	return rootCmd
@@ -204,39 +203,21 @@ func NewConfigCommand() *cobra.Command {
 	return cmd
 }
 
-func NewVersionCommand() *cobra.Command {
-	var versionFormat string
+func NewVersionCommand(version string) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "version [flags]",
+		Use:   "version",
 		Short: "Print the version",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			showVersion(versionFormat, cmd.Version, outputWriter)
-
+			output.DefaultLogger().Msgf("curio version: %s", version)
 			return nil
 		},
-		SilenceErrors: true,
-		SilenceUsage:  true,
+		SilenceErrors: false,
+		SilenceUsage:  false,
 	}
 	cmd.SetFlagErrorFunc(flagErrorFunc)
 
-	// Add version format flag, only json is supported
-	cmd.Flags().StringVarP(&versionFormat, flag.FormatFlag.Name, flag.FormatFlag.Shorthand, "", "version format (json)")
-
 	return cmd
-}
-
-func showVersion(outputFormat, version string, outputWriter io.Writer) {
-	switch outputFormat {
-	case "json":
-		b, _ := json.Marshal(VersionInfo{
-			Version: version,
-		})
-		fmt.Fprint(outputWriter, string(b))
-	default:
-		output := fmt.Sprintf("Version: %s\n", version)
-		fmt.Fprint(outputWriter, output)
-	}
 }
 
 // show help on using the command when an invalid flag is encountered


### PR DESCRIPTION
## Description
This pr adds support for version command as well as hardcoding tag version in binaries.


## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
