### PR TITLE
feat(policies): disable color in policy report when writing to file

### DIFF
--- a/pkg/report/output/output.go
+++ b/pkg/report/output/output.go
@@ -4,31 +4,21 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/bearer/curio/pkg/commands/process/settings"
 	"github.com/bearer/curio/pkg/flag"
 	"github.com/bearer/curio/pkg/report/output/dataflow"
-	"golang.org/x/exp/maps"
 
 	"github.com/bearer/curio/pkg/report/output/detectors"
 	"github.com/bearer/curio/pkg/report/output/policies"
 	"github.com/bearer/curio/pkg/report/output/stats"
 	"github.com/bearer/curio/pkg/types"
-	"github.com/fatih/color"
 	"gopkg.in/yaml.v3"
 
 	"github.com/rs/zerolog"
 )
 
 var ErrUndefinedFormat = errors.New("undefined output format")
-var underline = color.New(color.Underline).SprintFunc()
-var severityColorFns = map[string]func(x ...interface{}) string{
-	settings.LevelCritical: color.New(color.FgRed).SprintFunc(),
-	settings.LevelHigh:     color.New(color.FgHiRed).SprintFunc(),
-	settings.LevelMedium:   color.New(color.FgYellow).SprintFunc(),
-	settings.LevelLow:      color.New(color.FgBlue).SprintFunc(),
-}
 
 func ReportPolicies(report types.Report, output *zerolog.Event, config settings.Config) error {
 	policyResults, err := getPolicyReportOutput(report, config)
@@ -36,32 +26,8 @@ func ReportPolicies(report types.Report, output *zerolog.Event, config settings.
 		return err
 	}
 
-	reportStr := &strings.Builder{}
-	reportStr.WriteString("\n\nPolicy Report\n")
-	reportStr.WriteString("\n=====================================")
-
-	writePolicyListToString(reportStr, config.Policies)
-
-	breachedPolicies := map[string]map[string]bool{
-		settings.LevelCritical: make(map[string]bool),
-		settings.LevelHigh:     make(map[string]bool),
-		settings.LevelMedium:   make(map[string]bool),
-		settings.LevelLow:      make(map[string]bool),
-	}
-
-	for _, policyLevel := range []string{
-		settings.LevelCritical,
-		settings.LevelHigh,
-		settings.LevelMedium,
-		settings.LevelLow,
-	} {
-		for _, policyBreach := range policyResults[policyLevel] {
-			breachedPolicies[policyLevel][policyBreach.PolicyName] = true
-			writePolicyBreachToString(reportStr, policyBreach, policyLevel)
-		}
-	}
-
-	writeSummaryToString(reportStr, policyResults, len(config.Policies), breachedPolicies)
+	outputToFile := config.Report.Output != ""
+	reportStr := policies.BuildReportString(policyResults, config.Policies, outputToFile)
 
 	output.Msg(reportStr.String())
 
@@ -156,99 +122,4 @@ func getDataflow(report types.Report, config settings.Config, isInternal bool) (
 	}
 
 	return dataflow.GetOutput(reportedDetections, config, isInternal)
-}
-
-func writePolicyListToString(reportStr *strings.Builder, policies map[string]*settings.Policy) {
-	// list policies that were run
-	reportStr.WriteString("\nPolicy list: \n\n")
-	for key := range policies {
-		policy := policies[key]
-		reportStr.WriteString(color.HiBlackString("- " + policy.Name + "\n"))
-	}
-}
-
-func writeSummaryToString(
-	reportStr *strings.Builder,
-	policyResults map[string][]policies.PolicyResult,
-	policyCount int, breachedPolicies map[string]map[string]bool,
-) {
-	reportStr.WriteString("\n=====================================")
-
-	// give summary including counts
-	if len(policyResults) == 0 {
-		reportStr.WriteString("\n\n")
-		reportStr.WriteString(color.HiGreenString("SUCCESS\n\n"))
-		reportStr.WriteString(fmt.Sprint(policyCount) + " policies were run and no breaches were detected.\n\n")
-		return
-	}
-
-	criticalCount := len(policyResults[settings.LevelCritical])
-	highCount := len(policyResults[settings.LevelHigh])
-	mediumCount := len(policyResults[settings.LevelMedium])
-	lowCount := len(policyResults[settings.LevelLow])
-
-	totalCount := criticalCount + highCount + mediumCount + lowCount
-
-	reportStr.WriteString("\n\n")
-	reportStr.WriteString(color.RedString("Policy breaches detected\n\n"))
-	reportStr.WriteString(fmt.Sprint(policyCount) + " policies were run ")
-	reportStr.WriteString("and " + fmt.Sprint(totalCount) + " breaches were detected.\n\n")
-
-	// critical count
-	reportStr.WriteString(formatSeverity(settings.LevelCritical) + fmt.Sprint(criticalCount))
-	if len(breachedPolicies[settings.LevelCritical]) > 0 {
-		reportStr.WriteString(" (" + strings.Join(maps.Keys(breachedPolicies[settings.LevelCritical]), ", ") + ")")
-	}
-	// high count
-	reportStr.WriteString("\n" + formatSeverity(settings.LevelHigh) + fmt.Sprint(highCount))
-	if len(breachedPolicies[settings.LevelHigh]) > 0 {
-		reportStr.WriteString(" (" + strings.Join(maps.Keys(breachedPolicies[settings.LevelHigh]), ", ") + ")")
-	}
-	// medium count
-	reportStr.WriteString("\n" + formatSeverity(settings.LevelMedium) + fmt.Sprint(mediumCount))
-	if len(breachedPolicies[settings.LevelMedium]) > 0 {
-		reportStr.WriteString(" (" + strings.Join(maps.Keys(breachedPolicies[settings.LevelMedium]), ", ") + ")")
-	}
-	// low count
-	reportStr.WriteString("\n" + formatSeverity(settings.LevelLow) + fmt.Sprint(lowCount))
-	if len(breachedPolicies[settings.LevelLow]) > 0 {
-		reportStr.WriteString(" (" + strings.Join(maps.Keys(breachedPolicies[settings.LevelLow]), ", ") + ")")
-	}
-
-	reportStr.WriteString("\n\n")
-}
-
-func writePolicyBreachToString(reportStr *strings.Builder, policyBreach policies.PolicyResult, policySeverity string) {
-	reportStr.WriteString("\n\n")
-	reportStr.WriteString(formatSeverity(policySeverity))
-	reportStr.WriteString(policyBreach.PolicyName + " policy breach with " + policyBreach.CategoryGroup + "\n")
-	reportStr.WriteString(color.HiBlackString(policyBreach.PolicyDescription + "\n"))
-	reportStr.WriteString("\n")
-	reportStr.WriteString(color.HiBlueString("File: " + underline(policyBreach.Filename+":"+fmt.Sprint(policyBreach.LineNumber)) + "\n"))
-	reportStr.WriteString("\n")
-	reportStr.WriteString(highlightCodeExtract(policyBreach.LineNumber, policyBreach.ParentLineNumber, policyBreach.ParentContent))
-}
-
-func formatSeverity(policySeverity string) string {
-	severityColorFn, ok := severityColorFns[policySeverity]
-	if !ok {
-		return strings.ToUpper(policySeverity)
-	}
-	return severityColorFn(strings.ToUpper(policySeverity + ": "))
-}
-
-func highlightCodeExtract(lineNumber int, extractStartLineNumber int, extract string) string {
-	result := ""
-	targetIndex := lineNumber - extractStartLineNumber
-	for index, line := range strings.Split(extract, "\n") {
-		if index == targetIndex {
-			result += color.MagentaString(" " + fmt.Sprint(extractStartLineNumber+index) + " ")
-			result += color.MagentaString(line) + "\n"
-		} else {
-			result += " " + fmt.Sprint(extractStartLineNumber+index) + " "
-			result += line + "\n"
-		}
-	}
-
-	return result
 }

--- a/pkg/report/output/policies/policies.go
+++ b/pkg/report/output/policies/policies.go
@@ -2,13 +2,25 @@ package policies
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
 
 	"github.com/bearer/curio/pkg/classification/db"
 	"github.com/bearer/curio/pkg/commands/process/settings"
 	"github.com/bearer/curio/pkg/util/rego"
+	"github.com/fatih/color"
+	"golang.org/x/exp/maps"
 
 	"github.com/bearer/curio/pkg/report/output/dataflow"
 )
+
+var underline = color.New(color.Underline).SprintFunc()
+var severityColorFns = map[string]func(x ...interface{}) string{
+	settings.LevelCritical: color.New(color.FgRed).SprintFunc(),
+	settings.LevelHigh:     color.New(color.FgHiRed).SprintFunc(),
+	settings.LevelMedium:   color.New(color.FgYellow).SprintFunc(),
+	settings.LevelLow:      color.New(color.FgBlue).SprintFunc(),
+}
 
 type PolicyInput struct {
 	PolicyId       string             `json:"policy_id" yaml:"policy_id"`
@@ -89,10 +101,143 @@ func GetOutput(dataflow *dataflow.DataFlow, config settings.Config) (map[string]
 	return result, nil
 }
 
+func BuildReportString(policyResults map[string][]PolicyResult, policies map[string]*settings.Policy, withoutColor bool) *strings.Builder {
+	reportStr := &strings.Builder{}
+	reportStr.WriteString("\n\nPolicy Report\n")
+	reportStr.WriteString("\n=====================================")
+
+	initialColorSetting := color.NoColor
+	if withoutColor && !initialColorSetting {
+		color.NoColor = true
+	}
+
+	writePolicyListToString(reportStr, policies)
+
+	breachedPolicies := map[string]map[string]bool{
+		settings.LevelCritical: make(map[string]bool),
+		settings.LevelHigh:     make(map[string]bool),
+		settings.LevelMedium:   make(map[string]bool),
+		settings.LevelLow:      make(map[string]bool),
+	}
+
+	for _, policyLevel := range []string{
+		settings.LevelCritical,
+		settings.LevelHigh,
+		settings.LevelMedium,
+		settings.LevelLow,
+	} {
+		for _, policyBreach := range policyResults[policyLevel] {
+			breachedPolicies[policyLevel][policyBreach.PolicyName] = true
+			writePolicyBreachToString(reportStr, policyBreach, policyLevel)
+		}
+	}
+
+	writeSummaryToString(reportStr, policyResults, len(policies), breachedPolicies)
+
+	color.NoColor = initialColorSetting
+
+	return reportStr
+}
+
 func getFullFilename(path string, filename string) string {
 	if filename == "." {
 		return path
 	}
 
 	return path + filename
+}
+
+func writePolicyListToString(reportStr *strings.Builder, policies map[string]*settings.Policy) {
+	// list policies that were run
+	reportStr.WriteString("\nPolicy list: \n\n")
+	for key := range policies {
+		policy := policies[key]
+		reportStr.WriteString(color.HiBlackString("- " + policy.Name + "\n"))
+	}
+}
+
+func writeSummaryToString(
+	reportStr *strings.Builder,
+	policyResults map[string][]PolicyResult,
+	policyCount int, breachedPolicies map[string]map[string]bool,
+) {
+	reportStr.WriteString("\n=====================================")
+
+	// give summary including counts
+	if len(policyResults) == 0 {
+		reportStr.WriteString("\n\n")
+		reportStr.WriteString(color.HiGreenString("SUCCESS\n\n"))
+		reportStr.WriteString(fmt.Sprint(policyCount) + " policies were run and no breaches were detected.\n\n")
+		return
+	}
+
+	criticalCount := len(policyResults[settings.LevelCritical])
+	highCount := len(policyResults[settings.LevelHigh])
+	mediumCount := len(policyResults[settings.LevelMedium])
+	lowCount := len(policyResults[settings.LevelLow])
+
+	totalCount := criticalCount + highCount + mediumCount + lowCount
+
+	reportStr.WriteString("\n\n")
+	reportStr.WriteString(color.RedString("Policy breaches detected\n\n"))
+	reportStr.WriteString(fmt.Sprint(policyCount) + " policies were run ")
+	reportStr.WriteString("and " + fmt.Sprint(totalCount) + " breaches were detected.\n\n")
+
+	// critical count
+	reportStr.WriteString(formatSeverity(settings.LevelCritical) + fmt.Sprint(criticalCount))
+	if len(breachedPolicies[settings.LevelCritical]) > 0 {
+		reportStr.WriteString(" (" + strings.Join(maps.Keys(breachedPolicies[settings.LevelCritical]), ", ") + ")")
+	}
+	// high count
+	reportStr.WriteString("\n" + formatSeverity(settings.LevelHigh) + fmt.Sprint(highCount))
+	if len(breachedPolicies[settings.LevelHigh]) > 0 {
+		reportStr.WriteString(" (" + strings.Join(maps.Keys(breachedPolicies[settings.LevelHigh]), ", ") + ")")
+	}
+	// medium count
+	reportStr.WriteString("\n" + formatSeverity(settings.LevelMedium) + fmt.Sprint(mediumCount))
+	if len(breachedPolicies[settings.LevelMedium]) > 0 {
+		reportStr.WriteString(" (" + strings.Join(maps.Keys(breachedPolicies[settings.LevelMedium]), ", ") + ")")
+	}
+	// low count
+	reportStr.WriteString("\n" + formatSeverity(settings.LevelLow) + fmt.Sprint(lowCount))
+	if len(breachedPolicies[settings.LevelLow]) > 0 {
+		reportStr.WriteString(" (" + strings.Join(maps.Keys(breachedPolicies[settings.LevelLow]), ", ") + ")")
+	}
+
+	reportStr.WriteString("\n\n")
+}
+
+func writePolicyBreachToString(reportStr *strings.Builder, policyBreach PolicyResult, policySeverity string) {
+	reportStr.WriteString("\n\n")
+	reportStr.WriteString(formatSeverity(policySeverity))
+	reportStr.WriteString(policyBreach.PolicyName + " policy breach with " + policyBreach.CategoryGroup + "\n")
+	reportStr.WriteString(color.HiBlackString(policyBreach.PolicyDescription + "\n"))
+	reportStr.WriteString("\n")
+	reportStr.WriteString(color.HiBlueString("File: " + underline(policyBreach.Filename+":"+fmt.Sprint(policyBreach.LineNumber)) + "\n"))
+	reportStr.WriteString("\n")
+	reportStr.WriteString(highlightCodeExtract(policyBreach.LineNumber, policyBreach.ParentLineNumber, policyBreach.ParentContent))
+}
+
+func formatSeverity(policySeverity string) string {
+	severityColorFn, ok := severityColorFns[policySeverity]
+	if !ok {
+		return strings.ToUpper(policySeverity)
+	}
+	return severityColorFn(strings.ToUpper(policySeverity + ": "))
+}
+
+func highlightCodeExtract(lineNumber int, extractStartLineNumber int, extract string) string {
+	result := ""
+	targetIndex := lineNumber - extractStartLineNumber
+	for index, line := range strings.Split(extract, "\n") {
+		if index == targetIndex {
+			result += color.MagentaString(" " + fmt.Sprint(extractStartLineNumber+index) + " ")
+			result += color.MagentaString(line) + "\n"
+		} else {
+			result += " " + fmt.Sprint(extractStartLineNumber+index) + " "
+			result += line + "\n"
+		}
+	}
+
+	return result
 }


### PR DESCRIPTION
## Description
Disable color in report when we are writing to a file (i.e. avoid special characters in report)
Also some refactoring to move policy-report-specific methods to output/policies.go where they should have been in the first place


Output file before

```


Policy Report

=====================================
Policy list: 

[90m- Logger leaking
[0m[90m- Application level encryption missing
[0m

[31mCRITICAL: [0mLogger leaking policy breach with Personal data
[90mLogger leaks detected
[0m
[94mFile: [4m../../Desktop/example/services/log_contact.rb:3[0m
[0m
 1 logger.info(
 2   "contact city:",
[35m 3 [0m[35m  user.city,[0m
 4 )
```

Output file after

```


Policy Report

=====================================
Policy list:

- Logger leaking
- Application level encryption missing


CRITICAL: Logger leaking policy breach with Personal data
Logger leaks detected

File: ../../Desktop/example/services/log_contact.rb:3

 1 logger.info(
 2   "contact city:",
 3   user.city,
 4 )

...
```

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
