### PR TITLE
feat: add net http rule

### DIFF
--- a/integration/flags/.snapshots/TestInitCommand-init
+++ b/integration/flags/.snapshots/TestInitCommand-init
@@ -132,6 +132,22 @@ scan:
             root_lowercase: false
             metavars: {}
             stored: false
+        ruby_http_detection:
+            disabled: false
+            type: risk
+            languages:
+                - ruby
+            patterns:
+                - |
+                  URI.encode_www_form(<$DATA_TYPE>)
+                - |
+                  Net::HTTP.post_form(<$DATA_TYPE>)
+            param_parenting: false
+            processors: []
+            root_singularize: false
+            root_lowercase: false
+            metavars: {}
+            stored: false
     debug: false
     disable-domain-resolution: false
     domain-resolution-timeout: 3s

--- a/pkg/commands/process/settings/custom_detector.yml
+++ b/pkg/commands/process/settings/custom_detector.yml
@@ -1,3 +1,17 @@
+http_detection:
+  type: "risk"
+  languages:
+    - ruby
+  patterns:
+    - |
+      URI.encode_www_form(<$DATA_TYPE>)
+    - |
+      Net::HTTP.post_form(<$DATA_TYPE>)
+    # - |
+    #   $HTTP_CLIENT.$METHOD(<$DATA_TYPE>)
+  param_parenting: false
+  metavars: {}
+  stored: false
 ruby_file_detection:
   type: "risk"
   languages:

--- a/pkg/commands/process/settings/custom_detector.yml
+++ b/pkg/commands/process/settings/custom_detector.yml
@@ -1,4 +1,4 @@
-http_detection:
+ruby_http_detection:
   type: "risk"
   languages:
     - ruby

--- a/pkg/detectors/csharp/datatype/datatype.go
+++ b/pkg/detectors/csharp/datatype/datatype.go
@@ -217,5 +217,5 @@ func standardizeDataType(node *parser.Node, content string) string {
 		return schema.SimpleTypeObject
 	}
 
-	return schema.SimpleTypeUknown
+	return schema.SimpleTypeUnknown
 }

--- a/pkg/detectors/custom/custom.go
+++ b/pkg/detectors/custom/custom.go
@@ -170,7 +170,6 @@ func (detector *Detector) extractData(captures []parser.Captures, rule config.Co
 			var err error
 
 			if param.ArgumentsExtract || param.ClassNameExtract {
-				// @ToDo: This is where we need to define the parent that will get sent as parent
 				paramTypes, err = detector.extractArguments(lang, capture[param.BuildFullName()], idGenerator, fileinfo, filePath)
 				if err != nil {
 					return err
@@ -222,7 +221,7 @@ func (detector *Detector) extractData(captures []parser.Captures, rule config.Co
 							matchType := &schemadatatype.DataType{
 								Node:       matchNode,
 								Name:       string(match),
-								Type:       schema.SimpleTypeUknown,
+								Type:       schema.SimpleTypeUnknown,
 								Properties: make(map[string]schemadatatype.DataTypable),
 							}
 							matchNodeID := matchNode.ID()

--- a/pkg/detectors/java/datatype/datatype.go
+++ b/pkg/detectors/java/datatype/datatype.go
@@ -145,5 +145,5 @@ func standardizeDataType(node *parser.Node, content string) string {
 		return schema.SimpleTypeObject
 	}
 
-	return schema.SimpleTypeUknown
+	return schema.SimpleTypeUnknown
 }

--- a/pkg/detectors/javascript/datatype/objects.go
+++ b/pkg/detectors/javascript/datatype/objects.go
@@ -40,7 +40,7 @@ func addObjects(tree *parser.Tree, datatypes map[parser.NodeID]*schemadatatype.D
 			datatypes[objectNode.ID()] = &schemadatatype.DataType{
 				Node:       objectNode,
 				Name:       "",
-				Type:       schema.SimpleTypeUknown,
+				Type:       schema.SimpleTypeUnknown,
 				TextType:   "",
 				Properties: make(map[string]schemadatatype.DataTypable),
 			}
@@ -50,7 +50,7 @@ func addObjects(tree *parser.Tree, datatypes map[parser.NodeID]*schemadatatype.D
 		datatypes[objectNode.ID()].Properties[propertyName] = &schemadatatype.DataType{
 			Node:       propertyNode,
 			Name:       propertyNode.Content(),
-			Type:       schema.SimpleTypeUknown,
+			Type:       schema.SimpleTypeUnknown,
 			TextType:   "",
 			Properties: make(map[string]schemadatatype.DataTypable),
 		}

--- a/pkg/detectors/javascript/datatype/properties.go
+++ b/pkg/detectors/javascript/datatype/properties.go
@@ -34,7 +34,7 @@ func addProperties(tree *parser.Tree, helperDatatypes map[parser.NodeID]*schemad
 		helperDatatypes[rootPropertyNode.ID()] = &schemadatatype.DataType{
 			Node:       rootPropertyNode,
 			Name:       id,
-			Type:       schema.SimpleTypeUknown,
+			Type:       schema.SimpleTypeUnknown,
 			TextType:   "",
 			Properties: make(map[string]schemadatatype.DataTypable),
 			UUID:       "",
@@ -49,7 +49,7 @@ func addProperties(tree *parser.Tree, helperDatatypes map[parser.NodeID]*schemad
 		helperDatatypes[rootPropertyNode.ID()] = &schemadatatype.DataType{
 			Node:       rootPropertyNode,
 			Name:       id,
-			Type:       schema.SimpleTypeUknown,
+			Type:       schema.SimpleTypeUnknown,
 			TextType:   "",
 			Properties: make(map[string]schemadatatype.DataTypable),
 			UUID:       "",
@@ -65,7 +65,7 @@ func addProperties(tree *parser.Tree, helperDatatypes map[parser.NodeID]*schemad
 		helperDatatypes[objectNode.ID()] = &schemadatatype.DataType{
 			Node:       propertyNode,
 			Name:       id,
-			Type:       schema.SimpleTypeUknown,
+			Type:       schema.SimpleTypeUnknown,
 			TextType:   "",
 			Properties: make(map[string]schemadatatype.DataTypable),
 			UUID:       "",

--- a/pkg/detectors/php/datatype/datatype.go
+++ b/pkg/detectors/php/datatype/datatype.go
@@ -93,7 +93,7 @@ func discoverClassProperties(tree *parser.Tree, datatypes map[parser.NodeID]*sch
 		datatypes[classNode.ID()].Properties[propertyName] = &schemadatatype.DataType{
 			Node:     propertyNode,
 			Name:     propertyName,
-			Type:     schema.SimpleTypeUknown,
+			Type:     schema.SimpleTypeUnknown,
 			TextType: "",
 		}
 	}
@@ -114,7 +114,7 @@ func discoverClassFunctions(tree *parser.Tree, datatypes map[parser.NodeID]*sche
 		datatypes[classNode.ID()].Properties[functionName] = &schemadatatype.DataType{
 			Node:     functionNameNode,
 			Name:     functionName,
-			Type:     schema.SimpleTypeUknown,
+			Type:     schema.SimpleTypeUnknown,
 			TextType: "",
 		}
 	}

--- a/pkg/detectors/php/datatype/properties.go
+++ b/pkg/detectors/php/datatype/properties.go
@@ -31,7 +31,7 @@ func addProperties(tree *parser.Tree, helperDatatypes map[parser.NodeID]*schemad
 				helperDatatypes[propertyNode.ID()] = &schemadatatype.DataType{
 					Node:       propertyNode,
 					Name:       id,
-					Type:       schema.SimpleTypeUknown,
+					Type:       schema.SimpleTypeUnknown,
 					TextType:   "",
 					Properties: make(map[string]schemadatatype.DataTypable),
 					UUID:       "",
@@ -52,7 +52,7 @@ func addProperties(tree *parser.Tree, helperDatatypes map[parser.NodeID]*schemad
 			helperDatatypes[objectNode.ID()] = &schemadatatype.DataType{
 				Node:       objectNode,
 				Name:       id,
-				Type:       schema.SimpleTypeUknown,
+				Type:       schema.SimpleTypeUnknown,
 				TextType:   "",
 				Properties: make(map[string]schemadatatype.DataTypable),
 				UUID:       "",

--- a/pkg/detectors/python/datatype/datatype.go
+++ b/pkg/detectors/python/datatype/datatype.go
@@ -106,7 +106,7 @@ func discoverClassProperties(tree *parser.Tree, datatypes map[parser.NodeID]*sch
 		datatypes[classNode.ID()].Properties[propertyName] = &schemadatatype.DataType{
 			Node:       propertyNode,
 			Name:       propertyName,
-			Type:       schema.SimpleTypeUknown,
+			Type:       schema.SimpleTypeUnknown,
 			Properties: make(map[string]schemadatatype.DataTypable),
 			TextType:   "",
 		}
@@ -128,7 +128,7 @@ func discoverClassFunctions(tree *parser.Tree, datatypes map[parser.NodeID]*sche
 		datatypes[classNode.ID()].Properties[functionName] = &schemadatatype.DataType{
 			Node:     functionNameNode,
 			Name:     functionName,
-			Type:     schema.SimpleTypeUknown,
+			Type:     schema.SimpleTypeUnknown,
 			TextType: "",
 		}
 	}

--- a/pkg/detectors/python/datatype/properties.go
+++ b/pkg/detectors/python/datatype/properties.go
@@ -34,7 +34,7 @@ func addProperties(tree *parser.Tree, helperDatatypes map[parser.NodeID]*schemad
 			helperDatatypes[childNode.ID()] = &schemadatatype.DataType{
 				Node:       childNode,
 				Name:       id,
-				Type:       schema.SimpleTypeUknown,
+				Type:       schema.SimpleTypeUnknown,
 				TextType:   "",
 				Properties: make(map[string]schemadatatype.DataTypable),
 				UUID:       "",
@@ -47,7 +47,7 @@ func addProperties(tree *parser.Tree, helperDatatypes map[parser.NodeID]*schemad
 		helperDatatypes[elementNode.ID()] = &schemadatatype.DataType{
 			Node:       idNode,
 			Name:       idNode.Content(),
-			Type:       schema.SimpleTypeUknown,
+			Type:       schema.SimpleTypeUnknown,
 			TextType:   "",
 			Properties: make(map[string]schemadatatype.DataTypable),
 			UUID:       "",
@@ -63,7 +63,7 @@ func addProperties(tree *parser.Tree, helperDatatypes map[parser.NodeID]*schemad
 			helperDatatypes[childNode.ID()] = &schemadatatype.DataType{
 				Node:       childNode,
 				Name:       id,
-				Type:       schema.SimpleTypeUknown,
+				Type:       schema.SimpleTypeUnknown,
 				TextType:   "",
 				Properties: make(map[string]schemadatatype.DataTypable),
 				UUID:       "",
@@ -78,7 +78,7 @@ func addProperties(tree *parser.Tree, helperDatatypes map[parser.NodeID]*schemad
 		helperDatatypes[elementNode.ID()] = &schemadatatype.DataType{
 			Node:       idNode,
 			Name:       id,
-			Type:       schema.SimpleTypeUknown,
+			Type:       schema.SimpleTypeUnknown,
 			TextType:   "",
 			Properties: make(map[string]schemadatatype.DataTypable),
 			UUID:       "",

--- a/pkg/detectors/ruby/custom_detector/extract_arguments.go
+++ b/pkg/detectors/ruby/custom_detector/extract_arguments.go
@@ -19,7 +19,7 @@ func (detector *Detector) ExtractArguments(node *parser.Node, idGenerator nodeid
 
 	joinedDatatypes := make(map[parser.NodeID]*schemadatatype.DataType)
 
-	// handle classs name
+	// handle class name
 	if node.Type() == "constant" {
 		datatype := &schemadatatype.DataType{
 			Node:       node,
@@ -35,7 +35,6 @@ func (detector *Detector) ExtractArguments(node *parser.Node, idGenerator nodeid
 		singleArgument := node.Child(i)
 
 		if singleArgument.Type() == "identifier" || singleArgument.Type() == "simple_symbol" || singleArgument.Type() == "bare_symbol" {
-
 			content := singleArgument.Content()
 
 			if singleArgument.Type() == "simple_symbol" {
@@ -45,7 +44,7 @@ func (detector *Detector) ExtractArguments(node *parser.Node, idGenerator nodeid
 			datatype := &schemadatatype.DataType{
 				Node:       singleArgument,
 				Name:       content,
-				Type:       schema.SimpleTypeUknown,
+				Type:       schema.SimpleTypeUnknown,
 				Properties: make(map[string]schemadatatype.DataTypable),
 			}
 			joinedDatatypes[datatype.Node.ID()] = datatype

--- a/pkg/detectors/ruby/datatype/class_assignment.go
+++ b/pkg/detectors/ruby/datatype/class_assignment.go
@@ -12,7 +12,7 @@ import (
 var classAssignmentQuery = parser.QueryMustCompile(ruby.GetLanguage(),
 	`(assignment
 		left: (constant) @param_id
-		right: 
+		right:
 			(call
 				receiver: (constant) @helper_Class
 				method: (identifier) @helper_new
@@ -70,7 +70,7 @@ func discoverClassAssignmentProperties(tree *parser.Tree, datatypes map[parser.N
 		datatypes[classNode.ID()].Properties[propertyName] = &schemadatatype.DataType{
 			Node:       propertyNode,
 			Name:       propertyName,
-			Type:       schema.SimpleTypeUknown,
+			Type:       schema.SimpleTypeUnknown,
 			Properties: make(map[string]schemadatatype.DataTypable),
 			TextType:   "",
 		}
@@ -92,7 +92,7 @@ func discoverClassAssignmentFunctions(tree *parser.Tree, datatypes map[parser.No
 		datatypes[classNode.ID()].Properties[functionName] = &schemadatatype.DataType{
 			Node:     functionNameNode,
 			Name:     functionName,
-			Type:     schema.SimpleTypeUknown,
+			Type:     schema.SimpleTypeUnknown,
 			TextType: "",
 		}
 	}

--- a/pkg/detectors/ruby/datatype/datatype.go
+++ b/pkg/detectors/ruby/datatype/datatype.go
@@ -87,7 +87,7 @@ func discoverClassProperties(tree *parser.Tree, datatypes map[parser.NodeID]*sch
 		datatypes[classNode.ID()].Properties[propertyName] = &schemadatatype.DataType{
 			Node:       propertyNode,
 			Name:       propertyName,
-			Type:       schema.SimpleTypeUknown,
+			Type:       schema.SimpleTypeUnknown,
 			Properties: make(map[string]schemadatatype.DataTypable),
 			TextType:   "",
 		}
@@ -109,7 +109,7 @@ func discoverClassFunctions(tree *parser.Tree, datatypes map[parser.NodeID]*sche
 		datatypes[classNode.ID()].Properties[functionName] = &schemadatatype.DataType{
 			Node:     functionNameNode,
 			Name:     functionName,
-			Type:     schema.SimpleTypeUknown,
+			Type:     schema.SimpleTypeUnknown,
 			TextType: "",
 		}
 	}

--- a/pkg/detectors/ruby/datatype/structures.go
+++ b/pkg/detectors/ruby/datatype/structures.go
@@ -9,12 +9,13 @@ import (
 
 // Foo = Struct.new(foo: "foo", bar: "bar")
 // Foo.new(foo: "foo", bar: "bar")
-var structuresQuery = parser.QueryMustCompile(ruby.GetLanguage(),
-	`(call
+var structuresQuery = parser.QueryMustCompile(ruby.GetLanguage(), `
+(call
 		receiver: (constant) @receiver_id
 		method: (identifier) @method_id
 		arguments: (argument_list) @param_arguments
-	  ) @param_call`)
+) @param_call
+`)
 
 func discoverStructures(tree *parser.Tree, datatypes map[parser.NodeID]*schemadatatype.DataType) {
 	// add class properties
@@ -54,7 +55,7 @@ func discoverStructures(tree *parser.Tree, datatypes map[parser.NodeID]*schemada
 		parent := &schemadatatype.DataType{
 			Node:       receiver,
 			Name:       parentName,
-			Type:       schema.SimpleTypeUknown,
+			Type:       schema.SimpleTypeUnknown,
 			Properties: make(map[string]schemadatatype.DataTypable),
 			TextType:   "",
 		}
@@ -79,7 +80,7 @@ func discoverStructures(tree *parser.Tree, datatypes map[parser.NodeID]*schemada
 			parent.Properties[propertyName] = &schemadatatype.DataType{
 				Node:       key,
 				Name:       propertyName,
-				Type:       schema.SimpleTypeUknown,
+				Type:       schema.SimpleTypeUnknown,
 				TextType:   "",
 				Properties: make(map[string]schemadatatype.DataTypable),
 			}

--- a/pkg/detectors/typescript/datatype/datatype.go
+++ b/pkg/detectors/typescript/datatype/datatype.go
@@ -90,7 +90,7 @@ func annotateDataTypes(finder *datatype.Finder, node *parser.Node, value *schema
 			}
 		}
 
-		value.Type = schema.SimpleTypeUknown
+		value.Type = schema.SimpleTypeUnknown
 		return true
 	case "class_declaration":
 		name := node.ChildByFieldName("name")
@@ -209,7 +209,7 @@ func annotateDataTypeProperties(finder *datatype.PropertyFinder, node *parser.No
 				simpleType := standardizeDataType(typeChildNode, typeContent)
 				dataType.Type = simpleType
 
-				if simpleType != schema.SimpleTypeObject && simpleType != schema.SimpleTypeUknown && simpleType != schema.SimpleTypeFunction {
+				if simpleType != schema.SimpleTypeObject && simpleType != schema.SimpleTypeUnknown && simpleType != schema.SimpleTypeFunction {
 					dataType.TextType = typeChildNode.Content()
 				}
 			}
@@ -299,7 +299,7 @@ func standardizeDataType(node *parser.Node, content string) string {
 		return schema.SimpleTypeObject
 	}
 
-	return schema.SimpleTypeUknown
+	return schema.SimpleTypeUnknown
 }
 
 func standardizeTextType(node *parser.Node) string {

--- a/pkg/report/schema/schema.go
+++ b/pkg/report/schema/schema.go
@@ -13,7 +13,7 @@ const (
 	SimpleTypeString   = "string"
 	SimpleTypeBool     = "boolean"
 	SimpleTypeBinary   = "binary"
-	SimpleTypeUknown   = "unknown"
+	SimpleTypeUnknown  = "unknown"
 )
 
 type Schema struct {


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Add new `ruby_http_detection` rule
Also adds support for Hashes so that example like this will work

```ruby
user = {
  first_name: "John 1",
  last_name: "Doe",
  address: {
    city: "Paris",
    zip_code: "75010"
  }
}

uri.query = URI.encode_www_form({ user: { first_name: "John", last_name: "Doe" } })
uri.query = URI.encode_www_form(user.email)
```

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
