### PR TITLE
refactor(classification): prefer string to enum for url validation state

### DIFF
--- a/pkg/util/url/url.go
+++ b/pkg/util/url/url.go
@@ -176,13 +176,11 @@ var cloudDetectors = map[string]struct{}{
 	"sql-advanced": {},
 }
 
-type ValidationState int
+type ValidationState string
 
-const (
-	Valid ValidationState = iota + 1
-	Invalid
-	Potential
-)
+var Valid = ValidationState("valid")
+var Invalid = ValidationState("invalid")
+var Potential = ValidationState("potential")
 
 type ValidationResult struct {
 	State  ValidationState


### PR DESCRIPTION
## Description
Simplify URL validation state from Enum to String (as we have for e.g. RecipeType)

Strings are probably enough for us here, and they make the report friendlier to humans:

Report before these changes
```
	{
		"classification": {
			"decision": {
				"reason": "recipe_match",
				"state": 1
			}, ...
		},
	},
	{
		"classification": {
			"decision": {
				"reason": "domain_not_reachable",
				"state": 2
			}, ...
		},...
	},
```

Report after these changes

```
	{
		"classification": {
			"decision": {
				"reason": "recipe_match",
				"state": "valid"
			}, ...
		},
	},
	{
		"classification": {
			"decision": {
				"reason": "domain_not_reachable",
				"state": "invalid"
			}, ...
		},...
	},
```

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
