### PR TITLE
fix: typo in docs for internal domain flags

### DIFF
--- a/docs/_data/curio.yaml
+++ b/docs/_data/curio.yaml
@@ -1,12 +1,13 @@
 name: ""
 usage: ' [flags]'
 options:
-- name: help
-  shorthand: h
-  default_value: "false"
-  usage: help for this command
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for this command
 see_also:
-- config - Scan config files for misconfigurations
-- scan - Scan git repository
-- version - Print the version
+    - ' config - Scan config files for misconfigurations'
+    - ' init - writes default config to curio.yml'
+    - ' scan - Scan git repository'
+    - ' version - Print the version'
 aliases: 

--- a/docs/_data/curio_config.yaml
+++ b/docs/_data/curio_config.yaml
@@ -2,26 +2,26 @@ name: ' config'
 synopsis: Scan config files for misconfigurations
 usage: ' config [flags] DIR'
 options:
-- name: disable-domain-resolution
-  default_value: "false"
-  usage: |
-    do not attempt to resolve detected domains during classification (default false), eg. --disable-domain-resolution=true
-- name: domain-resolution-timeout
-  default_value: 3s
-  usage: |
-    set timeout when attempting to resolve detected domains during classification (default 3 seconds), eg. --domain-resolution-timeout=TODO
-- name: help
-  shorthand: h
-  default_value: "false"
-  usage: help for config
-- name: internal-domains
-  default_value: '[]'
-  usage: |
-    define regular expressions for better classification of private or unreachable domains eg. --internal-domains="/*.my-company.com/,/private.sh/"
-- name: skip-path
-  default_value: '[]'
-  usage: |
-    specify the comma separated files and directories to skip (supports * syntax), eg. --skip-path users/*.go,users/admin.sql
+    - name: disable-domain-resolution
+      default_value: "false"
+      usage: |
+        do not attempt to resolve detected domains during classification (default false), eg. --disable-domain-resolution=true
+    - name: domain-resolution-timeout
+      default_value: 3s
+      usage: |
+        set timeout when attempting to resolve detected domains during classification (default 3 seconds), eg. --domain-resolution-timeout=TODO
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for config
+    - name: internal-domains
+      default_value: '[]'
+      usage: |
+        define regular expressions for better classification of private or unreachable domains eg. --internal-domains="*.my-company.com,private.sh"
+    - name: skip-path
+      default_value: '[]'
+      usage: |
+        specify the comma separated files and directories to skip (supports * syntax), eg. --skip-path users/*.go,users/admin.sql
 see_also:
-- ' - '
+    - ' - '
 aliases: conf

--- a/docs/_data/curio_init.yaml
+++ b/docs/_data/curio_init.yaml
@@ -1,6 +1,6 @@
-name: ' scan'
-synopsis: Scan git repository
-usage: ' scan [flags] PATH'
+name: ' init'
+synopsis: writes default config to curio.yml
+usage: ' init [flags]'
 options:
     - name: config-file
       usage: file from which to load configurations
@@ -28,7 +28,7 @@ options:
     - name: help
       shorthand: h
       default_value: "false"
-      usage: help for scan
+      usage: help for init
     - name: internal-domains
       default_value: '[]'
       usage: |
@@ -67,11 +67,6 @@ options:
     - name: workers
       default_value: "1"
       usage: number of processing workers to spawn
-example: |4-
-      # Scan a local project including language-specific files
-      $ curio s /path/to/your_project
-      # Scan a single file
-      $ curio s ./curio-ci-test/Pipfile.lock
 see_also:
     - ' - '
-aliases: s
+aliases: 

--- a/docs/_data/curio_version.yaml
+++ b/docs/_data/curio_version.yaml
@@ -2,10 +2,10 @@ name: ' version'
 synopsis: Print the version
 usage: ' version [flags]'
 options:
-- name: help
-  shorthand: h
-  default_value: "false"
-  usage: help for version
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for version
 see_also:
-- ' - '
+    - ' - '
 aliases: 

--- a/pkg/flag/scan_flags.go
+++ b/pkg/flag/scan_flags.go
@@ -31,7 +31,7 @@ var (
 		Name:       "internal-domains",
 		ConfigName: "scan.internal-domains",
 		Value:      []string{},
-		Usage:      "define regular expressions for better classification of private or unreachable domains eg. --internal-domains=\"/*.my-company.com/,/private.sh/\"",
+		Usage:      "define regular expressions for better classification of private or unreachable domains eg. --internal-domains=\"*.my-company.com,private.sh\"",
 	}
 )
 


### PR DESCRIPTION
## Description
Fixing typo in internal -domains flag example (remove escaping `/`)
Update docs using `go run ./scripts/gen-doc-yaml.go`

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
