### PR TITLE
fix: Omit Commit SHA from detection output when empty

### DIFF
--- a/pkg/detectors/custom/.snapshots/TestRailsEncryptsJSON
+++ b/pkg/detectors/custom/.snapshots/TestRailsEncryptsJSON
@@ -2,7 +2,6 @@
 	{
 		"type": "custom",
 		"detector_type": "detect_rails_encrypts",
-		"commit_sha": "",
 		"source": {
 			"filename": "class.rb",
 			"language": "Ruby",
@@ -23,7 +22,6 @@
 	{
 		"type": "custom",
 		"detector_type": "detect_rails_encrypts",
-		"commit_sha": "",
 		"source": {
 			"filename": "class.rb",
 			"language": "Ruby",

--- a/pkg/detectors/custom/.snapshots/TestRubyLoggersJSON
+++ b/pkg/detectors/custom/.snapshots/TestRubyLoggersJSON
@@ -2,7 +2,6 @@
 	{
 		"type": "custom",
 		"detector_type": "detect_rails_logger",
-		"commit_sha": "",
 		"source": {
 			"filename": "log.rb",
 			"language": "Ruby",
@@ -23,7 +22,6 @@
 	{
 		"type": "custom",
 		"detector_type": "detect_rails_logger",
-		"commit_sha": "",
 		"source": {
 			"filename": "log.rb",
 			"language": "Ruby",
@@ -44,7 +42,6 @@
 	{
 		"type": "custom",
 		"detector_type": "detect_ruby_logger",
-		"commit_sha": "",
 		"source": {
 			"filename": "",
 			"language": "",
@@ -65,7 +62,6 @@
 	{
 		"type": "custom",
 		"detector_type": "detect_ruby_logger",
-		"commit_sha": "",
 		"source": {
 			"filename": "",
 			"language": "",
@@ -86,7 +82,6 @@
 	{
 		"type": "custom",
 		"detector_type": "detect_ruby_logger",
-		"commit_sha": "",
 		"source": {
 			"filename": "",
 			"language": "",
@@ -107,7 +102,6 @@
 	{
 		"type": "custom",
 		"detector_type": "detect_ruby_logger",
-		"commit_sha": "",
 		"source": {
 			"filename": "",
 			"language": "",
@@ -128,7 +122,6 @@
 	{
 		"type": "custom",
 		"detector_type": "detect_ruby_logger",
-		"commit_sha": "",
 		"source": {
 			"filename": "",
 			"language": "",
@@ -149,7 +142,6 @@
 	{
 		"type": "custom",
 		"detector_type": "detect_ruby_logger",
-		"commit_sha": "",
 		"source": {
 			"filename": "",
 			"language": "",
@@ -170,7 +162,6 @@
 	{
 		"type": "custom",
 		"detector_type": "detect_ruby_logger",
-		"commit_sha": "",
 		"source": {
 			"filename": "",
 			"language": "",
@@ -191,7 +182,6 @@
 	{
 		"type": "custom",
 		"detector_type": "detect_ruby_logger",
-		"commit_sha": "",
 		"source": {
 			"filename": "",
 			"language": "",
@@ -212,7 +202,6 @@
 	{
 		"type": "custom",
 		"detector_type": "detect_ruby_logger",
-		"commit_sha": "",
 		"source": {
 			"filename": "log.rb",
 			"language": "Ruby",
@@ -233,7 +222,6 @@
 	{
 		"type": "custom",
 		"detector_type": "detect_ruby_logger",
-		"commit_sha": "",
 		"source": {
 			"filename": "log.rb",
 			"language": "Ruby",
@@ -254,7 +242,6 @@
 	{
 		"type": "custom",
 		"detector_type": "detect_ruby_logger",
-		"commit_sha": "",
 		"source": {
 			"filename": "",
 			"language": "",
@@ -275,7 +262,6 @@
 	{
 		"type": "custom",
 		"detector_type": "detect_ruby_logger",
-		"commit_sha": "",
 		"source": {
 			"filename": "",
 			"language": "",
@@ -296,7 +282,6 @@
 	{
 		"type": "custom",
 		"detector_type": "detect_ruby_logger",
-		"commit_sha": "",
 		"source": {
 			"filename": "",
 			"language": "",
@@ -317,7 +302,6 @@
 	{
 		"type": "custom",
 		"detector_type": "detect_ruby_logger",
-		"commit_sha": "",
 		"source": {
 			"filename": "",
 			"language": "",
@@ -338,7 +322,6 @@
 	{
 		"type": "custom",
 		"detector_type": "detect_ruby_logger",
-		"commit_sha": "",
 		"source": {
 			"filename": "",
 			"language": "",
@@ -359,7 +342,6 @@
 	{
 		"type": "custom",
 		"detector_type": "detect_ruby_logger",
-		"commit_sha": "",
 		"source": {
 			"filename": "",
 			"language": "",

--- a/pkg/detectors/custom/.snapshots/TestSQLCreateFunctionJSON
+++ b/pkg/detectors/custom/.snapshots/TestSQLCreateFunctionJSON
@@ -2,7 +2,6 @@
 	{
 		"type": "custom",
 		"detector_type": "create_sql_function_detector",
-		"commit_sha": "",
 		"source": {
 			"filename": "structure.sql",
 			"language": "PLpgSQL",
@@ -23,7 +22,6 @@
 	{
 		"type": "custom",
 		"detector_type": "create_sql_function_detector",
-		"commit_sha": "",
 		"source": {
 			"filename": "structure.sql",
 			"language": "PLpgSQL",
@@ -44,7 +42,6 @@
 	{
 		"type": "custom",
 		"detector_type": "create_sql_function_detector",
-		"commit_sha": "",
 		"source": {
 			"filename": "structure.sql",
 			"language": "PLpgSQL",
@@ -65,7 +62,6 @@
 	{
 		"type": "custom",
 		"detector_type": "create_sql_function_detector",
-		"commit_sha": "",
 		"source": {
 			"filename": "structure.sql",
 			"language": "PLpgSQL",
@@ -86,7 +82,6 @@
 	{
 		"type": "custom",
 		"detector_type": "create_sql_function_detector",
-		"commit_sha": "",
 		"source": {
 			"filename": "structure.sql",
 			"language": "PLpgSQL",
@@ -107,7 +102,6 @@
 	{
 		"type": "custom",
 		"detector_type": "create_sql_function_detector",
-		"commit_sha": "",
 		"source": {
 			"filename": "structure.sql",
 			"language": "PLpgSQL",

--- a/pkg/detectors/custom/.snapshots/TestSQLCreateTableJSON
+++ b/pkg/detectors/custom/.snapshots/TestSQLCreateTableJSON
@@ -2,7 +2,6 @@
 	{
 		"type": "custom",
 		"detector_type": "detect_sql_create_table",
-		"commit_sha": "",
 		"source": {
 			"filename": "structure.sql",
 			"language": "SQL",
@@ -23,7 +22,6 @@
 	{
 		"type": "custom",
 		"detector_type": "detect_sql_create_table",
-		"commit_sha": "",
 		"source": {
 			"filename": "structure.sql",
 			"language": "SQL",
@@ -44,7 +42,6 @@
 	{
 		"type": "custom",
 		"detector_type": "detect_sql_create_table",
-		"commit_sha": "",
 		"source": {
 			"filename": "structure.sql",
 			"language": "SQL",
@@ -65,7 +62,6 @@
 	{
 		"type": "custom",
 		"detector_type": "detect_sql_create_table",
-		"commit_sha": "",
 		"source": {
 			"filename": "structure.sql",
 			"language": "SQL",
@@ -86,7 +82,6 @@
 	{
 		"type": "custom",
 		"detector_type": "detect_sql_create_table",
-		"commit_sha": "",
 		"source": {
 			"filename": "structure.sql",
 			"language": "SQL",
@@ -107,7 +102,6 @@
 	{
 		"type": "custom",
 		"detector_type": "detect_sql_create_table",
-		"commit_sha": "",
 		"source": {
 			"filename": "structure.sql",
 			"language": "SQL",
@@ -128,7 +122,6 @@
 	{
 		"type": "custom",
 		"detector_type": "detect_sql_create_table",
-		"commit_sha": "",
 		"source": {
 			"filename": "structure.sql",
 			"language": "SQL",
@@ -149,7 +142,6 @@
 	{
 		"type": "custom",
 		"detector_type": "detect_sql_create_table",
-		"commit_sha": "",
 		"source": {
 			"filename": "structure.sql",
 			"language": "SQL",
@@ -170,7 +162,6 @@
 	{
 		"type": "custom",
 		"detector_type": "detect_sql_create_table",
-		"commit_sha": "",
 		"source": {
 			"filename": "structure.sql",
 			"language": "SQL",
@@ -191,7 +182,6 @@
 	{
 		"type": "custom",
 		"detector_type": "detect_sql_create_table",
-		"commit_sha": "",
 		"source": {
 			"filename": "structure.sql",
 			"language": "SQL",
@@ -212,7 +202,6 @@
 	{
 		"type": "custom",
 		"detector_type": "detect_sql_create_table",
-		"commit_sha": "",
 		"source": {
 			"filename": "structure.sql",
 			"language": "SQL",
@@ -233,7 +222,6 @@
 	{
 		"type": "custom",
 		"detector_type": "detect_sql_create_table",
-		"commit_sha": "",
 		"source": {
 			"filename": "structure.sql",
 			"language": "SQL",

--- a/pkg/detectors/custom/.snapshots/TestSQLCreateTriggerJSON
+++ b/pkg/detectors/custom/.snapshots/TestSQLCreateTriggerJSON
@@ -2,7 +2,6 @@
  {
   "type": "custom",
   "detector_type": "sql_create_trigger_detector",
-  "commit_sha": "",
   "source": {
    "filename": "trigger.sql",
    "language": "SQL",
@@ -23,7 +22,6 @@
  {
   "type": "custom",
   "detector_type": "sql_create_trigger_detector",
-  "commit_sha": "",
   "source": {
    "filename": "trigger.sql",
    "language": "SQL",

--- a/pkg/detectors/sql/.snapshots/TestCreateView
+++ b/pkg/detectors/sql/.snapshots/TestCreateView
@@ -2,7 +2,6 @@
 	{
 		"type": "create_view",
 		"detector_type": "sql",
-		"commit_sha": "",
 		"source": {
 			"filename": "structure.sql",
 			"language": "SQL",
@@ -123,7 +122,6 @@
 	{
 		"type": "create_view",
 		"detector_type": "sql",
-		"commit_sha": "",
 		"source": {
 			"filename": "structure.sql",
 			"language": "SQL",
@@ -244,7 +242,6 @@
 	{
 		"type": "create_view",
 		"detector_type": "sql",
-		"commit_sha": "",
 		"source": {
 			"filename": "structure.sql",
 			"language": "SQL",
@@ -418,7 +415,6 @@
 	{
 		"type": "create_view",
 		"detector_type": "sql",
-		"commit_sha": "",
 		"source": {
 			"filename": "structure.sql",
 			"language": "SQL",
@@ -539,7 +535,6 @@
 	{
 		"type": "create_view",
 		"detector_type": "sql",
-		"commit_sha": "",
 		"source": {
 			"filename": "structure.sql",
 			"language": "SQL",
@@ -727,7 +722,6 @@
 	{
 		"type": "create_view",
 		"detector_type": "sql",
-		"commit_sha": "",
 		"source": {
 			"filename": "structure.sql",
 			"language": "SQL",

--- a/pkg/report/detections/detections.go
+++ b/pkg/report/detections/detections.go
@@ -48,7 +48,7 @@ type FrameworkDetection struct {
 	Type          DetectionType   `json:"type"`
 	DetectorType  detectors.Type  `json:"detector_type"`
 	FrameworkType frameworks.Type `json:"framework_detection_type"`
-	CommitSHA     string          `json:"commit_sha"`
+	CommitSHA     string          `json:"commit_sha,omitempty"`
 	Source        source.Source   `json:"source"`
 	Value         interface{}     `json:"value"`
 }
@@ -56,7 +56,7 @@ type FrameworkDetection struct {
 type Detection struct {
 	Type         DetectionType  `json:"type"`
 	DetectorType detectors.Type `json:"detector_type"`
-	CommitSHA    string         `json:"commit_sha"`
+	CommitSHA    string         `json:"commit_sha,omitempty"`
 	Source       source.Source  `json:"source"`
 	Value        interface{}    `json:"value"`
 }


### PR DESCRIPTION
## Description

When the commit SHA is empty, it should not appear in the raw detection output.

Example of raw output including empty commit SHA:

```json
{
		"classification": {
			"decision": {
				"reason": "domain_not_reachable",
				"state": 2
			},
			"recipe_match": false,
			"url": "https://datadoghq.eu"
		},
		"commit_sha": "",
		"detector_type": "yaml_config",
		"source": {
			"column_number": 7,
			"filename": ".drone.yml",
			"language": "YAML",
			"language_type": "data",
			"line_number": 83,
			"text": "DD_SITE: datadoghq.eu"
		},
		"type": "interface_classified",
		"value": {
			"type": "url",
			"value": {
				"parts": [
					{
						"type": "string",
						"value": "datadoghq.eu"
					}
				]
			},
			"variable_name": "DD_SITE"
		}
	}
```

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [X] I've updated or added documentation if required.
- [X] I've included usage information in the description if CLI behavior was updated or added.
- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
