### PR TITLE
fix: handle cases when classification is nil

### DIFF
--- a/pkg/report/output/dataflow/components/components.go
+++ b/pkg/report/output/dataflow/components/components.go
@@ -39,6 +39,10 @@ func (holder *Holder) AddInterface(detection interface{}) error {
 		return err
 	}
 
+	if value.Classification == nil {
+		return nil
+	}
+
 	if value.Classification.Decision.State == classify.Valid {
 		holder.addComponent(strings.ToLower(value.Classification.RecipeName), string(value.DetectorType), value.Source.Filename, *value.Source.LineNumber)
 	}
@@ -50,6 +54,10 @@ func (holder *Holder) AddDependency(detection interface{}) error {
 	value, err := detectiondecoder.GetClassifiedDependency(detection)
 	if err != nil {
 		return err
+	}
+
+	if value.Classification == nil {
+		return nil
 	}
 
 	if value.Classification.Decision.State == classify.Valid {

--- a/pkg/report/output/dataflow_components_test.go
+++ b/pkg/report/output/dataflow_components_test.go
@@ -35,6 +35,11 @@ func TestDataflowComponents(t *testing.T) {
 			},
 		},
 		{
+			Name: "single detection - dependency - no classification",
+			FileContent: `{	"detector_type": "gemfile-lock", "type": "dependency_classified", "source": {"filename": "Gemfile.lock", "line_number": 258}}`,
+			Want: []types.Component{},
+		},
+		{
 			Name: "single detection - interface",
 			FileContent: `{	"detector_type": "ruby", "type": "interface_classified", "source": {"filename": "billing.rb", "line_number": 2}, "classification": { "Decision": { "state": "valid" }, "recipe_name": "Stripe"}}`,
 			Want: []types.Component{
@@ -49,6 +54,11 @@ func TestDataflowComponents(t *testing.T) {
 					},
 				},
 			},
+		},
+		{
+			Name: "single detection - interface - no classification",
+			FileContent: `{	"detector_type": "ruby", "type": "interface_classified", "source": {"filename": "billing.rb", "line_number": 2}}`,
+			Want: []types.Component{},
 		},
 		{
 			Name: "single detection - duplicates",

--- a/pkg/report/output/dataflow_datatype_test.go
+++ b/pkg/report/output/dataflow_datatype_test.go
@@ -46,6 +46,12 @@ func TestDataflowDataType(t *testing.T) {
 			},
 		},
 		{
+			Name:        "single detection - no classification",
+			Config:      config,
+			FileContent: `{"type": "schema_classified", "detector_type":"ruby", "source": {"filename": "./users.rb", "line_number": 25}, "value": {"field_name": "User_name"}}`,
+			Want:        []types.Datatype{},
+		},
+		{
 			Name:   "single detection - duplicates",
 			Config: config,
 			FileContent: `{"type": "schema_classified", "detector_type":"ruby", "source": {"filename": "./users.rb", "line_number": 25}, "value": {"field_name": "User_name", "classification": {"data_type": {"data_category_name": "Username"} ,"decision":{"state": "valid"}}}}

--- a/pkg/report/output/dataflow_risks_test.go
+++ b/pkg/report/output/dataflow_risks_test.go
@@ -46,6 +46,12 @@ func TestDataflowRisks(t *testing.T) {
 			},
 		},
 		{
+			Name:        "single detection - no classification",
+			Config:      config,
+			FileContent: `{"type": "custom_classified", "detector_type":"rails_leak", "source": {"filename": "./users.rb", "line_number": 25}, "value": {"field_name": "User_name"}}`,
+			Want:        []types.RiskDetector{},
+		},
+		{
 			Name:   "single detection - duplicates",
 			Config: config,
 			FileContent: `{"type": "custom_classified", "detector_type":"rails_leak", "source": {"filename": "./users.rb", "line_number": 25}, "value": {"field_name": "User_name", "classification": {"data_type": {"data_category_name": "Username"} ,"decision":{"state": "valid"}}}}


### PR DESCRIPTION
## Description
Fixes nil pointer exceptions when dependency or interface has missing classification

## Checklist

- [x] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
