### PR TITLE
feat(policies): return exit status 1 when policy breaches have been detected

### DIFF
--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -135,10 +135,8 @@ func Run(ctx context.Context, opts flag.Options, targetKind TargetKind) (err err
 		return xerrors.Errorf("report error: %w", err)
 	}
 
-	if reportPassed {
-		os.Exit(0)
-	} else {
-		os.Exit(1)
+	if !reportPassed {
+		defer os.Exit(1)
 	}
 
 	return nil

--- a/pkg/report/output/output.go
+++ b/pkg/report/output/output.go
@@ -20,10 +20,10 @@ import (
 
 var ErrUndefinedFormat = errors.New("undefined output format")
 
-func ReportPolicies(report types.Report, output *zerolog.Event, config settings.Config) error {
+func ReportPolicies(report types.Report, output *zerolog.Event, config settings.Config) (bool, error) {
 	policyResults, err := getPolicyReportOutput(report, config)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	outputToFile := config.Report.Output != ""
@@ -31,7 +31,7 @@ func ReportPolicies(report types.Report, output *zerolog.Event, config settings.
 
 	output.Msg(reportStr.String())
 
-	return nil
+	return len(policyResults) == 0, nil
 }
 
 func ReportJSON(report types.Report, output *zerolog.Event, config settings.Config) error {


### PR DESCRIPTION
## Description
Return exit status of 1 (failure) when the report format is set to policies, and policy breaches have been detected

Policy breaches detected

![Screenshot 2022-11-28 at 11 59 28](https://user-images.githubusercontent.com/4560746/204249188-57b96e14-0c6a-46b0-b310-593b6bf72ead.png)

No policy breaches detected

![Screenshot 2022-11-28 at 11 59 42](https://user-images.githubusercontent.com/4560746/204249194-f773082e-1842-4b24-8fea-1cf6cb01c3a9.png)

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
