### PR TITLE
Add options to configure domain resolution check

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -35,6 +35,8 @@ curio scan [FLAGS] [PATH]
 
 - `--skip-path` specify the comma separated files and directories to skip (supports \* syntax), eg. --skip-path users/\*.go,users/admin.sql
 - `--debug` enable debug logs
+- `--disable-domain-resolution` skip attempt to resolve detected domains during classification (default false)
+- `--domain-resolution-timeout` set timeout when attempting to resolve detected domains during classification
 
 #### Worker Flags
 

--- a/pkg/classification/classification.go
+++ b/pkg/classification/classification.go
@@ -1,17 +1,20 @@
 package classsification
 
 import (
+	"regexp"
+
 	"github.com/bearer/curio/pkg/classification/db"
 	"github.com/bearer/curio/pkg/classification/dependencies"
 	"github.com/bearer/curio/pkg/classification/interfaces"
 	"github.com/bearer/curio/pkg/classification/schema"
 	config "github.com/bearer/curio/pkg/commands/process/settings"
+	"github.com/bearer/curio/pkg/util/url"
 )
 
 type Classifier struct {
 	config Config
 
-	Interfaces   interfaces.Classifier
+	Interfaces   *interfaces.Classifier
 	Schema       schema.Classifier
 	Dependencies *dependencies.Classifier
 }
@@ -20,8 +23,21 @@ type Config struct {
 	Config config.Config
 }
 
-func NewClassifier(config *Config) *Classifier {
-	// todo: config setup
+func NewClassifier(config *Config) (*Classifier, error) {
+	interfacesClassifier, err := interfaces.New(
+		interfaces.Config{
+			Recipes:                db.Default(),
+			InternalDomainMatchers: []*regexp.Regexp{},
+			DomainResolver: url.NewDomainResolver(
+				!config.Config.Scan.DisableDomainResolution,
+				config.Config.Scan.DomainResolutionTimeout,
+			),
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	dependenciesClassifier := dependencies.New(
 		dependencies.Config{
 			Recipes: db.Default(),
@@ -31,5 +47,6 @@ func NewClassifier(config *Config) *Classifier {
 	return &Classifier{
 		config:       *config,
 		Dependencies: dependenciesClassifier,
-	}
+		Interfaces:   interfacesClassifier,
+	}, nil
 }

--- a/pkg/classification/classification.go
+++ b/pkg/classification/classification.go
@@ -1,4 +1,4 @@
-package classsification
+package classification
 
 import (
 	"regexp"

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -181,11 +181,12 @@ func NewScanCommand() *cobra.Command {
 
 func NewConfigCommand() *cobra.Command {
 	scanFlags := &flag.ScanFlagGroup{
-		SkipPathFlag: &flag.SkipPathFlag,
+		SkipPathFlag:                &flag.SkipPathFlag,
+		DisableDomainResolutionFlag: &flag.DisableDomainResolutionFlag,
+		DomainResolutionTimeoutFlag: &flag.DomainResolutionTimeoutFlag,
 	}
 
 	configFlags := &flag.Flags{
-
 		ScanFlagGroup: scanFlags,
 	}
 

--- a/pkg/commands/process/worker/worker.go
+++ b/pkg/commands/process/worker/worker.go
@@ -15,8 +15,12 @@ import (
 )
 
 func Start(port string, config config.Config) error {
-	classifier := classsification.NewClassifier(&classsification.Config{Config: config})
-	err := detectors.SetupCustomDetector(config.CustomDetector.RulesConfig)
+	classifier, err := classsification.NewClassifier(&classsification.Config{Config: config})
+	if err != nil {
+		return err
+	}
+
+	err = detectors.SetupCustomDetector(config.CustomDetector.RulesConfig)
 	if err != nil {
 		return err
 	}

--- a/pkg/flag/scan_flags.go
+++ b/pkg/flag/scan_flags.go
@@ -1,5 +1,7 @@
 package flag
 
+import "time"
+
 var (
 	SkipPathFlag = Flag{
 		Name:       "skip-path",
@@ -13,23 +15,41 @@ var (
 		Value:      false,
 		Usage:      "enable debug logs",
 	}
+	DisableDomainResolutionFlag = Flag{
+		Name:       "disable-domain-resolution",
+		ConfigName: "scan.disable-domain-resolution",
+		Value:      false,
+		Usage:      "do not attempt to resolve detected domains during classification (default false), eg. --disable-domain-resolution=true",
+	}
+	DomainResolutionTimeoutFlag = Flag{
+		Name:       "domain-resolution-timeout",
+		ConfigName: "scan.domain-resolution-timeout",
+		Value:      3 * time.Second,
+		Usage:      "set timeout when attempting to resolve detected domains during classification (default 3 seconds), eg. --domain-resolution-timeout=TODO",
+	}
 )
 
 type ScanFlagGroup struct {
-	SkipPathFlag *Flag
-	DebugFlag    *Flag
+	SkipPathFlag                *Flag
+	DebugFlag                   *Flag
+	DisableDomainResolutionFlag *Flag
+	DomainResolutionTimeoutFlag *Flag
 }
 
 type ScanOptions struct {
-	Target   string   `json:"target"`
-	SkipPath []string `json:"skip_path"`
-	Debug    bool     `json:"debug"`
+	Target                  string        `json:"target"`
+	SkipPath                []string      `json:"skip_path"`
+	Debug                   bool          `json:"debug"`
+	DisableDomainResolution bool          `json:"disable_domain_resolution"`
+	DomainResolutionTimeout time.Duration `json:"domain_resolution_timeout"`
 }
 
 func NewScanFlagGroup() *ScanFlagGroup {
 	return &ScanFlagGroup{
-		SkipPathFlag: &SkipPathFlag,
-		DebugFlag:    &DebugFlag,
+		SkipPathFlag:                &SkipPathFlag,
+		DebugFlag:                   &DebugFlag,
+		DisableDomainResolutionFlag: &DisableDomainResolutionFlag,
+		DomainResolutionTimeoutFlag: &DomainResolutionTimeoutFlag,
 	}
 }
 
@@ -41,6 +61,8 @@ func (f *ScanFlagGroup) Flags() []*Flag {
 	return []*Flag{
 		f.SkipPathFlag,
 		f.DebugFlag,
+		f.DisableDomainResolutionFlag,
+		f.DomainResolutionTimeoutFlag,
 	}
 }
 
@@ -51,8 +73,10 @@ func (f *ScanFlagGroup) ToOptions(args []string) (ScanOptions, error) {
 	}
 
 	return ScanOptions{
-		SkipPath: getStringSlice(f.SkipPathFlag),
-		Debug:    getBool(f.DebugFlag),
-		Target:   target,
+		SkipPath:                getStringSlice(f.SkipPathFlag),
+		Debug:                   getBool(f.DebugFlag),
+		DisableDomainResolution: getBool(f.DisableDomainResolutionFlag),
+		DomainResolutionTimeout: getDuration(f.DomainResolutionTimeoutFlag),
+		Target:                  target,
 	}, nil
 }


### PR DESCRIPTION
## Description
Add two new Scan flags
- `--disable-domain-resolution=true` (default `false`)
- `--domain-resolution-timeout=10` (in seconds; default 3s)

And use these when initializing interfaces classifier

TBC if these stay as Scan flags or become Classification flags -- [see Delibr question](https://app.delibr.com/app/7N672vhuYhBZiL5i6/documents/Lxrhbdjay9FvcBySE?zoom=uXf5GaBmT6HuP86s8)


<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
