### PR TITLE
fix: fix faulty TCP location in worker.go

### DIFF
--- a/integration/internal/testhelper/testhelper.go
+++ b/integration/internal/testhelper/testhelper.go
@@ -23,8 +23,8 @@ type TestCase struct {
 
 func NewTestCase(name string, arguments []string) *TestCase {
 	return &TestCase{
-		Name: name,
-		Arguments: arguments,
+		Name:          name,
+		Arguments:     arguments,
 		ShouldSucceed: true,
 	}
 }
@@ -77,7 +77,7 @@ func executeApp(arguments []string, port int) (string, error) {
 func startWorker(port int) error {
 	app := commands.NewApp(build.Version, build.CommitSHA)
 
-	arguments := []string{"processing-worker", "--port=:" + strconv.Itoa(port), "--debug"}
+	arguments := []string{"processing-worker", "--port=" + strconv.Itoa(port), "--debug"}
 
 	app.SetArgs(arguments)
 

--- a/pkg/commands/process/worker/worker.go
+++ b/pkg/commands/process/worker/worker.go
@@ -18,7 +18,7 @@ import (
 func Start(port string) error {
 	var classifier *classification.Classifier
 
-	err := http.ListenAndServe(`localhost`+port, http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+	err := http.ListenAndServe(`localhost:`+port, http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close() //golint:all,errcheck
 
 		response := work.StatusResponse{}


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Fix this

```bash
$ go run cmd/curio/main.go scan ../api-management-app
2022/11/09 12:40:31 listen tcp: address localhost0: missing port in address
```

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
