### PR TITLE
fix: Use full file paths in dataflow report

### DIFF
--- a/pkg/report/output/dataflow/components/components.go
+++ b/pkg/report/output/dataflow/components/components.go
@@ -36,7 +36,7 @@ func New(isInternal bool) *Holder {
 	}
 }
 
-func (holder *Holder) AddInterface(detection interface{}) error {
+func (holder *Holder) AddInterface(detection interface{}, fullFilename string) error {
 	value, err := detectiondecoder.GetClassifiedInterface(detection)
 	if err != nil {
 		return err
@@ -51,7 +51,7 @@ func (holder *Holder) AddInterface(detection interface{}) error {
 			value.Classification.Name(),
 			value.Classification.RecipeUUID,
 			string(value.DetectorType),
-			value.Source.Filename,
+			fullFilename,
 			*value.Source.LineNumber,
 		)
 	}
@@ -59,7 +59,7 @@ func (holder *Holder) AddInterface(detection interface{}) error {
 	return nil
 }
 
-func (holder *Holder) AddDependency(detection interface{}) error {
+func (holder *Holder) AddDependency(detection interface{}, fullFilename string) error {
 	value, err := detectiondecoder.GetClassifiedDependency(detection)
 	if err != nil {
 		return err
@@ -74,7 +74,7 @@ func (holder *Holder) AddDependency(detection interface{}) error {
 			value.Classification.RecipeName,
 			value.Classification.RecipeUUID,
 			string(value.DetectorType),
-			value.Source.Filename,
+			fullFilename,
 			*value.Source.LineNumber,
 		)
 	}
@@ -82,7 +82,7 @@ func (holder *Holder) AddDependency(detection interface{}) error {
 	return nil
 }
 
-func (holder *Holder) AddFramework(detection interface{}) error {
+func (holder *Holder) AddFramework(detection interface{}, fullFilename string) error {
 	value, err := detectiondecoder.GetClassifiedFramework(detection)
 	if err != nil {
 		return err
@@ -97,7 +97,7 @@ func (holder *Holder) AddFramework(detection interface{}) error {
 			value.Classification.RecipeName,
 			value.Classification.RecipeUUID,
 			string(value.DetectorType),
-			value.Source.Filename,
+			fullFilename,
 			*value.Source.LineNumber,
 		)
 	}

--- a/pkg/report/output/dataflow/components/components.go
+++ b/pkg/report/output/dataflow/components/components.go
@@ -1,9 +1,11 @@
 package components
 
 import (
-	"github.com/bearer/curio/pkg/report/output/dataflow/detectiondecoder"
 	"github.com/bearer/curio/pkg/report/output/dataflow/types"
 
+	dependenciesclassification "github.com/bearer/curio/pkg/classification/dependencies"
+	frameworkclassification "github.com/bearer/curio/pkg/classification/frameworks"
+	interfaceclassification "github.com/bearer/curio/pkg/classification/interfaces"
 	"github.com/bearer/curio/pkg/util/classify"
 	"github.com/bearer/curio/pkg/util/maputil"
 )
@@ -36,69 +38,54 @@ func New(isInternal bool) *Holder {
 	}
 }
 
-func (holder *Holder) AddInterface(detection interface{}, fullFilename string) error {
-	value, err := detectiondecoder.GetClassifiedInterface(detection)
-	if err != nil {
-		return err
-	}
-
-	if value.Classification == nil {
+func (holder *Holder) AddInterface(classifiedDetection interfaceclassification.ClassifiedInterface) error {
+	if classifiedDetection.Classification == nil {
 		return nil
 	}
 
-	if value.Classification.Decision.State == classify.Valid {
+	if classifiedDetection.Classification.Decision.State == classify.Valid {
 		holder.addComponent(
-			value.Classification.Name(),
-			value.Classification.RecipeUUID,
-			string(value.DetectorType),
-			fullFilename,
-			*value.Source.LineNumber,
+			classifiedDetection.Classification.Name(),
+			classifiedDetection.Classification.RecipeUUID,
+			string(classifiedDetection.DetectorType),
+			classifiedDetection.Source.Filename,
+			*classifiedDetection.Source.LineNumber,
 		)
 	}
 
 	return nil
 }
 
-func (holder *Holder) AddDependency(detection interface{}, fullFilename string) error {
-	value, err := detectiondecoder.GetClassifiedDependency(detection)
-	if err != nil {
-		return err
-	}
-
-	if value.Classification == nil {
+func (holder *Holder) AddDependency(classifiedDetection dependenciesclassification.ClassifiedDependency) error {
+	if classifiedDetection.Classification == nil {
 		return nil
 	}
 
-	if value.Classification.Decision.State == classify.Valid {
+	if classifiedDetection.Classification.Decision.State == classify.Valid {
 		holder.addComponent(
-			value.Classification.RecipeName,
-			value.Classification.RecipeUUID,
-			string(value.DetectorType),
-			fullFilename,
-			*value.Source.LineNumber,
+			classifiedDetection.Classification.RecipeName,
+			classifiedDetection.Classification.RecipeUUID,
+			string(classifiedDetection.DetectorType),
+			classifiedDetection.Source.Filename,
+			*classifiedDetection.Source.LineNumber,
 		)
 	}
 
 	return nil
 }
 
-func (holder *Holder) AddFramework(detection interface{}, fullFilename string) error {
-	value, err := detectiondecoder.GetClassifiedFramework(detection)
-	if err != nil {
-		return err
-	}
-
-	if value.Classification == nil {
+func (holder *Holder) AddFramework(classifiedDetection frameworkclassification.ClassifiedFramework) error {
+	if classifiedDetection.Classification == nil {
 		return nil
 	}
 
-	if value.Classification.Decision.State == classify.Valid {
+	if classifiedDetection.Classification.Decision.State == classify.Valid {
 		holder.addComponent(
-			value.Classification.RecipeName,
-			value.Classification.RecipeUUID,
-			string(value.DetectorType),
-			fullFilename,
-			*value.Source.LineNumber,
+			classifiedDetection.Classification.RecipeName,
+			classifiedDetection.Classification.RecipeUUID,
+			string(classifiedDetection.DetectorType),
+			classifiedDetection.Source.Filename,
+			*classifiedDetection.Source.LineNumber,
 		)
 	}
 

--- a/pkg/report/output/dataflow/dataflow.go
+++ b/pkg/report/output/dataflow/dataflow.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bearer/curio/pkg/report/detections"
 	"github.com/bearer/curio/pkg/report/output/dataflow/components"
 	"github.com/bearer/curio/pkg/report/output/dataflow/datatypes"
+	"github.com/bearer/curio/pkg/report/output/dataflow/detectiondecoder"
 	"github.com/bearer/curio/pkg/report/output/dataflow/risks"
 
 	"github.com/bearer/curio/pkg/report/output/dataflow/types"
@@ -112,17 +113,35 @@ func GetOutput(input []interface{}, config settings.Config, isInternal bool) (*D
 			}
 
 		case detections.TypeDependencyClassified:
-			err := componentsHolder.AddDependency(detection, fullFilename)
+			classifiedDetection, err := detectiondecoder.GetClassifiedDependency(detection)
+			if err != nil {
+				return nil, err
+			}
+
+			classifiedDetection.Source.Filename = fullFilename
+			err = componentsHolder.AddDependency(classifiedDetection)
 			if err != nil {
 				return nil, err
 			}
 		case detections.TypeInterfaceClassified:
-			err := componentsHolder.AddInterface(detection, fullFilename)
+			classifiedDetection, err := detectiondecoder.GetClassifiedInterface(detection)
+			if err != nil {
+				return nil, err
+			}
+
+			classifiedDetection.Source.Filename = fullFilename
+			err = componentsHolder.AddInterface(classifiedDetection)
 			if err != nil {
 				return nil, err
 			}
 		case detections.TypeFrameworkClassified:
-			err := componentsHolder.AddFramework(detection, fullFilename)
+			classifiedDetection, err := detectiondecoder.GetClassifiedFramework(detection)
+			if err != nil {
+				return nil, err
+			}
+
+			classifiedDetection.Source.Filename = fullFilename
+			err = componentsHolder.AddFramework(classifiedDetection)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
## Description

All filenames in the output should consistently use the full path, including the scan target directory prefix.

### Sample output before

```yaml
data_types:
    - name: Email Address
      detectors:
        - name: rails
          locations:
            - filename: ../scan_target_rails/db/schema.rb
              line_number: 18
        - name: ruby
          locations:
            - filename: ../scan_target_rails/config/initializers/devise.rb
              line_number: 186
components:
    - name: Disk
      locations:
        - detector: rails
          filename: config/storage.yml
          line_number: 5
    - name: PostgreSQL
      locations:
        - detector: rails
          filename: config/database.yml
          line_number: 85
    - name: Redis
      locations:
        - detector: gemfile-lock
          filename: Gemfile.lock
          line_number: 191
```

### Sample output after

```yaml
data_types:
    - name: Email Address
      detectors:
        - name: rails
          locations:
            - filename: ../scan_target_rails/db/schema.rb
              line_number: 18
        - name: ruby
          locations:
            - filename: ../scan_target_rails/config/initializers/devise.rb
              line_number: 186
components:
    - name: Disk
      locations:
        - detector: rails
          filename: ../scan_target_rails/config/storage.yml
          line_number: 5
    - name: PostgreSQL
      locations:
        - detector: rails
          filename: ../scan_target_rails/config/database.yml
          line_number: 85
    - name: Redis
      locations:
        - detector: gemfile-lock
          filename: ../scan_target_rails/Gemfile.lock
          line_number: 191
```

## Checklist

- [X] I've added test coverage that shows my fix or feature works as expected.
- [X] I've updated or added documentation if required.
- [X] I've included usage information in the description if CLI behavior was updated or added.
- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
