### PR TITLE
fix(classification): include classification errors as debug rather than report errors

### DIFF
--- a/pkg/report/writer/detectors.go
+++ b/pkg/report/writer/detectors.go
@@ -7,6 +7,7 @@ import (
 
 	classification "github.com/bearer/curio/pkg/classification"
 	classificationschema "github.com/bearer/curio/pkg/classification/schema"
+	zerolog "github.com/rs/zerolog/log"
 
 	"github.com/bearer/curio/pkg/parser"
 	"github.com/bearer/curio/pkg/parser/nodeid"
@@ -41,7 +42,7 @@ func (report *Detectors) AddInterface(
 	detection := &detections.Detection{DetectorType: detectorType, Value: data, Source: source, Type: detections.TypeInterface}
 	classifiedDetection, err := report.Classifier.Interfaces.Classify(*detection)
 	if err != nil {
-		report.AddError(detection.Source.Filename, fmt.Errorf("classification interfaces error: %s", err))
+		zerolog.Debug().Msgf("classification interfaces error from %s: %s", detection.Source.Filename, err)
 		return
 	}
 


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Swallows errors from the interface/URL classifier unless we are in debug mode

Why?

They're not useful (i.e. the scan user can't address them) and can be quite noisy

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
