### PR TITLE
docs: update base path for sh domain

### DIFF
--- a/docs/.eleventy.js
+++ b/docs/.eleventy.js
@@ -34,7 +34,7 @@ module.exports = function (eleventyConfig) {
   });
   eleventyConfig.setLibrary("md", mdSetup);
   eleventyConfig.addPlugin(EleventyHtmlBasePlugin, {
-    baseHref: process.env.ELEVENTY_PRODUCTION ? "/curio/" : "/",
+    baseHref: "/",
   });
 
   eleventyConfig.addPlugin(EleventyRenderPlugin);


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->
Now that curio.sh is working, this adjusts the production base path. AKA: removes the github.io subdomain workaround.
<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [] I've added test coverage that shows my fix or feature works as expected.
- [] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
