### PR TITLE
fix(report): fix filename for dataflow report

### DIFF
--- a/integration/flags/.snapshots/TestReportFlags-report-dataflow
+++ b/integration/flags/.snapshots/TestReportFlags-report-dataflow
@@ -1,4 +1,4 @@
-{"data_types":[{"name":"Email Address","detectors":[{"name":"detect_ruby_logger","locations":[{"filename":"main.rb","line_number":1}]},{"name":"ruby","locations":[{"filename":"main.rb","line_number":1}]}]}],"risks":[{"detector_id":"detect_ruby_logger","data_types":[{"name":"Email Address","stored":false,"locations":[{"filename":"main.rb","line_number":1}]}]}],"components":[]}
+{"data_types":[{"name":"Email Address","detectors":[{"name":"detect_ruby_logger","locations":[{"filename":"testdata/simple/main.rb","line_number":1}]},{"name":"ruby","locations":[{"filename":"testdata/simple/main.rb","line_number":1}]}]}],"risks":[{"detector_id":"detect_ruby_logger","data_types":[{"name":"Email Address","stored":false,"locations":[{"filename":"testdata/simple/main.rb","line_number":1}]}]}],"components":[]}
 
 --
 

--- a/integration/flags/.snapshots/TestReportFlags-report-dataflow-verified-by
+++ b/integration/flags/.snapshots/TestReportFlags-report-dataflow-verified-by
@@ -3,7 +3,7 @@ data_types:
       detectors:
         - name: detect_sql_create_public_table
           locations:
-            - filename: schema.sql
+            - filename: testdata/verified_by/schema.sql
               line_number: 8
               encrypted: true
               verified_by:
@@ -12,19 +12,19 @@ data_types:
                   line_number: 2
         - name: ruby
           locations:
-            - filename: user.rb
+            - filename: testdata/verified_by/user.rb
               line_number: 2
     - name: Date of birth
       detectors:
         - name: detect_sql_create_public_table
           locations:
-            - filename: schema.sql
+            - filename: testdata/verified_by/schema.sql
               line_number: 6
     - name: Email Address
       detectors:
         - name: detect_sql_create_public_table
           locations:
-            - filename: schema.sql
+            - filename: testdata/verified_by/schema.sql
               line_number: 5
               encrypted: true
               verified_by:
@@ -33,25 +33,25 @@ data_types:
                   line_number: 2
         - name: ruby
           locations:
-            - filename: user.rb
+            - filename: testdata/verified_by/user.rb
               line_number: 2
     - name: Firstname
       detectors:
         - name: detect_sql_create_public_table
           locations:
-            - filename: schema.sql
+            - filename: testdata/verified_by/schema.sql
               line_number: 3
     - name: Lastname
       detectors:
         - name: detect_sql_create_public_table
           locations:
-            - filename: schema.sql
+            - filename: testdata/verified_by/schema.sql
               line_number: 4
     - name: Physical Address
       detectors:
         - name: detect_sql_create_public_table
           locations:
-            - filename: schema.sql
+            - filename: testdata/verified_by/schema.sql
               line_number: 7
               encrypted: true
               verified_by:
@@ -60,7 +60,7 @@ data_types:
                   line_number: 2
         - name: ruby
           locations:
-            - filename: user.rb
+            - filename: testdata/verified_by/user.rb
               line_number: 2
 components: []
 

--- a/integration/flags/.snapshots/TestReportFlags-report-policies
+++ b/integration/flags/.snapshots/TestReportFlags-report-policies
@@ -2,7 +2,7 @@ critical:
     - policy_name: Logger leaking
       policy_description: Logger leaks detected
       line_number: 1
-      filename: testdata/policiesusers.rb
+      filename: testdata/policies/users.rb
       category_group: Personal data
       parent_line_number: 1
       parent_content: logger.info(user.address)

--- a/pkg/report/output/dataflow/dataflow.go
+++ b/pkg/report/output/dataflow/dataflow.go
@@ -141,5 +141,9 @@ func getFullFilename(path string, filename string) string {
 		return path
 	}
 
+	if path == "" {
+		return filename
+	}
+
 	return path + "/" + filename
 }

--- a/pkg/report/output/dataflow/dataflow.go
+++ b/pkg/report/output/dataflow/dataflow.go
@@ -63,6 +63,9 @@ func GetOutput(input []interface{}, config settings.Config, isInternal bool) (*D
 			return nil, err
 		}
 
+		// add full path to filename
+		castDetection.Source.Filename = getFullFilename(config.Target, castDetection.Source.Filename)
+
 		switch detectionType {
 		case detections.TypeSchemaClassified:
 			err = dataTypesHolder.AddSchema(castDetection, nil)
@@ -131,4 +134,12 @@ func GetOutput(input []interface{}, config settings.Config, isInternal bool) (*D
 	}
 
 	return dataflow, nil
+}
+
+func getFullFilename(path string, filename string) string {
+	if filename == "." {
+		return path
+	}
+
+	return path + "/" + filename
 }

--- a/pkg/report/output/policies/policies.go
+++ b/pkg/report/output/policies/policies.go
@@ -85,7 +85,7 @@ func GetOutput(dataflow *dataflow.DataFlow, config settings.Config) (map[string]
 					policyResult := PolicyResult{
 						PolicyName:        policy.Name,
 						PolicyDescription: policy.Description,
-						Filename:          getFullFilename(config.Target, policyOutput.Filename),
+						Filename:          policyOutput.Filename,
 						LineNumber:        policyOutput.LineNumber,
 						CategoryGroup:     policyOutput.CategoryGroup,
 						ParentLineNumber:  policyOutput.ParentLineNumber,
@@ -137,14 +137,6 @@ func BuildReportString(policyResults map[string][]PolicyResult, policies map[str
 	color.NoColor = initialColorSetting
 
 	return reportStr
-}
-
-func getFullFilename(path string, filename string) string {
-	if filename == "." {
-		return path
-	}
-
-	return path + filename
 }
 
 func writePolicyListToString(reportStr *strings.Builder, policies map[string]*settings.Policy) {


### PR DESCRIPTION
## Description
If we scan a single file (not a directory), in the dataflow report the filename displays as `"."` instead of e.g. `"~../../test/test.rb"`

In this PR we move the fix we applied to the policy report higher up in the chain to the dataflow report. 

Note: this does not address `"."` filenames in the detectors report -- ping @cfabianski let me know if this is an issue (it looks like it will require us to cast the detections, which is doable but is a bigger change)

After

Policy Report (no change)

Dataflow Report
```
{
  "data_types": [
    {
      "name": "Country",
      "detectors": [
        {
          "name": "ruby",
          "locations": [
            {
              "filename": "../../Desktop/example/user.rb",
              "line_number": 2
            }
          ]
        }
      ]
    },...
  ],
  "risks": [
    {
      "detector_id": "detect_ruby_logger",
      "data_types": [
        {
          "name": "Firstname",
          "stored": false,
          "locations": [
            {
              "filename": "../../Desktop/example/user.rb",
              "line_number": 7
            }
          ]
        },...
  ],
  "components": []
```

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
