### PR TITLE
fix(detectors): handle arrays when checking for openapi and swagger

### DIFF
--- a/pkg/detectors/openapi/.snapshots/TestOtherjson
+++ b/pkg/detectors/openapi/.snapshots/TestOtherjson
@@ -1,0 +1,1 @@
+([]*detections.Detection) <nil>

--- a/pkg/detectors/openapi/openapi.go
+++ b/pkg/detectors/openapi/openapi.go
@@ -1,6 +1,7 @@
 package openapi
 
 import (
+	"bytes"
 	"encoding/json"
 	"io/ioutil"
 
@@ -73,6 +74,10 @@ func getFileType(file *file.FileInfo) (detectors.OpenAPIFileType, error) {
 
 	var version version
 	if ext == ".json" {
+		if isArray(input) { // fallback to json|yaml detector
+			return "", nil
+		}
+
 		err := json.Unmarshal(input, &version)
 		if err != nil {
 			return detectors.OpenAPIFileType(""), err
@@ -108,4 +113,8 @@ func getFileType(file *file.FileInfo) (detectors.OpenAPIFileType, error) {
 		return detectors.OpenApi2YAMLFile, nil
 	}
 
+}
+
+func isArray(input []byte) bool {
+	return bytes.HasPrefix(bytes.TrimSpace(input), []byte("["))
 }

--- a/pkg/detectors/openapi/openapi_test.go
+++ b/pkg/detectors/openapi/openapi_test.go
@@ -40,3 +40,9 @@ func TestDetectorV2yaml(t *testing.T) {
 
 	cupaloy.SnapshotT(t, report.Detections)
 }
+
+func TestOtherjson(t *testing.T) {
+	report := testhelper.Extract(t, filepath.Join("testdata", "arrayjson"), registrations, detectorType)
+
+	cupaloy.SnapshotT(t, report.Detections)
+}

--- a/pkg/detectors/openapi/testdata/arrayjson/packages.json
+++ b/pkg/detectors/openapi/testdata/arrayjson/packages.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name": "actioncable",
+    "package_type": "rubygems",
+    "fallback_state": "reviewed",
+    "fallback_detected_data_store_technology": null
+  },
+  {
+    "name": "actionmailbox",
+    "package_type": "rubygems",
+    "fallback_state": "reviewed",
+    "fallback_detected_data_store_technology": null
+  }
+]


### PR DESCRIPTION
## Description
If we have a JSON array, the OpenAPI detector can't convert it into the expected OpenAPI struct.
Fallback to json/yml detectors in this case

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
