### PR TITLE
feat: add components to dataflow

### DIFF
--- a/pkg/report/output/dataflow/components/components.go
+++ b/pkg/report/output/dataflow/components/components.go
@@ -1,0 +1,121 @@
+package components
+
+import (
+	"strings"
+
+	"github.com/bearer/curio/pkg/report/output/dataflow/detectiondecoder"
+	"github.com/bearer/curio/pkg/report/output/dataflow/types"
+
+	"github.com/bearer/curio/pkg/util/classify"
+	"github.com/bearer/curio/pkg/util/maputil"
+)
+
+type Holder struct {
+	components map[string]*component // group components by name
+}
+
+type component struct {
+	name      string
+	detectors map[string]*detector // group detectors by detectorName
+}
+type detector struct {
+	name  string
+	files map[string]*fileHolder // group files by filename
+}
+type fileHolder struct {
+	name        string
+	lineNumbers map[int]int //group lines by linenumber
+}
+
+func New() *Holder {
+	return &Holder{
+		components: make(map[string]*component),
+	}
+}
+
+func (holder *Holder) AddInterface(detection interface{}) error {
+	value, err := detectiondecoder.GetClassifiedInterface(detection)
+	if err != nil {
+		return err
+	}
+
+	if value.Classification.Decision.State == classify.Valid {
+		holder.addComponent(strings.ToLower(value.Classification.RecipeName), string(value.DetectorType), value.Source.Filename, *value.Source.LineNumber)
+	}
+
+	return nil
+}
+
+func (holder *Holder) AddDependency(detection interface{}) error {
+	value, err := detectiondecoder.GetClassifiedDependency(detection)
+	if err != nil {
+		return err
+	}
+
+	if value.Classification.Decision.State == classify.Valid {
+		holder.addComponent(strings.ToLower(value.Classification.RecipeName), string(value.DetectorType), value.Source.Filename, *value.Source.LineNumber)
+	}
+
+	return nil
+}
+
+// addComponent adds component to hash list and at the same time blocks duplicates
+func (holder *Holder) addComponent(componentName string, detectorName string, fileName string, lineNumber int) {
+	// create component entry if it doesn't exist
+	if _, exists := holder.components[componentName]; !exists {
+		holder.components[componentName] = &component{
+			name:      componentName,
+			detectors: make(map[string]*detector),
+		}
+	}
+
+	targetComponent := holder.components[componentName]
+	// create detector entry if it doesn't exist
+	if _, exists := targetComponent.detectors[detectorName]; !exists {
+		targetComponent.detectors[detectorName] = &detector{
+			name:  detectorName,
+			files: make(map[string]*fileHolder),
+		}
+	}
+
+	targetDetector := targetComponent.detectors[detectorName]
+	// create file entry if it doesn't exist
+	if _, exists := targetDetector.files[fileName]; !exists {
+		targetDetector.files[fileName] = &fileHolder{
+			name:        fileName,
+			lineNumbers: make(map[int]int),
+		}
+	}
+
+	targetDetector.files[fileName].lineNumbers[lineNumber] = lineNumber
+
+}
+
+func (holder *Holder) ToDataFlow() []types.Component {
+	data := make([]types.Component, 0)
+
+	availableComponents := maputil.ToSortedSlice(holder.components)
+
+	for _, targetComponent := range availableComponents {
+		constructedComponent := types.Component{
+			Name:      targetComponent.name,
+			Locations: make([]types.ComponentLocation, 0),
+		}
+
+		for _, targetDetector := range maputil.ToSortedSlice(targetComponent.detectors) {
+			for _, targetFile := range maputil.ToSortedSlice(targetDetector.files) {
+				for _, targetLineNumber := range maputil.ToSortedSlice(targetFile.lineNumbers) {
+					constructedComponent.Locations = append(constructedComponent.Locations, types.ComponentLocation{
+						Filename:   targetFile.name,
+						LineNumber: targetLineNumber,
+						Detector:   targetDetector.name,
+					})
+				}
+			}
+		}
+
+		data = append(data, constructedComponent)
+	}
+
+	return data
+}

--- a/pkg/report/output/dataflow/datatypes/datatypes.go
+++ b/pkg/report/output/dataflow/datatypes/datatypes.go
@@ -33,7 +33,7 @@ func New() *Holder {
 }
 
 func (holder *Holder) AddSchema(detection detections.Detection) error {
-	classification, err := detectiondecoder.GetClassification(detection)
+	classification, err := detectiondecoder.GetSchemaClassification(detection)
 	if err != nil {
 		return err
 	}

--- a/pkg/report/output/dataflow/detectiondecoder/dependency_classification.go
+++ b/pkg/report/output/dataflow/detectiondecoder/dependency_classification.go
@@ -1,0 +1,24 @@
+package detectiondecoder
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	dependenciesclassification "github.com/bearer/curio/pkg/classification/dependencies"
+)
+
+func GetClassifiedDependency(detection interface{}) (dependenciesclassification.ClassifiedDependency, error) {
+	var value dependenciesclassification.ClassifiedDependency
+	buf := bytes.NewBuffer(nil)
+	err := json.NewEncoder(buf).Encode(detection)
+	if err != nil {
+		return dependenciesclassification.ClassifiedDependency{}, fmt.Errorf("expect detection to have value of type schema %#v", detection)
+	}
+	err = json.NewDecoder(buf).Decode(&value)
+	if err != nil {
+		return dependenciesclassification.ClassifiedDependency{}, fmt.Errorf("expect detection to have value of type schema %#v", detection)
+	}
+
+	return value, nil
+}

--- a/pkg/report/output/dataflow/detectiondecoder/interface_classification.go
+++ b/pkg/report/output/dataflow/detectiondecoder/interface_classification.go
@@ -1,0 +1,24 @@
+package detectiondecoder
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	interfaceclassification "github.com/bearer/curio/pkg/classification/interfaces"
+)
+
+func GetClassifiedInterface(detection interface{}) (interfaceclassification.ClassifiedInterface, error) {
+	var value interfaceclassification.ClassifiedInterface
+	buf := bytes.NewBuffer(nil)
+	err := json.NewEncoder(buf).Encode(detection)
+	if err != nil {
+		return interfaceclassification.ClassifiedInterface{}, fmt.Errorf("expect detection to have value of type schema %#v", detection)
+	}
+	err = json.NewDecoder(buf).Decode(&value)
+	if err != nil {
+		return interfaceclassification.ClassifiedInterface{}, fmt.Errorf("expect detection to have value of type schema %#v", detection)
+	}
+
+	return value, nil
+}

--- a/pkg/report/output/dataflow/detectiondecoder/schema_classification.go
+++ b/pkg/report/output/dataflow/detectiondecoder/schema_classification.go
@@ -11,7 +11,7 @@ import (
 	"github.com/bearer/curio/pkg/report/schema"
 )
 
-func GetClassification(detection detections.Detection) (schemaclassification.Classification, error) {
+func GetSchemaClassification(detection detections.Detection) (schemaclassification.Classification, error) {
 	// decode schema
 	var value schema.Schema
 	buf := bytes.NewBuffer(nil)

--- a/pkg/report/output/dataflow/risks/risks.go
+++ b/pkg/report/output/dataflow/risks/risks.go
@@ -36,9 +36,9 @@ func New(config settings.Config) *Holder {
 }
 
 func (holder *Holder) AddSchema(detection detections.Detection) error {
-	classification, err := detectiondecoder.GetClassification(detection)
+	classification, err := detectiondecoder.GetSchemaClassification(detection)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	if classification.Decision.State == classify.Valid {
@@ -48,7 +48,7 @@ func (holder *Holder) AddSchema(detection detections.Detection) error {
 	return nil
 }
 
-// addDatatype adds datatype to hash list and at the same time blocks duplicates
+// addDatatype adds detector to hash list and at the same time blocks duplicates
 func (holder *Holder) addDatatype(ruleName string, datatypeName string, fileName string, lineNumber int) {
 	// create detector entry if it doesn't exist
 	if _, exists := holder.detectors[ruleName]; !exists {

--- a/pkg/report/output/dataflow/types/components.go
+++ b/pkg/report/output/dataflow/types/components.go
@@ -1,0 +1,12 @@
+package types
+
+type Component struct {
+	Name      string
+	Locations []ComponentLocation
+}
+
+type ComponentLocation struct {
+	Detector   string
+	Filename   string
+	LineNumber int
+}

--- a/pkg/report/output/dataflow_components_test.go
+++ b/pkg/report/output/dataflow_components_test.go
@@ -1,0 +1,126 @@
+package output_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/bearer/curio/pkg/commands/process/settings"
+	"github.com/bearer/curio/pkg/report/output"
+	"github.com/bearer/curio/pkg/report/output/dataflow"
+	"github.com/bearer/curio/pkg/report/output/dataflow/types"
+	globaltypes "github.com/bearer/curio/pkg/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDataflowComponents(t *testing.T) {
+	testCases := []struct {
+		Name        string
+		FileContent string
+		Want        []types.Component
+	}{
+		{
+			Name: "single detection - dependency",
+			FileContent: `{	"detector_type": "gemfile-lock", "type": "dependency_classified", "source": {"filename": "Gemfile.lock", "line_number": 258}, "classification": { "Decision": { "state": "valid" }, "recipe_name": "stripe"}}`,
+			Want: []types.Component{
+				{
+					Name: "stripe",
+					Locations: []types.ComponentLocation{
+						{
+							Detector:   "gemfile-lock",
+							Filename:   "Gemfile.lock",
+							LineNumber: 258,
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "single detection - interface",
+			FileContent: `{	"detector_type": "ruby", "type": "interface_classified", "source": {"filename": "billing.rb", "line_number": 2}, "classification": { "Decision": { "state": "valid" }, "recipe_name": "Stripe"}}`,
+			Want: []types.Component{
+				{
+					Name: "stripe",
+					Locations: []types.ComponentLocation{
+						{
+							Detector:   "ruby",
+							Filename:   "billing.rb",
+							LineNumber: 2,
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "single detection - duplicates",
+			FileContent: `{	"detector_type": "ruby", "type": "interface_classified", "source": {"filename": "billing.rb", "line_number": 2}, "classification": { "Decision": { "state": "valid" }, "recipe_name": "Stripe"}}
+{ "detector_type": "ruby", "type": "interface_classified", "source": {"filename": "billing.rb", "line_number": 2}, "classification": { "Decision": { "state": "valid" }, "recipe_name": "Stripe"}}`,
+			Want: []types.Component{
+				{
+					Name: "stripe",
+					Locations: []types.ComponentLocation{
+						{
+							Detector:   "ruby",
+							Filename:   "billing.rb",
+							LineNumber: 2,
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "multiple detections - deterministic output",
+			FileContent: `{	"detector_type": "ruby", "type": "interface_classified", "source": {"filename": "billing.rb", "line_number": 2}, "classification": { "Decision": { "state": "valid" }, "recipe_name": "Stripe"}}
+{"detector_type": "gemfile-lock", "type": "dependency_classified", "source": {"filename": "Gemfile.lock", "line_number": 258}, "classification": { "Decision": { "state": "valid" }, "recipe_name": "stripe"}}`,
+			Want: []types.Component{
+				{
+					Name: "stripe",
+					Locations: []types.ComponentLocation{
+						{
+							Detector:   "gemfile-lock",
+							Filename:   "Gemfile.lock",
+							LineNumber: 258,
+						},
+						{
+							Detector:   "ruby",
+							Filename:   "billing.rb",
+							LineNumber: 2,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.Name, func(t *testing.T) {
+			file, err := os.CreateTemp("", "*test.jsonlines")
+			if err != nil {
+				t.Fatalf("failed to create tmp file for report %s", err)
+				return
+			}
+			defer os.Remove(file.Name())
+			_, err = file.Write([]byte(test.FileContent))
+			if err != nil {
+				t.Fatalf("failed to write to tmp file %s", err)
+				return
+			}
+			file.Close()
+
+			detections, err := output.GetDetectorsOutput(globaltypes.Report{
+				Path: file.Name(),
+			})
+			if err != nil {
+				t.Fatalf("failed to get detectors output %s", err)
+				return
+			}
+
+			dataflow, err := dataflow.GetOuput(detections, settings.Config{})
+			if err != nil {
+				t.Fatalf("failed to get detectors output %s", err)
+				return
+			}
+
+			assert.Equal(t, test.Want, dataflow.Components)
+		})
+	}
+}


### PR DESCRIPTION
## Description
This pr adds support for dataflow components.
We take classified interfaces and dependencies (with valid classification), standardize classification name (there were some discrepancies there, dependency was `Stripe` while interfaces one was `stripe`) and put them as components inside dataflow. 


## Checklist

- [x] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
