### PR TITLE
fix: domain resolver expects a domain

### DIFF
--- a/pkg/util/url/domain_resolver.go
+++ b/pkg/util/url/domain_resolver.go
@@ -41,7 +41,7 @@ func NewDomainResolverDefault() *DomainResolver {
 	}
 }
 
-func (domainResolver *DomainResolver) CanReach(myURL string) bool {
+func (domainResolver *DomainResolver) CanReach(domain string) bool {
 	if domainResolver == nil || !domainResolver.Enabled {
 		// skip disabled check
 		return true
@@ -50,19 +50,19 @@ func (domainResolver *DomainResolver) CanReach(myURL string) bool {
 	resolverContext, cancel := context.WithTimeout(context.TODO(), domainResolver.Timeout)
 	defer cancel()
 
-	staticDomain := getStaticDomain(myURL)
-	if myURL == staticDomain {
-		return domainResolver.domainResolves(myURL, resolverContext)
+	staticDomain := getStaticDomain(domain)
+	if domain == staticDomain {
+		return domainResolver.domainResolves(domain, resolverContext)
 	}
 
-	if domainResolver.isNameserver(myURL, staticDomain, resolverContext) {
+	if domainResolver.isNameserver(domain, staticDomain, resolverContext) {
 		return true
 	}
 
-	return domainResolver.domainResolves(myURL, resolverContext)
+	return domainResolver.domainResolves(domain, resolverContext)
 }
 
-func (domainResolver *DomainResolver) isNameserver(myURL string, staticDomain string, resolverContext context.Context) bool {
+func (domainResolver *DomainResolver) isNameserver(domain string, staticDomain string, resolverContext context.Context) bool {
 	_, err := publicsuffix.ParseFromListWithOptions(
 		publicsuffix.DefaultList,
 		staticDomain,
@@ -82,9 +82,9 @@ func (domainResolver *DomainResolver) isNameserver(myURL string, staticDomain st
 	return len(nameserver) > 0
 }
 
-func (domainResolver *DomainResolver) domainResolves(myURL string, resolverContext context.Context) bool {
+func (domainResolver *DomainResolver) domainResolves(domain string, resolverContext context.Context) bool {
 	// handle any special characters
-	sanitizedURL, err := publicsuffix.ToASCII(myURL)
+	sanitizedURL, err := publicsuffix.ToASCII(domain)
 	if err != nil {
 		return false
 	}
@@ -98,12 +98,12 @@ func (domainResolver *DomainResolver) domainResolves(myURL string, resolverConte
 	return len(names) > 0
 }
 
-func getStaticDomain(myURL string) string {
-	domainSplit := regexpDomainSplitMatcher.Split(myURL, -1)
+func getStaticDomain(domain string) string {
+	domainSplit := regexpDomainSplitMatcher.Split(domain, -1)
 	lenDomainSplit := len(domainSplit)
 	if lenDomainSplit <= 1 {
 		// single part, no static domain
-		return myURL
+		return domain
 	}
 
 	return domainSplit[lenDomainSplit-1]

--- a/pkg/util/url/domain_resolver_test.go
+++ b/pkg/util/url/domain_resolver_test.go
@@ -12,56 +12,56 @@ import (
 
 func TestCanReach(t *testing.T) {
 	tests := []struct {
-		Name, URL      string
+		Name, Domain   string
 		MockLookUpAddr func(ctx context.Context, addr string) ([]string, error)
 		MockLookUpNS   func(ctx context.Context, name string) ([]*net.NS, error)
 		Want           bool
 	}{
 		{
-			Name: "when we have non-ASCII chars",
-			URL:  "meghívó-måradt.com",
-			Want: true,
+			Name:   "when we have non-ASCII chars",
+			Domain: "meghívó-måradt.com",
+			Want:   true,
 		},
 		{
-			Name: "when the domain contains wildcards and the non wildcard part is not a valid TLD",
-			URL:  "_oidc-client-*-partial.tf",
+			Name:   "when the domain contains wildcards and the non wildcard part is not a valid TLD",
+			Domain: "_oidc-client-*-partial.tf",
 			MockLookUpAddr: func(ctx context.Context, addr string) ([]string, error) {
 				return []string{}, nil
 			},
 			Want: false,
 		},
 		{
-			Name: "when the domain is static and resolves",
-			URL:  "www.example.co.za",
-			Want: true,
+			Name:   "when the domain is static and resolves",
+			Domain: "example.co.za",
+			Want:   true,
 		},
 		{
-			Name: "when the domain is static and does not resolve",
-			URL:  "www.example.co.za",
+			Name:   "when the domain is static and does not resolve",
+			Domain: "example.co.za",
 			MockLookUpAddr: func(ctx context.Context, addr string) ([]string, error) {
 				return []string{}, nil
 			},
 			Want: false,
 		},
 		{
-			Name: "when the domain is static and the DNS server has an error",
-			URL:  "www.example.co.za",
+			Name:   "when the domain is static and the DNS server has an error",
+			Domain: "example.co.za",
 			MockLookUpAddr: func(ctx context.Context, addr string) ([]string, error) {
 				return []string{}, errors.New("just being nervous")
 			},
 			Want: false,
 		},
 		{
-			Name: "when the domain is static it does not lookup the nameserver",
-			URL:  "www.example.co.za",
+			Name:   "when the domain is static it does not lookup the nameserver",
+			Domain: "example.co.za",
 			MockLookUpNS: func(ctx context.Context, name string) ([]*net.NS, error) {
 				panic("we shouldn't reach this")
 			},
 			Want: true,
 		},
 		{
-			Name: "when a wildcard domain does not resolve and its static domain has no nameserver",
-			URL:  "*-test.example.co.uk",
+			Name:   "when a wildcard domain does not resolve and its static domain has no nameserver",
+			Domain: "*-test.example.co.uk",
 			MockLookUpAddr: func(ctx context.Context, addr string) ([]string, error) {
 				return []string{}, nil
 			},
@@ -71,24 +71,24 @@ func TestCanReach(t *testing.T) {
 			Want: false,
 		},
 		{
-			Name: "when a wildcard domain resolves and its static domain has no nameserver",
-			URL:  "*-test.example.co.uk",
+			Name:   "when a wildcard domain resolves and its static domain has no nameserver",
+			Domain: "*-test.example.co.uk",
 			MockLookUpNS: func(ctx context.Context, name string) ([]*net.NS, error) {
 				return []*net.NS{}, nil
 			},
 			Want: true,
 		},
 		{
-			Name: "when a wildcard domain does not resolve but its static domain has a nameserver",
-			URL:  "*-test.example.co.uk",
+			Name:   "when a wildcard domain does not resolve but its static domain has a nameserver",
+			Domain: "*-test.example.co.uk",
 			MockLookUpAddr: func(ctx context.Context, addr string) ([]string, error) {
 				return []string{}, nil
 			},
 			Want: true,
 		},
 		{
-			Name: "when both the DNS and nameserver lookup raises errors for a wildcard domain",
-			URL:  "*-test.example.co.uk",
+			Name:   "when both the DNS and nameserver lookup raises errors for a wildcard domain",
+			Domain: "*-test.example.co.uk",
 			MockLookUpAddr: func(ctx context.Context, addr string) ([]string, error) {
 				return []string{}, errors.New("just being nervous")
 			},
@@ -104,7 +104,7 @@ func TestCanReach(t *testing.T) {
 			// reset mocks
 			domainResolver := url.NewDomainResolverDefault()
 			domainResolver.LookUpAddr = func(ctx context.Context, addr string) ([]string, error) {
-				return []string{"www.example.co.za"}, nil
+				return []string{"example.co.za"}, nil
 			}
 			domainResolver.LookUpNS = func(ctx context.Context, name string) ([]*net.NS, error) {
 				return []*net.NS{{Host: "example.co.za"}}, nil
@@ -117,7 +117,7 @@ func TestCanReach(t *testing.T) {
 			if testCase.MockLookUpNS != nil {
 				domainResolver.LookUpNS = testCase.MockLookUpNS
 			}
-			output := domainResolver.CanReach(testCase.URL)
+			output := domainResolver.CanReach(testCase.Domain)
 			assert.Equal(t, testCase.Want, output)
 		})
 	}

--- a/pkg/util/url/url.go
+++ b/pkg/util/url/url.go
@@ -387,7 +387,7 @@ func Validate(myURL string, domainResolver *DomainResolver) (*ValidationResult, 
 		return &ValidationResult, nil
 	}
 
-	if !domainResolver.CanReach(myURL) {
+	if !domainResolver.CanReach(parsedDomain.SLD + "." + parsedDomain.TLD) {
 		ValidationResult.Reason = "domain_not_reachable"
 		return &ValidationResult, nil
 	}


### PR DESCRIPTION
## Description

LookUpAddr expects a domain (i.e. no scheme) and falls over if it is given a full URL with scheme

Update url and domainResolver utility methods so that we're passing just the domain (example.co.za) to LookUpAddr and not the whole URL (https://example.co.za)

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
