### PR TITLE
feat(classification): update schema classify method signature

### DIFF
--- a/pkg/classification/schema/schema.go
+++ b/pkg/classification/schema/schema.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"github.com/bearer/curio/pkg/parser/datatype"
+	"github.com/bearer/curio/pkg/report/detectors"
 )
 
 type ClassifiedDatatype struct {
@@ -25,9 +26,15 @@ func New(config Config) *Classifier {
 	return &Classifier{config: config}
 }
 
-func (classifier *Classifier) Classify(data datatype.DataType) (ClassifiedDatatype, error) {
+type DataTypeDetection struct {
+	Value        datatype.DataType
+	Filename     string
+	DetectorType detectors.Type
+}
+
+func (classifier *Classifier) Classify(data DataTypeDetection) (*ClassifiedDatatype, error) {
 	// todo: implement interface classification (bigbear etc...)
-	return ClassifiedDatatype{
+	return &ClassifiedDatatype{
 		DataType: &datatype.DataType{
 			UUID: "1",
 		},

--- a/pkg/classification/schema/schema_test.go
+++ b/pkg/classification/schema/schema_test.go
@@ -3,6 +3,7 @@ package schema_test
 import (
 	"testing"
 
+	"github.com/bearer/curio/pkg/report/detectors"
 	reportschema "github.com/bearer/curio/pkg/report/schema"
 	"github.com/stretchr/testify/assert"
 
@@ -12,7 +13,7 @@ import (
 
 type testCase struct {
 	Name  string
-	Input datatype.DataType
+	Input schema.DataTypeDetection
 	Want  schema.ClassifiedDatatype
 }
 
@@ -20,21 +21,24 @@ func TestSchema(t *testing.T) {
 	tests := []testCase{
 		{
 			Name: "simple path",
-			Input: datatype.DataType{
-				Name: "user",
-				Type: reportschema.SimpleTypeObject,
-				Properties: map[string]*datatype.DataType{
-					"address": {
-						Type: reportschema.SimpleTypeString,
-						UUID: "2",
+			Input: schema.DataTypeDetection{
+				Filename:     "db/schema.rb",
+				DetectorType: detectors.DetectorRuby,
+				Value: datatype.DataType{
+					Name: "user",
+					Type: reportschema.SimpleTypeObject,
+					Properties: map[string]*datatype.DataType{
+						"address": {
+							Type: reportschema.SimpleTypeString,
+							UUID: "2",
+						},
+						"age": {
+							Type: reportschema.SimpleTypeString,
+							UUID: "3",
+						},
 					},
-					"age": {
-						Type: reportschema.SimpleTypeString,
-						UUID: "3",
-					},
-				},
-				UUID: "1",
-			},
+					UUID: "1",
+				}},
 			Want: schema.ClassifiedDatatype{
 				DataType: &datatype.DataType{
 					UUID: "1",


### PR DESCRIPTION
## Description

Introduce new type: data type detection, so we can pass filename and detector type to schema classification
Update schema classify method signature to take data type detection

Note: we do not e.g. pass the full detection, as with interface and package detections, because of the nesting we have with schema detections (e.g. the `Properties` or child data type detections). Instead, we pass just what we need for the classification, namely, the filename and detector type. 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
