### PR TITLE
fix: config erroring when config is not found

### DIFF
--- a/pkg/commands/scan.go
+++ b/pkg/commands/scan.go
@@ -1,9 +1,7 @@
 package commands
 
 import (
-	"errors"
 	"fmt"
-	"os"
 
 	"github.com/bearer/curio/pkg/commands/artifact"
 	"github.com/bearer/curio/pkg/flag"
@@ -88,11 +86,10 @@ func NewScanCommand() *cobra.Command {
 }
 
 func readConfig(configFile string) error {
-	// Read from config
 	viper.SetConfigFile(configFile)
 	viper.SetConfigType("yaml")
 	if err := viper.ReadInConfig(); err != nil {
-		if errors.Is(err, os.ErrNotExist) {
+		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
 			return nil
 		}
 


### PR DESCRIPTION
## Description
We have probably upgraded viper version, making previous error checking mehanics for config existance invalid.
This PR fixes it.

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
