### PR TITLE
chore: Consolidate output and error stream usage

### DIFF
--- a/integration/flags/.snapshots/TestMetadataFlags-version
+++ b/integration/flags/.snapshots/TestMetadataFlags-version
@@ -1,5 +1,5 @@
-
---
 curio version: dev
 sha: devSHA
+
+--
 

--- a/integration/internal/testhelper/testhelper.go
+++ b/integration/internal/testhelper/testhelper.go
@@ -46,18 +46,8 @@ func executeApp(arguments []string, port int) (string, error) {
 		panic(err)
 	}
 
-	stdout := os.Stdout
-	os.Stdout = stdoutWriter
-	defer func() {
-		os.Stdout = stdout
-	}()
-
-	stderr := os.Stderr
-	os.Stderr = stderrWriter
-	defer func() {
-		os.Stderr = stderr
-	}()
-
+	app.SetOut(stdoutWriter)
+	app.SetErr(stderrWriter)
 	app.SetArgs(arguments)
 
 	if err := app.Execute(); err != nil {

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -2,8 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"io"
-	"os"
 
 	"github.com/bearer/curio/pkg/commands/artifact"
 	"github.com/bearer/curio/pkg/flag"
@@ -14,15 +12,6 @@ import (
 // VersionInfo holds the curio version
 type VersionInfo struct {
 	Version string `json:",omitempty"`
-}
-
-var (
-	outputWriter io.Writer = os.Stdout
-)
-
-// SetOut overrides the destination for messages
-func SetOut(out io.Writer) {
-	outputWriter = out
 }
 
 // NewApp is the factory method to return Curio CLI
@@ -89,7 +78,7 @@ func NewConfigCommand() *cobra.Command {
 			if err := configFlags.Bind(cmd); err != nil {
 				return xerrors.Errorf("flag bind error: %w", err)
 			}
-			options, err := configFlags.ToOptions(args, outputWriter)
+			options, err := configFlags.ToOptions(args, cmd.OutOrStdout())
 			if err != nil {
 				return xerrors.Errorf("flag error: %w", err)
 			}

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -78,7 +78,7 @@ func NewConfigCommand() *cobra.Command {
 			if err := configFlags.Bind(cmd); err != nil {
 				return xerrors.Errorf("flag bind error: %w", err)
 			}
-			options, err := configFlags.ToOptions(args, cmd.OutOrStdout())
+			options, err := configFlags.ToOptions(args)
 			if err != nil {
 				return xerrors.Errorf("flag error: %w", err)
 			}

--- a/pkg/commands/init.go
+++ b/pkg/commands/init.go
@@ -19,7 +19,7 @@ func NewInitCommand() *cobra.Command {
 				return fmt.Errorf("flag bind error: %w", err)
 			}
 
-			options, err := scanFlags.ToOptions(args, cmd.OutOrStdout())
+			options, err := scanFlags.ToOptions(args)
 			if err != nil {
 				return xerrors.Errorf("flag error: %w", err)
 			}

--- a/pkg/commands/init.go
+++ b/pkg/commands/init.go
@@ -19,7 +19,7 @@ func NewInitCommand() *cobra.Command {
 				return fmt.Errorf("flag bind error: %w", err)
 			}
 
-			options, err := scanFlags.ToOptions(args, outputWriter)
+			options, err := scanFlags.ToOptions(args, cmd.OutOrStdout())
 			if err != nil {
 				return xerrors.Errorf("flag error: %w", err)
 			}

--- a/pkg/commands/processing_worker.go
+++ b/pkg/commands/processing_worker.go
@@ -24,7 +24,7 @@ func NewProcessingWorkerCommand() *cobra.Command {
 				return fmt.Errorf("flag bind error: %w", err)
 			}
 
-			generalOptions, err := flags.ToOptions(args, cmd.OutOrStdout())
+			generalOptions, err := flags.ToOptions(args)
 			if err != nil {
 				return fmt.Errorf("options binding error: %w", err)
 			}

--- a/pkg/commands/processing_worker.go
+++ b/pkg/commands/processing_worker.go
@@ -24,7 +24,7 @@ func NewProcessingWorkerCommand() *cobra.Command {
 				return fmt.Errorf("flag bind error: %w", err)
 			}
 
-			generalOptions, err := flags.ToOptions(args, outputWriter)
+			generalOptions, err := flags.ToOptions(args, cmd.OutOrStdout())
 			if err != nil {
 				return fmt.Errorf("options binding error: %w", err)
 			}

--- a/pkg/commands/processing_worker.go
+++ b/pkg/commands/processing_worker.go
@@ -29,7 +29,7 @@ func NewProcessingWorkerCommand() *cobra.Command {
 				return fmt.Errorf("options binding error: %w", err)
 			}
 
-			output.Setup(generalOptions)
+			output.Setup(cmd, generalOptions)
 
 			processOptions, err := flags.ProcessFlagGroup.ToOptions()
 			if err != nil {

--- a/pkg/commands/scan.go
+++ b/pkg/commands/scan.go
@@ -62,7 +62,7 @@ func NewScanCommand() *cobra.Command {
 				return err
 			}
 
-			options, err := scanFlags.ToOptions(args, outputWriter)
+			options, err := scanFlags.ToOptions(args, cmd.OutOrStdout())
 			if err != nil {
 				return xerrors.Errorf("flag error: %w", err)
 			}

--- a/pkg/commands/scan.go
+++ b/pkg/commands/scan.go
@@ -67,7 +67,7 @@ func NewScanCommand() *cobra.Command {
 				return xerrors.Errorf("flag error: %w", err)
 			}
 
-			output.Setup(options)
+			output.Setup(cmd, options)
 
 			if options.Target == "" {
 				return cmd.Help()

--- a/pkg/commands/scan.go
+++ b/pkg/commands/scan.go
@@ -62,7 +62,7 @@ func NewScanCommand() *cobra.Command {
 				return err
 			}
 
-			options, err := scanFlags.ToOptions(args, cmd.OutOrStdout())
+			options, err := scanFlags.ToOptions(args)
 			if err != nil {
 				return xerrors.Errorf("flag error: %w", err)
 			}

--- a/pkg/flag/options.go
+++ b/pkg/flag/options.go
@@ -2,7 +2,6 @@ package flag
 
 import (
 	"fmt"
-	"io"
 	"strings"
 	"time"
 
@@ -232,7 +231,7 @@ func (f *Flags) bind(cmd *cobra.Command, supportIgnoreConfig bool) error {
 }
 
 // nolint: gocyclo
-func (f *Flags) ToOptions(args []string, output io.Writer) (Options, error) {
+func (f *Flags) ToOptions(args []string) (Options, error) {
 	var err error
 	opts := Options{}
 
@@ -241,7 +240,7 @@ func (f *Flags) ToOptions(args []string, output io.Writer) (Options, error) {
 	}
 
 	if f.ReportFlagGroup != nil {
-		opts.ReportOptions = f.ReportFlagGroup.ToOptions(output)
+		opts.ReportOptions = f.ReportFlagGroup.ToOptions()
 	}
 
 	if f.WorkerFlagGroup != nil {

--- a/pkg/flag/report_flags.go
+++ b/pkg/flag/report_flags.go
@@ -1,7 +1,6 @@
 package flag
 
 import (
-	"io"
 )
 
 type Severity int
@@ -68,7 +67,7 @@ func (f *ReportFlagGroup) Flags() []*Flag {
 	}
 }
 
-func (f *ReportFlagGroup) ToOptions(out io.Writer) ReportOptions {
+func (f *ReportFlagGroup) ToOptions() ReportOptions {
 	return ReportOptions{
 		Format: getString(f.Format),
 		Report: getString(f.Report),

--- a/pkg/util/output/output.go
+++ b/pkg/util/output/output.go
@@ -7,15 +7,21 @@ import (
 	"github.com/bearer/curio/pkg/flag"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+)
+
+var (
+	outputWriter io.Writer = os.Stdout
+	errorWriter io.Writer = os.Stderr
 )
 
 // DefaultLogger returns default output logger
 func StdOutLogger() *zerolog.Event {
-	return PlainLogger(os.Stdout)
+	return PlainLogger(outputWriter)
 }
 
 func StdErrLogger() *zerolog.Event {
-	return PlainLogger(os.Stderr)
+	return PlainLogger(errorWriter)
 }
 
 func PlainLogger(out io.Writer) *zerolog.Event {
@@ -33,7 +39,10 @@ func PlainLogger(out io.Writer) *zerolog.Event {
 	return logger.Info()
 }
 
-func Setup(options flag.Options) {
+func Setup(cmd *cobra.Command, options flag.Options) {
+	outputWriter = cmd.OutOrStdout()
+	errorWriter = cmd.ErrOrStderr()
+
 	if options.Debug {
 		zerolog.SetGlobalLevel(zerolog.DebugLevel)
 	} else {

--- a/pkg/util/output/progress_bar.go
+++ b/pkg/util/output/progress_bar.go
@@ -1,8 +1,6 @@
 package output
 
 import (
-	"os"
-
 	"github.com/bearer/curio/pkg/commands/process/settings"
 	"github.com/schollz/progressbar/v3"
 )
@@ -10,7 +8,7 @@ import (
 func GetProgressBar(filesLength int, config settings.Config) *progressbar.ProgressBar {
 	return progressbar.NewOptions(filesLength,
 		progressbar.OptionSetVisibility(!config.Scan.Debug),
-		progressbar.OptionSetWriter(os.Stderr),
+		progressbar.OptionSetWriter(outputWriter),
 		progressbar.OptionShowCount(),
 		progressbar.OptionEnableColorCodes(false),
 		progressbar.OptionShowElapsedTimeOnFinish(),


### PR DESCRIPTION
## Description

Curio's CLI architecture is obtained from the use of the Cobra framework. If we use the Cobra output and error streams correctly, then it would not be necessary to temporarily switch stdout/stderr in integration tests.

This change makes a start on consolidating and standardizing the various output stream mechanisms that are currently in use. The primary objective is to be capture the Cobra output and error streams directly in the integration tests. There may be further work to do around consolidating/standardizing output and error stream usage in the codebase.

## Checklist

- [X] I've added test coverage that shows my fix or feature works as expected.
- [X] I've updated or added documentation if required.
- [X] I've included usage information in the description if CLI behavior was updated or added.
- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
