### PR TITLE
fix: Detect Net::FTP.open in Ruby custom detector

### DIFF
--- a/integration/flags/.snapshots/TestInitCommand-init
+++ b/integration/flags/.snapshots/TestInitCommand-init
@@ -55,7 +55,10 @@ scan:
             processors: []
             patterns:
                 - pattern: |
-                    Net::FTP::new()
+                    Net::FTP.new()
+                  filters: []
+                - pattern: |
+                    Net::FTP.open()
                   filters: []
             root_singularize: false
             root_lowercase: false

--- a/integration/policies/.snapshots/TestPolicies-insecure_ftp_with_sensitive_data
+++ b/integration/policies/.snapshots/TestPolicies-insecure_ftp_with_sensitive_data
@@ -8,7 +8,23 @@ medium:
         - PII
         - Sensitive data
       parent_line_number: 10
-      parent_content: Net::FTP::new("ftp.ruby-lang.org")
+      parent_content: Net::FTP.new("ftp.ruby-lang.org")
+    - policy_name: Insecure FTP
+      policy_description: Communication with insecure FTP in an application processing sensitive data
+      line_number: 17
+      filename: testdata/ruby/insecure_ftp/with_sensitive_data.rb
+      category_groups:
+        - PHI
+        - PII
+        - Sensitive data
+      parent_line_number: 17
+      parent_content: |-
+        Net::FTP.open('example.com') do |ftp|
+          ftp.login
+          files = ftp.chdir('pub/lang/ruby/contrib')
+          files = ftp.list('n*')
+          ftp.getbinaryfile('nif.rb-0.91.gz', 'nif.gz', 1024)
+        end
 
 
 --

--- a/integration/policies/testdata/ruby/insecure_ftp/with_sensitive_data.rb
+++ b/integration/policies/testdata/ruby/insecure_ftp/with_sensitive_data.rb
@@ -7,12 +7,19 @@ end
 ## Detected
 require "net/ftp"
 
-ftp = Net::FTP::new("ftp.ruby-lang.org")
+ftp = Net::FTP.new("ftp.ruby-lang.org")
 ftp.login("anonymous", "matz@ruby-lang.org")
 ftp.chdir("/pub/ruby")
 tgz = ftp.list("ruby-*.tar.gz").sort.last
 ftp.getbinaryfile(tgz, tgz)
 ftp.close
+
+Net::FTP.open('example.com') do |ftp|
+  ftp.login
+  files = ftp.chdir('pub/lang/ruby/contrib')
+  files = ftp.list('n*')
+  ftp.getbinaryfile('nif.rb-0.91.gz', 'nif.gz', 1024)
+end
 
 ## Not detected
 require "net/sftp"

--- a/integration/policies/testdata/ruby/insecure_ftp/without_sensitive_data.rb
+++ b/integration/policies/testdata/ruby/insecure_ftp/without_sensitive_data.rb
@@ -7,12 +7,19 @@ end
 ## Detected
 require "net/ftp"
 
-ftp = Net::FTP::new("ftp.ruby-lang.org")
+ftp = Net::FTP.new("ftp.ruby-lang.org")
 ftp.login("anonymous", "matz@ruby-lang.org")
 ftp.chdir("/pub/ruby")
 tgz = ftp.list("ruby-*.tar.gz").sort.last
 ftp.getbinaryfile(tgz, tgz)
 ftp.close
+
+Net::FTP.open('example.com') do |ftp|
+  ftp.login
+  files = ftp.chdir('pub/lang/ruby/contrib')
+  files = ftp.list('n*')
+  ftp.getbinaryfile('nif.rb-0.91.gz', 'nif.gz', 1024)
+end
 
 ## Not detected
 require "net/sftp"

--- a/pkg/commands/process/settings/custom_detector.yml
+++ b/pkg/commands/process/settings/custom_detector.yml
@@ -181,7 +181,9 @@ detect_rails_insecure_ftp:
   type: "risk"
   patterns:
     - |
-      Net::FTP::new()
+      Net::FTP.new()
+    - |
+      Net::FTP.open()
   languages:
     - ruby
   detect_presence: true

--- a/pkg/detectors/custom/.snapshots/TestInsecureFTPJSON
+++ b/pkg/detectors/custom/.snapshots/TestInsecureFTPJSON
@@ -8,11 +8,27 @@
    "language_type": "programming",
    "line_number": 5,
    "column_number": 7,
-   "text": "Net::FTP::new()\n"
+   "text": "Net::FTP.new()\n"
   },
   "value": {
    "line_number": 5,
-   "content": "Net::FTP::new(\"ftp.ruby-lang.org\")"
+   "content": "Net::FTP.new(\"ftp.ruby-lang.org\")"
+  }
+ },
+ {
+  "type": "custom_risk",
+  "detector_type": "detect_rails_insecure_ftp",
+  "source": {
+   "filename": "config.rb",
+   "language": "Ruby",
+   "language_type": "programming",
+   "line_number": 12,
+   "column_number": 1,
+   "text": "Net::FTP.open()\n"
+  },
+  "value": {
+   "line_number": 12,
+   "content": "Net::FTP.open('example.com') do |ftp|\n  ftp.login\n  files = ftp.chdir('pub/lang/ruby/contrib')\n  files = ftp.list('n*')\n  ftp.getbinaryfile('nif.rb-0.91.gz', 'nif.gz', 1024)\nend"
   }
  }
 ]

--- a/pkg/detectors/custom/testdata/config/insecure_ftp.yml
+++ b/pkg/detectors/custom/testdata/config/insecure_ftp.yml
@@ -2,7 +2,9 @@ detect_rails_insecure_ftp:
   type: "risk"
   patterns:
     - |
-      Net::FTP::new()
+      Net::FTP.new()
+    - |
+      Net::FTP.open()
   languages:
     - ruby
   detect_presence: true

--- a/pkg/detectors/custom/testdata/ruby/insecure_ftp/config.rb
+++ b/pkg/detectors/custom/testdata/ruby/insecure_ftp/config.rb
@@ -2,12 +2,19 @@
 ## Detected
 require "net/ftp"
 
-ftp = Net::FTP::new("ftp.ruby-lang.org")
+ftp = Net::FTP.new("ftp.ruby-lang.org")
 ftp.login("anonymous", "matz@ruby-lang.org")
 ftp.chdir("/pub/ruby")
 tgz = ftp.list("ruby-*.tar.gz").sort.last
 ftp.getbinaryfile(tgz, tgz)
 ftp.close
+
+Net::FTP.open('example.com') do |ftp|
+  ftp.login
+  files = ftp.chdir('pub/lang/ruby/contrib')
+  files = ftp.list('n*')
+  ftp.getbinaryfile('nif.rb-0.91.gz', 'nif.gz', 1024)
+end
 
 ## Not detected
 require "net/sftp"


### PR DESCRIPTION
## Description

As well as `Net::FTP.new`, we also need to support the `Net::FTP.open` API, for the Ruby insecure FTP policy.

## Checklist

- [X] I've added test coverage that shows my fix or feature works as expected.
- [X] I've updated or added documentation if required.
- [X] I've included usage information in the description if CLI behavior was updated or added.
- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
