### PR TITLE
fix: fix datatype docs

### DIFF
--- a/docs/_data/datatypes.js
+++ b/docs/_data/datatypes.js
@@ -30,16 +30,33 @@ function sortData(typesFile, catsFile, groupsFile) {
 
   // setup groups
   for (const key in groupsFile.groups) {
-    output[key] = { uuid: key, name: groupsFile.groups[key], categories: {} };
+    outputResult = {
+      uuid: key,
+      name: groupsFile.groups[key].name,
+      categories: {}
+    };
+
+    parentGroups = []
+    for (const parentKey of groupsFile.groups[key].parent_uuids) {
+      parentGroups += groupsFile.groups[parentKey]
+    }
+    if (parentGroups.length > 0) {
+      outputResult.parentGroups = parentGroups
+    }
+
+    output[key] = outputResult
   }
 
   // add categories to each group
   for (const key in groupsFile.category_mapping) {
-    output[groupsFile.category_mapping[key].group_uuid].categories[key] = {
-      types: [],
-      uuid: key,
-      ...groupsFile.category_mapping[key],
-    };
+    for (const groupUUID of groupsFile.category_mapping[key].group_uuids) {
+      console.log(groupUUID)
+      output[groupUUID].categories[key] = {
+        types: [],
+        uuid: key,
+        ...groupsFile.category_mapping[key],
+      };
+    }
   }
 
   // add types to each category


### PR DESCRIPTION
## Description
Update datatypes.js to handle updated structure of category grouping JSON
Note: categories can now be in more than one group, so there will be some duplicate displays (e.g. "Medical and Health" appears in PHI, Sensitive, and Personal Data groups)

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
