### PR TITLE
chore: automate tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,6 @@
 name: release
 on:
+  workflow_dispatch:
   push:
     tags:
       - "v*"
@@ -9,7 +10,24 @@ permissions:
   packages: write
 
 jobs:
+  tag:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Bump version and push tag
+        if: startsWith(github.ref, 'refs/tags') != true
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tag_prefix: release-v
+          default_bump: patch
+    outputs:
+      tag_name: ${{ steps.tag_version.outputs.new_tag || github.ref }}
+
   build-linux:
+    needs: [tag]
     name: build-linux
     runs-on: ubuntu-latest
     steps:
@@ -17,6 +35,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ needs.tag.outputs.tag_name }}
       - run: git fetch --force --tags
       - name: Set up Go
         uses: actions/setup-go@v3
@@ -39,6 +58,7 @@ jobs:
           path: dist/curio*
 
   build-darwin:
+    needs: [tag]
     name: build-darwin
     runs-on: macos-latest
     steps:
@@ -46,6 +66,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ needs.tag.outputs.tag_name }}
       - run: git fetch --force --tags
       - name: Set up Go
         uses: actions/setup-go@v3
@@ -66,12 +87,13 @@ jobs:
           path: dist/curio*
 
   publish:
-    needs: [build-darwin, build-linux]
+    needs: [tag, build-darwin, build-linux]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ needs.tag.outputs.tag_name }}
       - run: git fetch --force --tags
       - name: Make directories
         run: |


### PR DESCRIPTION
## Description
Tags for release can now be generated automatically by manually triggering the release action.

### How it works
- When the release job is run if no tag ref is given it will generate a new symantic tag. 
- If a tag is created manually the action will continue to work as before.
- Tags can be created from any branch provided that branch is selected when manually triggering the action.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
