### PR TITLE
fix(classification): prefer LookupIPAddr to LookupAddr

### DIFF
--- a/pkg/util/url/domain_resolver.go
+++ b/pkg/util/url/domain_resolver.go
@@ -15,8 +15,8 @@ var regexpDomainSplitMatcher = regexp.MustCompile(`\*\s*(.*?)\s*\.`)
 type DomainResolver struct {
 	Enabled      bool
 	Timeout      time.Duration
-	LookupIPAddr func(ctx context.Context, addr string) ([]net.IPAddr, error)
-	LookupNS     func(ctx context.Context, addr string) ([]*net.NS, error)
+	LookupIPAddr func(ctx context.Context, host string) ([]net.IPAddr, error)
+	LookupNS     func(ctx context.Context, host string) ([]*net.NS, error)
 }
 
 func NewDomainResolver(enabled bool, timeout time.Duration) *DomainResolver {
@@ -84,12 +84,12 @@ func (domainResolver *DomainResolver) isNameserver(domain string, staticDomain s
 
 func (domainResolver *DomainResolver) domainResolves(domain string, resolverContext context.Context) bool {
 	// handle any special characters
-	sanitizedURL, err := publicsuffix.ToASCII(domain)
+	sanitizedDomain, err := publicsuffix.ToASCII(domain)
 	if err != nil {
 		return false
 	}
 
-	names, err := domainResolver.LookupIPAddr(resolverContext, sanitizedURL)
+	names, err := domainResolver.LookupIPAddr(resolverContext, sanitizedDomain)
 	if err != nil {
 		// return false even for transient errors
 		return false

--- a/pkg/util/url/domain_resolver.go
+++ b/pkg/util/url/domain_resolver.go
@@ -13,20 +13,20 @@ import (
 var regexpDomainSplitMatcher = regexp.MustCompile(`\*\s*(.*?)\s*\.`)
 
 type DomainResolver struct {
-	Enabled    bool
-	Timeout    time.Duration
-	LookUpAddr func(ctx context.Context, addr string) ([]string, error)
-	LookUpNS   func(ctx context.Context, addr string) ([]*net.NS, error)
+	Enabled      bool
+	Timeout      time.Duration
+	LookupIPAddr func(ctx context.Context, addr string) ([]net.IPAddr, error)
+	LookupNS     func(ctx context.Context, addr string) ([]*net.NS, error)
 }
 
 func NewDomainResolver(enabled bool, timeout time.Duration) *DomainResolver {
 	var resolver = net.Resolver{PreferGo: true}
 
 	return &DomainResolver{
-		Enabled:    enabled,
-		Timeout:    timeout,
-		LookUpAddr: resolver.LookupAddr,
-		LookUpNS:   resolver.LookupNS,
+		Enabled:      enabled,
+		Timeout:      timeout,
+		LookupNS:     resolver.LookupNS,
+		LookupIPAddr: resolver.LookupIPAddr,
 	}
 }
 
@@ -34,10 +34,10 @@ func NewDomainResolverDefault() *DomainResolver {
 	var resolver = net.Resolver{PreferGo: true}
 
 	return &DomainResolver{
-		Enabled:    true,
-		Timeout:    3 * time.Second,
-		LookUpAddr: resolver.LookupAddr,
-		LookUpNS:   resolver.LookupNS,
+		Enabled:      true,
+		Timeout:      3 * time.Second,
+		LookupNS:     resolver.LookupNS,
+		LookupIPAddr: resolver.LookupIPAddr,
 	}
 }
 
@@ -73,7 +73,7 @@ func (domainResolver *DomainResolver) isNameserver(domain string, staticDomain s
 		return false
 	}
 
-	nameserver, err := domainResolver.LookUpNS(resolverContext, staticDomain)
+	nameserver, err := domainResolver.LookupNS(resolverContext, staticDomain)
 	if err != nil {
 		// return false even for transient errors
 		return false
@@ -89,7 +89,7 @@ func (domainResolver *DomainResolver) domainResolves(domain string, resolverCont
 		return false
 	}
 
-	names, err := domainResolver.LookUpAddr(resolverContext, sanitizedURL)
+	names, err := domainResolver.LookupIPAddr(resolverContext, sanitizedURL)
 	if err != nil {
 		// return false even for transient errors
 		return false

--- a/pkg/util/url/domain_resolver_test.go
+++ b/pkg/util/url/domain_resolver_test.go
@@ -13,7 +13,7 @@ import (
 func TestCanReach(t *testing.T) {
 	tests := []struct {
 		Name, Domain     string
-		MockLookupIPAddr func(ctx context.Context, addr string) ([]net.IPAddr, error)
+		MockLookupIPAddr func(ctx context.Context, host string) ([]net.IPAddr, error)
 		MockLookupNS     func(ctx context.Context, name string) ([]*net.NS, error)
 		Want             bool
 	}{
@@ -25,7 +25,7 @@ func TestCanReach(t *testing.T) {
 		{
 			Name:   "when the domain contains wildcards and the non wildcard part is not a valid TLD",
 			Domain: "_oidc-client-*-partial.tf",
-			MockLookupIPAddr: func(ctx context.Context, addr string) ([]net.IPAddr, error) {
+			MockLookupIPAddr: func(ctx context.Context, host string) ([]net.IPAddr, error) {
 				return []net.IPAddr{}, nil
 			},
 			Want: false,
@@ -38,7 +38,7 @@ func TestCanReach(t *testing.T) {
 		{
 			Name:   "when the domain is static and does not resolve",
 			Domain: "example.co.za",
-			MockLookupIPAddr: func(ctx context.Context, addr string) ([]net.IPAddr, error) {
+			MockLookupIPAddr: func(ctx context.Context, host string) ([]net.IPAddr, error) {
 				return []net.IPAddr{}, nil
 			},
 			Want: false,
@@ -46,7 +46,7 @@ func TestCanReach(t *testing.T) {
 		{
 			Name:   "when the domain is static and the DNS server has an error",
 			Domain: "example.co.za",
-			MockLookupIPAddr: func(ctx context.Context, addr string) ([]net.IPAddr, error) {
+			MockLookupIPAddr: func(ctx context.Context, host string) ([]net.IPAddr, error) {
 				return []net.IPAddr{}, errors.New("just being nervous")
 			},
 			Want: false,
@@ -62,7 +62,7 @@ func TestCanReach(t *testing.T) {
 		{
 			Name:   "when a wildcard domain does not resolve and its static domain has no nameserver",
 			Domain: "*-test.example.co.uk",
-			MockLookupIPAddr: func(ctx context.Context, addr string) ([]net.IPAddr, error) {
+			MockLookupIPAddr: func(ctx context.Context, host string) ([]net.IPAddr, error) {
 				return []net.IPAddr{}, nil
 			},
 			MockLookupNS: func(ctx context.Context, name string) ([]*net.NS, error) {
@@ -81,7 +81,7 @@ func TestCanReach(t *testing.T) {
 		{
 			Name:   "when a wildcard domain does not resolve but its static domain has a nameserver",
 			Domain: "*-test.example.co.uk",
-			MockLookupIPAddr: func(ctx context.Context, addr string) ([]net.IPAddr, error) {
+			MockLookupIPAddr: func(ctx context.Context, host string) ([]net.IPAddr, error) {
 				return []net.IPAddr{}, nil
 			},
 			Want: true,
@@ -89,7 +89,7 @@ func TestCanReach(t *testing.T) {
 		{
 			Name:   "when both the DNS and nameserver lookup raises errors for a wildcard domain",
 			Domain: "*-test.example.co.uk",
-			MockLookupIPAddr: func(ctx context.Context, addr string) ([]net.IPAddr, error) {
+			MockLookupIPAddr: func(ctx context.Context, host string) ([]net.IPAddr, error) {
 				return []net.IPAddr{}, errors.New("just being nervous")
 			},
 			MockLookupNS: func(ctx context.Context, name string) ([]*net.NS, error) {
@@ -103,7 +103,7 @@ func TestCanReach(t *testing.T) {
 		t.Run(testCase.Name, func(t *testing.T) {
 			// reset mocks
 			domainResolver := url.NewDomainResolverDefault()
-			domainResolver.LookupIPAddr = func(ctx context.Context, addr string) ([]net.IPAddr, error) {
+			domainResolver.LookupIPAddr = func(ctx context.Context, host string) ([]net.IPAddr, error) {
 				return []net.IPAddr{{IP: []byte{1}}}, nil
 			}
 			domainResolver.LookupNS = func(ctx context.Context, name string) ([]*net.NS, error) {

--- a/pkg/util/url/url_test.go
+++ b/pkg/util/url/url_test.go
@@ -555,10 +555,10 @@ func TestValidate(t *testing.T) {
 	// test domain reachability
 	t.Run("unreachable domain", func(t *testing.T) {
 		domainResolver := url.NewDomainResolverDefault()
-		domainResolver.LookUpAddr = func(ctx context.Context, addr string) ([]string, error) {
-			return []string{}, nil // no DNS address found
+		domainResolver.LookupIPAddr = func(ctx context.Context, host string) ([]net.IPAddr, error) {
+			return []net.IPAddr{}, nil // no DNS address found
 		}
-		domainResolver.LookUpNS = func(ctx context.Context, name string) ([]*net.NS, error) {
+		domainResolver.LookupNS = func(ctx context.Context, name string) ([]*net.NS, error) {
 			return []*net.NS{}, nil // no NS found
 		}
 


### PR DESCRIPTION
## Description
We need to use LookupIPAddr and not LookupAddr - this fixes the issue of e.g. https://datadog.eu being classed as unreachable

Also some renaming clean-up since we are in the area

DD report after this fix: 

```
{
		"classification": {
			"decision": {
				"reason": "no_subdomain",
				"state": "potential"
			},
			"recipe_match": false,
			"url": "https://datadoghq.eu"
		},
		"commit_sha": "",
		"detector_type": "ruby",
		"source": {
			"column_number": 6,
			"filename": ".",
			"language": "Ruby",
			"language_type": "programming",
			"line_number": 4,
			"text": "\"https://datadoghq.eu\""
		},
		"type": "interface_classified",
		"value": {
			"type": "url",
			"value": {
				"parts": [
					{
						"type": "string",
						"value": "https://datadoghq.eu"
					}
				]
			}
		}
	}
```

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
