### PR TITLE
fix(policies): improve sensitive data check

### DIFF
--- a/pkg/commands/process/settings/policies/ssl_certificate_verification_disabled.rego
+++ b/pkg/commands/process/settings/policies/ssl_certificate_verification_disabled.rego
@@ -4,19 +4,23 @@ import future.keywords
 
 sensitive_data_group_uuid := "f6a0c071-5908-4420-bac2-bba28d41223e"
 
-medium[item] {
+has_sensitive_data if {
   some data_type in input.dataflow.data_types
 
   some category in input.data_categories
   category.uuid == data_type.category_uuid
   category.group_uuid == sensitive_data_group_uuid
+}
+
+medium[item] {
+  has_sensitive_data == true
 
   some detector in input.dataflow.risks
   detector.detector_id == input.policy_id
   location = detector.locations[_]
 
   item = {
-    "category_group": category.group_name,
+    "category_group": "sensitive data",
     "filename": location.filename,
     "line_number": location.line_number,
     "parent_line_number": location.parent.line_number,


### PR DESCRIPTION
## Description
Avoid checking for sensitive data for each risk

This is an improvement on the current code but ideally we would do this once per scan... wondering if there's a clean / rego way to do this 🤔 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
