### PR TITLE
feat(policies): expand data category grouping structure

### DIFF
--- a/integration/flags/.snapshots/TestInitCommand-init
+++ b/integration/flags/.snapshots/TestInitCommand-init
@@ -312,91 +312,231 @@ scan:
     policies:
         application_level_encryption_missing:
             query: |
-                critical = data.bearer.application_level_encryption.critical
-                high = data.bearer.application_level_encryption.high
+                policy_breach = data.bearer.application_level_encryption.policy_breach
             id: detect_sql_create_public_table
             name: Application level encryption missing
             description: Application level encryption missing
             level: ""
             modules:
-                - path: policies/application_level_encryption.rego
-                  name: bearer.application_level_encryption
-                  content: "package bearer.application_level_encryption\n\nimport future.keywords\n\nsensitive_data_group_uuid := \"f6a0c071-5908-4420-bac2-bba28d41223e\"\npersonal_data_group_uuid := \"e1d3135b-3c0f-4b55-abce-19f27a26cbb3\"\n\nhigh[item] {\n    some datatype in input.dataflow.data_types    \n    some detector in datatype.detectors\n    detector.name == input.policy_id\n    \n    some location in detector.locations\n    not location.encrypted\n\n    some category in input.data_categories\n    category.uuid == datatype.category_uuid\n    category.group_uuid == sensitive_data_group_uuid\n\n    item = {\n        \"category_group\":  category.group_name,\n        \"filename\": location.filename,\n        \"line_number\": location.line_number,\n        \"parent_line_number\": detector.parent.line_number,\n        \"parent_content\": detector.parent.content\n\n    }\n}\n\ncritical[item] {\n    some datatype in input.dataflow.data_types    \n    some detector in datatype.detectors\n    detector.name == input.policy_id\n    \n    some location in detector.locations\n    not location.encrypted\n\n    some category in input.data_categories\n    category.uuid == datatype.category_uuid\n    category.group_uuid == personal_data_group_uuid\n\n    item = {\n        \"category_group\":  category.group_name,\n        \"filename\": location.filename,\n        \"line_number\": location.line_number,\n        \"parent_line_number\": detector.parent.line_number,\n        \"parent_content\": detector.parent.content\n    }\n}"
-        http_get_parameters:
-            query: |
-                critical = data.bearer.http_get_parameters.critical
-                high = data.bearer.http_get_parameters.high
-            id: ruby_http_get_detection
-            name: HTTP GET parameters
-            description: Sending data as HTTP GET parameters
-            level: ""
-            modules:
-                - path: policies/http_get_parameters.rego
-                  name: bearer.http_get_parameters
-                  content: |
-                    package bearer.http_get_parameters
+                - path: policies/common.rego
+                  name: bearer.common
+                  content: |-
+                    package bearer.common
 
                     import future.keywords
 
                     sensitive_data_group_uuid := "f6a0c071-5908-4420-bac2-bba28d41223e"
                     personal_data_group_uuid := "e1d3135b-3c0f-4b55-abce-19f27a26cbb3"
 
-                    item_in_data_category contains [category_group_uuid, item] if {
+                    has_sensitive_data(data_type) := true if {
+                        some category in input.data_categories
+                        category.uuid == data_type.category_uuid
+
+                        some group in category.groups
+                        group.uuid == sensitive_data_group_uuid
+                    }
+
+                    severity_of_datatype(data_type) := "critical" if {
+                        some category in input.data_categories
+                        category.uuid == data_type.category_uuid
+
+                        some group in category.groups
+                        group.uuid == sensitive_data_group_uuid
+                    }
+
+                    severity_of_datatype(data_type) := "high" if {
+                        some category in input.data_categories
+                        category.uuid == data_type.category_uuid
+
+                        some group in category.groups
+                        group.uuid == personal_data_group_uuid
+
+                        every group_1 in category.groups {
+                            group_1.uuid != sensitive_data_group_uuid
+                        }
+                    }
+
+                    groups_for_datatype(data_type) := x if {
+                        some category in input.data_categories
+                        category.uuid == data_type.category_uuid
+
+                        x := {name | name := category.groups[_].name}
+                    }
+                - path: policies/application_level_encryption.rego
+                  name: bearer.application_level_encryption
+                  content: |-
+                    package bearer.application_level_encryption
+
+                    import data.bearer.common
+
+                    import future.keywords
+
+                    policy_breach contains item if {
+                        some datatype in input.dataflow.data_types
+                        some detector in datatype.detectors
+                        detector.name == input.policy_id
+
+                        some location in detector.locations
+                        not location.encrypted
+
+                        item := {
+                            "category_group": data.bearer.common.groups_for_datatype(datatype),
+                            "severity": data.bearer.common.severity_of_datatype(datatype),
+                            "filename": location.filename,
+                            "line_number": location.line_number,
+                            "parent_line_number": detector.parent.line_number,
+                            "parent_content": detector.parent.content
+                        }
+                    }
+        http_get_parameters:
+            query: |
+                policy_breach = data.bearer.http_get_parameters.policy_breach
+            id: ruby_http_get_detection
+            name: HTTP GET parameters
+            description: Sending data as HTTP GET parameters
+            level: ""
+            modules:
+                - path: policies/common.rego
+                  name: bearer.common
+                  content: |-
+                    package bearer.common
+
+                    import future.keywords
+
+                    sensitive_data_group_uuid := "f6a0c071-5908-4420-bac2-bba28d41223e"
+                    personal_data_group_uuid := "e1d3135b-3c0f-4b55-abce-19f27a26cbb3"
+
+                    has_sensitive_data(data_type) := true if {
+                        some category in input.data_categories
+                        category.uuid == data_type.category_uuid
+
+                        some group in category.groups
+                        group.uuid == sensitive_data_group_uuid
+                    }
+
+                    severity_of_datatype(data_type) := "critical" if {
+                        some category in input.data_categories
+                        category.uuid == data_type.category_uuid
+
+                        some group in category.groups
+                        group.uuid == sensitive_data_group_uuid
+                    }
+
+                    severity_of_datatype(data_type) := "high" if {
+                        some category in input.data_categories
+                        category.uuid == data_type.category_uuid
+
+                        some group in category.groups
+                        group.uuid == personal_data_group_uuid
+
+                        every group_1 in category.groups {
+                            group_1.uuid != sensitive_data_group_uuid
+                        }
+                    }
+
+                    groups_for_datatype(data_type) := x if {
+                        some category in input.data_categories
+                        category.uuid == data_type.category_uuid
+
+                        x := {name | name := category.groups[_].name}
+                    }
+                - path: policies/http_get_parameters.rego
+                  name: bearer.http_get_parameters
+                  content: |-
+                    package bearer.http_get_parameters
+
+                    import data.bearer.common
+
+                    import future.keywords
+
+                    policy_breach contains item if {
                         some detector in input.dataflow.risks
                         detector.detector_id == input.policy_id
 
                         data_type = detector.data_types[_]
 
-                        some category in input.data_categories
-                        category.uuid == data_type.category_uuid
-                        category_group_uuid := category.group_uuid
-
                         location = data_type.locations[_]
                         item := {
-                            "category_group": category.group_name,
+                            "category_group": data.bearer.common.groups_for_datatype(data_type),
+                            "severity": data.bearer.common.severity_of_datatype(data_type),
                             "filename": location.filename,
                             "line_number": location.line_number,
                             "parent_line_number": location.parent.line_number,
                             "parent_content": location.parent.content
                         }
                     }
-
-                    high[item] {
-                        item_in_data_category[[sensitive_data_group_uuid, item]]
-                    }
-
-                    critical[item] {
-                        item_in_data_category[[personal_data_group_uuid, item]]
-                    }
         insecure_communication_processing_sensitive_data:
             query: |
-                medium = data.bearer.insecure_communication.medium
+                policy_breach = data.bearer.insecure_communication.policy_breach
             id: detect_rails_insecure_communication
             name: Insecure communication
             description: Insecure communication in an application processing sensitive data
             level: ""
             modules:
+                - path: policies/common.rego
+                  name: bearer.common
+                  content: |-
+                    package bearer.common
+
+                    import future.keywords
+
+                    sensitive_data_group_uuid := "f6a0c071-5908-4420-bac2-bba28d41223e"
+                    personal_data_group_uuid := "e1d3135b-3c0f-4b55-abce-19f27a26cbb3"
+
+                    has_sensitive_data(data_type) := true if {
+                        some category in input.data_categories
+                        category.uuid == data_type.category_uuid
+
+                        some group in category.groups
+                        group.uuid == sensitive_data_group_uuid
+                    }
+
+                    severity_of_datatype(data_type) := "critical" if {
+                        some category in input.data_categories
+                        category.uuid == data_type.category_uuid
+
+                        some group in category.groups
+                        group.uuid == sensitive_data_group_uuid
+                    }
+
+                    severity_of_datatype(data_type) := "high" if {
+                        some category in input.data_categories
+                        category.uuid == data_type.category_uuid
+
+                        some group in category.groups
+                        group.uuid == personal_data_group_uuid
+
+                        every group_1 in category.groups {
+                            group_1.uuid != sensitive_data_group_uuid
+                        }
+                    }
+
+                    groups_for_datatype(data_type) := x if {
+                        some category in input.data_categories
+                        category.uuid == data_type.category_uuid
+
+                        x := {name | name := category.groups[_].name}
+                    }
                 - path: policies/insecure_communication.rego
                   name: bearer.insecure_communication
                   content: |
                     package bearer.insecure_communication
 
+                    import data.bearer.common
+
                     import future.keywords
 
-                    sensitive_data_group_uuid := "f6a0c071-5908-4420-bac2-bba28d41223e"
-
-                    medium[item] {
+                    policy_breach contains item if {
                         some data_type in input.dataflow.data_types
-                        some data_category in input.data_categories
-                        data_category.uuid == data_type.category_uuid
-                        data_category.group_uuid == sensitive_data_group_uuid
+                        data.bearer.common.has_sensitive_data(data_type)
 
                         some detector in input.dataflow.risks
                         detector.detector_id == input.policy_id
 
                         location = detector.locations[_]
                         item := {
-                          "category_group": data_category.group_name,
+                          "category_group": data.bearer.common.groups_for_datatype(data_type),
+                          "severity": "medium",
                           "filename": location.filename,
                           "line_number": location.line_number,
                           "parent_line_number": location.parent.line_number,
@@ -405,73 +545,154 @@ scan:
                     }
         insecure_ftp_processing_sensitive_data:
             query: |
-                medium = data.bearer.insecure_ftp.medium
+                policy_breach = data.bearer.insecure_ftp.policy_breach
             id: detect_rails_insecure_ftp
             name: Insecure FTP
             description: Communication with insecure FTP in an application processing sensitive data
             level: ""
             modules:
+                - path: policies/common.rego
+                  name: bearer.common
+                  content: |-
+                    package bearer.common
+
+                    import future.keywords
+
+                    sensitive_data_group_uuid := "f6a0c071-5908-4420-bac2-bba28d41223e"
+                    personal_data_group_uuid := "e1d3135b-3c0f-4b55-abce-19f27a26cbb3"
+
+                    has_sensitive_data(data_type) := true if {
+                        some category in input.data_categories
+                        category.uuid == data_type.category_uuid
+
+                        some group in category.groups
+                        group.uuid == sensitive_data_group_uuid
+                    }
+
+                    severity_of_datatype(data_type) := "critical" if {
+                        some category in input.data_categories
+                        category.uuid == data_type.category_uuid
+
+                        some group in category.groups
+                        group.uuid == sensitive_data_group_uuid
+                    }
+
+                    severity_of_datatype(data_type) := "high" if {
+                        some category in input.data_categories
+                        category.uuid == data_type.category_uuid
+
+                        some group in category.groups
+                        group.uuid == personal_data_group_uuid
+
+                        every group_1 in category.groups {
+                            group_1.uuid != sensitive_data_group_uuid
+                        }
+                    }
+
+                    groups_for_datatype(data_type) := x if {
+                        some category in input.data_categories
+                        category.uuid == data_type.category_uuid
+
+                        x := {name | name := category.groups[_].name}
+                    }
                 - path: policies/insecure_ftp.rego
                   name: bearer.insecure_ftp
                   content: |
                     package bearer.insecure_ftp
 
+                    import data.bearer.common
+
                     import future.keywords
 
-                    sensitive_data_group_uuid := "f6a0c071-5908-4420-bac2-bba28d41223e"
-
-                    has_sensitive_data if {
+                    policy_breach[item] {
                         some data_type in input.dataflow.data_types
-                        some data_category in input.data_categories
-                        data_category.uuid == data_type.category_uuid
-                        data_category.group_uuid == sensitive_data_group_uuid
-                    }
-
-                    medium[item] {
-                        has_sensitive_data == true
+                        data.bearer.common.has_sensitive_data(data_type)
 
                         some detector in input.dataflow.risks
                         detector.detector_id == input.policy_id
 
                         location = detector.locations[_]
                         item := {
-                             "category_group": "sensitive data",
-                             "filename": location.filename,
-                             "line_number": location.line_number,
-                             "parent_line_number": location.parent.line_number,
-                             "parent_content": location.parent.content
+                            "category_group": data.bearer.common.groups_for_datatype(data_type),
+                            "severity": "medium",
+                            "filename": location.filename,
+                            "line_number": location.line_number,
+                            "parent_line_number": location.parent.line_number,
+                            "parent_content": location.parent.content
                         }
                     }
         insecure_smtp_processing_sensitive_data:
             query: |
-                medium = data.bearer.insecure_smtp.medium
+                policy_breach = data.bearer.insecure_smtp.policy_breach
             id: detect_rails_insecure_smtp
             name: Insecure SMTP
             description: Communication with insecure SMTP in an application processing sensitive data
             level: ""
             modules:
+                - path: policies/common.rego
+                  name: bearer.common
+                  content: |-
+                    package bearer.common
+
+                    import future.keywords
+
+                    sensitive_data_group_uuid := "f6a0c071-5908-4420-bac2-bba28d41223e"
+                    personal_data_group_uuid := "e1d3135b-3c0f-4b55-abce-19f27a26cbb3"
+
+                    has_sensitive_data(data_type) := true if {
+                        some category in input.data_categories
+                        category.uuid == data_type.category_uuid
+
+                        some group in category.groups
+                        group.uuid == sensitive_data_group_uuid
+                    }
+
+                    severity_of_datatype(data_type) := "critical" if {
+                        some category in input.data_categories
+                        category.uuid == data_type.category_uuid
+
+                        some group in category.groups
+                        group.uuid == sensitive_data_group_uuid
+                    }
+
+                    severity_of_datatype(data_type) := "high" if {
+                        some category in input.data_categories
+                        category.uuid == data_type.category_uuid
+
+                        some group in category.groups
+                        group.uuid == personal_data_group_uuid
+
+                        every group_1 in category.groups {
+                            group_1.uuid != sensitive_data_group_uuid
+                        }
+                    }
+
+                    groups_for_datatype(data_type) := x if {
+                        some category in input.data_categories
+                        category.uuid == data_type.category_uuid
+
+                        x := {name | name := category.groups[_].name}
+                    }
                 - path: policies/insecure_smtp.rego
                   name: bearer.insecure_smtp
                   content: |
                     package bearer.insecure_smtp
 
+                    import data.bearer.common
+
                     import future.keywords
 
-                    sensitive_data_group_uuid := "f6a0c071-5908-4420-bac2-bba28d41223e"
-
-                    medium[item] {
+                    policy_breach contains item if {
                         some data_type in input.dataflow.data_types
-                        some data_category in input.data_categories
-                        data_category.uuid == data_type.category_uuid
-                        data_category.group_uuid == sensitive_data_group_uuid
+                        data.bearer.common.has_sensitive_data(data_type)
 
                         some detector in input.dataflow.risks
                         detector.detector_id == input.policy_id
 
                         location = detector.locations[_]
                         item := {
-                            "category_group": data_category.group_name,
-                            "filename": location.filename,
+                            "category_group": data.bearer.common.groups_for_datatype(data_type),
+                            "severity": "medium",
                             "line_number": location.line_number,
                             "parent_line_number": location.parent.line_number,
                             "parent_content": location.parent.content
@@ -479,56 +700,75 @@ scan:
                     }
         jwt_leaks:
             query: |
-                critical = data.bearer.leakage.critical
-                high = data.bearer.leakage.high
+                policy_breach = data.bearer.leakage.policy_breach
             id: detect_rails_jwt
             name: JWT leaking
             description: JWT leaks detected
             level: ""
             modules:
-                - path: policies/leakage.rego
-                  name: bearer.leakage
-                  content: |
-                    package bearer.leakage
+                - path: policies/common.rego
+                  name: bearer.common
+                  content: |-
+                    package bearer.common
 
                     import future.keywords
 
                     sensitive_data_group_uuid := "f6a0c071-5908-4420-bac2-bba28d41223e"
                     personal_data_group_uuid := "e1d3135b-3c0f-4b55-abce-19f27a26cbb3"
 
-                    high[item] {
-                        some detector in input.dataflow.risks
-                        detector.detector_id == input.policy_id
-
-                        data_type = detector.data_types[_]
-
+                    has_sensitive_data(data_type) := true if {
                         some category in input.data_categories
                         category.uuid == data_type.category_uuid
-                        category.group_uuid == sensitive_data_group_uuid
 
-                        location = data_type.locations[_]
-                        item := {
-                            "category_group": category.group_name,
-                            "filename": location.filename,
-                            "line_number": location.line_number,
-                            "parent_line_number": location.parent.line_number,
-                            "parent_content": location.parent.content
+                        some group in category.groups
+                        group.uuid == sensitive_data_group_uuid
+                    }
+
+                    severity_of_datatype(data_type) := "critical" if {
+                        some category in input.data_categories
+                        category.uuid == data_type.category_uuid
+
+                        some group in category.groups
+                        group.uuid == sensitive_data_group_uuid
+                    }
+
+                    severity_of_datatype(data_type) := "high" if {
+                        some category in input.data_categories
+                        category.uuid == data_type.category_uuid
+
+                        some group in category.groups
+                        group.uuid == personal_data_group_uuid
+
+                        every group_1 in category.groups {
+                            group_1.uuid != sensitive_data_group_uuid
                         }
                     }
 
-                    critical[item] {
+                    groups_for_datatype(data_type) := x if {
+                        some category in input.data_categories
+                        category.uuid == data_type.category_uuid
+
+                        x := {name | name := category.groups[_].name}
+                    }
+                - path: policies/leakage.rego
+                  name: bearer.leakage
+                  content: |
+                    package bearer.leakage
+
+                    import data.bearer.common
+
+                    import future.keywords
+
+                    policy_breach contains item if {
                         some detector in input.dataflow.risks
                         detector.detector_id == input.policy_id
 
                         data_type = detector.data_types[_]
 
-                        some category in input.data_categories
-                        category.uuid == data_type.category_uuid
-                        category.group_uuid == personal_data_group_uuid
-
                         location = data_type.locations[_]
                         item := {
-                            "category_group": category.group_name,
+                            "category_group": data.bearer.common.groups_for_datatype(data_type),
+                            "severity": data.bearer.common.severity_of_datatype(data_type),
                             "filename": location.filename,
                             "line_number": location.line_number,
                             "parent_line_number": location.parent.line_number,
@@ -537,56 +777,75 @@ scan:
                     }
         logger_leaks:
             query: |
-                critical = data.bearer.leakage.critical
-                high = data.bearer.leakage.high
+                policy_breach = data.bearer.leakage.policy_breach
             id: detect_ruby_logger
             name: Logger leaking
             description: Logger leaks detected
             level: ""
             modules:
-                - path: policies/leakage.rego
-                  name: bearer.leakage
-                  content: |
-                    package bearer.leakage
+                - path: policies/common.rego
+                  name: bearer.common
+                  content: |-
+                    package bearer.common
 
                     import future.keywords
 
                     sensitive_data_group_uuid := "f6a0c071-5908-4420-bac2-bba28d41223e"
                     personal_data_group_uuid := "e1d3135b-3c0f-4b55-abce-19f27a26cbb3"
 
-                    high[item] {
-                        some detector in input.dataflow.risks
-                        detector.detector_id == input.policy_id
-
-                        data_type = detector.data_types[_]
-
+                    has_sensitive_data(data_type) := true if {
                         some category in input.data_categories
                         category.uuid == data_type.category_uuid
-                        category.group_uuid == sensitive_data_group_uuid
 
-                        location = data_type.locations[_]
-                        item := {
-                            "category_group": category.group_name,
-                            "filename": location.filename,
-                            "line_number": location.line_number,
-                            "parent_line_number": location.parent.line_number,
-                            "parent_content": location.parent.content
+                        some group in category.groups
+                        group.uuid == sensitive_data_group_uuid
+                    }
+
+                    severity_of_datatype(data_type) := "critical" if {
+                        some category in input.data_categories
+                        category.uuid == data_type.category_uuid
+
+                        some group in category.groups
+                        group.uuid == sensitive_data_group_uuid
+                    }
+
+                    severity_of_datatype(data_type) := "high" if {
+                        some category in input.data_categories
+                        category.uuid == data_type.category_uuid
+
+                        some group in category.groups
+                        group.uuid == personal_data_group_uuid
+
+                        every group_1 in category.groups {
+                            group_1.uuid != sensitive_data_group_uuid
                         }
                     }
 
-                    critical[item] {
+                    groups_for_datatype(data_type) := x if {
+                        some category in input.data_categories
+                        category.uuid == data_type.category_uuid
+
+                        x := {name | name := category.groups[_].name}
+                    }
+                - path: policies/leakage.rego
+                  name: bearer.leakage
+                  content: |
+                    package bearer.leakage
+
+                    import data.bearer.common
+
+                    import future.keywords
+
+                    policy_breach contains item if {
                         some detector in input.dataflow.risks
                         detector.detector_id == input.policy_id
 
                         data_type = detector.data_types[_]
 
-                        some category in input.data_categories
-                        category.uuid == data_type.category_uuid
-                        category.group_uuid == personal_data_group_uuid
-
                         location = data_type.locations[_]
                         item := {
-                            "category_group": category.group_name,
+                            "category_group": data.bearer.common.groups_for_datatype(data_type),
+                            "severity": data.bearer.common.severity_of_datatype(data_type),
                             "filename": location.filename,
                             "line_number": location.line_number,
                             "parent_line_number": location.parent.line_number,
@@ -595,56 +854,75 @@ scan:
                     }
         session_leaks:
             query: |
-                critical = data.bearer.leakage.critical
-                high = data.bearer.leakage.high
+                policy_breach = data.bearer.leakage.policy_breach
             id: detect_rails_session
             name: Session leaking
             description: Session leaks detected
             level: ""
             modules:
-                - path: policies/leakage.rego
-                  name: bearer.leakage
-                  content: |
-                    package bearer.leakage
+                - path: policies/common.rego
+                  name: bearer.common
+                  content: |-
+                    package bearer.common
 
                     import future.keywords
 
                     sensitive_data_group_uuid := "f6a0c071-5908-4420-bac2-bba28d41223e"
                     personal_data_group_uuid := "e1d3135b-3c0f-4b55-abce-19f27a26cbb3"
 
-                    high[item] {
-                        some detector in input.dataflow.risks
-                        detector.detector_id == input.policy_id
-
-                        data_type = detector.data_types[_]
-
+                    has_sensitive_data(data_type) := true if {
                         some category in input.data_categories
                         category.uuid == data_type.category_uuid
-                        category.group_uuid == sensitive_data_group_uuid
 
-                        location = data_type.locations[_]
-                        item := {
-                            "category_group": category.group_name,
-                            "filename": location.filename,
-                            "line_number": location.line_number,
-                            "parent_line_number": location.parent.line_number,
-                            "parent_content": location.parent.content
+                        some group in category.groups
+                        group.uuid == sensitive_data_group_uuid
+                    }
+
+                    severity_of_datatype(data_type) := "critical" if {
+                        some category in input.data_categories
+                        category.uuid == data_type.category_uuid
+
+                        some group in category.groups
+                        group.uuid == sensitive_data_group_uuid
+                    }
+
+                    severity_of_datatype(data_type) := "high" if {
+                        some category in input.data_categories
+                        category.uuid == data_type.category_uuid
+
+                        some group in category.groups
+                        group.uuid == personal_data_group_uuid
+
+                        every group_1 in category.groups {
+                            group_1.uuid != sensitive_data_group_uuid
                         }
                     }
 
-                    critical[item] {
+                    groups_for_datatype(data_type) := x if {
+                        some category in input.data_categories
+                        category.uuid == data_type.category_uuid
+
+                        x := {name | name := category.groups[_].name}
+                    }
+                - path: policies/leakage.rego
+                  name: bearer.leakage
+                  content: |
+                    package bearer.leakage
+
+                    import data.bearer.common
+
+                    import future.keywords
+
+                    policy_breach contains item if {
                         some detector in input.dataflow.risks
                         detector.detector_id == input.policy_id
 
                         data_type = detector.data_types[_]
 
-                        some category in input.data_categories
-                        category.uuid == data_type.category_uuid
-                        category.group_uuid == personal_data_group_uuid
-
                         location = data_type.locations[_]
                         item := {
-                            "category_group": category.group_name,
+                            "category_group": data.bearer.common.groups_for_datatype(data_type),
+                            "severity": data.bearer.common.severity_of_datatype(data_type),
                             "filename": location.filename,
                             "line_number": location.line_number,
                             "parent_line_number": location.parent.line_number,
@@ -653,34 +931,76 @@ scan:
                     }
         ssl_certificate_verification_disabled:
             query: |
-                medium = data.bearer.ssl_certificate_verification_disabled.medium
+                policy_breach = data.bearer.ssl_certificate_verification_disabled.policy_breach
             id: ssl_certificate_verification_disabled
             name: SSL certificate verification disabled
             description: SSL certificate verification disabled in an application processing sensitive data
             level: ""
             modules:
+                - path: policies/common.rego
+                  name: bearer.common
+                  content: |-
+                    package bearer.common
+
+                    import future.keywords
+
+                    sensitive_data_group_uuid := "f6a0c071-5908-4420-bac2-bba28d41223e"
+                    personal_data_group_uuid := "e1d3135b-3c0f-4b55-abce-19f27a26cbb3"
+
+                    has_sensitive_data(data_type) := true if {
+                        some category in input.data_categories
+                        category.uuid == data_type.category_uuid
+
+                        some group in category.groups
+                        group.uuid == sensitive_data_group_uuid
+                    }
+
+                    severity_of_datatype(data_type) := "critical" if {
+                        some category in input.data_categories
+                        category.uuid == data_type.category_uuid
+
+                        some group in category.groups
+                        group.uuid == sensitive_data_group_uuid
+                    }
+
+                    severity_of_datatype(data_type) := "high" if {
+                        some category in input.data_categories
+                        category.uuid == data_type.category_uuid
+
+                        some group in category.groups
+                        group.uuid == personal_data_group_uuid
+
+                        every group_1 in category.groups {
+                            group_1.uuid != sensitive_data_group_uuid
+                        }
+                    }
+
+                    groups_for_datatype(data_type) := x if {
+                        some category in input.data_categories
+                        category.uuid == data_type.category_uuid
+
+                        x := {name | name := category.groups[_].name}
+                    }
                 - path: policies/ssl_certificate_verification_disabled.rego
                   name: bearer.ssl_certificate_verification_disabled
                   content: |
                     package bearer.ssl_certificate_verification_disabled
 
+                    import data.bearer.common
+
                     import future.keywords
 
-                    sensitive_data_group_uuid := "f6a0c071-5908-4420-bac2-bba28d41223e"
-
-                    medium[item] {
+                    policy_breach contains item if {
                       some data_type in input.dataflow.data_types
-
-                      some category in input.data_categories
-                      category.uuid == data_type.category_uuid
-                      category.group_uuid == sensitive_data_group_uuid
+                      data.bearer.common.has_sensitive_data(data_type)
 
                       some detector in input.dataflow.risks
                       detector.detector_id == input.policy_id
                       location = detector.locations[_]
 
                       item = {
-                        "category_group": category.group_name,
+                        "category_group": data.bearer.common.groups_for_datatype(data_type),
+                        "severity": "medium",
                         "filename": location.filename,
                         "line_number": location.line_number,
                         "parent_line_number": location.parent.line_number,

--- a/integration/flags/.snapshots/TestReportFlags-report-policies
+++ b/integration/flags/.snapshots/TestReportFlags-report-policies
@@ -1,9 +1,10 @@
-critical:
+high:
     - policy_name: Logger leaking
       policy_description: Logger leaks detected
       line_number: 1
       filename: testdata/policies/users.rb
-      category_group: Personal data
+      category_group:
+        - PII
       parent_line_number: 1
       parent_content: logger.info(user.address)
 

--- a/integration/policies/.snapshots/TestPolicies-http_get_parameters
+++ b/integration/policies/.snapshots/TestPolicies-http_get_parameters
@@ -1,19 +1,22 @@
 critical:
     - policy_name: HTTP GET parameters
       policy_description: Sending data as HTTP GET parameters
-      line_number: 4
+      line_number: 1
       filename: testdata/ruby/http_get_parameters.rb
-      category_group: Personal data
-      parent_line_number: 5
-      parent_content: URI.encode_www_form(user)
+      category_group:
+        - PII
+        - Sensitive data
+      parent_line_number: 1
+      parent_content: URI("http://my.api.com/users/search?ethnic_origin=#{user_1.ethnic_origin}")
 high:
     - policy_name: HTTP GET parameters
       policy_description: Sending data as HTTP GET parameters
-      line_number: 1
+      line_number: 4
       filename: testdata/ruby/http_get_parameters.rb
-      category_group: Sensitive data
-      parent_line_number: 1
-      parent_content: URI("http://my.api.com/users/search?ethnic_origin=#{user_1.ethnic_origin}")
+      category_group:
+        - PII
+      parent_line_number: 5
+      parent_content: URI.encode_www_form(user)
 
 
 --

--- a/integration/policies/.snapshots/TestPolicies-insecure_communication_with_sensitive_data
+++ b/integration/policies/.snapshots/TestPolicies-insecure_communication_with_sensitive_data
@@ -3,7 +3,9 @@ medium:
       policy_description: Insecure communication in an application processing sensitive data
       line_number: 8
       filename: testdata/ruby/insecure_communication/with_sensitive_data.rb
-      category_group: Sensitive data
+      category_group:
+        - PII
+        - Sensitive data
       parent_line_number: 1
       parent_content: |-
         # Insecure communication

--- a/integration/policies/.snapshots/TestPolicies-insecure_ftp_with_sensitive_data
+++ b/integration/policies/.snapshots/TestPolicies-insecure_ftp_with_sensitive_data
@@ -3,7 +3,9 @@ medium:
       policy_description: Communication with insecure FTP in an application processing sensitive data
       line_number: 10
       filename: testdata/ruby/insecure_ftp/with_sensitive_data.rb
-      category_group: sensitive data
+      category_group:
+        - PII
+        - Sensitive data
       parent_line_number: 10
       parent_content: Net::FTP::new("ftp.ruby-lang.org")
 

--- a/integration/policies/.snapshots/TestPolicies-insecure_smtp_with_sensitive_data
+++ b/integration/policies/.snapshots/TestPolicies-insecure_smtp_with_sensitive_data
@@ -2,8 +2,9 @@ medium:
     - policy_name: Insecure SMTP
       policy_description: Communication with insecure SMTP in an application processing sensitive data
       line_number: 8
-      filename: testdata/ruby/insecure_smtp/with_sensitive_data.rb
-      category_group: Sensitive data
+      category_group:
+        - PII
+        - Sensitive data
       parent_line_number: 1
       parent_content: |-
         # Insecure SMTP
@@ -40,8 +41,9 @@ medium:
     - policy_name: Insecure SMTP
       policy_description: Communication with insecure SMTP in an application processing sensitive data
       line_number: 14
-      filename: testdata/ruby/insecure_smtp/with_sensitive_data.rb
-      category_group: Sensitive data
+      category_group:
+        - PII
+        - Sensitive data
       parent_line_number: 1
       parent_content: |-
         # Insecure SMTP

--- a/integration/policies/.snapshots/TestPolicies-logger_leaking
+++ b/integration/policies/.snapshots/TestPolicies-logger_leaking
@@ -1,9 +1,10 @@
-critical:
+high:
     - policy_name: Logger leaking
       policy_description: Logger leaks detected
       line_number: 1
       filename: testdata/ruby/logger_leaking.rb
-      category_group: Personal data
+      category_group:
+        - PII
       parent_line_number: 1
       parent_content: logger.info(user.address)
 

--- a/pkg/classification/db/category_grouping.json
+++ b/pkg/classification/db/category_grouping.json
@@ -1,100 +1,169 @@
 {
   "groups": {
-    "e1d3135b-3c0f-4b55-abce-19f27a26cbb3": "Personal data",
-    "f6a0c071-5908-4420-bac2-bba28d41223e": "Sensitive data"
+    "e1d3135b-3c0f-4b55-abce-19f27a26cbb3": {
+      "name": "Personal data",
+      "parent_uuids": []
+    },
+    "247fa503-115b-490a-96e5-bcd357bd5686": {
+      "name": "PHI",
+      "parent_uuids": [
+        "e1d3135b-3c0f-4b55-abce-19f27a26cbb3"
+      ]
+    },
+    "172d90e3-cb9a-46b6-90e5-dd7169c3af54": {
+      "name": "PII",
+      "parent_uuids": [
+        "e1d3135b-3c0f-4b55-abce-19f27a26cbb3"
+      ]
+    },
+    "f6a0c071-5908-4420-bac2-bba28d41223e": {
+      "name": "Sensitive data",
+      "parent_uuids": []
+    }
   },
   "category_mapping": {
     "dd88aee5-9d40-4ad2-8983-0c791ddec47c": {
       "name": "Authenticating",
-      "group_uuid": "e1d3135b-3c0f-4b55-abce-19f27a26cbb3"
+      "group_uuids": [
+        "172d90e3-cb9a-46b6-90e5-dd7169c3af54"
+      ]
     },
     "8099225c-7e49-414f-aac2-e7045379bb40": {
       "name": "Behavioral Information",
-      "group_uuid": "e1d3135b-3c0f-4b55-abce-19f27a26cbb3"
+      "group_uuids": [
+        "e1d3135b-3c0f-4b55-abce-19f27a26cbb3"
+      ]
     },
     "79a36d6e-c5ca-4f61-ba53-0d7ad42cbe5a": {
       "name": "Communication",
-      "group_uuid": "e1d3135b-3c0f-4b55-abce-19f27a26cbb3"
+      "group_uuids": [
+        "172d90e3-cb9a-46b6-90e5-dd7169c3af54"
+      ]
     },
     "b5a3b0fd-dd5c-420d-91ce-dd2dddc8cc38": {
       "name": "Computer Device",
-      "group_uuid": "e1d3135b-3c0f-4b55-abce-19f27a26cbb3"
+      "group_uuids": [
+        "e1d3135b-3c0f-4b55-abce-19f27a26cbb3"
+      ]
     },
     "cef587dd-76db-430b-9e18-7b031e1a193b": {
       "name": "Contact",
-      "group_uuid": "e1d3135b-3c0f-4b55-abce-19f27a26cbb3"
+      "group_uuids": [
+        "172d90e3-cb9a-46b6-90e5-dd7169c3af54"
+      ]
     },
     "4eda81b6-1314-47e2-bc4e-59d6024be4f4": {
       "name": "Credit History",
-      "group_uuid": "e1d3135b-3c0f-4b55-abce-19f27a26cbb3"
+      "group_uuids": [
+        "172d90e3-cb9a-46b6-90e5-dd7169c3af54"
+      ]
     },
     "5ab40519-89e8-4e4e-b2ef-2dabc13b352a": {
       "name": "Criminal Records",
-      "group_uuid": "f6a0c071-5908-4420-bac2-bba28d41223e"
+      "group_uuids": [
+        "172d90e3-cb9a-46b6-90e5-dd7169c3af54",
+        "f6a0c071-5908-4420-bac2-bba28d41223e"
+      ]
     },
     "c3119d43-0562-48ac-9a8e-7217aa8686b8": {
       "name": "Demographic",
-      "group_uuid": "e1d3135b-3c0f-4b55-abce-19f27a26cbb3"
+      "group_uuids": [
+        "172d90e3-cb9a-46b6-90e5-dd7169c3af54"
+      ]
     },
     "35b94efa-9b67-49b2-abb9-29b6a759a030": {
       "name": "Ethnicity",
-      "group_uuid": "f6a0c071-5908-4420-bac2-bba28d41223e"
+      "group_uuids": [
+        "172d90e3-cb9a-46b6-90e5-dd7169c3af54",
+        "f6a0c071-5908-4420-bac2-bba28d41223e"
+      ]
     },
     "e4d1e39a-6380-4da0-9596-642777f1b76d": {
       "name": "Family",
-      "group_uuid": "e1d3135b-3c0f-4b55-abce-19f27a26cbb3"
+      "group_uuids": [
+        "172d90e3-cb9a-46b6-90e5-dd7169c3af54"
+      ]
     },
     "7a794bd6-a6d1-429d-91a2-377acce9e9db": {
       "name": "Financial Accounts",
-      "group_uuid": "e1d3135b-3c0f-4b55-abce-19f27a26cbb3"
+      "group_uuids": [
+        "172d90e3-cb9a-46b6-90e5-dd7169c3af54"
+      ]
     },
     "14124881-6b92-4fc5-8005-ea7c1c09592e": {
       "name": "Identification",
-      "group_uuid": "e1d3135b-3c0f-4b55-abce-19f27a26cbb3"
-    },
-    "623a4f94-0e23-411e-9bb3-481602f1757d": {
-      "name": "Knowledge and Belief",
-      "group_uuid": "f6a0c071-5908-4420-bac2-bba28d41223e"
+      "group_uuids": [
+        "172d90e3-cb9a-46b6-90e5-dd7169c3af54"
+      ]
     },
     "c6622b62-bc22-4c0c-a2e4-5fc97d99e11a": {
       "name": "Location",
-      "group_uuid": "e1d3135b-3c0f-4b55-abce-19f27a26cbb3"
+      "group_uuids": [
+        "172d90e3-cb9a-46b6-90e5-dd7169c3af54"
+      ]
     },
     "7b1d36e7-46f9-4664-85a2-44fb15fbefd1": {
       "name": "Medical and Health",
-      "group_uuid": "f6a0c071-5908-4420-bac2-bba28d41223e"
+      "group_uuids": [
+        "247fa503-115b-490a-96e5-bcd357bd5686",
+        "f6a0c071-5908-4420-bac2-bba28d41223e"
+      ]
     },
     "ebaa9c6a-8fbf-4e45-85e1-40799dfac414": {
       "name": "Personal Ownership",
-      "group_uuid": "e1d3135b-3c0f-4b55-abce-19f27a26cbb3"
+      "group_uuids": [
+        "172d90e3-cb9a-46b6-90e5-dd7169c3af54"
+      ]
     },
     "94007e1e-57d8-43e8-90f2-246236dc5dde": {
       "name": "Physical Characteristic",
-      "group_uuid": "e1d3135b-3c0f-4b55-abce-19f27a26cbb3"
+      "group_uuids": [
+        "172d90e3-cb9a-46b6-90e5-dd7169c3af54"
+      ]
     },
     "bc536e1e-e0d1-4b88-96d2-a2eaad1620d4": {
       "name": "Preference",
-      "group_uuid": "e1d3135b-3c0f-4b55-abce-19f27a26cbb3"
+      "group_uuids": [
+        "e1d3135b-3c0f-4b55-abce-19f27a26cbb3"
+      ]
     },
     "ef613213-a222-4c01-ae38-c3043b68f738": {
       "name": "Professional Information",
-      "group_uuid": "e1d3135b-3c0f-4b55-abce-19f27a26cbb3"
+      "group_uuids": [
+        "172d90e3-cb9a-46b6-90e5-dd7169c3af54"
+      ]
     },
     "e354099e-b80c-47b5-a86c-8d936b520387": {
       "name": "Public Life",
-      "group_uuid": "e1d3135b-3c0f-4b55-abce-19f27a26cbb3"
+      "group_uuids": [
+        "172d90e3-cb9a-46b6-90e5-dd7169c3af54"
+      ]
+    },
+    "623a4f94-0e23-411e-9bb3-481602f1757d": {
+      "name": "Religion, Philosophical, Political Beliefs",
+      "group_uuids": [
+        "172d90e3-cb9a-46b6-90e5-dd7169c3af54",
+        "f6a0c071-5908-4420-bac2-bba28d41223e"
+      ]
     },
     "1d4000a7-93ec-4dd5-9f3b-0f2ff7026a0c": {
       "name": "Sexual",
-      "group_uuid": "f6a0c071-5908-4420-bac2-bba28d41223e"
+      "group_uuids": [
+        "172d90e3-cb9a-46b6-90e5-dd7169c3af54",
+        "f6a0c071-5908-4420-bac2-bba28d41223e"
+      ]
     },
     "68631dba-5696-4cc0-b6a8-0175ca99a7a2": {
       "name": "Social Network",
-      "group_uuid": "e1d3135b-3c0f-4b55-abce-19f27a26cbb3"
+      "group_uuids": [
+        "172d90e3-cb9a-46b6-90e5-dd7169c3af54"
+      ]
     },
     "deda0a0f-029c-44ee-9cac-9f059866723e": {
       "name": "Transactional",
-      "group_uuid": "e1d3135b-3c0f-4b55-abce-19f27a26cbb3"
+      "group_uuids": [
+        "172d90e3-cb9a-46b6-90e5-dd7169c3af54"
+      ]
     }
   }
 }

--- a/pkg/commands/process/settings/policies.yml
+++ b/pkg/commands/process/settings/policies.yml
@@ -3,9 +3,10 @@ logger_leaks:
   name: "Logger leaking"
   id: "detect_ruby_logger"
   query: |
-    critical = data.bearer.leakage.critical
-    high = data.bearer.leakage.high
+    policy_breach = data.bearer.leakage.policy_breach
   modules:
+    - path: policies/common.rego
+      name: bearer.common
     - path: policies/leakage.rego
       name: bearer.leakage
 session_leaks:
@@ -13,9 +14,10 @@ session_leaks:
   name: "Session leaking"
   id: "detect_rails_session"
   query: |
-    critical = data.bearer.leakage.critical
-    high = data.bearer.leakage.high
+    policy_breach = data.bearer.leakage.policy_breach
   modules:
+    - path: policies/common.rego
+      name: bearer.common
     - path: policies/leakage.rego
       name: bearer.leakage
 jwt_leaks:
@@ -23,9 +25,10 @@ jwt_leaks:
   name: "JWT leaking"
   id: "detect_rails_jwt"
   query: |
-    critical = data.bearer.leakage.critical
-    high = data.bearer.leakage.high
+    policy_breach = data.bearer.leakage.policy_breach
   modules:
+    - path: policies/common.rego
+      name: bearer.common
     - path: policies/leakage.rego
       name: bearer.leakage
 ssl_certificate_verification_disabled:
@@ -33,8 +36,10 @@ ssl_certificate_verification_disabled:
   name: "SSL certificate verification disabled"
   id: "ssl_certificate_verification_disabled"
   query: |
-    medium = data.bearer.ssl_certificate_verification_disabled.medium
+    policy_breach = data.bearer.ssl_certificate_verification_disabled.policy_breach
   modules:
+    - path: policies/common.rego
+      name: bearer.common
     - path: policies/ssl_certificate_verification_disabled.rego
       name: bearer.ssl_certificate_verification_disabled
 application_level_encryption_missing:
@@ -42,9 +47,10 @@ application_level_encryption_missing:
   name: "Application level encryption missing"
   id: "detect_sql_create_public_table"
   query: |
-    critical = data.bearer.application_level_encryption.critical
-    high = data.bearer.application_level_encryption.high
+    policy_breach = data.bearer.application_level_encryption.policy_breach
   modules:
+    - path: policies/common.rego
+      name: bearer.common
     - path: policies/application_level_encryption.rego
       name: bearer.application_level_encryption
 insecure_smtp_processing_sensitive_data:
@@ -52,8 +58,10 @@ insecure_smtp_processing_sensitive_data:
   name: "Insecure SMTP"
   id: "detect_rails_insecure_smtp"
   query: |
-    medium = data.bearer.insecure_smtp.medium
+    policy_breach = data.bearer.insecure_smtp.policy_breach
   modules:
+    - path: policies/common.rego
+      name: bearer.common
     - path: policies/insecure_smtp.rego
       name: bearer.insecure_smtp
 http_get_parameters:
@@ -61,9 +69,10 @@ http_get_parameters:
   name: "HTTP GET parameters"
   id: "ruby_http_get_detection"
   query: |
-    critical = data.bearer.http_get_parameters.critical
-    high = data.bearer.http_get_parameters.high
+    policy_breach = data.bearer.http_get_parameters.policy_breach
   modules:
+    - path: policies/common.rego
+      name: bearer.common
     - path: policies/http_get_parameters.rego
       name: bearer.http_get_parameters
 insecure_communication_processing_sensitive_data:
@@ -71,8 +80,10 @@ insecure_communication_processing_sensitive_data:
   name: "Insecure communication"
   id: "detect_rails_insecure_communication"
   query: |
-    medium = data.bearer.insecure_communication.medium
+    policy_breach = data.bearer.insecure_communication.policy_breach
   modules:
+    - path: policies/common.rego
+      name: bearer.common
     - path: policies/insecure_communication.rego
       name: bearer.insecure_communication
 insecure_ftp_processing_sensitive_data:

--- a/pkg/commands/process/settings/policies.yml
+++ b/pkg/commands/process/settings/policies.yml
@@ -91,7 +91,9 @@ insecure_ftp_processing_sensitive_data:
   name: "Insecure FTP"
   id: "detect_rails_insecure_ftp"
   query: |
-    medium = data.bearer.insecure_ftp.medium
+    policy_breach = data.bearer.insecure_ftp.policy_breach
   modules:
+    - path: policies/common.rego
+      name: bearer.common
     - path: policies/insecure_ftp.rego
       name: bearer.insecure_ftp

--- a/pkg/commands/process/settings/policies/application_level_encryption.rego
+++ b/pkg/commands/process/settings/policies/application_level_encryption.rego
@@ -1,46 +1,20 @@
 package bearer.application_level_encryption
 
+import data.bearer.common
+
 import future.keywords
 
-sensitive_data_group_uuid := "f6a0c071-5908-4420-bac2-bba28d41223e"
-personal_data_group_uuid := "e1d3135b-3c0f-4b55-abce-19f27a26cbb3"
-
-high[item] {
-    some datatype in input.dataflow.data_types    
+policy_breach contains item if {
+    some datatype in input.dataflow.data_types
     some detector in datatype.detectors
     detector.name == input.policy_id
-    
+
     some location in detector.locations
     not location.encrypted
 
-    some category in input.data_categories
-    category.uuid == datatype.category_uuid
-    category.group_uuid == sensitive_data_group_uuid
-
-    item = {
-        "category_group":  category.group_name,
-        "filename": location.filename,
-        "line_number": location.line_number,
-        "parent_line_number": detector.parent.line_number,
-        "parent_content": detector.parent.content
-
-    }
-}
-
-critical[item] {
-    some datatype in input.dataflow.data_types    
-    some detector in datatype.detectors
-    detector.name == input.policy_id
-    
-    some location in detector.locations
-    not location.encrypted
-
-    some category in input.data_categories
-    category.uuid == datatype.category_uuid
-    category.group_uuid == personal_data_group_uuid
-
-    item = {
-        "category_group":  category.group_name,
+    item := {
+        "category_group": data.bearer.common.groups_for_datatype(datatype),
+        "severity": data.bearer.common.severity_of_datatype(datatype),
         "filename": location.filename,
         "line_number": location.line_number,
         "parent_line_number": detector.parent.line_number,

--- a/pkg/commands/process/settings/policies/common.rego
+++ b/pkg/commands/process/settings/policies/common.rego
@@ -1,0 +1,41 @@
+package bearer.common
+
+import future.keywords
+
+sensitive_data_group_uuid := "f6a0c071-5908-4420-bac2-bba28d41223e"
+personal_data_group_uuid := "e1d3135b-3c0f-4b55-abce-19f27a26cbb3"
+
+has_sensitive_data(data_type) := true if {
+    some category in input.data_categories
+    category.uuid == data_type.category_uuid
+
+    some group in category.groups
+    group.uuid == sensitive_data_group_uuid
+}
+
+severity_of_datatype(data_type) := "critical" if {
+    some category in input.data_categories
+    category.uuid == data_type.category_uuid
+
+    some group in category.groups
+    group.uuid == sensitive_data_group_uuid
+}
+
+severity_of_datatype(data_type) := "high" if {
+    some category in input.data_categories
+    category.uuid == data_type.category_uuid
+
+    some group in category.groups
+    group.uuid == personal_data_group_uuid
+
+    every group_1 in category.groups {
+        group_1.uuid != sensitive_data_group_uuid
+    }
+}
+
+groups_for_datatype(data_type) := x if {
+    some category in input.data_categories
+    category.uuid == data_type.category_uuid
+
+    x := {name | name := category.groups[_].name}
+}

--- a/pkg/commands/process/settings/policies/http_get_parameters.rego
+++ b/pkg/commands/process/settings/policies/http_get_parameters.rego
@@ -1,34 +1,22 @@
 package bearer.http_get_parameters
 
+import data.bearer.common
+
 import future.keywords
 
-sensitive_data_group_uuid := "f6a0c071-5908-4420-bac2-bba28d41223e"
-personal_data_group_uuid := "e1d3135b-3c0f-4b55-abce-19f27a26cbb3"
-
-item_in_data_category contains [category_group_uuid, item] if {
+policy_breach contains item if {
     some detector in input.dataflow.risks
     detector.detector_id == input.policy_id
 
     data_type = detector.data_types[_]
 
-    some category in input.data_categories
-    category.uuid == data_type.category_uuid
-    category_group_uuid := category.group_uuid
-
     location = data_type.locations[_]
     item := {
-        "category_group": category.group_name,
+        "category_group": data.bearer.common.groups_for_datatype(data_type),
+        "severity": data.bearer.common.severity_of_datatype(data_type),
         "filename": location.filename,
         "line_number": location.line_number,
         "parent_line_number": location.parent.line_number,
         "parent_content": location.parent.content
     }
-}
-
-high[item] {
-    item_in_data_category[[sensitive_data_group_uuid, item]]
-}
-
-critical[item] {
-    item_in_data_category[[personal_data_group_uuid, item]]
 }

--- a/pkg/commands/process/settings/policies/insecure_communication.rego
+++ b/pkg/commands/process/settings/policies/insecure_communication.rego
@@ -1,21 +1,20 @@
 package bearer.insecure_communication
 
+import data.bearer.common
+
 import future.keywords
 
-sensitive_data_group_uuid := "f6a0c071-5908-4420-bac2-bba28d41223e"
-
-medium[item] {
+policy_breach contains item if {
     some data_type in input.dataflow.data_types
-    some data_category in input.data_categories
-    data_category.uuid == data_type.category_uuid
-    data_category.group_uuid == sensitive_data_group_uuid
+    data.bearer.common.has_sensitive_data(data_type)
 
     some detector in input.dataflow.risks
     detector.detector_id == input.policy_id
 
     location = detector.locations[_]
     item := {
-      "category_group": data_category.group_name,
+      "category_group": data.bearer.common.groups_for_datatype(data_type),
+      "severity": "medium",
       "filename": location.filename,
       "line_number": location.line_number,
       "parent_line_number": location.parent.line_number,

--- a/pkg/commands/process/settings/policies/insecure_ftp.rego
+++ b/pkg/commands/process/settings/policies/insecure_ftp.rego
@@ -1,28 +1,23 @@
 package bearer.insecure_ftp
 
+import data.bearer.common
+
 import future.keywords
 
-sensitive_data_group_uuid := "f6a0c071-5908-4420-bac2-bba28d41223e"
-
-has_sensitive_data if {
+policy_breach[item] {
     some data_type in input.dataflow.data_types
-    some data_category in input.data_categories
-    data_category.uuid == data_type.category_uuid
-    data_category.group_uuid == sensitive_data_group_uuid
-}
-
-medium[item] {
-    has_sensitive_data == true
+    data.bearer.common.has_sensitive_data(data_type)
 
     some detector in input.dataflow.risks
     detector.detector_id == input.policy_id
 
     location = detector.locations[_]
     item := {
-         "category_group": "sensitive data",
-         "filename": location.filename,
-         "line_number": location.line_number,
-         "parent_line_number": location.parent.line_number,
-         "parent_content": location.parent.content
+        "category_group": data.bearer.common.groups_for_datatype(data_type),
+        "severity": "medium",
+        "filename": location.filename,
+        "line_number": location.line_number,
+        "parent_line_number": location.parent.line_number,
+        "parent_content": location.parent.content
     }
 }

--- a/pkg/commands/process/settings/policies/insecure_smtp.rego
+++ b/pkg/commands/process/settings/policies/insecure_smtp.rego
@@ -1,22 +1,20 @@
 package bearer.insecure_smtp
 
+import data.bearer.common
+
 import future.keywords
 
-sensitive_data_group_uuid := "f6a0c071-5908-4420-bac2-bba28d41223e"
-
-medium[item] {
+policy_breach contains item if {
     some data_type in input.dataflow.data_types
-    some data_category in input.data_categories
-    data_category.uuid == data_type.category_uuid
-    data_category.group_uuid == sensitive_data_group_uuid
+    data.bearer.common.has_sensitive_data(data_type)
 
     some detector in input.dataflow.risks
     detector.detector_id == input.policy_id
 
     location = detector.locations[_]
     item := {
-        "category_group": data_category.group_name,
-        "filename": location.filename,
+        "category_group": data.bearer.common.groups_for_datatype(data_type),
+        "severity": "medium",
         "line_number": location.line_number,
         "parent_line_number": location.parent.line_number,
         "parent_content": location.parent.content

--- a/pkg/commands/process/settings/policies/leakage.rego
+++ b/pkg/commands/process/settings/policies/leakage.rego
@@ -1,43 +1,19 @@
 package bearer.leakage
 
+import data.bearer.common
+
 import future.keywords
 
-sensitive_data_group_uuid := "f6a0c071-5908-4420-bac2-bba28d41223e"
-personal_data_group_uuid := "e1d3135b-3c0f-4b55-abce-19f27a26cbb3"
-
-high[item] {
+policy_breach contains item if {
     some detector in input.dataflow.risks
     detector.detector_id == input.policy_id
 
     data_type = detector.data_types[_]
 
-    some category in input.data_categories
-    category.uuid == data_type.category_uuid
-    category.group_uuid == sensitive_data_group_uuid
-
     location = data_type.locations[_]
     item := {
-        "category_group": category.group_name,
-        "filename": location.filename,
-        "line_number": location.line_number,
-        "parent_line_number": location.parent.line_number,
-        "parent_content": location.parent.content
-    }
-}
-
-critical[item] {
-    some detector in input.dataflow.risks
-    detector.detector_id == input.policy_id
-
-    data_type = detector.data_types[_]
-
-    some category in input.data_categories
-    category.uuid == data_type.category_uuid
-    category.group_uuid == personal_data_group_uuid
-
-    location = data_type.locations[_]
-    item := {
-        "category_group": category.group_name,
+        "category_group": data.bearer.common.groups_for_datatype(data_type),
+        "severity": data.bearer.common.severity_of_datatype(data_type),
         "filename": location.filename,
         "line_number": location.line_number,
         "parent_line_number": location.parent.line_number,

--- a/pkg/commands/process/settings/policies/ssl_certificate_verification_disabled.rego
+++ b/pkg/commands/process/settings/policies/ssl_certificate_verification_disabled.rego
@@ -1,26 +1,20 @@
 package bearer.ssl_certificate_verification_disabled
 
+import data.bearer.common
+
 import future.keywords
 
-sensitive_data_group_uuid := "f6a0c071-5908-4420-bac2-bba28d41223e"
-
-has_sensitive_data if {
+policy_breach contains item if {
   some data_type in input.dataflow.data_types
-
-  some category in input.data_categories
-  category.uuid == data_type.category_uuid
-  category.group_uuid == sensitive_data_group_uuid
-}
-
-medium[item] {
-  has_sensitive_data == true
+  data.bearer.common.has_sensitive_data(data_type)
 
   some detector in input.dataflow.risks
   detector.detector_id == input.policy_id
   location = detector.locations[_]
 
   item = {
-    "category_group": "sensitive data",
+    "category_group": data.bearer.common.groups_for_datatype(data_type),
+    "severity": "medium",
     "filename": location.filename,
     "line_number": location.line_number,
     "parent_line_number": location.parent.line_number,


### PR DESCRIPTION
## Description
* Update data category grouping structure to product requirements
* Rework policy rules following data category restructuring
* Some rework of policy output method to adapt to new policy structure
* Also fix severity mistake - breaches that include sensitive data are critical, not high (as it was previously)

Things to note: 
* Policy rules now return policy breaches, which include a severity level, and we group breaches by severity on the Go side
* We introduced a shared module for common Rego functions (e.g. `has_sensitive_data`, `groups_for_datatype`)

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
