### PR TITLE
feat: add yaml support

### DIFF
--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -152,6 +152,11 @@ func (r *runner) Report(config settings.Config, report types.Report) error {
 		if err != nil {
 			return fmt.Errorf("error generating report %w", err)
 		}
+	case flag.FormatYAML:
+		err := reportoutput.ReportYAML(report, logger, config)
+		if err != nil {
+			return fmt.Errorf("error generating report %w", err)
+		}
 	}
 	return nil
 }

--- a/pkg/flag/report_flags.go
+++ b/pkg/flag/report_flags.go
@@ -1,13 +1,10 @@
 package flag
 
-import (
-)
-
 type Severity int
 
 var (
-	FormatJSON      = "json"
-	FormatJSONLines = "jsonlines"
+	FormatJSON = "json"
+	FormatYAML = "yaml"
 
 	ReportDetectors = "detectors"
 	ReportDataFlow  = "dataflow"

--- a/pkg/flag/report_flags.go
+++ b/pkg/flag/report_flags.go
@@ -16,7 +16,7 @@ var (
 		ConfigName: "report.format",
 		Shorthand:  "f",
 		Value:      FormatJSON,
-		Usage:      "format (json)",
+		Usage:      "format (json, yaml)",
 	}
 	ReportFlag = Flag{
 		Name:       "report",


### PR DESCRIPTION
## Description
This pr strip json formatting.
It also adds support for writing report (dataflow, detectors) as yaml by specifying `--format=yaml`


## Related
https://bearer.atlassian.net/browse/AMA-3147
https://bearer.atlassian.net/browse/AMA-3159

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [x] I've updated or added documentation if required.
- [x] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
