### PR TITLE
fix(temp): remove parents from report

### DIFF
--- a/integration/custom_detectors/.snapshots/TestCustomDetectors-detect_rails_jwt
+++ b/integration/custom_detectors/.snapshots/TestCustomDetectors-detect_rails_jwt
@@ -27,17 +27,11 @@ risks:
           locations:
             - filename: testdata/ruby/detect_rails_jwt.rb
               line_number: 12
-          parent:
-            line_number: 10
-            content: JWT.encode user.address, nil, "none"
         - name: Physical Address
           stored: false
           locations:
             - filename: testdata/ruby/detect_rails_jwt.rb
               line_number: 10
-          parent:
-            line_number: 10
-            content: JWT.encode user.address, nil, "none"
 components: []
 
 

--- a/integration/custom_detectors/.snapshots/TestCustomDetectors-detect_rails_session
+++ b/integration/custom_detectors/.snapshots/TestCustomDetectors-detect_rails_session
@@ -23,9 +23,6 @@ risks:
           locations:
             - filename: testdata/ruby/detect_rails_session.rb
               line_number: 2
-          parent:
-            line_number: 2
-            content: session[:current_user] = user.email
 components: []
 
 

--- a/integration/custom_detectors/.snapshots/TestCustomDetectors-detect_ruby_logger
+++ b/integration/custom_detectors/.snapshots/TestCustomDetectors-detect_ruby_logger
@@ -27,27 +27,11 @@ risks:
           locations:
             - filename: testdata/ruby/detect_ruby_logger.rb
               line_number: 3
-          parent:
-            line_number: 1
-            content: |-
-                logger.info(
-                  "user info are:",
-                  user.email,
-                  user.address
-                )
         - name: Physical Address
           stored: false
           locations:
             - filename: testdata/ruby/detect_ruby_logger.rb
               line_number: 4
-          parent:
-            line_number: 1
-            content: |-
-                logger.info(
-                  "user info are:",
-                  user.email,
-                  user.address
-                )
 components: []
 
 

--- a/integration/custom_detectors/.snapshots/TestCustomDetectors-ruby_file_detection
+++ b/integration/custom_detectors/.snapshots/TestCustomDetectors-ruby_file_detection
@@ -63,19 +63,6 @@ risks:
               line_number: 12
             - filename: testdata/ruby/ruby_file_detection.rb
               line_number: 16
-          parent:
-            line_number: 1
-            content: |-
-                CSV.open("path/to/user.csv", "wb") do |csv|
-                  csv << ["email", "first_name", "last_name"]
-                	users.each do |user|
-                		csv << [
-                			user.email,
-                			user.first_name,
-                			user.last_name
-                		]
-                	end
-                end
         - name: Firstname
           stored: false
           locations:
@@ -83,19 +70,6 @@ risks:
               line_number: 6
             - filename: testdata/ruby/ruby_file_detection.rb
               line_number: 16
-          parent:
-            line_number: 1
-            content: |-
-                CSV.open("path/to/user.csv", "wb") do |csv|
-                  csv << ["email", "first_name", "last_name"]
-                	users.each do |user|
-                		csv << [
-                			user.email,
-                			user.first_name,
-                			user.last_name
-                		]
-                	end
-                end
         - name: Lastname
           stored: false
           locations:
@@ -103,19 +77,6 @@ risks:
               line_number: 7
             - filename: testdata/ruby/ruby_file_detection.rb
               line_number: 16
-          parent:
-            line_number: 1
-            content: |-
-                CSV.open("path/to/user.csv", "wb") do |csv|
-                  csv << ["email", "first_name", "last_name"]
-                	users.each do |user|
-                		csv << [
-                			user.email,
-                			user.first_name,
-                			user.last_name
-                		]
-                	end
-                end
 components: []
 
 

--- a/integration/flags/.snapshots/TestReportFlags-report-dataflow
+++ b/integration/flags/.snapshots/TestReportFlags-report-dataflow
@@ -1,4 +1,4 @@
-{"data_types":[{"name":"Email Address","detectors":[{"name":"detect_ruby_logger","locations":[{"filename":"testdata/simple/main.rb","line_number":1}]},{"name":"ruby","locations":[{"filename":"testdata/simple/main.rb","line_number":1}]}]}],"risks":[{"detector_id":"detect_ruby_logger","data_types":[{"name":"Email Address","stored":false,"locations":[{"filename":"testdata/simple/main.rb","line_number":1}],"parent":{"line_number":1,"content":"logger.info(\"user info\", user.email)"}}]}],"components":[]}
+{"data_types":[{"name":"Email Address","detectors":[{"name":"detect_ruby_logger","locations":[{"filename":"testdata/simple/main.rb","line_number":1}]},{"name":"ruby","locations":[{"filename":"testdata/simple/main.rb","line_number":1}]}]}],"risks":[{"detector_id":"detect_ruby_logger","data_types":[{"name":"Email Address","stored":false,"locations":[{"filename":"testdata/simple/main.rb","line_number":1}]}]}],"components":[]}
 
 --
 

--- a/integration/flags/.snapshots/TestReportFlags-report-policies
+++ b/integration/flags/.snapshots/TestReportFlags-report-policies
@@ -4,8 +4,6 @@ critical:
       line_number: 1
       filename: testdata/policies/users.rb
       category_group: Personal data
-      parent_line_number: 1
-      parent_content: logger.info(user.address)
 
 
 --

--- a/pkg/report/output/dataflow/risks/risks.go
+++ b/pkg/report/output/dataflow/risks/risks.go
@@ -83,9 +83,9 @@ func (holder *Holder) addDatatype(ruleName string, datatype *db.DataType, fileNa
 			}
 		} else {
 			detector.datatypes[datatype.Name] = &datatypeHolder{
-				name:   datatype.Name,
-				files:  make(map[string]*fileHolder),
-				parent: parent,
+				name:  datatype.Name,
+				files: make(map[string]*fileHolder),
+				// parent: parent,
 			}
 		}
 	}

--- a/pkg/report/output/policies/policies.go
+++ b/pkg/report/output/policies/policies.go
@@ -88,8 +88,8 @@ func GetOutput(dataflow *dataflow.DataFlow, config settings.Config) (map[string]
 						Filename:          policyOutput.Filename,
 						LineNumber:        policyOutput.LineNumber,
 						CategoryGroup:     policyOutput.CategoryGroup,
-						ParentLineNumber:  policyOutput.ParentLineNumber,
-						ParentContent:     policyOutput.ParentContent,
+						// ParentLineNumber:  policyOutput.ParentLineNumber,
+						// ParentContent:     policyOutput.ParentContent,
 					}
 
 					result[severity] = append(result[severity], policyResult)


### PR DESCRIPTION
## Description
Temporarily remove parents from risk / dataflow reports.
There's an issue with parents that is causing flaky tests on all PRs. 

We will address parent issue fully here https://github.com/Bearer/curio/pull/184 or related

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
