### PR TITLE
fix: process port undefined

### DIFF
--- a/pkg/commands/process/balancer/worker.go
+++ b/pkg/commands/process/balancer/worker.go
@@ -235,6 +235,7 @@ func (worker *Worker) SpawnProcess(task *workertype.ProcessRequest) error {
 		task:           worker.task,
 		workerUrl:      worker.workerURL,
 
+		port:   worker.port,
 		config: worker.config,
 
 		uuid:       uuid.NewString(),


### PR DESCRIPTION
## Description
Fixes bug when process was looking for worker on undefined `0` port


## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
