### PR TITLE
test: Add an integration test for the "scan --help" command

### DIFF
--- a/integration/flags/.snapshots/TestMetadataFlags-scan-help
+++ b/integration/flags/.snapshots/TestMetadataFlags-scan-help
@@ -1,0 +1,45 @@
+Scan git repository
+
+Usage:
+   scan [flags] PATH
+Aliases:
+  scan, s
+Examples:
+  # Scan a local project including language-specific files
+  $ curio s /path/to/your_project
+  # Scan a single file
+  $ curio s ./curio-ci-test/Pipfile.lock
+
+
+Scan Flags
+      --context string                       expand context of schema classification e.g. --context=health to include data types particular to health
+      --debug                                enable debug logs
+      --disable-domain-resolution            do not attempt to resolve detected domains during classification (default false), eg. --disable-domain-resolution=true
+      --domain-resolution-timeout duration   set timeout when attempting to resolve detected domains during classification (default 3 seconds), eg. --domain-resolution-timeout=TODO (default 3s)
+      --internal-domains strings             define regular expressions for better classification of private or unreachable domains eg. --internal-domains="*.my-company.com,private.sh"
+      --quiet                                suppress non-essential messages
+      --skip-path strings                    specify the comma separated files and directories to skip (supports * syntax), eg. --skip-path users/*.go,users/admin.sql
+
+Worker Flags
+      --existing-worker string              URL of an existing worker
+      --file-size-max int                   ignore files with file size larger than this config (default 25000000)
+      --files-to-batch int                  number of files to batch to worker (default 1)
+      --memory-max int                      if memory needed to scan a file surpasses this limit, skip the file (default 800000000)
+      --timeout duration                    time allowed to complete scan (default 10m0s)
+      --timeout-file-max duration           maximum timeout assigned to scanning file, this config superseeds timeout-second-per-bytes (default 5m0s)
+      --timeout-file-min duration           minimum timeout assigned to scanning file, this config superseeds timeout-second-per-bytes (default 5s)
+      --timeout-file-second-per-bytes int   number of file size bytes producing a second of timeout assigned to scanning a file (default 10000)
+      --timeout-worker-online duration      maximum time for worker process to come online (default 1m0s)
+      --workers int                         number of processing workers to spawn (default 1)
+
+Report Flags
+  -f, --format string   format (json, yaml) (default "json")
+      --output string   path where to save report
+      --report string   specify the kind of report (detectors, dataflow) (default "detectors")
+
+General Flags
+      --config-file string   file from which to load configurations
+
+
+--
+

--- a/integration/flags/metadata_flags_test.go
+++ b/integration/flags/metadata_flags_test.go
@@ -6,14 +6,15 @@ import (
 	"github.com/bearer/curio/integration/internal/testhelper"
 )
 
-func newTest(name string) *testhelper.TestCase {
-	return testhelper.NewTestCase(name, []string{name}, testhelper.TestCaseOptions{})
+func newMetadataTest(name string, arguments []string) *testhelper.TestCase {
+	return testhelper.NewTestCase(name, arguments, testhelper.TestCaseOptions{})
 }
 
 func TestMetadataFlags(t *testing.T) {
 	tests := []testhelper.TestCase{
-		*newTest("help"),
-		*newTest("version"),
+		*newMetadataTest("help", []string{"help"}),
+		*newMetadataTest("version", []string{"version"}),
+		*newMetadataTest("scan-help", []string{"scan", "--help"}),
 	}
 
 	testhelper.RunTests(t, tests)


### PR DESCRIPTION
## Description

Add a snapshot-based integration test to cover the usage information specific to the `scan` command.

## Checklist

- [X] I've added test coverage that shows my fix or feature works as expected.
- [X] I've updated or added documentation if required.
- [X] I've included usage information in the description if CLI behavior was updated or added.
- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
