### PR TITLE
docs: autogenerate data type docs

### DIFF
--- a/docs/_data/datatypes.js
+++ b/docs/_data/datatypes.js
@@ -1,14 +1,19 @@
 const { readdir, readFile } = require("node:fs/promises");
 const path = require("path");
 
+async function fetchFile(location) {
+  return readFile(location, { encoding: "utf8" }).then((file) =>
+    JSON.parse(file)
+  );
+}
+
 async function fetchData(dir) {
   try {
     const files = await readdir(dir);
+    console.log(files.length);
     let result = await Promise.all(
       files.map(async (file) => {
-        let data = await readFile(path.join(dir, file), { encoding: "utf8" });
-        // console.log(data);
-        return JSON.parse(data);
+        return await fetchFile(path.join(dir, file));
       })
     );
     return result;
@@ -17,25 +22,45 @@ async function fetchData(dir) {
   }
 }
 
-function sortData(types, cats) {
-  let workingData = {};
-  let output = [];
-  cats.forEach((cat) => {
-    workingData[cat.uuid] = { name: cat.name, types: [] };
-  });
+function sortData(typesFile, catsFile, groupsFile) {
+  let output = {};
+  let counts = {
+    types: typesFile.length,
+  };
 
-  types.forEach((item) => {
-    workingData[item.category_uuid].types.push(item);
-  });
-
-  for (const key in workingData) {
-    output.push({ ...workingData[key] });
+  // setup groups
+  for (const key in groupsFile.groups) {
+    output[key] = { uuid: key, name: groupsFile.groups[key], categories: {} };
   }
-  return output;
+
+  // add categories to each group
+  for (const key in groupsFile.category_mapping) {
+    output[groupsFile.category_mapping[key].group_uuid].categories[key] = {
+      types: [],
+      uuid: key,
+      ...groupsFile.category_mapping[key],
+    };
+  }
+
+  // add types to each category
+  // output[group uuid].categories[category uuid].types[]
+  // note: inefficient, needs rewrite
+  for (const key in output) {
+    typesFile.forEach((item) => {
+      if (output[key].categories[item.category_uuid]) {
+        output[key].categories[item.category_uuid].types.push(item);
+      }
+    });
+  }
+
+  return { output, counts };
 }
 // example();
 module.exports = async function () {
   let dataTypes = await fetchData("../pkg/classification/db/data_types/");
   let dataCats = await fetchData("../pkg/classification/db/data_categories/");
-  return sortData(dataTypes, dataCats);
+  let groupings = await fetchFile(
+    "../pkg/classification/db/category_grouping.json"
+  );
+  return sortData(dataTypes, dataCats, groupings);
 };

--- a/docs/_data/datatypes.js
+++ b/docs/_data/datatypes.js
@@ -1,0 +1,41 @@
+const { readdir, readFile } = require("node:fs/promises");
+const path = require("path");
+
+async function fetchData(dir) {
+  try {
+    const files = await readdir(dir);
+    let result = await Promise.all(
+      files.map(async (file) => {
+        let data = await readFile(path.join(dir, file), { encoding: "utf8" });
+        // console.log(data);
+        return JSON.parse(data);
+      })
+    );
+    return result;
+  } catch (err) {
+    throw err;
+  }
+}
+
+function sortData(types, cats) {
+  let workingData = {};
+  let output = [];
+  cats.forEach((cat) => {
+    workingData[cat.uuid] = { name: cat.name, types: [] };
+  });
+
+  types.forEach((item) => {
+    workingData[item.category_uuid].types.push(item);
+  });
+
+  for (const key in workingData) {
+    output.push({ ...workingData[key] });
+  }
+  return output;
+}
+// example();
+module.exports = async function () {
+  let dataTypes = await fetchData("../pkg/classification/db/data_types/");
+  let dataCats = await fetchData("../pkg/classification/db/data_categories/");
+  return sortData(dataTypes, dataCats);
+};

--- a/docs/_data/nav.js
+++ b/docs/_data/nav.js
@@ -16,6 +16,9 @@ module.exports = [
   // },
   {
     name: "Reference",
-    items: [{ name: "Commands", url: "/reference/commands/" }],
+    items: [
+      { name: "Commands", url: "/reference/commands/" },
+      { name: "Data Types", url: "/reference/datatypes/" },
+    ],
   },
 ];

--- a/docs/_src/_includes/layouts/doc.njk
+++ b/docs/_src/_includes/layouts/doc.njk
@@ -8,7 +8,7 @@ layout: layouts/base.njk
 			{% for heading in nav %}
 				<li class="mb-4">
 					<h2 class="font-bold text-md">{{heading.name}}</h2>
-					<ul class="">
+					<ul class="ml-2">
 						{% for item in heading.items %}
 							<li>
 								<a class="hover:underline" {% if currentUrl === item.url %}aria-current="page" {% endif %} href="{{item.url}}">{{item.name}}</a>

--- a/docs/reference/datatypes.njk
+++ b/docs/reference/datatypes.njk
@@ -2,17 +2,22 @@
 title: Data Types
 layout: layouts/doc.njk
 ---
-{% renderTemplate "md" %}
+{% renderTemplate "liquid,md",
+datatypes %}
 # Supported Data Types
-Curio supports 120+ data types including Personal Data (PD), Personally Identifiable Information (PII), Protected Health Information (PHI), and Financial Data. 
+Curio supports {{counts.types}} data types including Personal Data (PD), Personally Identifiable Information (PII), Protected Health Information (PHI), and Financial Data. 
 
 The following is a catagorized list of the supported data types.
 {% endrenderTemplate %}
-{% for cat in datatypes %}
-  <h2 id="{{cat.name}}">{{cat.name}}</h2>
-  <ul>
-    {% for item in cat.types %}
-      <li>{{item.name}}</li>
-    {% endfor %}
-  </ul>
+
+{% for key, group in datatypes.output %}
+  <h2 id="{{group.name}}">{{group.name}}</h2>
+  {% for key, cat in group.categories %}
+    <h3 id="{{cat.name}}">{{cat.name}}</h3>
+    <ul>
+      {% for item in cat.types %}
+        <li>{{item.name}}</li>
+      {% endfor %}
+    </ul>
+  {% endfor %}
 {% endfor %}

--- a/docs/reference/datatypes.njk
+++ b/docs/reference/datatypes.njk
@@ -1,0 +1,18 @@
+---
+title: Data Types
+layout: layouts/doc.njk
+---
+{% renderTemplate "md" %}
+# Supported Data Types
+Curio supports 120+ data types including Personal Data (PD), Personally Identifiable Information (PII), Protected Health Information (PHI), and Financial Data. 
+
+The following is a catagorized list of the supported data types.
+{% endrenderTemplate %}
+{% for cat in datatypes %}
+  <h2 id="{{cat.name}}">{{cat.name}}</h2>
+  <ul>
+    {% for item in cat.types %}
+      <li>{{item.name}}</li>
+    {% endfor %}
+  </ul>
+{% endfor %}


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->
Builds supported data types page based on classification db types, categories, and category groups.

<img width="905" alt="CleanShot 2022-11-30 at 17 12 36@2x" src="https://user-images.githubusercontent.com/1649672/204941968-85ab0725-a828-4b4d-bae5-c89137c26e28.png">

## Related
This directly relies on the structure of the data type and category files. New types, categories, and groups can be added/modified without a problem, but changes to their format or file locations will break it.

<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
