### PR TITLE
test: Hide the progress bar when running integration tests

### DIFF
--- a/integration/internal/testhelper/testhelper.go
+++ b/integration/internal/testhelper/testhelper.go
@@ -34,7 +34,7 @@ func executeApp(arguments []string, port int) (string, error) {
 	app := commands.NewApp(build.Version, build.CommitSHA)
 
 	if arguments[0] == "scan" {
-		arguments = append(arguments, "--existing-worker=http://localhost:"+strconv.Itoa(port))
+		arguments = append(arguments, "--existing-worker=http://localhost:"+strconv.Itoa(port), "--quiet")
 	}
 
 	stdoutReader, stdoutWriter, err := os.Pipe()

--- a/pkg/flag/scan_flags.go
+++ b/pkg/flag/scan_flags.go
@@ -48,6 +48,12 @@ var (
 		Value:      "",
 		Usage:      "expand context of schema classification e.g. --context=health to include data types particular to health",
 	}
+	QuietFlag = Flag{
+		Name:       "quiet",
+		ConfigName: "scan.quiet",
+		Value:      false,
+		Usage:      "suppress non-essential messages",
+	}
 )
 
 type ScanFlagGroup struct {
@@ -57,6 +63,7 @@ type ScanFlagGroup struct {
 	DomainResolutionTimeoutFlag *Flag
 	InternalDomainsFlag         *Flag
 	ContextFlag                 *Flag
+	QuietFlag                   *Flag
 }
 
 type ScanOptions struct {
@@ -67,6 +74,7 @@ type ScanOptions struct {
 	DomainResolutionTimeout time.Duration `json:"domain_resolution_timeout"`
 	InternalDomains         []string      `json:"internal_domains"`
 	Context                 Context       `json:"context"`
+	Quiet                   bool          `json:"quiet"`
 }
 
 func NewScanFlagGroup() *ScanFlagGroup {
@@ -77,6 +85,7 @@ func NewScanFlagGroup() *ScanFlagGroup {
 		DomainResolutionTimeoutFlag: &DomainResolutionTimeoutFlag,
 		InternalDomainsFlag:         &InternalDomainsFlag,
 		ContextFlag:                 &ContextFlag,
+		QuietFlag:                   &QuietFlag,
 	}
 }
 
@@ -92,6 +101,7 @@ func (f *ScanFlagGroup) Flags() []*Flag {
 		f.DomainResolutionTimeoutFlag,
 		f.InternalDomainsFlag,
 		f.ContextFlag,
+		f.QuietFlag,
 	}
 }
 
@@ -108,6 +118,7 @@ func (f *ScanFlagGroup) ToOptions(args []string) (ScanOptions, error) {
 		DomainResolutionTimeout: getDuration(f.DomainResolutionTimeoutFlag),
 		InternalDomains:         getStringSlice(f.InternalDomainsFlag),
 		Context:                 getContext(f.ContextFlag),
+		Quiet:                   getBool(f.QuietFlag),
 		Target:                  target,
 	}, nil
 }

--- a/pkg/util/output/progress_bar.go
+++ b/pkg/util/output/progress_bar.go
@@ -6,8 +6,9 @@ import (
 )
 
 func GetProgressBar(filesLength int, config settings.Config) *progressbar.ProgressBar {
+	hideProgress := config.Scan.Quiet || config.Scan.Debug
 	return progressbar.NewOptions(filesLength,
-		progressbar.OptionSetVisibility(!config.Scan.Debug),
+		progressbar.OptionSetVisibility(!hideProgress),
 		progressbar.OptionSetWriter(errorWriter),
 		progressbar.OptionShowCount(),
 		progressbar.OptionEnableColorCodes(false),


### PR DESCRIPTION
## Description

Add a `--quiet` flag to suppress non-essential output. In particular, this hides the progress bar, which is problematical for the integration tests.

The progress bar itself is not problematical, but the iterations per second ("files/s") component causes problems for snapshot-based testing, as the processing rate will vary between runs.

After this change, the progress bar is shown unless either (or both) of the `--debug` or `-quiet` flags are provided.

## Checklist

- [X] I've added test coverage that shows my fix or feature works as expected.
- [X] I've updated or added documentation if required.
- [X] I've included usage information in the description if CLI behavior was updated or added.
- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format