### PR TITLE
feat: implement config serialization and loading between main and processing worker

### DIFF
--- a/pkg/classification/classification.go
+++ b/pkg/classification/classification.go
@@ -5,6 +5,7 @@ import (
 	"github.com/bearer/curio/pkg/classification/dependencies"
 	"github.com/bearer/curio/pkg/classification/interfaces"
 	"github.com/bearer/curio/pkg/classification/schema"
+	config "github.com/bearer/curio/pkg/commands/process/settings"
 )
 
 type Classifier struct {
@@ -16,6 +17,7 @@ type Classifier struct {
 }
 
 type Config struct {
+	Config config.Config
 }
 
 func NewClassifier(config *Config) *Classifier {

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/bearer/curio/pkg/commands/artifact"
+	config "github.com/bearer/curio/pkg/commands/process/settings"
 	"github.com/bearer/curio/pkg/commands/process/worker"
 	"github.com/bearer/curio/pkg/flag"
 	"github.com/bearer/curio/pkg/util/output"
@@ -66,10 +67,16 @@ func NewProcessingServerCommand() *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "processing-worker",
+		Use:   "processing-worker [flags] PATH",
 		Short: "start scan processing server",
-		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			log.Debug().Msgf("started scan processing")
+
+			var config config.Config
+			if err := json.Unmarshal([]byte(args[0]), &config); err != nil {
+				return err
+			}
+
 			if err := flags.Bind(cmd); err != nil {
 				return fmt.Errorf("flag bind error: %w", err)
 			}
@@ -89,7 +96,7 @@ func NewProcessingServerCommand() *cobra.Command {
 			log.Debug().Msgf("started scan processing")
 			log.Debug().Msgf("running scan worker on port `%s`", processOptions.Port)
 
-			return worker.Start(processOptions.Port)
+			return worker.Start(processOptions.Port, config)
 		},
 		Hidden:        true,
 		SilenceErrors: true,

--- a/pkg/commands/process/balancer/process.go
+++ b/pkg/commands/process/balancer/process.go
@@ -44,12 +44,17 @@ func (process *Process) StartProcess(task *workertype.ProcessRequest) error {
 		log.Fatal().Msgf("failed to get current command executable %e", err)
 	}
 
-	args := []string{"processing-worker", "--port=" + port}
+	marshalledConfig, err := json.Marshal(&process.config)
+	if err != nil {
+		log.Fatal().Err(fmt.Errorf("couldn't marshal config %w", err)).Send()
+	}
+	args := []string{"processing-worker", "--port=" + port, string(marshalledConfig)}
 	if process.config.Scan.Debug {
 		args = append(args, "--debug")
 	}
 
 	log.Debug().Msgf("spawning on port %s", port)
+
 	cmd := exec.Command(currentCommand, args...)
 	cmd.Dir, err = os.Getwd()
 	if err != nil {
@@ -109,15 +114,9 @@ func (process *Process) WaitForOnline(task *workertype.ProcessRequest) error {
 			return ErrorProcessNotSpawned
 		}
 
-		taskBytes, err := json.Marshal(task)
-		if err != nil {
-			log.Debug().Msgf("failed to marshall task %e", err)
-			continue
-		}
-
 		url := "http://localhost:" + strconv.Itoa(process.port) + workertype.RouteStatus
 
-		req, err := http.NewRequestWithContext(process.context, http.MethodPost, url, bytes.NewBuffer(taskBytes))
+		req, err := http.NewRequestWithContext(process.context, http.MethodPost, url, bytes.NewBuffer(nil))
 		if err != nil {
 			log.Debug().Msgf("%s %s failed to build status online request %e", process.uuid, process.workeruuid, err)
 			continue
@@ -139,10 +138,6 @@ func (process *Process) WaitForOnline(task *workertype.ProcessRequest) error {
 			err := json.NewDecoder(resp.Body).Decode(&result)
 			if err != nil {
 				return err
-			}
-
-			if result.Error != nil {
-				return fmt.Errorf("custom config invalid : %w", result.Error)
 			}
 
 			return nil

--- a/pkg/commands/process/settings/settings.go
+++ b/pkg/commands/process/settings/settings.go
@@ -10,17 +10,17 @@ import (
 )
 
 type Config struct {
-	Worker         flag.WorkerOptions
-	Scan           flag.ScanOptions
-	CustomDetector CustomDetector
+	Worker         flag.WorkerOptions `json:"worker"`
+	Scan           flag.ScanOptions   `json:"scan"`
+	CustomDetector CustomDetector     `json:"custom_detector"`
 }
 
 type CustomDetector struct {
-	RulesConfig *RulesConfig
+	RulesConfig *RulesConfig `json:"rules_config"`
 }
 
 type RulesConfig struct {
-	Rules map[string]Rule
+	Rules map[string]Rule `json:"rules"`
 }
 
 type Rule struct {

--- a/pkg/flag/scan_flags.go
+++ b/pkg/flag/scan_flags.go
@@ -21,9 +21,9 @@ type ScanFlagGroup struct {
 }
 
 type ScanOptions struct {
-	Target   string
-	SkipPath []string
-	Debug    bool
+	Target   string   `json:"target"`
+	SkipPath []string `json:"skip_path"`
+	Debug    bool     `json:"debug"`
 }
 
 func NewScanFlagGroup() *ScanFlagGroup {

--- a/pkg/flag/worker_flags.go
+++ b/pkg/flag/worker_flags.go
@@ -84,15 +84,15 @@ type WorkerFlagGroup struct {
 
 // GlobalOptions defines flags and other configuration parameters for all the subcommands
 type WorkerOptions struct {
-	Workers                   int
-	Timeout                   time.Duration
-	TimeoutFileMinimum        time.Duration
-	TimeoutFileMaximum        time.Duration
-	TimeoutFileSecondPerBytes int
-	TimeoutWorkerOnline       time.Duration
-	FileSizeMaximum           int
-	FilesToBatch              int
-	MemoryMaximum             int
+	Workers                   int           `json:"workers"`
+	Timeout                   time.Duration `json:"timeout"`
+	TimeoutFileMinimum        time.Duration `json:"timeout_file_minimum"`
+	TimeoutFileMaximum        time.Duration `json:"timeout_file_maximum"`
+	TimeoutFileSecondPerBytes int           `json:"timeout_file_second_per_bytes"`
+	TimeoutWorkerOnline       time.Duration `json:"timeout_worker_online"`
+	FileSizeMaximum           int           `json:"file_size_maximum"`
+	FilesToBatch              int           `json:"files_to_batch"`
+	MemoryMaximum             int           `json:"memory_maximum"`
 }
 
 func NewWorkerFlagGroup() *WorkerFlagGroup {

--- a/pkg/scanner/scan.go
+++ b/pkg/scanner/scan.go
@@ -10,7 +10,7 @@ import (
 	"github.com/bearer/curio/pkg/util/blamer"
 )
 
-func Scan(rootDir string, FilesToScan []string, blamer blamer.Blamer, outputPath string) error {
+func Scan(rootDir string, FilesToScan []string, blamer blamer.Blamer, outputPath string, classifier *classsification.Classifier) error {
 	file, err := os.OpenFile(outputPath, os.O_RDWR|os.O_TRUNC, 0666)
 
 	if err != nil {
@@ -20,7 +20,7 @@ func Scan(rootDir string, FilesToScan []string, blamer blamer.Blamer, outputPath
 
 	rep := writer.JSONLines{
 		Blamer:     blamer,
-		Classifier: classsification.NewClassifier(&classsification.Config{}),
+		Classifier: classifier,
 		File:       file,
 	}
 


### PR DESCRIPTION
## Description
Serialize config options and pass these from main to processing worker
Scan now has access to config with all flags

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
