### PR TITLE
fix: Suppress "Target ..." informational message when run --quiet

### DIFF
--- a/pkg/commands/process/balancer/worker.go
+++ b/pkg/commands/process/balancer/worker.go
@@ -77,7 +77,9 @@ func (worker *Worker) Start() {
 		return
 	}
 
-	output.StdErrLogger().Msgf("Target %s", worker.config.Scan.Target)
+	if !worker.config.Scan.Quiet {
+		output.StdErrLogger().Msgf("Target %s", worker.config.Scan.Target)
+	}
 	bar := output.GetProgressBar(len(worker.FileList), worker.config)
 
 	reportFile, err := os.Create(worker.task.Definition.FilePath)


### PR DESCRIPTION
## Description

There is informational output showing the path of the scan target; this should be suppressed when the `--quiet` option has been passed.

## Checklist

- [X] I've added test coverage that shows my fix or feature works as expected.
- [X] I've updated or added documentation if required.
- [X] I've included usage information in the description if CLI behavior was updated or added.
- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
