### PR TITLE
fix(policies): align category grouping JSON with Airtable

### DIFF
--- a/integration/flags/.snapshots/TestReportFlags-report-policies
+++ b/integration/flags/.snapshots/TestReportFlags-report-policies
@@ -4,6 +4,7 @@ high:
       line_number: 1
       filename: testdata/policies/users.rb
       category_groups:
+        - PHI
         - PII
       parent_line_number: 1
       parent_content: logger.info(user.address)

--- a/integration/policies/.snapshots/TestPolicies-http_get_parameters
+++ b/integration/policies/.snapshots/TestPolicies-http_get_parameters
@@ -14,6 +14,7 @@ high:
       line_number: 4
       filename: testdata/ruby/http_get_parameters.rb
       category_groups:
+        - PHI
         - PII
       parent_line_number: 5
       parent_content: URI.encode_www_form(user)

--- a/integration/policies/.snapshots/TestPolicies-logger_leaking
+++ b/integration/policies/.snapshots/TestPolicies-logger_leaking
@@ -4,6 +4,7 @@ high:
       line_number: 1
       filename: testdata/ruby/logger_leaking.rb
       category_groups:
+        - PHI
         - PII
       parent_line_number: 1
       parent_content: logger.info(user.address)

--- a/pkg/classification/db/category_grouping.json
+++ b/pkg/classification/db/category_grouping.json
@@ -37,7 +37,8 @@
     "79a36d6e-c5ca-4f61-ba53-0d7ad42cbe5a": {
       "name": "Communication",
       "group_uuids": [
-        "172d90e3-cb9a-46b6-90e5-dd7169c3af54"
+        "172d90e3-cb9a-46b6-90e5-dd7169c3af54",
+        "247fa503-115b-490a-96e5-bcd357bd5686"
       ]
     },
     "b5a3b0fd-dd5c-420d-91ce-dd2dddc8cc38": {
@@ -49,7 +50,8 @@
     "cef587dd-76db-430b-9e18-7b031e1a193b": {
       "name": "Contact",
       "group_uuids": [
-        "172d90e3-cb9a-46b6-90e5-dd7169c3af54"
+        "172d90e3-cb9a-46b6-90e5-dd7169c3af54",
+        "247fa503-115b-490a-96e5-bcd357bd5686"
       ]
     },
     "4eda81b6-1314-47e2-bc4e-59d6024be4f4": {
@@ -93,7 +95,8 @@
     "14124881-6b92-4fc5-8005-ea7c1c09592e": {
       "name": "Identification",
       "group_uuids": [
-        "172d90e3-cb9a-46b6-90e5-dd7169c3af54"
+        "172d90e3-cb9a-46b6-90e5-dd7169c3af54",
+        "247fa503-115b-490a-96e5-bcd357bd5686"
       ]
     },
     "c6622b62-bc22-4c0c-a2e4-5fc97d99e11a": {


### PR DESCRIPTION
## Description
Small tweaks to data category groups (i.e. adding missing PHI to select categories)
Category grouping JSON is now aligned with Airtable: https://airtable.com/shr3WpHaBrpWGGqM1/tblQOszezMkN7n7G2

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
