### PR TITLE
feat(policies): add summary with counts to policy report

### DIFF
--- a/integration/flags/.snapshots/TestReportFlags-report-dataflow-verified-by
+++ b/integration/flags/.snapshots/TestReportFlags-report-dataflow-verified-by
@@ -10,16 +10,19 @@ data_types:
                 - detector: detect_encrypted_ruby_class_properties
                   filename: user.rb
                   line_number: 2
+          parent: null
         - name: ruby
           locations:
             - filename: user.rb
               line_number: 2
+          parent: null
     - name: Date of birth
       detectors:
         - name: detect_sql_create_public_table
           locations:
             - filename: schema.sql
               line_number: 6
+          parent: null
     - name: Email Address
       detectors:
         - name: detect_sql_create_public_table
@@ -31,22 +34,26 @@ data_types:
                 - detector: detect_encrypted_ruby_class_properties
                   filename: user.rb
                   line_number: 2
+          parent: null
         - name: ruby
           locations:
             - filename: user.rb
               line_number: 2
+          parent: null
     - name: Firstname
       detectors:
         - name: detect_sql_create_public_table
           locations:
             - filename: schema.sql
               line_number: 3
+          parent: null
     - name: Lastname
       detectors:
         - name: detect_sql_create_public_table
           locations:
             - filename: schema.sql
               line_number: 4
+          parent: null
     - name: Physical Address
       detectors:
         - name: detect_sql_create_public_table
@@ -58,10 +65,12 @@ data_types:
                 - detector: detect_encrypted_ruby_class_properties
                   filename: user.rb
                   line_number: 2
+          parent: null
         - name: ruby
           locations:
             - filename: user.rb
               line_number: 2
+          parent: null
 components: []
 
 

--- a/integration/flags/.snapshots/TestReportFlags-report-dataflow-verified-by
+++ b/integration/flags/.snapshots/TestReportFlags-report-dataflow-verified-by
@@ -10,19 +10,16 @@ data_types:
                 - detector: detect_encrypted_ruby_class_properties
                   filename: user.rb
                   line_number: 2
-          parent: null
         - name: ruby
           locations:
             - filename: user.rb
               line_number: 2
-          parent: null
     - name: Date of birth
       detectors:
         - name: detect_sql_create_public_table
           locations:
             - filename: schema.sql
               line_number: 6
-          parent: null
     - name: Email Address
       detectors:
         - name: detect_sql_create_public_table
@@ -34,26 +31,22 @@ data_types:
                 - detector: detect_encrypted_ruby_class_properties
                   filename: user.rb
                   line_number: 2
-          parent: null
         - name: ruby
           locations:
             - filename: user.rb
               line_number: 2
-          parent: null
     - name: Firstname
       detectors:
         - name: detect_sql_create_public_table
           locations:
             - filename: schema.sql
               line_number: 3
-          parent: null
     - name: Lastname
       detectors:
         - name: detect_sql_create_public_table
           locations:
             - filename: schema.sql
               line_number: 4
-          parent: null
     - name: Physical Address
       detectors:
         - name: detect_sql_create_public_table
@@ -65,12 +58,10 @@ data_types:
                 - detector: detect_encrypted_ruby_class_properties
                   filename: user.rb
                   line_number: 2
-          parent: null
         - name: ruby
           locations:
             - filename: user.rb
               line_number: 2
-          parent: null
 components: []
 
 

--- a/pkg/commands/process/settings/policies/application_level_encryption.rego
+++ b/pkg/commands/process/settings/policies/application_level_encryption.rego
@@ -20,6 +20,10 @@ high[item] {
     item = {
         "category_group":  category.group_name,
         "filename": location.filename,
+        "line_number": location.line_number,
+        "parent_line_number": detector.parent.line_number,
+        "parent_content": detector.parent.content
+
     }
 }
 
@@ -38,5 +42,8 @@ critical[item] {
     item = {
         "category_group":  category.group_name,
         "filename": location.filename,
+        "line_number": location.line_number,
+        "parent_line_number": detector.parent.line_number,
+        "parent_content": detector.parent.content
     }
 }

--- a/pkg/report/output/dataflow/types/datatypes.go
+++ b/pkg/report/output/dataflow/types/datatypes.go
@@ -1,5 +1,7 @@
 package types
 
+import "github.com/bearer/curio/pkg/report/schema"
+
 type Datatype struct {
 	UUID         string             `json:"uuid,omitempty" yaml:"uuid,omitempty"`
 	CategoryUUID string             `json:"category_uuid,omitempty" yaml:"category_uuid,omitempty"`
@@ -10,6 +12,7 @@ type Datatype struct {
 type DatatypeDetector struct {
 	Name      string             `json:"name" yaml:"name"`
 	Locations []DatatypeLocation `json:"locations" yaml:"locations"`
+	Parent    *schema.Parent     `json:"parent" yaml:"parent"`
 }
 
 type DatatypeLocation struct {

--- a/pkg/report/output/dataflow/types/datatypes.go
+++ b/pkg/report/output/dataflow/types/datatypes.go
@@ -12,7 +12,7 @@ type Datatype struct {
 type DatatypeDetector struct {
 	Name      string             `json:"name" yaml:"name"`
 	Locations []DatatypeLocation `json:"locations" yaml:"locations"`
-	Parent    *schema.Parent     `json:"parent" yaml:"parent"`
+	Parent    *schema.Parent     `json:"parent,omitempty" yaml:"parent,omitempty"`
 }
 
 type DatatypeLocation struct {

--- a/pkg/report/output/output.go
+++ b/pkg/report/output/output.go
@@ -38,7 +38,7 @@ func ReportPolicies(report types.Report, output *zerolog.Event, config settings.
 
 	reportStr := &strings.Builder{}
 	reportStr.WriteString("\n\nPolicy Report\n")
-	reportStr.WriteString("\n=============\n")
+	reportStr.WriteString("\n=====================================")
 
 	writePolicyListToString(reportStr, config.Policies)
 
@@ -214,6 +214,8 @@ func writeSummaryToString(
 	if len(breachedPolicies[settings.LevelLow]) > 0 {
 		reportStr.WriteString(" (" + strings.Join(maps.Keys(breachedPolicies[settings.LevelLow]), ", ") + ")")
 	}
+
+	reportStr.WriteString("\n\n")
 }
 
 func writePolicyBreachToString(reportStr *strings.Builder, policyBreach policies.PolicyResult, policySeverity string) {


### PR DESCRIPTION
## Description
Add summary to policy report, to count number of policies run and number of breaches, with a breakdown by severity level. 

This is shown even if no policy breaches have been detected

Example output: 

Start of report (title and list of all policies to be run)

<img width="1038" alt="Screenshot 2022-11-25 at 15 26 03" src="https://user-images.githubusercontent.com/4560746/203996255-0a938465-ca38-42a7-a059-b5b4f55672c0.png">



End of report (summary & breakdown)

<img width="737" alt="Screenshot 2022-11-25 at 15 25 55" src="https://user-images.githubusercontent.com/4560746/203996262-9164aee8-63bd-4e47-b4a4-b41d1801adae.png">


<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
