### PR TITLE
feat(policies): add risk severity via data category

### DIFF
--- a/integration/flags/.snapshots/TestReportFlags-report-policies
+++ b/integration/flags/.snapshots/TestReportFlags-report-policies
@@ -1,4 +1,4 @@
-- locations:
+- result:
     - data_type: Physical Address
       filename: users.rb
       line_number: "1"

--- a/integration/flags/.snapshots/TestReportFlags-report-policies
+++ b/integration/flags/.snapshots/TestReportFlags-report-policies
@@ -2,14 +2,17 @@
     - data_type: Physical Address
       filename: users.rb
       line_number: "1"
+      policy_description: Logger leaks detected
+      policy_id: detect_ruby_logger
+      policy_name: Logger leaks
       severity: high
     - data_type: Unique Identifier
       filename: users.rb
       line_number: "1"
+      policy_description: Logger leaks detected
+      policy_id: detect_ruby_logger
+      policy_name: Logger leaks
       severity: critical
-  policy_description: Logger leaks detected
-  policy_id: detect_ruby_logger
-  policy_name: Logger leaks
 
 
 --

--- a/integration/flags/.snapshots/TestReportFlags-report-policies
+++ b/integration/flags/.snapshots/TestReportFlags-report-policies
@@ -1,7 +1,15 @@
-- level: warning
-  locations:
-    - filename: users.rb
+- locations:
+    - data_type: Physical Address
+      filename: users.rb
       line_number: "1"
+      severity: high
+    - data_type: Unique Identifier
+      filename: users.rb
+      line_number: "1"
+      severity: critical
+  policy_description: Logger leaks detected
+  policy_id: detect_ruby_logger
+  policy_name: Logger leaks
 
 
 --

--- a/pkg/classification/db/data_categories/authenticating.json
+++ b/pkg/classification/db/data_categories/authenticating.json
@@ -1,0 +1,8 @@
+{
+  "metadata": {
+    "version": "1.0"
+  },
+  "uuid": "12f0efe5-ee25-4688-b111-4b8b120fcd96",
+  "name": "Authenticating",
+  "severity": "critical"
+}

--- a/pkg/classification/db/data_categories/behavioral_information.json
+++ b/pkg/classification/db/data_categories/behavioral_information.json
@@ -1,0 +1,6 @@
+{
+  "metadata": { "version": "1.0" },
+  "uuid": "fbd60d10-7408-4d52-9d9b-7d9cdf633099",
+  "name": "Behavioral Information",
+  "severity": "high"
+}

--- a/pkg/classification/db/data_categories/communication.json
+++ b/pkg/classification/db/data_categories/communication.json
@@ -1,0 +1,6 @@
+{
+  "metadata": { "version": "1.0" },
+  "uuid": "b089d17c-9fcb-45f3-8b14-f2dc9eac26a6",
+  "name": "Communication",
+  "severity": "high"
+}

--- a/pkg/classification/db/data_categories/computer_device.json
+++ b/pkg/classification/db/data_categories/computer_device.json
@@ -1,0 +1,6 @@
+{
+  "metadata": { "version": "1.0" },
+  "uuid": "5e116e08-9d86-4b78-b2af-b345e82e1e9b",
+  "name": "Computer Device",
+  "severity": "medium"
+}

--- a/pkg/classification/db/data_categories/contact.json
+++ b/pkg/classification/db/data_categories/contact.json
@@ -1,0 +1,6 @@
+{
+  "metadata": { "version": "1.0" },
+  "uuid": "e22bfd4a-9afe-4b6f-9436-33bc9c034798",
+  "name": "Contact",
+  "severity": "high"
+}

--- a/pkg/classification/db/data_categories/credit_history.json
+++ b/pkg/classification/db/data_categories/credit_history.json
@@ -1,0 +1,6 @@
+{
+  "metadata": { "version": "1.0" },
+  "uuid": "ff748c7f-8cf7-40aa-b398-242983f54dfa",
+  "name": "Credit History",
+  "severity": "medium"
+}

--- a/pkg/classification/db/data_categories/criminal_records.json
+++ b/pkg/classification/db/data_categories/criminal_records.json
@@ -1,0 +1,6 @@
+{
+  "metadata": { "version": "1.0" },
+  "uuid": "a997f160-35ba-495d-8fe3-4ea546a4beee",
+  "name": "Criminal Records",
+  "severity": "high"
+}

--- a/pkg/classification/db/data_categories/demographic.json
+++ b/pkg/classification/db/data_categories/demographic.json
@@ -1,0 +1,6 @@
+{
+  "metadata": { "version": "1.0" },
+  "uuid": "57880e92-e6f8-48a9-9b05-e3ebc4dbe919",
+  "name": "Demographic",
+  "severity": "medium"
+}

--- a/pkg/classification/db/data_categories/ethnicity.json
+++ b/pkg/classification/db/data_categories/ethnicity.json
@@ -1,0 +1,6 @@
+{
+  "metadata": { "version": "1.0" },
+  "uuid": "d4191777-ed6b-4aa7-bd3f-e9b4130baa99",
+  "name": "Ethnicity",
+  "severity": "medium"
+}

--- a/pkg/classification/db/data_categories/family.json
+++ b/pkg/classification/db/data_categories/family.json
@@ -1,0 +1,6 @@
+{
+  "metadata": { "version": "1.0" },
+  "uuid": "478b57e8-bfe5-474e-8dad-8581da06475d",
+  "name": "Family",
+  "severity": "medium"
+}

--- a/pkg/classification/db/data_categories/financial_accounts.json
+++ b/pkg/classification/db/data_categories/financial_accounts.json
@@ -1,0 +1,6 @@
+{
+  "metadata": { "version": "1.0" },
+  "uuid": "b1740ff1-64c1-453e-ba80-91d238b0692e",
+  "name": "Financial Accounts",
+  "severity": "high"
+}

--- a/pkg/classification/db/data_categories/identification.json
+++ b/pkg/classification/db/data_categories/identification.json
@@ -1,0 +1,6 @@
+{
+  "metadata": { "version": "1.0" },
+  "uuid": "f72d3ea0-d7a2-4279-8686-59da3780c211",
+  "name": "Identification",
+  "severity": "critical"
+}

--- a/pkg/classification/db/data_categories/knowledge_and_belief.json
+++ b/pkg/classification/db/data_categories/knowledge_and_belief.json
@@ -1,0 +1,6 @@
+{
+  "metadata": { "version": "1.0" },
+  "uuid": "5ca4d3b7-8500-4b42-9357-f555b006fd30",
+  "name": "Knowledge and Belief",
+  "severity": "medium"
+}

--- a/pkg/classification/db/data_categories/location.json
+++ b/pkg/classification/db/data_categories/location.json
@@ -1,0 +1,6 @@
+{
+  "metadata": { "version": "1.0" },
+  "uuid": "75b53b6a-2257-4be7-b3b1-1f4b0367e3f7",
+  "name": "Location",
+  "severity": "high"
+}

--- a/pkg/classification/db/data_categories/medical_and_health.json
+++ b/pkg/classification/db/data_categories/medical_and_health.json
@@ -1,0 +1,6 @@
+{
+  "metadata": { "version": "1.0" },
+  "uuid": "0fbee18e-4d96-4d8e-b8f6-bc5b04bba2f3",
+  "name": "Medical and Health",
+  "severity": "high"
+}

--- a/pkg/classification/db/data_categories/personal_ownership.json
+++ b/pkg/classification/db/data_categories/personal_ownership.json
@@ -1,0 +1,6 @@
+{
+  "metadata": { "version": "1.0" },
+  "uuid": "df05de69-b59b-4d11-8d58-71a51b1102f8",
+  "name": "Personal Ownership",
+  "severity": "high"
+}

--- a/pkg/classification/db/data_categories/physical_characteristic.json
+++ b/pkg/classification/db/data_categories/physical_characteristic.json
@@ -1,0 +1,6 @@
+{
+  "metadata": { "version": "1.0" },
+  "uuid": "9555eb1f-f18d-47aa-b081-7513258fe039",
+  "name": "Physical Characteristic",
+  "severity": "high"
+}

--- a/pkg/classification/db/data_categories/preference.json
+++ b/pkg/classification/db/data_categories/preference.json
@@ -1,0 +1,6 @@
+{
+  "metadata": { "version": "1.0" },
+  "uuid": "6fac9d01-6831-47ea-a4e1-94f62e963e45",
+  "name": "Preference",
+  "severity": "medium"
+}

--- a/pkg/classification/db/data_categories/professional_information.json
+++ b/pkg/classification/db/data_categories/professional_information.json
@@ -1,0 +1,6 @@
+{
+  "metadata": { "version": "1.0" },
+  "uuid": "f04418cb-14d9-4739-938e-2cc0666cd0cf",
+  "name": "Professional Information",
+  "severity": "high"
+}

--- a/pkg/classification/db/data_categories/public_life.json
+++ b/pkg/classification/db/data_categories/public_life.json
@@ -1,0 +1,6 @@
+{
+  "metadata": { "version": "1.0" },
+  "uuid": "2951ab57-8c24-4123-932f-e24608fb8c2d",
+  "name": "Public Life",
+  "severity": "high"
+}

--- a/pkg/classification/db/data_categories/sexual.json
+++ b/pkg/classification/db/data_categories/sexual.json
@@ -1,0 +1,6 @@
+{
+  "metadata": { "version": "1.0" },
+  "uuid": "1825df39-1aeb-4c96-9e0a-cdbbcde8d792",
+  "name": "Sexual",
+  "severity": "high"
+}

--- a/pkg/classification/db/data_categories/social_network.json
+++ b/pkg/classification/db/data_categories/social_network.json
@@ -1,0 +1,6 @@
+{
+  "metadata": { "version": "1.0" },
+  "uuid": "dee7b0c2-74cd-4632-8a59-87b25a875835",
+  "name": "Social Network",
+  "severity": "medium"
+}

--- a/pkg/classification/db/data_categories/transactional.json
+++ b/pkg/classification/db/data_categories/transactional.json
@@ -1,0 +1,6 @@
+{
+  "metadata": { "version": "1.0" },
+  "uuid": "aee749bc-ec52-49c8-9603-3620eff0a165",
+  "name": "Transactional",
+  "severity": "high"
+}

--- a/pkg/classification/db/db.go
+++ b/pkg/classification/db/db.go
@@ -16,6 +16,9 @@ var recipesDir embed.FS
 //go:embed data_types
 var dataTypesDir embed.FS
 
+//go:embed data_categories
+var dataCategoriesDir embed.FS
+
 //go:embed data_type_classification_patterns
 var dataTypeClassificationPatternsDir embed.FS
 
@@ -25,6 +28,7 @@ var knownPersonObjectPatternsDir embed.FS
 type DefaultDB struct {
 	Recipes                        []Recipe
 	DataTypes                      []DataType
+	DataCategories                 []DataCategory
 	DataTypeClassificationPatterns []DataTypeClassificationPattern
 	KnownPersonObjectPatterns      []KnownPersonObjectPattern
 }
@@ -52,6 +56,12 @@ type DataType struct {
 	DefaultCategory  string `json:"default_category"`
 	Id               int    `json:"id"`
 	UUID             string `json:"uuid"`
+}
+
+type DataCategory struct {
+	Name     string `json:"name"`
+	Severity string `json:"severity"`
+	UUID     string `json:"uuid"`
 }
 
 type ObjectType string
@@ -98,6 +108,7 @@ func Default() DefaultDB {
 	return DefaultDB{
 		Recipes:                        defaultRecipes(),
 		DataTypes:                      dataTypes,
+		DataCategories:                 defaultDataCategories(),
 		DataTypeClassificationPatterns: defaultDataTypeClassificationPatterns(dataTypes),
 		KnownPersonObjectPatterns:      defaultKnownPersonObjectPatterns(dataTypes),
 	}
@@ -128,6 +139,33 @@ func defaultRecipes() []Recipe {
 	}
 
 	return recipes
+}
+
+func defaultDataCategories() []DataCategory {
+	dataCategories := []DataCategory{}
+
+	files, err := dataCategoriesDir.ReadDir("data_categories")
+	if err != nil {
+		handleError(err)
+	}
+
+	for _, file := range files {
+		val, err := dataCategoriesDir.ReadFile("data_categories/" + file.Name())
+		if err != nil {
+			handleError(err)
+		}
+
+		var dataCategory DataCategory
+		rawBytes := []byte(val)
+		err = json.Unmarshal(rawBytes, &dataCategory)
+		if err != nil {
+			handleError(err)
+		}
+
+		dataCategories = append(dataCategories, dataCategory)
+	}
+
+	return dataCategories
 }
 
 func defaultDataTypes() []DataType {

--- a/pkg/commands/process/settings/policies.yml
+++ b/pkg/commands/process/settings/policies.yml
@@ -1,11 +1,9 @@
 logger_leaks:
   description: "Logger leaks detected"
   name: "Logger leaks"
+  id: "detect_ruby_logger"
   query: |
     locations = data.bearer.logger_leaks.locations
-    policy_id = data.bearer.logger_leaks.policy_id
-    policy_name = data.bearer.logger_leaks.policy_name
-    policy_description = data.bearer.logger_leaks.policy_description
   modules:
     - path: policies/logger_leaks.rego
       name: bearer.logger_leaks

--- a/pkg/commands/process/settings/policies.yml
+++ b/pkg/commands/process/settings/policies.yml
@@ -2,8 +2,10 @@ logger_leaks:
   message: "Logger leaks detected"
   level: "warning"
   query: |
-    level = data.bearer.logger_leaks.level
     locations = data.bearer.logger_leaks.locations
+    policy_id = data.bearer.logger_leaks.policy_id
+    policy_name = data.bearer.logger_leaks.policy_name
+    policy_description = data.bearer.logger_leaks.policy_description
   modules:
     - path: policies/logger_leaks.rego
       name: bearer.logger_leaks

--- a/pkg/commands/process/settings/policies.yml
+++ b/pkg/commands/process/settings/policies.yml
@@ -3,7 +3,7 @@ logger_leaks:
   name: "Logger leaks"
   id: "detect_ruby_logger"
   query: |
-    locations = data.bearer.logger_leaks.locations
+    result = data.bearer.logger_leaks.result
   modules:
     - path: policies/logger_leaks.rego
       name: bearer.logger_leaks

--- a/pkg/commands/process/settings/policies.yml
+++ b/pkg/commands/process/settings/policies.yml
@@ -1,6 +1,6 @@
 logger_leaks:
-  message: "Logger leaks detected"
-  level: "warning"
+  description: "Logger leaks detected"
+  name: "Logger leaks"
   query: |
     locations = data.bearer.logger_leaks.locations
     policy_id = data.bearer.logger_leaks.policy_id

--- a/pkg/commands/process/settings/policies/logger_leaks.rego
+++ b/pkg/commands/process/settings/policies/logger_leaks.rego
@@ -2,16 +2,25 @@ package bearer.logger_leaks
 
 import future.keywords
 
-default level := "none"
+policy_id := "detect_ruby_logger"
+policy_name := "Logger leak"
+policy_description := "Logger leak"
 
+locations[item] {
+    some detector in input.dataflow.risks
+    detector.detector_id == policy_id
 
-locations[location] {
-    some detector in input.risks
-    detector.detector_id == "detect_ruby_logger"
-    location = detector.data_types[_].locations[_]
+    data_type = detector.data_types[_]
+
+    some category in input.data_categories
+    category.name == data_type.category
+
+    location = data_type.locations[_]
+    item := {
+        "policy": policy_name,
+        "data_type": data_type.name,
+        "severity": category.severity,
+        "filename": location.filename,
+        "line_number": location.line_number
+    }
 }
-
-level = "warning" if {
-    count(locations) > 0
-}
-

--- a/pkg/commands/process/settings/policies/logger_leaks.rego
+++ b/pkg/commands/process/settings/policies/logger_leaks.rego
@@ -2,7 +2,7 @@ package bearer.logger_leaks
 
 import future.keywords
 
-locations[item] {
+result[item] {
     some detector in input.dataflow.risks
     detector.detector_id == input.policy_id
 

--- a/pkg/commands/process/settings/policies/logger_leaks.rego
+++ b/pkg/commands/process/settings/policies/logger_leaks.rego
@@ -2,13 +2,9 @@ package bearer.logger_leaks
 
 import future.keywords
 
-policy_id := "detect_ruby_logger"
-policy_name := input.name
-policy_description := input.description
-
 locations[item] {
     some detector in input.dataflow.risks
-    detector.detector_id == policy_id
+    detector.detector_id == input.policy_id
 
     data_type = detector.data_types[_]
 
@@ -17,6 +13,9 @@ locations[item] {
 
     location = data_type.locations[_]
     item := {
+        "policy_description": input.policy_description,
+        "policy_id": input.policy_id,
+        "policy_name": input.policy_name,
         "data_type": data_type.name,
         "severity": category.severity,
         "filename": location.filename,

--- a/pkg/commands/process/settings/policies/logger_leaks.rego
+++ b/pkg/commands/process/settings/policies/logger_leaks.rego
@@ -3,8 +3,8 @@ package bearer.logger_leaks
 import future.keywords
 
 policy_id := "detect_ruby_logger"
-policy_name := "Logger leak"
-policy_description := "Logger leak"
+policy_name := input.name
+policy_description := input.description
 
 locations[item] {
     some detector in input.dataflow.risks
@@ -17,7 +17,6 @@ locations[item] {
 
     location = data_type.locations[_]
     item := {
-        "policy": policy_name,
         "data_type": data_type.name,
         "severity": category.severity,
         "filename": location.filename,

--- a/pkg/commands/process/settings/settings.go
+++ b/pkg/commands/process/settings/settings.go
@@ -29,6 +29,7 @@ var LevelLow = "low"
 type Policy struct {
 	Query       string
 	Name        string
+	Id          string
 	Description string
 	Modules     []*PolicyModule
 	Level       policyLevel

--- a/pkg/commands/process/settings/settings.go
+++ b/pkg/commands/process/settings/settings.go
@@ -21,9 +21,10 @@ type Config struct {
 
 type policyLevel string
 
-var LevelMedium = "medium"
-var LevelWarning = "warning"
 var LevelCritical = "critical"
+var LevelHigh = "high"
+var LevelMedium = "medium"
+var LevelLow = "low"
 
 type Policy struct {
 	Query   string

--- a/pkg/commands/process/settings/settings.go
+++ b/pkg/commands/process/settings/settings.go
@@ -27,10 +27,11 @@ var LevelMedium = "medium"
 var LevelLow = "low"
 
 type Policy struct {
-	Query   string
-	Message string
-	Modules []*PolicyModule
-	Level   policyLevel
+	Query       string
+	Name        string
+	Description string
+	Modules     []*PolicyModule
+	Level       policyLevel
 }
 
 type PolicyModule struct {

--- a/pkg/report/output/dataflow/types/risks.go
+++ b/pkg/report/output/dataflow/types/risks.go
@@ -7,6 +7,7 @@ type RiskDetector struct {
 
 type RiskDatatype struct {
 	Name      string         `json:"name"`
+	Category  string         `json:"category"`
 	Stored    bool           `json:"stored"`
 	Locations []RiskLocation `json:"locations"`
 }

--- a/pkg/report/output/policies/policies.go
+++ b/pkg/report/output/policies/policies.go
@@ -11,10 +11,11 @@ import (
 )
 
 type PolicyInput struct {
-	Name           string             `json:"name"`
-	Description    string             `json:"description"`
-	Dataflow       *dataflow.DataFlow `json:"dataflow"`
-	DataCategories []db.DataCategory  `json:"data_categories"`
+	PolicyName        string             `json:"policy_name"`
+	PolicyId          string             `json:"policy_id"`
+	PolicyDescription string             `json:"policy_description"`
+	Dataflow          *dataflow.DataFlow `json:"dataflow"`
+	DataCategories    []db.DataCategory  `json:"data_categories"`
 }
 
 func GetOutput(dataflow *dataflow.DataFlow, config settings.Config) ([]rego.Vars, error) {
@@ -39,10 +40,11 @@ func GetOutput(dataflow *dataflow.DataFlow, config settings.Config) ([]rego.Vars
 			ctx,
 			rego.EvalInput(
 				PolicyInput{
-					Name:           policy.Name,
-					Description:    policy.Description,
-					Dataflow:       dataflow,
-					DataCategories: db.Default().DataCategories,
+					PolicyName:        policy.Name,
+					PolicyDescription: policy.Description,
+					PolicyId:          policy.Id,
+					Dataflow:          dataflow,
+					DataCategories:    db.Default().DataCategories,
 				},
 			),
 		)

--- a/pkg/report/output/policies/policies.go
+++ b/pkg/report/output/policies/policies.go
@@ -3,11 +3,17 @@ package policies
 import (
 	"context"
 
+	"github.com/bearer/curio/pkg/classification/db"
 	"github.com/bearer/curio/pkg/commands/process/settings"
 	"github.com/bearer/curio/pkg/report/output/dataflow"
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/rs/zerolog/log"
 )
+
+type PolicyInput struct {
+	Dataflow       *dataflow.DataFlow `json:"dataflow"`
+	DataCategories []db.DataCategory  `json:"data_categories"`
+}
 
 func GetOutput(dataflow *dataflow.DataFlow, config settings.Config) ([]rego.Vars, error) {
 	ctx := context.TODO()
@@ -27,7 +33,15 @@ func GetOutput(dataflow *dataflow.DataFlow, config settings.Config) ([]rego.Vars
 		}
 
 		// Create a prepared query that can be evaluated.
-		rs, err := query.Eval(ctx, rego.EvalInput(dataflow))
+		rs, err := query.Eval(
+			ctx,
+			rego.EvalInput(
+				PolicyInput{
+					Dataflow:       dataflow,
+					DataCategories: db.Default().DataCategories,
+				},
+			),
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/report/output/policies/policies.go
+++ b/pkg/report/output/policies/policies.go
@@ -11,6 +11,8 @@ import (
 )
 
 type PolicyInput struct {
+	Name           string             `json:"name"`
+	Description    string             `json:"description"`
 	Dataflow       *dataflow.DataFlow `json:"dataflow"`
 	DataCategories []db.DataCategory  `json:"data_categories"`
 }
@@ -37,6 +39,8 @@ func GetOutput(dataflow *dataflow.DataFlow, config settings.Config) ([]rego.Vars
 			ctx,
 			rego.EvalInput(
 				PolicyInput{
+					Name:           policy.Name,
+					Description:    policy.Description,
 					Dataflow:       dataflow,
 					DataCategories: db.Default().DataCategories,
 				},

--- a/pkg/report/output/policies/policies.go
+++ b/pkg/report/output/policies/policies.go
@@ -52,7 +52,9 @@ func GetOutput(dataflow *dataflow.DataFlow, config settings.Config) ([]rego.Vars
 
 		log.Debug().Msgf("result %#v", rs)
 
-		result = append(result, rs[0].Bindings)
+		if len(rs) > 0 {
+			result = append(result, rs[0].Bindings)
+		}
 	}
 
 	// Create a prepared query that can be evaluated.

--- a/scripts/data_categories.json
+++ b/scripts/data_categories.json
@@ -1,0 +1,94 @@
+[
+  {
+    "name": "Authenticating",
+    "severity": "critical"
+  },
+  {
+    "name": "Behavioral Information",
+    "severity": "high"
+  },
+  {
+    "name": "Communication",
+    "severity": "high"
+  },
+  {
+    "name": "Computer Device",
+    "severity": "medium"
+  },
+  {
+    "name": "Contact",
+    "severity": "high"
+  },
+  {
+    "name": "Credit History",
+    "severity": "medium"
+  },
+  {
+    "name": "Criminal Records",
+    "severity": "high"
+  },
+  {
+    "name": "Demographic",
+    "severity": "medium"
+  },
+  {
+    "name": "Ethnicity",
+    "severity": "medium"
+  },
+  {
+    "name": "Location",
+    "severity": "high"
+  },
+  {
+    "name": "Financial Accounts",
+    "severity": "high"
+  },
+  {
+    "name": "Identification",
+    "severity": "critical"
+  },
+  {
+    "name": "Personal Ownership",
+    "severity": "high"
+  },
+  {
+    "name": "Medical and Health",
+    "severity": "high"
+  },
+  {
+    "name": "Family",
+    "severity": "medium"
+  },
+  {
+    "name": "Social Network",
+    "severity": "medium"
+  },
+  {
+    "name": "Public Life",
+    "severity": "high"
+  },
+  {
+    "name": "Sexual",
+    "severity": "high"
+  },
+  {
+    "name": "Professional Information",
+    "severity": "high"
+  },
+  {
+    "name": "Preference",
+    "severity": "medium"
+  },
+  {
+    "name": "Knowledge and Belief",
+    "severity": "medium"
+  },
+  {
+    "name": "Transactional",
+    "severity": "high"
+  },
+  {
+    "name": "Physical Characteristic",
+    "severity": "high"
+  }
+]

--- a/scripts/main.rb
+++ b/scripts/main.rb
@@ -1,4 +1,5 @@
 require "json"
+require "securerandom"
 
 # move recipes into separate JSON files
 recipes_file = File.read("scripts/recipes.json")
@@ -9,6 +10,22 @@ JSON.parse(recipes_file).each do |recipe|
     new_file << {metadata: {version: "1.0"}}.merge(recipe).to_json
   end
 end
+
+# move data_category into separate JSON files (and add UUID)
+# NOTE: running this will re-create UUIDs for the data categories
+# data_category = File.read("scripts/data_categories.json")
+# JSON.parse(temp).each do |data_cat|
+#   puts "processing #{data_cat["name"]}..."
+#   filename = "pkg/classification/db/data_categories/#{data_cat["name"].downcase.gsub(" ", "_")}.json"
+#   File.open(filename, "w") do |new_file|
+#     new_file << {
+#       metadata: {
+#         version: "1.0"
+#       },
+#       uuid: SecureRandom.uuid
+#     }.merge(data_cat).to_json
+#   end
+# end
 
 # YAML to JSON conversion:
 #   ruby -ryaml -rjson -e "puts YAML.load_file('path-to-your-file.yml').to_json"


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

- Update `RiskDatatype` type to include data type category
- Update logger_leaks policy to output locations with severity
- Update Policy type to include Name and Description, and pass these to rego policies
- Add data categories to DB and use these in policies.GetOutput

New logger policy output

```

=> go run cmd/curio/main.go scan ~/test --report=policies
=> [
  {
    "result": [
      {
        "data_type": "Physical Address",
        "filename": "temp.rb",
        "line_number": 1,
        "policy_description": "Logger leaks detected",
        "policy_id": "detect_ruby_logger",
        "policy_name": "Logger leaks",
        "severity": "high"
      },
      {
        "data_type": "Unique Identifier",
        "filename": "temp.rb",
        "line_number": 1,
        "policy_description": "Logger leaks detected",
        "policy_id": "detect_ruby_logger",
        "policy_name": "Logger leaks",
        "severity": "critical"
      }
    ]
  }
]
```

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
