### PR TITLE
feat: policy for communicating data category via insecure http

### DIFF
--- a/integration/custom_detectors/.snapshots/TestCustomDetectors-ruby_http_detection
+++ b/integration/custom_detectors/.snapshots/TestCustomDetectors-ruby_http_detection
@@ -312,6 +312,85 @@ risks:
             content: HTTPX.get("http://my.api.com/users/1")
           content: |
             $CLIENT.get(<$INSECURE_URL>)
+    - detector_id: ruby_http_post_insecure
+      locations:
+        - filename: testdata/ruby/ruby_http_detection.rb
+          line_number: 24
+          parent:
+            line_number: 24
+            content: Curl.post("http://my.api.com/users/create", user_4)
+          content: |
+            $CLIENT.post(<$INSECURE_URL>)
+        - filename: testdata/ruby/ruby_http_detection.rb
+          line_number: 26
+          parent:
+            line_number: 26
+            content: 'Curl.post("http://my.api.com/users/create", { user_5: { first_name: "John", last_name: "Doe" } })'
+          content: |
+            $CLIENT.post(<$INSECURE_URL>)
+        - filename: testdata/ruby/ruby_http_detection.rb
+          line_number: 35
+          parent:
+            line_number: 35
+            content: 'RestClient.post("http://my.api.com/users/create", { user_6: { first_name: "John", last_name: "Doe" } })'
+          content: |
+            $CLIENT.post(<$INSECURE_URL>)
+        - filename: testdata/ruby/ruby_http_detection.rb
+          line_number: 41
+          parent:
+            line_number: 41
+            content: Typhoeus.post("http://my.api.com/users/create", options)
+          content: |
+            $CLIENT.post(<$INSECURE_URL>)
+        - filename: testdata/ruby/ruby_http_detection.rb
+          line_number: 43
+          parent:
+            line_number: 43
+            content: 'Typhoeus.post("http://my.api.com/users/create", { body: { user_8: { first_name: "John", last_name: "Doe" } } })'
+          content: |
+            $CLIENT.post(<$INSECURE_URL>)
+        - filename: testdata/ruby/ruby_http_detection.rb
+          line_number: 64
+          parent:
+            line_number: 64
+            content: HTTParty.post("http://my.api.com/users/create", params)
+          content: |
+            $CLIENT.post(<$INSECURE_URL>)
+        - filename: testdata/ruby/ruby_http_detection.rb
+          line_number: 66
+          parent:
+            line_number: 66
+            content: 'HTTParty.post("http://my.api.com/users/create", { body: { user: { first_name: "John", last_name: "Doe" } } })'
+          content: |
+            $CLIENT.post(<$INSECURE_URL>)
+        - filename: testdata/ruby/ruby_http_detection.rb
+          line_number: 75
+          parent:
+            line_number: 75
+            content: 'HTTP.post("http://my.api.com/users/create", form: { user_9: { first_name: "John", last_name: "Doe" } })'
+          content: |
+            $CLIENT.post(<$INSECURE_URL>)
+        - filename: testdata/ruby/ruby_http_detection.rb
+          line_number: 84
+          parent:
+            line_number: 84
+            content: 'Excon.post("http://my.api.com/users/create", body: { user_10: { first_name: "John", last_name: "Doe" } })'
+          content: |
+            $CLIENT.post(<$INSECURE_URL>)
+        - filename: testdata/ruby/ruby_http_detection.rb
+          line_number: 97
+          parent:
+            line_number: 97
+            content: Faraday.post("http://my.api.com/users/create", encoded_params)
+          content: |
+            $CLIENT.post(<$INSECURE_URL>)
+        - filename: testdata/ruby/ruby_http_detection.rb
+          line_number: 106
+          parent:
+            line_number: 106
+            content: 'HTTPX.post("http://my.api.com/users/create", json: { user_12: { first_name: "John", last_name: "Doe" } })'
+          content: |
+            $CLIENT.post(<$INSECURE_URL>)
 components: []
 
 

--- a/integration/flags/.snapshots/TestInitCommand-init
+++ b/integration/flags/.snapshots/TestInitCommand-init
@@ -333,6 +333,36 @@ scan:
             stored: false
             detect_presence: false
             omit_parent: false
+        ruby_http_post_insecure:
+            disabled: false
+            type: risk
+            languages:
+                - ruby
+            param_parenting: false
+            processors: []
+            patterns:
+                - pattern: |
+                    Net::HTTP.post_form(<$INSECURE_URL>)
+                  filters: []
+                - pattern: |
+                    $CLIENT.post(<$INSECURE_URL>)
+                  filters:
+                    - variable: CLIENT
+                      values:
+                        - Curl
+                        - Excon
+                        - Faraday
+                        - HTTP
+                        - HTTParty
+                        - HTTPX
+                        - RestClient
+                        - Typhoeus
+            root_singularize: false
+            root_lowercase: false
+            metavars: {}
+            stored: false
+            detect_presence: true
+            omit_parent: false
         ssl_certificate_verification_disabled:
             disabled: false
             type: risk
@@ -761,6 +791,101 @@ scan:
                             "parent_line_number": location.parent.line_number,
                             "parent_content": location.parent.content
                         }
+                    }
+        insecure_http_with_data_category:
+            query: |
+                policy_breach = data.bearer.insecure_http_with_data_category.policy_breach
+            id: insecure_http_with_data_category
+            name: Insecure HTTP with Data Category
+            description: Communicating Data Category with insecure HTTP
+            level: ""
+            modules:
+                - path: policies/common.rego
+                  name: bearer.common
+                  content: |
+                    package bearer.common
+
+                    import future.keywords
+
+                    sensitive_data_group_uuid := "f6a0c071-5908-4420-bac2-bba28d41223e"
+                    personal_data_group_uuid := "e1d3135b-3c0f-4b55-abce-19f27a26cbb3"
+
+                    has_sensitive_data(data_type) := true if {
+                        some category in input.data_categories
+                        category.uuid == data_type.category_uuid
+
+                        some group in category.groups
+                        group.uuid == sensitive_data_group_uuid
+                    }
+
+                    severity_of_datatype(data_type) := "critical" if {
+                        some category in input.data_categories
+                        category.uuid == data_type.category_uuid
+
+                        some group in category.groups
+                        group.uuid == sensitive_data_group_uuid
+                    }
+
+                    severity_of_datatype(data_type) := "high" if {
+                        some category in input.data_categories
+                        category.uuid == data_type.category_uuid
+
+                        some group in category.groups
+                        group.uuid == personal_data_group_uuid
+
+                        every group_1 in category.groups {
+                            group_1.uuid != sensitive_data_group_uuid
+                        }
+                    }
+
+                    groups_for_datatype(data_type) := x if {
+                        some category in input.data_categories
+                        category.uuid == data_type.category_uuid
+
+                        x := {name | name := category.groups[_].name}
+                    }
+
+                    groups_for_datatypes(data_types) := groups if {
+                        groups := {name | name := groups_for_datatype(data_types[_])[_]}
+                    }
+                - path: policies/insecure_http_with_data_category.rego
+                  name: bearer.insecure_http_with_data_category
+                  content: |
+                    package bearer.insecure_http_with_data_category
+
+                    import data.bearer.common
+
+                    import future.keywords
+
+                    insecure_http_with_data contains [data_detector_id, insecure_detector_id, item] if {
+                        some data_risk in input.dataflow.risks
+                        data_detector_id := data_risk.detector_id
+
+                        data_type = data_risk.data_types[_]
+                        data_location = data_type.locations[_]
+
+                        some insecure_risk in input.dataflow.risks
+                        insecure_detector_id := insecure_risk.detector_id
+                        some insecure_location in insecure_risk.locations
+                        data_location.filename == insecure_location.filename
+                        data_location.parent.line_number == insecure_location.parent.line_number
+
+                        item := {
+                            "category_groups": data.bearer.common.groups_for_datatype(data_type),
+                            "severity": data.bearer.common.severity_of_datatype(data_type),
+                            "filename": data_location.filename,
+                            "line_number": data_location.line_number,
+                            "parent_line_number": data_location.parent.line_number,
+                            "parent_content": data_location.parent.content
+                        }
+                    }
+
+                    policy_breach contains item if {
+                      insecure_http_with_data[["ruby_http_get_detection", "ruby_http_get_insecure", item]]
+                    }
+
+                    policy_breach contains item if {
+                      insecure_http_with_data[["ruby_http_post_detection", "ruby_http_post_insecure", item]]
                     }
         insecure_smtp_processing_sensitive_data:
             query: |

--- a/integration/policies/.snapshots/TestPolicies-http_with_sensitive_data
+++ b/integration/policies/.snapshots/TestPolicies-http_with_sensitive_data
@@ -8,6 +8,15 @@ critical:
         - Sensitive data
       parent_line_number: 1
       parent_content: URI("http://my.api.com/users/search?ethnic_origin=#{user_1.ethnic_origin}")
+    - policy_name: Insecure HTTP with Data Category
+      policy_description: Communicating Data Category with insecure HTTP
+      line_number: 1
+      filename: testdata/ruby/http/with_sensitive_data.rb
+      category_groups:
+        - PII
+        - Sensitive data
+      parent_line_number: 1
+      parent_content: URI("http://my.api.com/users/search?ethnic_origin=#{user_1.ethnic_origin}")
 high:
     - policy_name: HTTP GET parameters
       policy_description: Sending data as HTTP GET parameters
@@ -18,6 +27,15 @@ high:
         - PII
       parent_line_number: 5
       parent_content: URI.encode_www_form(user)
+    - policy_name: Insecure HTTP with Data Category
+      policy_description: Communicating Data Category with insecure HTTP
+      line_number: 11
+      filename: testdata/ruby/http/with_sensitive_data.rb
+      category_groups:
+        - PHI
+        - PII
+      parent_line_number: 11
+      parent_content: 'Net::HTTP.post_form(''http://my.api.com/users/search'', { user: { first_name: "John", last_name: "Doe" } })'
 medium:
     - policy_name: Insecure HTTP GET
       policy_description: Communicating with insecure HTTP GET in an application processing sensitive data

--- a/integration/policies/testdata/ruby/http/with_sensitive_data.rb
+++ b/integration/policies/testdata/ruby/http/with_sensitive_data.rb
@@ -1,9 +1,12 @@
-uri = URI("http://my.api.com/users/search?ethnic_origin=#{user_1.ethnic_origin}")
+uri_1 = URI("http://my.api.com/users/search?ethnic_origin=#{user_1.ethnic_origin}")
 
-uri = URI('http://my.api.com/users/search')
+uri_2 = URI('http://my.api.com/users/search')
 user = { first_name: "John", last_name: "Doe" }
-uri.query = URI.encode_www_form(user)
+uri_2.query = URI.encode_www_form(user)
 
-response = Net::HTTP.post_form(uri, { user: { first_name: "John", last_name: "Doe" } })
+response = Net::HTTP.post_form(uri_2, { user: { first_name: "John", last_name: "Doe" } })
 
-uri = URI('https://my.api.com/users/search')
+uri_3 = URI('https://my.api.com/users/search')
+
+Net::HTTP.post_form('http://my.api.com/users/search', { user: { first_name: "John", last_name: "Doe" } })
+Net::HTTP.post_form('https://my.api.com/users/search', { user: { first_name: "John", last_name: "Doe" } })

--- a/pkg/commands/process/settings/custom_detector.yml
+++ b/pkg/commands/process/settings/custom_detector.yml
@@ -65,6 +65,27 @@ ruby_http_get_insecure:
             - RestClient
             - Typhoeus
   detect_presence: true
+ruby_http_post_insecure:
+  type: "risk"
+  languages:
+    - ruby
+  patterns:
+    - |
+      Net::HTTP.post_form(<$INSECURE_URL>)
+    - pattern: |
+        $CLIENT.post(<$INSECURE_URL>)
+      filters:
+        - variable: CLIENT
+          values:
+            - Curl
+            - Excon
+            - Faraday
+            - HTTP
+            - HTTParty
+            - HTTPX
+            - RestClient
+            - Typhoeus
+  detect_presence: true
 ruby_file_detection:
   type: "risk"
   languages:

--- a/pkg/commands/process/settings/policies.yml
+++ b/pkg/commands/process/settings/policies.yml
@@ -108,3 +108,14 @@ insecure_http_get:
       name: bearer.common
     - path: policies/insecure_http_get.rego
       name: bearer.insecure_http_get
+insecure_http_with_data_category:
+  description: "Communicating Data Category with insecure HTTP"
+  name: "Insecure HTTP with Data Category"
+  id: insecure_http_with_data_category
+  query: |
+    policy_breach = data.bearer.insecure_http_with_data_category.policy_breach
+  modules:
+    - path: policies/common.rego
+      name: bearer.common
+    - path: policies/insecure_http_with_data_category.rego
+      name: bearer.insecure_http_with_data_category

--- a/pkg/commands/process/settings/policies/insecure_http_with_data_category.rego
+++ b/pkg/commands/process/settings/policies/insecure_http_with_data_category.rego
@@ -1,0 +1,36 @@
+package bearer.insecure_http_with_data_category
+
+import data.bearer.common
+
+import future.keywords
+
+insecure_http_with_data contains [data_detector_id, insecure_detector_id, item] if {
+    some data_risk in input.dataflow.risks
+    data_detector_id := data_risk.detector_id
+
+    data_type = data_risk.data_types[_]
+    data_location = data_type.locations[_]
+
+    some insecure_risk in input.dataflow.risks
+    insecure_detector_id := insecure_risk.detector_id
+    some insecure_location in insecure_risk.locations
+    data_location.filename == insecure_location.filename
+    data_location.parent.line_number == insecure_location.parent.line_number
+
+    item := {
+        "category_groups": data.bearer.common.groups_for_datatype(data_type),
+        "severity": data.bearer.common.severity_of_datatype(data_type),
+        "filename": data_location.filename,
+        "line_number": data_location.line_number,
+        "parent_line_number": data_location.parent.line_number,
+        "parent_content": data_location.parent.content
+    }
+}
+
+policy_breach contains item if {
+  insecure_http_with_data[["ruby_http_get_detection", "ruby_http_get_insecure", item]]
+}
+
+policy_breach contains item if {
+  insecure_http_with_data[["ruby_http_post_detection", "ruby_http_post_insecure", item]]
+}


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Adds a policy for detecting sending a data category via insecure HTTP. 

Due to current limitations of custom rules, this is implemented by looking for a HTTP data risk and HTTP insecure URL risk on the same line number.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [x] I've added test coverage that shows my fix or feature works as expected.
- [x] I've updated or added documentation if required.
- [x] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
