### PR TITLE
chore: Remove object and field UUIDs from output

### DIFF
--- a/pkg/detectors/custom/.snapshots/TestRailsEncryptsJSON
+++ b/pkg/detectors/custom/.snapshots/TestRailsEncryptsJSON
@@ -12,9 +12,7 @@
 		},
 		"value": {
 			"object_name": "",
-			"object_uuid": "1",
 			"field_name": "User",
-			"field_uuid": "2",
 			"field_type": "",
 			"field_type_simple": "object",
 			"classification": null
@@ -33,9 +31,7 @@
 		},
 		"value": {
 			"object_name": "User",
-			"object_uuid": "2",
 			"field_name": "email",
-			"field_uuid": "3",
 			"field_type": "",
 			"field_type_simple": "unknown",
 			"classification": null

--- a/pkg/detectors/custom/.snapshots/TestRubyLoggersJSON
+++ b/pkg/detectors/custom/.snapshots/TestRubyLoggersJSON
@@ -12,9 +12,7 @@
 		},
 		"value": {
 			"object_name": "",
-			"object_uuid": "1",
 			"field_name": "address",
-			"field_uuid": "2",
 			"field_type": "",
 			"field_type_simple": "unknown",
 			"classification": null
@@ -33,9 +31,7 @@
 		},
 		"value": {
 			"object_name": "",
-			"object_uuid": "3",
 			"field_name": "address2",
-			"field_uuid": "4",
 			"field_type": "",
 			"field_type_simple": "unknown",
 			"classification": null
@@ -54,9 +50,7 @@
 		},
 		"value": {
 			"object_name": "",
-			"object_uuid": "7",
 			"field_name": "user",
-			"field_uuid": "5",
 			"field_type": "",
 			"field_type_simple": "unknown",
 			"classification": null
@@ -75,9 +69,7 @@
 		},
 		"value": {
 			"object_name": "user",
-			"object_uuid": "5",
 			"field_name": "email",
-			"field_uuid": "6",
 			"field_type": "",
 			"field_type_simple": "unknown",
 			"classification": null
@@ -96,9 +88,7 @@
 		},
 		"value": {
 			"object_name": "",
-			"object_uuid": "10",
 			"field_name": "user",
-			"field_uuid": "8",
 			"field_type": "",
 			"field_type_simple": "unknown",
 			"classification": null
@@ -117,9 +107,7 @@
 		},
 		"value": {
 			"object_name": "user",
-			"object_uuid": "8",
 			"field_name": "email",
-			"field_uuid": "9",
 			"field_type": "",
 			"field_type_simple": "unknown",
 			"classification": null
@@ -138,9 +126,7 @@
 		},
 		"value": {
 			"object_name": "",
-			"object_uuid": "15",
 			"field_name": "user",
-			"field_uuid": "11",
 			"field_type": "",
 			"field_type_simple": "unknown",
 			"classification": null
@@ -159,9 +145,7 @@
 		},
 		"value": {
 			"object_name": "user",
-			"object_uuid": "11",
 			"field_name": "contact",
-			"field_uuid": "12",
 			"field_type": "",
 			"field_type_simple": "unknown",
 			"classification": null
@@ -180,9 +164,7 @@
 		},
 		"value": {
 			"object_name": "contact",
-			"object_uuid": "12",
 			"field_name": "email",
-			"field_uuid": "13",
 			"field_type": "",
 			"field_type_simple": "unknown",
 			"classification": null
@@ -201,9 +183,7 @@
 		},
 		"value": {
 			"object_name": "email",
-			"object_uuid": "13",
 			"field_name": "address",
-			"field_uuid": "14",
 			"field_type": "",
 			"field_type_simple": "unknown",
 			"classification": null
@@ -222,9 +202,7 @@
 		},
 		"value": {
 			"object_name": "",
-			"object_uuid": "16",
 			"field_name": "user",
-			"field_uuid": "17",
 			"field_type": "",
 			"field_type_simple": "unknown",
 			"classification": null
@@ -243,9 +221,7 @@
 		},
 		"value": {
 			"object_name": "",
-			"object_uuid": "16",
 			"field_name": "email",
-			"field_uuid": "18",
 			"field_type": "",
 			"field_type_simple": "unknown",
 			"classification": null
@@ -264,9 +240,7 @@
 		},
 		"value": {
 			"object_name": "",
-			"object_uuid": "21",
 			"field_name": "user",
-			"field_uuid": "19",
 			"field_type": "",
 			"field_type_simple": "unknown",
 			"classification": null
@@ -285,9 +259,7 @@
 		},
 		"value": {
 			"object_name": "user",
-			"object_uuid": "19",
 			"field_name": "email",
-			"field_uuid": "20",
 			"field_type": "",
 			"field_type_simple": "unknown",
 			"classification": null
@@ -306,9 +278,7 @@
 		},
 		"value": {
 			"object_name": "",
-			"object_uuid": "25",
 			"field_name": "user",
-			"field_uuid": "22",
 			"field_type": "",
 			"field_type_simple": "unknown",
 			"classification": null
@@ -327,9 +297,7 @@
 		},
 		"value": {
 			"object_name": "user",
-			"object_uuid": "22",
 			"field_name": "name",
-			"field_uuid": "23",
 			"field_type": "",
 			"field_type_simple": "unknown",
 			"classification": null
@@ -348,9 +316,7 @@
 		},
 		"value": {
 			"object_name": "",
-			"object_uuid": "25",
 			"field_name": "user",
-			"field_uuid": "22",
 			"field_type": "",
 			"field_type_simple": "unknown",
 			"classification": null
@@ -369,9 +335,7 @@
 		},
 		"value": {
 			"object_name": "user",
-			"object_uuid": "22",
 			"field_name": "email",
-			"field_uuid": "24",
 			"field_type": "",
 			"field_type_simple": "unknown",
 			"classification": null

--- a/pkg/detectors/custom/.snapshots/TestSQLCreateFunctionJSON
+++ b/pkg/detectors/custom/.snapshots/TestSQLCreateFunctionJSON
@@ -12,9 +12,7 @@
 		},
 		"value": {
 			"object_name": "",
-			"object_uuid": "1",
 			"field_name": "anon_account",
-			"field_uuid": "2",
 			"field_type": "",
 			"field_type_simple": "object",
 			"classification": null
@@ -33,9 +31,7 @@
 		},
 		"value": {
 			"object_name": "anon_account",
-			"object_uuid": "2",
 			"field_name": "first_name",
-			"field_uuid": "3",
 			"field_type": "",
 			"field_type_simple": "unknown",
 			"classification": null
@@ -54,9 +50,7 @@
 		},
 		"value": {
 			"object_name": "anon_account",
-			"object_uuid": "2",
 			"field_name": "kind",
-			"field_uuid": "4",
 			"field_type": "",
 			"field_type_simple": "unknown",
 			"classification": null
@@ -75,9 +69,7 @@
 		},
 		"value": {
 			"object_name": "anon_account",
-			"object_uuid": "2",
 			"field_name": "last_name",
-			"field_uuid": "5",
 			"field_type": "",
 			"field_type_simple": "unknown",
 			"classification": null
@@ -96,9 +88,7 @@
 		},
 		"value": {
 			"object_name": "anon_account",
-			"object_uuid": "2",
 			"field_name": "phone_number",
-			"field_uuid": "6",
 			"field_type": "",
 			"field_type_simple": "unknown",
 			"classification": null
@@ -117,9 +107,7 @@
 		},
 		"value": {
 			"object_name": "anon_account",
-			"object_uuid": "2",
 			"field_name": "pin_digest",
-			"field_uuid": "7",
 			"field_type": "",
 			"field_type_simple": "unknown",
 			"classification": null

--- a/pkg/detectors/custom/.snapshots/TestSQLCreateTableJSON
+++ b/pkg/detectors/custom/.snapshots/TestSQLCreateTableJSON
@@ -12,9 +12,7 @@
 		},
 		"value": {
 			"object_name": "",
-			"object_uuid": "1",
 			"field_name": "users",
-			"field_uuid": "2",
 			"field_type": "",
 			"field_type_simple": "object",
 			"classification": null
@@ -33,9 +31,7 @@
 		},
 		"value": {
 			"object_name": "users",
-			"object_uuid": "2",
 			"field_name": "id",
-			"field_uuid": "3",
 			"field_type": "bigint",
 			"field_type_simple": "number",
 			"classification": null
@@ -54,9 +50,7 @@
 		},
 		"value": {
 			"object_name": "",
-			"object_uuid": "4",
 			"field_name": "users",
-			"field_uuid": "5",
 			"field_type": "",
 			"field_type_simple": "object",
 			"classification": null
@@ -75,9 +69,7 @@
 		},
 		"value": {
 			"object_name": "users",
-			"object_uuid": "5",
 			"field_name": "class_id",
-			"field_uuid": "6",
 			"field_type": "bigint",
 			"field_type_simple": "number",
 			"classification": null
@@ -96,9 +88,7 @@
 		},
 		"value": {
 			"object_name": "",
-			"object_uuid": "7",
 			"field_name": "users",
-			"field_uuid": "8",
 			"field_type": "",
 			"field_type_simple": "object",
 			"classification": null
@@ -117,9 +107,7 @@
 		},
 		"value": {
 			"object_name": "users",
-			"object_uuid": "8",
 			"field_name": "type",
-			"field_uuid": "9",
 			"field_type": "character",
 			"field_type_simple": "string",
 			"classification": null
@@ -138,9 +126,7 @@
 		},
 		"value": {
 			"object_name": "",
-			"object_uuid": "10",
 			"field_name": "users",
-			"field_uuid": "11",
 			"field_type": "",
 			"field_type_simple": "object",
 			"classification": null
@@ -159,9 +145,7 @@
 		},
 		"value": {
 			"object_name": "users",
-			"object_uuid": "11",
 			"field_name": "metadata",
-			"field_uuid": "12",
 			"field_type": "json",
 			"field_type_simple": "object",
 			"classification": null
@@ -180,9 +164,7 @@
 		},
 		"value": {
 			"object_name": "",
-			"object_uuid": "13",
 			"field_name": "users",
-			"field_uuid": "14",
 			"field_type": "",
 			"field_type_simple": "object",
 			"classification": null
@@ -201,9 +183,7 @@
 		},
 		"value": {
 			"object_name": "users",
-			"object_uuid": "14",
 			"field_name": "created_at",
-			"field_uuid": "15",
 			"field_type": "timestamp",
 			"field_type_simple": "date",
 			"classification": null
@@ -222,9 +202,7 @@
 		},
 		"value": {
 			"object_name": "",
-			"object_uuid": "16",
 			"field_name": "users",
-			"field_uuid": "17",
 			"field_type": "",
 			"field_type_simple": "object",
 			"classification": null
@@ -243,9 +221,7 @@
 		},
 		"value": {
 			"object_name": "users",
-			"object_uuid": "17",
 			"field_name": "updated_at",
-			"field_uuid": "18",
 			"field_type": "timestamp",
 			"field_type_simple": "date",
 			"classification": null

--- a/pkg/detectors/custom/.snapshots/TestSQLCreateTriggerJSON
+++ b/pkg/detectors/custom/.snapshots/TestSQLCreateTriggerJSON
@@ -12,9 +12,7 @@
   },
   "value": {
    "object_name": "",
-   "object_uuid": "1",
    "field_name": "accounts",
-   "field_uuid": "2",
    "field_type": "",
    "field_type_simple": "object",
    "classification": null
@@ -33,9 +31,7 @@
   },
   "value": {
    "object_name": "accounts",
-   "object_uuid": "2",
    "field_name": "anon_account",
-   "field_uuid": "3",
    "field_type": "",
    "field_type_simple": "object",
    "classification": null

--- a/pkg/report/schema/schema.go
+++ b/pkg/report/schema/schema.go
@@ -18,9 +18,9 @@ const (
 
 type Schema struct {
 	ObjectName      string      `json:"object_name"`
-	ObjectUUID      string      `json:"object_uuid"`
+	ObjectUUID      string      `json:"-"`
 	FieldName       string      `json:"field_name"`
-	FieldUUID       string      `json:"field_uuid"`
+	FieldUUID       string      `json:"-"`
 	FieldType       string      `json:"field_type"`
 	SimpleFieldType string      `json:"field_type_simple"`
 	Classification  interface{} `json:"classification"`


### PR DESCRIPTION
## Description

We should not expose UUIDs of objects and fields in the output: being non-deterministic for the represented objects/fields, these are not currently suitable for external consumption.

## Checklist

- [X] I've added test coverage that shows my fix or feature works as expected.
- [X] I've updated or added documentation if required.
- [X] I've included usage information in the description if CLI behavior was updated or added.
- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
