### PR TITLE
feat(policies): group policy breaches by severity

### DIFF
--- a/integration/flags/.snapshots/TestReportFlags-report-policies
+++ b/integration/flags/.snapshots/TestReportFlags-report-policies
@@ -1,11 +1,9 @@
-- result:
-    - category_group: Personal data
+critical:
+    - policyname: Logger leaks
+      policydescription: Logger leaks detected
+      linenumber: ""
       filename: users.rb
-      line_number: "1"
-      policy_description: Logger leaks detected
-      policy_id: detect_ruby_logger
-      policy_name: Logger leaks
-      severity: high
+      category: Contact
 
 
 --

--- a/pkg/commands/process/settings/policies.yml
+++ b/pkg/commands/process/settings/policies.yml
@@ -3,7 +3,8 @@ logger_leaks:
   name: "Logger leaks"
   id: "detect_ruby_logger"
   query: |
-    result = data.bearer.logger_leaks.result
+    critical = data.bearer.logger_leaks.critical
+    high = data.bearer.logger_leaks.high
   modules:
     - path: policies/logger_leaks.rego
       name: bearer.logger_leaks

--- a/pkg/commands/process/settings/policies/logger_leaks.rego
+++ b/pkg/commands/process/settings/policies/logger_leaks.rego
@@ -5,7 +5,7 @@ import future.keywords
 sensitive_data_group_uuid := "f6a0c071-5908-4420-bac2-bba28d41223e"
 personal_data_group_uuid := "e1d3135b-3c0f-4b55-abce-19f27a26cbb3"
 
-result[item] {
+high[item] {
     some detector in input.dataflow.risks
     detector.detector_id == input.policy_id
 
@@ -17,17 +17,12 @@ result[item] {
 
     location = data_type.locations[_]
     item := {
-        "policy_id": input.policy_id,
-        "policy_name": input.policy_name,
-        "policy_description": input.policy_description,
-        "severity": "critical",
-        "category_group": category.group_name,
-        "filename": location.filename,
-        "line_number": location.line_number
+        "category": category.name,
+        "filename": location.filename
     }
 }
 
-result[item] {
+critical[item] {
     some detector in input.dataflow.risks
     detector.detector_id == input.policy_id
 
@@ -39,12 +34,7 @@ result[item] {
 
     location = data_type.locations[_]
     item := {
-        "policy_id": input.policy_id,
-        "policy_name": input.policy_name,
-        "policy_description": input.policy_description,
-        "severity": "high",
-        "category_group": category.group_name,
-        "filename": location.filename,
-        "line_number": location.line_number
+        "category": category.name,
+        "filename": location.filename
     }
 }

--- a/pkg/commands/process/settings/settings.go
+++ b/pkg/commands/process/settings/settings.go
@@ -19,7 +19,7 @@ type Config struct {
 	Policies       map[string]*Policy `json:"policies" yaml:"policies"`
 }
 
-type policyLevel string
+type PolicyLevel string
 
 var LevelCritical = "critical"
 var LevelHigh = "high"
@@ -32,7 +32,7 @@ type Policy struct {
 	Id          string
 	Description string
 	Modules     []*PolicyModule
-	Level       policyLevel
+	Level       PolicyLevel
 }
 
 type PolicyModule struct {


### PR DESCRIPTION
## Description
- Some refactoring and clean up for logger leaks policy
- Group policy breaches by severity levels

We'll use this in a subsequent PR to display table format for policies by default

```
{
  "critical": [
    {
      "policy_name": "Logger leaks",
      "policy_description": "Logger leaks detected",
      "filename": ".",
      "category": "Contact"
    },
    {
      "policy_name": "Logger leaks",
      "policy_description": "Logger leaks detected",
      "filename": ".",
      "category": "Identification"
    }
  ],
  "high": [
    {
      "policy_name": "Logger leaks",
      "policy_description": "Logger leaks detected",
      "filename": ".",
      "category": "Sexual"
    }
  ]
}
```

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
