### PR TITLE
fix: remove duplicate log debug

### DIFF
--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -70,8 +70,6 @@ func NewProcessingServerCommand() *cobra.Command {
 		Use:   "processing-worker [flags] PATH",
 		Short: "start scan processing server",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			log.Debug().Msgf("started scan processing")
-
 			var config config.Config
 			if err := json.Unmarshal([]byte(args[0]), &config); err != nil {
 				return err


### PR DESCRIPTION
## Description
Remove duplicate logs,
There shouldn't be any logs before calling `output.Setup()`
It appears somehow this log was left over.

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
