### PR TITLE
chore: More minor output stream consolidation

### DIFF
--- a/pkg/commands/init.go
+++ b/pkg/commands/init.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/bearer/curio/pkg/commands/process/settings"
-	"github.com/bearer/curio/pkg/util/output"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"golang.org/x/xerrors"
@@ -35,7 +34,7 @@ func NewInitCommand() *cobra.Command {
 				return err
 			}
 
-			output.StdErrLogger().Msgf("created: curio.yml (default configuration file)")
+			cmd.PrintErrln("created: curio.yml (default configuration file)")
 			return nil
 		},
 	}

--- a/pkg/util/output/progress_bar.go
+++ b/pkg/util/output/progress_bar.go
@@ -14,7 +14,7 @@ func GetProgressBar(filesLength int, config settings.Config) *progressbar.Progre
 		progressbar.OptionEnableColorCodes(false),
 		progressbar.OptionShowElapsedTimeOnFinish(),
 		progressbar.OptionOnCompletion(func() {
-			StdErrLogger().Msgf("\n")
+			errorWriter.Write([]byte("\n")) //nolint:all,errcheck
 		}),
 		progressbar.OptionShowIts(),
 		progressbar.OptionSetItsString("files"),


### PR DESCRIPTION
## Description

* Use the Cobra standard error writer directly for the informational output of the `init` command
* Use the global error writer consistently for the progress bar: both the bar itself and the terminating newline should use the same writer

## Related

Follow-up for #105

## Checklist

- [X] I've added test coverage that shows my fix or feature works as expected.
- [X] I've updated or added documentation if required.
- [X] I've included usage information in the description if CLI behavior was updated or added.
- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format