### PR TITLE
feat(policies): add support for SSL verification disabled

### DIFF
--- a/integration/custom_detectors/.snapshots/TestCustomDetectors-ssl_certificate_verification_disabled
+++ b/integration/custom_detectors/.snapshots/TestCustomDetectors-ssl_certificate_verification_disabled
@@ -11,8 +11,18 @@ risks:
         - risklocation:
             filename: testdata/ruby/ssl_certificate_verification_disabled.rb
             line_number: 4
+            parent:
+                line_number: 1
+                content: |-
+                    user.gender_identity # processing sensitive data
+
+                    # Detected
+                    http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+
+                    # Not detected
+                    http.verify_mode = OpenSSL::SSL::VERIFY_PEER
           content: |
-            http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+            $_.verify_mode = OpenSSL::SSL::VERIFY_NONE
 components: []
 
 

--- a/integration/custom_detectors/.snapshots/TestCustomDetectors-ssl_certificate_verification_disabled
+++ b/integration/custom_detectors/.snapshots/TestCustomDetectors-ssl_certificate_verification_disabled
@@ -1,0 +1,20 @@
+data_types:
+    - name: Gender identity
+      detectors:
+        - name: ruby
+          locations:
+            - filename: testdata/ruby/ssl_certificate_verification_disabled.rb
+              line_number: 1
+risks:
+    - detector_id: ssl_certificate_verification_disabled
+      locations:
+        - risklocation:
+            filename: testdata/ruby/ssl_certificate_verification_disabled.rb
+            line_number: 4
+          content: |
+            http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+components: []
+
+
+--
+

--- a/integration/custom_detectors/custom_detectors_test.go
+++ b/integration/custom_detectors/custom_detectors_test.go
@@ -20,6 +20,7 @@ func TestCustomDetectors(t *testing.T) {
 		newScanTest("ruby", "detect_rails_session", "detect_rails_session.rb"),
 		newScanTest("ruby", "detect_ruby_logger", "detect_ruby_logger.rb"),
 		newScanTest("ruby", "ruby_file_detection", "ruby_file_detection.rb"),
+		newScanTest("ruby", "ssl_certificate_verification_disabled", "ssl_certificate_verification_disabled.rb"),
 		// newScanTest("ruby", "ruby_http_detection", "ruby_http_detection.rb"),
 	}
 

--- a/integration/custom_detectors/testdata/ruby/ssl_certificate_verification_disabled.rb
+++ b/integration/custom_detectors/testdata/ruby/ssl_certificate_verification_disabled.rb
@@ -1,0 +1,7 @@
+user.gender_identity # processing sensitive data
+
+# Detected
+http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+
+# Not detected
+http.verify_mode = OpenSSL::SSL::VERIFY_PEER

--- a/integration/flags/.snapshots/TestInitCommand-init
+++ b/integration/flags/.snapshots/TestInitCommand-init
@@ -255,6 +255,22 @@ scan:
             metavars: {}
             stored: false
             detect_presence: false
+        ssl_certificate_verification_disabled:
+            disabled: false
+            type: risk
+            languages:
+                - ruby
+            patterns:
+                - pattern: |
+                    $_.verify_mode = OpenSSL::SSL::VERIFY_NONE
+                  filters: []
+            param_parenting: false
+            processors: []
+            root_singularize: false
+            root_lowercase: false
+            metavars: {}
+            stored: false
+            detect_presence: true
     debug: false
     disable-domain-resolution: false
     domain-resolution-timeout: 3s

--- a/integration/flags/.snapshots/TestReportFlags-report-policies
+++ b/integration/flags/.snapshots/TestReportFlags-report-policies
@@ -4,6 +4,8 @@ critical:
       line_number: 1
       filename: testdata/policies/users.rb
       category_group: Personal data
+      parent_line_number: 1
+      parent_content: logger.info(user.address)
 
 
 --

--- a/pkg/commands/process/settings/custom_detector.yml
+++ b/pkg/commands/process/settings/custom_detector.yml
@@ -87,6 +87,14 @@ detect_rails_jwt:
       JWT.encode(<$ARGUMENT>)
   languages:
     - ruby
+ssl_certificate_verification_disabled:
+  type: "risk"
+  patterns:
+    - |
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+  languages:
+    - ruby
+  detect_presence: true
 detect_encrypted_ruby_class_properties:
   type: "verifier"
   patterns:

--- a/pkg/commands/process/settings/custom_detector.yml
+++ b/pkg/commands/process/settings/custom_detector.yml
@@ -91,7 +91,7 @@ ssl_certificate_verification_disabled:
   type: "risk"
   patterns:
     - |
-      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      $_.verify_mode = OpenSSL::SSL::VERIFY_NONE
   languages:
     - ruby
   detect_presence: true

--- a/pkg/commands/process/settings/policies.yml
+++ b/pkg/commands/process/settings/policies.yml
@@ -28,6 +28,15 @@ jwt_leaks:
   modules:
     - path: policies/leakage.rego
       name: bearer.leakage
+ssl_certificate_verification_disabled:
+  description: "SSL certificate verification disabled in an application processing sensitive data"
+  name: "SSL certificate verification disabled"
+  id: "ssl_certificate_verification_disabled"
+  query: |
+    medium = data.bearer.ssl_certificate_verification_disabled.medium
+  modules:
+    - path: policies/ssl_certificate_verification_disabled.rego
+      name: bearer.ssl_certificate_verification_disabled
 application_level_encryption_missing:
   description: "Application level encryption missing"
   name: "Application level encryption missing"

--- a/pkg/commands/process/settings/policies/ssl_certificate_verification_disabled.rego
+++ b/pkg/commands/process/settings/policies/ssl_certificate_verification_disabled.rego
@@ -1,0 +1,25 @@
+package bearer.ssl_certificate_verification_disabled
+
+import future.keywords
+
+sensitive_data_group_uuid := "f6a0c071-5908-4420-bac2-bba28d41223e"
+
+medium[item] {
+  some data_type in input.dataflow.data_types
+
+  some category in input.data_categories
+  category.uuid == data_type.category_uuid
+  category.group_uuid == sensitive_data_group_uuid
+
+  some detector in input.dataflow.risks
+  detector.detector_id == input.policy_id
+  location = detector.locations[_]
+
+  item = {
+    "category_group": category.group_name,
+    "filename": location.filename,
+    "line_number": location.line_number,
+    "parent_line_number": 2,
+    "parent_content": "FIXME"
+  }
+}

--- a/pkg/commands/process/settings/policies/ssl_certificate_verification_disabled.rego
+++ b/pkg/commands/process/settings/policies/ssl_certificate_verification_disabled.rego
@@ -19,7 +19,7 @@ medium[item] {
     "category_group": category.group_name,
     "filename": location.filename,
     "line_number": location.line_number,
-    "parent_line_number": 2,
-    "parent_content": "FIXME"
+    "parent_line_number": location.parent.line_number,
+    "parent_content": location.parent.content
   }
 }

--- a/pkg/detectors/custom/.snapshots/TestInsecureSMTPJSON
+++ b/pkg/detectors/custom/.snapshots/TestInsecureSMTPJSON
@@ -10,7 +10,10 @@
    "column_number": 1,
    "text": "Rails.application.configure do\n  config.action_mailer.smtp_settings = {\n    openssl_verify_mode: OpenSSL::SSL::VERIFY_NONE\n  }\nend\n"
   },
-  "value": null
+  "value": {
+   "line_number": 1,
+   "content": "# Insecure SMTP\n## Detected\nRails.application.configure do\n  config.action_mailer.smtp_settings = {\n    openssl_verify_mode: OpenSSL::SSL::VERIFY_NONE\n  }\nend\n\nRails.application.configure do\n  config.action_mailer.smtp_settings = {\n    openssl_verify_mode: \"none\"\n  }\nend\n\n## Not Detected\nRails.application.configure do\n  config.action_mailer.smtp_settings = {\n    openssl_verify_mode: OpenSSL::SSL::VERIFY_PEER\n  }\nend\n\nRails.application.configure do\n  config.action_mailer.smtp_settings = {\n    openssl_verify_mode: \"peer\"\n  }\nend"
+  }
  },
  {
   "type": "custom_risk",
@@ -23,6 +26,9 @@
    "column_number": 1,
    "text": "Rails.application.configure do\n  config.action_mailer.smtp_settings = {\n    openssl_verify_mode: \"none\"\n  }\nend\n"
   },
-  "value": null
+  "value": {
+   "line_number": 1,
+   "content": "# Insecure SMTP\n## Detected\nRails.application.configure do\n  config.action_mailer.smtp_settings = {\n    openssl_verify_mode: OpenSSL::SSL::VERIFY_NONE\n  }\nend\n\nRails.application.configure do\n  config.action_mailer.smtp_settings = {\n    openssl_verify_mode: \"none\"\n  }\nend\n\n## Not Detected\nRails.application.configure do\n  config.action_mailer.smtp_settings = {\n    openssl_verify_mode: OpenSSL::SSL::VERIFY_PEER\n  }\nend\n\nRails.application.configure do\n  config.action_mailer.smtp_settings = {\n    openssl_verify_mode: \"peer\"\n  }\nend"
+  }
  }
 ]

--- a/pkg/detectors/custom/custom.go
+++ b/pkg/detectors/custom/custom.go
@@ -190,7 +190,11 @@ func (detector *Detector) executeRule(rule config.CompiledRule, file *file.FileI
 			for _, capture := range filteredCaptures {
 				content := capture["rule"].Source(false)
 				content.Text = &rule.Pattern
-				report.AddDetection(detections.TypeCustomRisk, detectors.Type(rule.RuleName), content, nil)
+				parent := capture["rule"].Parent().Source(true)
+				report.AddDetection(detections.TypeCustomRisk, detectors.Type(rule.RuleName), content, schema.Parent{
+					LineNumber: *parent.LineNumber,
+					Content:    *parent.Text,
+				})
 			}
 			continue
 		}

--- a/pkg/report/output/policies/policies.go
+++ b/pkg/report/output/policies/policies.go
@@ -88,8 +88,8 @@ func GetOutput(dataflow *dataflow.DataFlow, config settings.Config) (map[string]
 						Filename:          policyOutput.Filename,
 						LineNumber:        policyOutput.LineNumber,
 						CategoryGroup:     policyOutput.CategoryGroup,
-						// ParentLineNumber:  policyOutput.ParentLineNumber,
-						// ParentContent:     policyOutput.ParentContent,
+						ParentLineNumber:  policyOutput.ParentLineNumber,
+						ParentContent:     policyOutput.ParentContent,
 					}
 
 					result[severity] = append(result[severity], policyResult)


### PR DESCRIPTION
## Description
Support for SSL verification

- Policy triggers only when we have sensitive data types detected

Also adds parent to risk location for custom risk detections (the `detectPresence` case)

Code sample

```ruby
user.gender_identity

class InsecureService
  def unverified_http_client
    http = Net::HTTP.new(uri.host, uri.port)
    http.use_ssl = true
    http.verify_mode = OpenSSL::SSL::VERIFY_NONE
    http
  end
end
```

Policy report

<img width="1064" alt="Screenshot 2022-12-02 at 15 53 27" src="https://user-images.githubusercontent.com/4560746/205308262-cc408de4-e7d8-4a7b-aec7-a47976c86565.png">


<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
