### PR TITLE
fix(classification): add data type to classification

### DIFF
--- a/pkg/classification/schema/schema.go
+++ b/pkg/classification/schema/schema.go
@@ -1,7 +1,6 @@
 package schema
 
 import (
-	"fmt"
 	"regexp"
 
 	"github.com/bearer/curio/pkg/report/schema/datatype"
@@ -13,41 +12,15 @@ import (
 )
 
 var regexpIdentifierMatcher = regexp.MustCompile(`(uu)?id\z`)
-var objectStopWords = map[string]struct{}{
-	"this":        {},
-	"props":       {},
-	"prop types":  {},
-	"exports":     {},
-	"export":      {},
-	"env":         {},
-	"argv":        {},
-	"arguments":   {},
-	"errors":      {},
-	"args":        {},
-	"state":       {},
-	"filter":      {},
-	"memberships": {},
-}
-var propertyStopWords = map[string]struct{}{
-	"on click":      {},
-	"disable click": {},
-}
-var databaseDetectorTypes = map[string]struct{}{
-	"sql":   {},
-	"rails": {},
-}
-var expectedIdentifierDataTypeIds = map[string]struct{}{
-	"132": {}, // Unique Identifier
-	"13":  {}, // Device Identifier
-}
 
 type ClassifiedDatatype struct {
-	*datatype.DataType
+	datatype.DataTypable
 	Classification Classification `json:"classification"`
 }
 
 type Classification struct {
-	Name     string
+	Name     string                          `json:"name"`
+	DataType db.DataType                     `json:"data_type,omitempty"`
 	Decision classify.ClassificationDecision `json:"decision"`
 }
 
@@ -71,23 +44,12 @@ type DataTypeDetection struct {
 	DetectorType detectors.Type
 }
 
-func extractDataType(value datatype.DataTypable) *datatype.DataType {
-	return &datatype.DataType{
-		Node:       value.GetNode(),
-		Name:       value.GetName(),
-		Type:       value.GetType(),
-		TextType:   value.GetTextType(),
-		Properties: value.GetProperties(),
-		IsHelper:   value.GetIsHelper(),
-		UUID:       value.GetUUID(),
-	}
-}
-
 func (classifier *Classifier) Classify(data DataTypeDetection) (*ClassifiedDatatype, error) {
-	detectedDataType := extractDataType(data.Value)
-	normalizedObjectName := normalize_key.Normalize(detectedDataType.Name)
+	dataTypeable := data.Value
+	normalizedObjectName := normalize_key.Normalize(dataTypeable.GetName())
+	objectProperties := dataTypeable.GetProperties()
 	classifiedDataType := &ClassifiedDatatype{
-		DataType:       detectedDataType,
+		DataTypable:    dataTypeable,
 		Classification: Classification{Name: normalizedObjectName},
 	}
 
@@ -105,7 +67,7 @@ func (classifier *Classifier) Classify(data DataTypeDetection) (*ClassifiedDatat
 		}
 	}
 
-	if objectStopWordDetected(normalizedObjectName) {
+	if classify.ObjectStopWordDetected(normalizedObjectName) {
 		classifiedDataType.Classification.Decision = classify.ClassificationDecision{
 			State:  classify.Invalid,
 			Reason: "stop_word",
@@ -117,8 +79,8 @@ func (classifier *Classifier) Classify(data DataTypeDetection) (*ClassifiedDatat
 		// mark all first level children as invalid
 
 		// todo: handle children that are themselves schema objects
-		for _, property := range detectedDataType.Properties {
-			detectedDataType.Properties[property.GetName()] = classifyAsInvalid(property)
+		for _, property := range objectProperties {
+			objectProperties[property.GetName()] = classifyAsInvalid(property)
 		}
 
 		return classifiedDataType, nil
@@ -126,18 +88,21 @@ func (classifier *Classifier) Classify(data DataTypeDetection) (*ClassifiedDatat
 
 	var isJSDetection = data.DetectorType == detectors.DetectorJavascript || data.DetectorType == detectors.DetectorTypescript
 
-	if classifier.isKnownPersonObject(normalizedObjectName) {
+	matchedKnownPersonObject := classifier.matchKnownPersonObjectPatterns(normalizedObjectName, false)
+	if matchedKnownPersonObject != nil {
+		// add data type to object
+		classifiedDataType.Classification.DataType = matchedKnownPersonObject.DataType
+
 		hasKnownObjectProperties := false
 		hasKnownDBIdentifierProperties := false
 
 		// todo: handle children that are themselves schema objects
-		for _, property := range detectedDataType.Properties {
-			propertyDataType := extractDataType(property)
-			normalizedPropertyName := normalize_key.Normalize(propertyDataType.Name)
+		for _, property := range objectProperties {
+			normalizedPropertyName := normalize_key.Normalize(property.GetName())
 
-			if isJSDetection && propertyStopWordDetected(normalizedPropertyName) {
-				detectedDataType.Properties[propertyDataType.Name] = ClassifiedDatatype{
-					DataType: propertyDataType,
+			if isJSDetection && classify.PropertyStopWordDetected(normalizedPropertyName) {
+				objectProperties[property.GetName()] = ClassifiedDatatype{
+					DataTypable: property,
 					Classification: Classification{
 						Name: normalizedPropertyName,
 						Decision: classify.ClassificationDecision{
@@ -150,12 +115,14 @@ func (classifier *Classifier) Classify(data DataTypeDetection) (*ClassifiedDatat
 				continue
 			}
 
-			if classifier.isKnownObjectPattern(normalizedPropertyName, propertyDataType.Type) {
+			matchedKnownObject := classifier.matchKnownObjectPatterns(normalizedPropertyName, property.GetType())
+			if matchedKnownObject != nil {
 				hasKnownObjectProperties = true
-				detectedDataType.Properties[propertyDataType.Name] = ClassifiedDatatype{
-					DataType: propertyDataType,
+				objectProperties[property.GetName()] = ClassifiedDatatype{
+					DataTypable: property,
 					Classification: Classification{
-						Name: normalizedPropertyName,
+						Name:     normalizedPropertyName,
+						DataType: matchedKnownObject.DataType, // todo: check for health context
 						Decision: classify.ClassificationDecision{
 							State:  classify.Valid,
 							Reason: "known_classification_pattern",
@@ -166,12 +133,14 @@ func (classifier *Classifier) Classify(data DataTypeDetection) (*ClassifiedDatat
 				continue
 			}
 
-			if classifier.isKnownDBIdentifierPattern(normalizedPropertyName) {
+			matchedKnownIdentifier := classifier.matchKnownPersonObjectPatterns(normalizedPropertyName, true)
+			if matchedKnownIdentifier != nil {
 				hasKnownDBIdentifierProperties = true
-				detectedDataType.Properties[propertyDataType.Name] = ClassifiedDatatype{
-					DataType: propertyDataType,
+				objectProperties[property.GetName()] = ClassifiedDatatype{
+					DataTypable: property,
 					Classification: Classification{
-						Name: normalizedPropertyName,
+						Name:     normalizedPropertyName,
+						DataType: matchedKnownIdentifier.DataType, // always "Unique Identifier"
 						Decision: classify.ClassificationDecision{
 							State:  classify.Valid,
 							Reason: "known_database_identifier",
@@ -182,8 +151,8 @@ func (classifier *Classifier) Classify(data DataTypeDetection) (*ClassifiedDatat
 				continue
 			}
 
-			detectedDataType.Properties[propertyDataType.Name] = ClassifiedDatatype{
-				DataType: propertyDataType,
+			objectProperties[property.GetName()] = ClassifiedDatatype{
+				DataTypable: property,
 				Classification: Classification{
 					Name: normalizedPropertyName,
 					Decision: classify.ClassificationDecision{
@@ -203,7 +172,7 @@ func (classifier *Classifier) Classify(data DataTypeDetection) (*ClassifiedDatat
 		}
 
 		objectState := classify.Invalid
-		if isDatabase(data.DetectorType) {
+		if classify.IsDatabase(data.DetectorType) {
 			objectState = classify.Potential
 		}
 		classifiedDataType.Classification.Decision = classify.ClassificationDecision{
@@ -217,36 +186,19 @@ func (classifier *Classifier) Classify(data DataTypeDetection) (*ClassifiedDatat
 	return classifiedDataType, nil
 }
 
-func (classifier *Classifier) isKnownPersonObject(name string) bool {
-	result := false
-	for _, pattern := range classifier.config.KnownPersonObjectPatterns {
-		if pattern.IncludeRegexpMatcher.MatchString(name) {
-			result = true
-			break
-		}
-
-		if pattern.ExcludeRegexpMatcher != nil && !pattern.ExcludeRegexpMatcher.MatchString(name) {
-			result = true
-			break
-		}
-	}
-
-	return result
-}
-
-func (classifier *Classifier) isKnownObjectPattern(name string, simpleType string) bool {
-	result := false
+func (classifier *Classifier) matchKnownObjectPatterns(name string, simpleType string) *db.DataTypeClassificationPattern {
+	var matchedPattern *db.DataTypeClassificationPattern
 	for _, pattern := range classifier.config.DataTypeClassificationPatterns {
 		if _, isKnown := pattern.ObjectTypeMapping["known"]; !isKnown {
 			continue
 		}
-		if pattern.DataTypeUUID == nil {
+		if pattern.DataTypeUUID == "" {
 			continue
 		}
 		if !pattern.IncludeRegexpMatcher.MatchString(name) {
 			continue
 		}
-		if !isExpectedIdentifierDataTypeId(pattern.Id) && regexpIdentifierMatcher.MatchString(name) {
+		if !classify.IsExpectedIdentifierDataTypeId(pattern.Id) && regexpIdentifierMatcher.MatchString(name) {
 			continue
 		}
 		if pattern.ExcludeRegexpMatcher != nil && pattern.ExcludeRegexpMatcher.MatchString(name) {
@@ -259,18 +211,19 @@ func (classifier *Classifier) isKnownObjectPattern(name string, simpleType strin
 			continue
 		}
 
-		result = true
+		matchedPattern = &pattern
 		break
 	}
 
-	return result
+	return matchedPattern
 }
 
-func (classifier *Classifier) isKnownDBIdentifierPattern(name string) bool {
+func (classifier *Classifier) matchKnownPersonObjectPatterns(name string, matchAsIdentifier bool) *db.KnownPersonObjectPattern {
+	var matchedPattern *db.KnownPersonObjectPattern
+
 	// todo: support health context
-	result := false
 	for _, pattern := range classifier.config.KnownPersonObjectPatterns {
-		if !pattern.ActAsIdentifier {
+		if matchAsIdentifier && !pattern.ActAsIdentifier {
 			continue
 		}
 		if !pattern.IncludeRegexpMatcher.MatchString(name) {
@@ -279,43 +232,22 @@ func (classifier *Classifier) isKnownDBIdentifierPattern(name string) bool {
 		if pattern.ExcludeRegexpMatcher != nil && pattern.ExcludeRegexpMatcher.MatchString(name) {
 			continue
 		}
-		if pattern.IdentifierRegexpMatcher != nil && !pattern.IdentifierRegexpMatcher.MatchString(name) {
+		if matchAsIdentifier && pattern.IdentifierRegexpMatcher != nil && !pattern.IdentifierRegexpMatcher.MatchString(name) {
 			continue
 		}
 
-		result = true
+		matchedPattern = &pattern
 		break
 	}
 
-	return result
-}
-
-func isDatabase(detectorType detectors.Type) bool {
-	_, ok := databaseDetectorTypes[string(detectorType)]
-	return ok
-}
-
-func isExpectedIdentifierDataTypeId(id int) bool {
-	_, ok := expectedIdentifierDataTypeIds[fmt.Sprint(id)]
-	return ok
-}
-
-func objectStopWordDetected(name string) bool {
-	_, ok := objectStopWords[name]
-	return ok
-}
-
-func propertyStopWordDetected(name string) bool {
-	_, ok := propertyStopWords[name]
-	return ok
+	return matchedPattern
 }
 
 func classifyAsInvalid(property datatype.DataTypable) ClassifiedDatatype {
-	propertyDataType := extractDataType(property)
-	normalizedPropertyName := normalize_key.Normalize(propertyDataType.Name)
+	normalizedPropertyName := normalize_key.Normalize(property.GetName())
 
 	return ClassifiedDatatype{
-		DataType: propertyDataType,
+		DataTypable: property,
 		Classification: Classification{
 			Name: normalizedPropertyName,
 			Decision: classify.ClassificationDecision{

--- a/pkg/classification/schema/schema_test.go
+++ b/pkg/classification/schema/schema_test.go
@@ -14,11 +14,43 @@ import (
 )
 
 func TestSchemaObjectClassification(t *testing.T) {
+	knownObjectDataType := db.DataType{
+		DataCategoryName: "Unique Identifier",
+		DefaultCategory:  "Identification",
+		Id:               86,
+		UUID:             "12d44ae0-1df7-4faf-9fb1-b46cc4b4dce9",
+	}
 	tests := []struct {
 		Name  string
 		Input schema.DataTypeDetection
 		Want  schema.Classification
 	}{
+		{
+			Name: "from vendors folder",
+			Input: schema.DataTypeDetection{
+				Filename:     "vendor/vendor.rb",
+				DetectorType: detectors.DetectorRuby,
+				Value: &datatype.DataType{
+					Name: "User",
+					UUID: "1",
+					Type: reportschema.SimpleTypeObject,
+					Properties: map[string]datatype.DataTypable{
+						"sku_name": &datatype.DataType{
+							Name: "sku_name",
+							Type: reportschema.SimpleTypeString,
+							UUID: "3",
+						},
+					},
+				},
+			},
+			Want: schema.Classification{
+				Name: "user",
+				Decision: classify.ClassificationDecision{
+					State:  classify.Invalid,
+					Reason: "included_in_vendor_folder",
+				},
+			},
+		},
 		{
 			Name: "known object with no valid properties",
 			Input: schema.DataTypeDetection{
@@ -78,7 +110,8 @@ func TestSchemaObjectClassification(t *testing.T) {
 				},
 			},
 			Want: schema.Classification{
-				Name: "user",
+				Name:     "user",
+				DataType: knownObjectDataType,
 				Decision: classify.ClassificationDecision{
 					State:  classify.Invalid,
 					Reason: "valid_object_with_invalid_properties",
@@ -109,7 +142,8 @@ func TestSchemaObjectClassification(t *testing.T) {
 				},
 			},
 			Want: schema.Classification{
-				Name: "user",
+				Name:     "user",
+				DataType: knownObjectDataType,
 				Decision: classify.ClassificationDecision{
 					State:  classify.Valid,
 					Reason: "valid_object_with_valid_properties",
@@ -145,7 +179,8 @@ func TestSchemaObjectClassification(t *testing.T) {
 				},
 			},
 			Want: schema.Classification{
-				Name: "seller fiscal information",
+				Name:     "seller fiscal information",
+				DataType: knownObjectDataType,
 				Decision: classify.ClassificationDecision{
 					State:  classify.Valid,
 					Reason: "valid_object_with_valid_properties",
@@ -186,7 +221,8 @@ func TestSchemaObjectClassification(t *testing.T) {
 				},
 			},
 			Want: schema.Classification{
-				Name: "seller fiscal information",
+				Name:     "seller fiscal information",
+				DataType: knownObjectDataType,
 				Decision: classify.ClassificationDecision{
 					State:  classify.Invalid,
 					Reason: "valid_object_with_invalid_properties",
@@ -212,7 +248,8 @@ func TestSchemaObjectClassification(t *testing.T) {
 				},
 			},
 			Want: schema.Classification{
-				Name: "applicant",
+				Name:     "applicant",
+				DataType: knownObjectDataType,
 				Decision: classify.ClassificationDecision{
 					State:  classify.Valid,
 					Reason: "valid_object_with_valid_properties",
@@ -238,7 +275,8 @@ func TestSchemaObjectClassification(t *testing.T) {
 				},
 			},
 			Want: schema.Classification{
-				Name: "bank accounts",
+				Name:     "bank accounts",
+				DataType: knownObjectDataType,
 				Decision: classify.ClassificationDecision{
 					State:  classify.Valid,
 					Reason: "valid_object_with_valid_properties",
@@ -264,7 +302,8 @@ func TestSchemaObjectClassification(t *testing.T) {
 				},
 			},
 			Want: schema.Classification{
-				Name: "bank accounts",
+				Name:     "bank accounts",
+				DataType: knownObjectDataType,
 				Decision: classify.ClassificationDecision{
 					State:  classify.Invalid,
 					Reason: "valid_object_with_invalid_properties",
@@ -290,7 +329,8 @@ func TestSchemaObjectClassification(t *testing.T) {
 				},
 			},
 			Want: schema.Classification{
-				Name: "patients",
+				Name:     "patients",
+				DataType: knownObjectDataType,
 				Decision: classify.ClassificationDecision{
 					State:  classify.Invalid,
 					Reason: "valid_object_with_invalid_properties",
@@ -316,7 +356,8 @@ func TestSchemaObjectClassification(t *testing.T) {
 				},
 			},
 			Want: schema.Classification{
-				Name: "accounts",
+				Name:     "accounts",
+				DataType: knownObjectDataType,
 				Decision: classify.ClassificationDecision{
 					State:  classify.Valid,
 					Reason: "valid_object_with_valid_properties",
@@ -342,7 +383,8 @@ func TestSchemaObjectClassification(t *testing.T) {
 				},
 			},
 			Want: schema.Classification{
-				Name: "accounts",
+				Name:     "accounts",
+				DataType: knownObjectDataType,
 				Decision: classify.ClassificationDecision{
 					State:  classify.Invalid,
 					Reason: "valid_object_with_invalid_properties",
@@ -368,7 +410,8 @@ func TestSchemaObjectClassification(t *testing.T) {
 				},
 			},
 			Want: schema.Classification{
-				Name: "accounts",
+				Name:     "accounts",
+				DataType: knownObjectDataType,
 				Decision: classify.ClassificationDecision{
 					State:  classify.Invalid,
 					Reason: "valid_object_with_invalid_properties",
@@ -394,7 +437,8 @@ func TestSchemaObjectClassification(t *testing.T) {
 				},
 			},
 			Want: schema.Classification{
-				Name: "accounts",
+				Name:     "accounts",
+				DataType: knownObjectDataType,
 				Decision: classify.ClassificationDecision{
 					State:  classify.Potential,
 					Reason: "valid_object_with_invalid_properties",

--- a/pkg/report/schema/datatype/datatype.go
+++ b/pkg/report/schema/datatype/datatype.go
@@ -41,6 +41,10 @@ func (datatype *DataType) GetProperties() map[string]DataTypable {
 	return datatype.Properties
 }
 
+func (datatype *DataType) SetProperties(properties map[string]DataTypable) {
+	datatype.Properties = properties
+}
+
 func (datatype *DataType) GetUUID() string {
 	return datatype.UUID
 }
@@ -76,6 +80,7 @@ type DataTypable interface {
 	SetName(string)
 	GetNode() *parser.Node
 	GetProperties() map[string]DataTypable
+	SetProperties(map[string]DataTypable)
 }
 
 func ExportClassified[D DataTypable](report detections.ReportDetection, detectionType detections.DetectionType, detectorType detectors.Type, idGenerator nodeid.Generator, ignoreFirst bool, values map[parser.NodeID]D) {

--- a/pkg/util/classify/classify_schema.go
+++ b/pkg/util/classify/classify_schema.go
@@ -1,0 +1,55 @@
+package classify
+
+import (
+	"fmt"
+
+	"github.com/bearer/curio/pkg/report/detectors"
+)
+
+var objectStopWords = map[string]struct{}{
+	"this":        {},
+	"props":       {},
+	"prop types":  {},
+	"exports":     {},
+	"export":      {},
+	"env":         {},
+	"argv":        {},
+	"arguments":   {},
+	"errors":      {},
+	"args":        {},
+	"state":       {},
+	"filter":      {},
+	"memberships": {},
+}
+var propertyStopWords = map[string]struct{}{
+	"on click":      {},
+	"disable click": {},
+}
+var databaseDetectorTypes = map[string]struct{}{
+	"sql":   {},
+	"rails": {},
+}
+var expectedIdentifierDataTypeIds = map[string]struct{}{
+	"132": {}, // Unique Identifier
+	"13":  {}, // Device Identifier
+}
+
+func IsDatabase(detectorType detectors.Type) bool {
+	_, ok := databaseDetectorTypes[string(detectorType)]
+	return ok
+}
+
+func ObjectStopWordDetected(name string) bool {
+	_, ok := objectStopWords[name]
+	return ok
+}
+
+func PropertyStopWordDetected(name string) bool {
+	_, ok := propertyStopWords[name]
+	return ok
+}
+
+func IsExpectedIdentifierDataTypeId(id int) bool {
+	_, ok := expectedIdentifierDataTypeIds[fmt.Sprint(id)]
+	return ok
+}

--- a/pkg/util/classify/classify_schema_test.go
+++ b/pkg/util/classify/classify_schema_test.go
@@ -1,0 +1,117 @@
+package classify_test
+
+import (
+	"testing"
+
+	"github.com/bearer/curio/pkg/report/detectors"
+	"github.com/bearer/curio/pkg/util/classify"
+	"github.com/stretchr/testify/assert"
+)
+
+func IsDatabase(t *testing.T) {
+	tests := []struct {
+		Name  string
+		Input detectors.Type
+		Want  bool
+	}{
+		{
+			Name:  "Rails detector",
+			Input: detectors.DetectorRails,
+			Want:  true,
+		},
+		{
+			Name:  "SQL detector",
+			Input: "migrations/user.txt",
+			Want:  true,
+		},
+		{
+			Name:  "Other detector",
+			Input: detectors.DetectorDjango,
+			Want:  false,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.Name, func(t *testing.T) {
+			assert.Equal(t, testCase.Want, classify.IsDatabase(testCase.Input))
+		})
+	}
+}
+
+func ObjectStopWordDetected(t *testing.T) {
+	tests := []struct {
+		Name, Input string
+		Want        bool
+	}{
+		{
+			Name:  "Object stop word",
+			Input: "prop types",
+			Want:  true,
+		},
+		{
+			Name:  "Not an object stop word",
+			Input: "hello world",
+			Want:  false,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.Name, func(t *testing.T) {
+			assert.Equal(t, testCase.Want, classify.ObjectStopWordDetected(testCase.Input))
+		})
+	}
+}
+
+func PropertyStopWordDetected(t *testing.T) {
+	tests := []struct {
+		Name, Input string
+		Want        bool
+	}{
+		{
+			Name:  "Property stop word",
+			Input: "disable click",
+			Want:  true,
+		},
+		{
+			Name:  "Not a property stop word",
+			Input: "hello world",
+			Want:  false,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.Name, func(t *testing.T) {
+			assert.Equal(t, testCase.Want, classify.PropertyStopWordDetected(testCase.Input))
+		})
+	}
+}
+
+func IsExpectedIdentifierDataTypeId(t *testing.T) {
+	tests := []struct {
+		Name  string
+		Input int
+		Want  bool
+	}{
+		{
+			Name:  "Expected identifier data type id",
+			Input: 132,
+			Want:  true,
+		},
+		{
+			Name:  "Expected identifier data type id",
+			Input: 13,
+			Want:  true,
+		},
+		{
+			Name:  "Not an identifier data type id",
+			Input: 244,
+			Want:  false,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.Name, func(t *testing.T) {
+			assert.Equal(t, testCase.Want, classify.IsExpectedIdentifierDataTypeId(testCase.Input))
+		})
+	}
+}


### PR DESCRIPTION
## Description

Add data type to schema classification object

Also some refactoring / clean up of schema classification, namely:

- Nest data type in classification / object patterns
- Return DataTypable in classification object (instead of casting to a data type)
- Pull out some private methods from schema classify method
- Pull out some helper methods from schema classification file to a new `classify_schema` util
- Change data type UUIDs to strings for simplicity (this is what we're [using elsewhere in Curio for UUIDs](https://github.com/Bearer/curio/blob/main/pkg/report/schema/datatype/datatype.go#L25))
- Some refactoring of schema classification methods

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
