### PR TITLE
fix: handle policy report when parent is omitted

### DIFF
--- a/integration/custom_detectors/.snapshots/TestCustomDetectors-ruby_file_detection
+++ b/integration/custom_detectors/.snapshots/TestCustomDetectors-ruby_file_detection
@@ -46,10 +46,10 @@ risks:
             - filename: testdata/ruby/ruby_file_detection.rb
               line_number: 5
               parent:
-                line_number: 1
+                line_number: 20
                 content: |-
-                    CSV.open("path/to/user.csv", "wb") do |csv|
-                      csv << ["email", "first_name", "last_name"]
+                    CSV.generate do |csv|
+                    	csv << ["email", "first_name", "last_name"]
                     	users.each do |user|
                     		csv << [
                     			user.email,
@@ -94,10 +94,10 @@ risks:
             - filename: testdata/ruby/ruby_file_detection.rb
               line_number: 6
               parent:
-                line_number: 1
+                line_number: 20
                 content: |-
-                    CSV.open("path/to/user.csv", "wb") do |csv|
-                      csv << ["email", "first_name", "last_name"]
+                    CSV.generate do |csv|
+                    	csv << ["email", "first_name", "last_name"]
                     	users.each do |user|
                     		csv << [
                     			user.email,
@@ -137,10 +137,10 @@ risks:
             - filename: testdata/ruby/ruby_file_detection.rb
               line_number: 7
               parent:
-                line_number: 1
+                line_number: 20
                 content: |-
-                    CSV.open("path/to/user.csv", "wb") do |csv|
-                      csv << ["email", "first_name", "last_name"]
+                    CSV.generate do |csv|
+                    	csv << ["email", "first_name", "last_name"]
                     	users.each do |user|
                     		csv << [
                     			user.email,

--- a/integration/flags/.snapshots/TestInitCommand-init
+++ b/integration/flags/.snapshots/TestInitCommand-init
@@ -608,7 +608,8 @@ scan:
                           "category_groups": data.bearer.common.groups_for_datatypes(input.dataflow.data_types),
                           "severity": "medium",
                           "filename": location.filename,
-                          "line_number": location.line_number
+                          "line_number": location.line_number,
+                          "omit_parent": true
                         }
                     }
         insecure_ftp_processing_sensitive_data:
@@ -911,7 +912,9 @@ scan:
                         item := {
                             "category_groups": data.bearer.common.groups_for_datatypes(input.dataflow.data_types),
                             "severity": "medium",
-                            "line_number": location.line_number
+                            "filename": location.filename,
+                            "line_number": location.line_number,
+                            "omit_parent": true
                         }
                     }
         jwt_leaks:

--- a/integration/flags/.snapshots/TestReportFlags-report-policies
+++ b/integration/flags/.snapshots/TestReportFlags-report-policies
@@ -8,6 +8,7 @@ high:
         - PII
       parent_line_number: 1
       parent_content: logger.info(user.address)
+      omit_parent: false
 
 
 --

--- a/integration/policies/.snapshots/TestPolicies-http_with_sensitive_data
+++ b/integration/policies/.snapshots/TestPolicies-http_with_sensitive_data
@@ -1,4 +1,17 @@
 critical:
+<<<<<<< HEAD
+=======
+    - policy_name: HTTP GET parameters
+      policy_description: Sending data as HTTP GET parameters
+      line_number: 1
+      filename: testdata/ruby/http/with_sensitive_data.rb
+      category_groups:
+        - PII
+        - Sensitive data
+      parent_line_number: 1
+      parent_content: URI("http://my.api.com/users/search?ethnic_origin=#{user_1.ethnic_origin}")
+      omit_parent: false
+>>>>>>> f93966b (chore: update snapshots)
     - policy_name: Insecure HTTP with Data Category
       policy_description: Communicating Data Category with insecure HTTP
       line_number: 1
@@ -17,16 +30,10 @@ critical:
         - Sensitive personal data
       parent_line_number: 1
       parent_content: URI("http://my.api.com/users/search?ethnic_origin=#{user_1.ethnic_origin}")
+      omit_parent: false
 high:
-    - policy_name: Insecure HTTP with Data Category
-      policy_description: Communicating Data Category with insecure HTTP
-      line_number: 11
-      filename: testdata/ruby/http/with_sensitive_data.rb
-      category_groups:
-        - PHI
-        - PII
-      parent_line_number: 11
-      parent_content: 'Net::HTTP.post_form(''http://my.api.com/users/search'', { user: { first_name: "John", last_name: "Doe" } })'
+<<<<<<< HEAD
+=======
     - policy_name: HTTP GET parameters
       policy_description: Sending data as HTTP GET parameters
       line_number: 4
@@ -36,6 +43,30 @@ high:
         - PII
       parent_line_number: 5
       parent_content: URI.encode_www_form(user)
+      omit_parent: false
+>>>>>>> f93966b (chore: update snapshots)
+    - policy_name: Insecure HTTP with Data Category
+      policy_description: Communicating Data Category with insecure HTTP
+      line_number: 11
+      filename: testdata/ruby/http/with_sensitive_data.rb
+      category_groups:
+        - PHI
+        - PII
+      parent_line_number: 11
+      parent_content: 'Net::HTTP.post_form(''http://my.api.com/users/search'', { user: { first_name: "John", last_name: "Doe" } })'
+<<<<<<< HEAD
+    - policy_name: HTTP GET parameters
+      policy_description: Sending data as HTTP GET parameters
+      line_number: 4
+      filename: testdata/ruby/http/with_sensitive_data.rb
+      category_groups:
+        - PHI
+        - PII
+      parent_line_number: 5
+      parent_content: URI.encode_www_form(user)
+=======
+      omit_parent: false
+>>>>>>> f93966b (chore: update snapshots)
 medium:
     - policy_name: Insecure HTTP GET
       policy_description: Communicating with insecure HTTP GET in an application processing sensitive data
@@ -47,6 +78,7 @@ medium:
         - Sensitive personal data
       parent_line_number: 1
       parent_content: URI("http://my.api.com/users/search?ethnic_origin=#{user_1.ethnic_origin}")
+      omit_parent: false
     - policy_name: Insecure HTTP GET
       policy_description: Communicating with insecure HTTP GET in an application processing sensitive data
       line_number: 3
@@ -57,6 +89,7 @@ medium:
         - Sensitive personal data
       parent_line_number: 3
       parent_content: URI('http://my.api.com/users/search')
+      omit_parent: false
 
 
 --

--- a/integration/policies/.snapshots/TestPolicies-insecure_communication
+++ b/integration/policies/.snapshots/TestPolicies-insecure_communication
@@ -6,6 +6,7 @@ medium:
       category_groups:
         - PHI
         - PII
+      omit_parent: true
 
 
 --

--- a/integration/policies/.snapshots/TestPolicies-insecure_communication_with_sensitive_data
+++ b/integration/policies/.snapshots/TestPolicies-insecure_communication_with_sensitive_data
@@ -6,7 +6,12 @@ medium:
       category_groups:
         - PHI
         - PII
+<<<<<<< HEAD
         - Sensitive personal data
+=======
+        - Sensitive data
+      omit_parent: true
+>>>>>>> f93966b (chore: update snapshots)
 
 
 --

--- a/integration/policies/.snapshots/TestPolicies-insecure_ftp
+++ b/integration/policies/.snapshots/TestPolicies-insecure_ftp
@@ -8,6 +8,7 @@ medium:
         - PII
       parent_line_number: 10
       parent_content: Net::FTP.new("ftp.ruby-lang.org")
+      omit_parent: false
     - policy_name: Insecure FTP
       policy_description: Communication with insecure FTP in an application processing sensitive data
       line_number: 17
@@ -23,6 +24,7 @@ medium:
           files = ftp.list('n*')
           ftp.getbinaryfile('nif.rb-0.91.gz', 'nif.gz', 1024)
         end
+      omit_parent: false
 
 
 --

--- a/integration/policies/.snapshots/TestPolicies-insecure_ftp_with_sensitive_data
+++ b/integration/policies/.snapshots/TestPolicies-insecure_ftp_with_sensitive_data
@@ -9,6 +9,7 @@ medium:
         - Sensitive personal data
       parent_line_number: 10
       parent_content: Net::FTP.new("ftp.ruby-lang.org")
+      omit_parent: false
     - policy_name: Insecure FTP
       policy_description: Communication with insecure FTP in an application processing sensitive data
       line_number: 17
@@ -25,6 +26,7 @@ medium:
           files = ftp.list('n*')
           ftp.getbinaryfile('nif.rb-0.91.gz', 'nif.gz', 1024)
         end
+      omit_parent: false
 
 
 --

--- a/integration/policies/.snapshots/TestPolicies-insecure_smtp
+++ b/integration/policies/.snapshots/TestPolicies-insecure_smtp
@@ -2,15 +2,19 @@ medium:
     - policy_name: Insecure SMTP
       policy_description: Communication with insecure SMTP in an application processing sensitive data
       line_number: 8
+      filename: testdata/ruby/insecure_smtp.rb
       category_groups:
         - PHI
         - PII
+      omit_parent: true
     - policy_name: Insecure SMTP
       policy_description: Communication with insecure SMTP in an application processing sensitive data
       line_number: 14
+      filename: testdata/ruby/insecure_smtp.rb
       category_groups:
         - PHI
         - PII
+      omit_parent: true
 
 
 --

--- a/integration/policies/.snapshots/TestPolicies-insecure_smtp_with_sensitive_data
+++ b/integration/policies/.snapshots/TestPolicies-insecure_smtp_with_sensitive_data
@@ -2,17 +2,29 @@ medium:
     - policy_name: Insecure SMTP
       policy_description: Communication with insecure SMTP in an application processing sensitive data
       line_number: 8
+      filename: testdata/ruby/insecure_smtp/with_sensitive_data.rb
       category_groups:
         - PHI
         - PII
+<<<<<<< HEAD
         - Sensitive personal data
+=======
+        - Sensitive data
+      omit_parent: true
+>>>>>>> f93966b (chore: update snapshots)
     - policy_name: Insecure SMTP
       policy_description: Communication with insecure SMTP in an application processing sensitive data
       line_number: 14
+      filename: testdata/ruby/insecure_smtp/with_sensitive_data.rb
       category_groups:
         - PHI
         - PII
+<<<<<<< HEAD
         - Sensitive personal data
+=======
+        - Sensitive data
+      omit_parent: true
+>>>>>>> f93966b (chore: update snapshots)
 
 
 --

--- a/integration/policies/.snapshots/TestPolicies-logger_leaking
+++ b/integration/policies/.snapshots/TestPolicies-logger_leaking
@@ -8,6 +8,7 @@ high:
         - PII
       parent_line_number: 1
       parent_content: logger.info(user.address)
+      omit_parent: false
 
 
 --

--- a/pkg/commands/process/settings/policies/insecure_communication.rego
+++ b/pkg/commands/process/settings/policies/insecure_communication.rego
@@ -15,6 +15,7 @@ policy_breach contains item if {
       "category_groups": data.bearer.common.groups_for_datatypes(input.dataflow.data_types),
       "severity": "medium",
       "filename": location.filename,
-      "line_number": location.line_number
+      "line_number": location.line_number,
+      "omit_parent": true
     }
 }

--- a/pkg/commands/process/settings/policies/insecure_smtp.rego
+++ b/pkg/commands/process/settings/policies/insecure_smtp.rego
@@ -14,6 +14,8 @@ policy_breach contains item if {
     item := {
         "category_groups": data.bearer.common.groups_for_datatypes(input.dataflow.data_types),
         "severity": "medium",
-        "line_number": location.line_number
+        "filename": location.filename,
+        "line_number": location.line_number,
+        "omit_parent": true
     }
 }

--- a/pkg/report/output/policies/policies.go
+++ b/pkg/report/output/policies/policies.go
@@ -35,6 +35,7 @@ type PolicyOutput struct {
 	Filename         string   `json:"filename,omitempty" yaml:"filename,omitempty"`
 	CategoryGroups   []string `json:"category_groups,omitempty" yaml:"category_groups,omitempty"`
 	Severity         string   `json:"severity,omitempty" yaml:"severity,omitempty"`
+	OmitParent       bool     `json:"omit_parent" yaml:"omit_parent"`
 }
 
 type PolicyResult struct {
@@ -45,6 +46,7 @@ type PolicyResult struct {
 	CategoryGroups    []string `json:"category_groups,omitempty" yaml:"category_groups,omitempty"`
 	ParentLineNumber  int      `json:"parent_line_number,omitempty" yaml:"parent_line_number,omitempty"`
 	ParentContent     string   `json:"parent_content,omitempty" yaml:"parent_content,omitempty"`
+	OmitParent        bool     `json:"omit_parent" yaml:"omit_parent"`
 }
 
 func GetOutput(dataflow *dataflow.DataFlow, config settings.Config) (map[string][]PolicyResult, error) {
@@ -83,6 +85,7 @@ func GetOutput(dataflow *dataflow.DataFlow, config settings.Config) (map[string]
 					Filename:          policyOutput.Filename,
 					LineNumber:        policyOutput.LineNumber,
 					CategoryGroups:    policyOutput.CategoryGroups,
+					OmitParent:        policyOutput.OmitParent,
 					ParentLineNumber:  policyOutput.ParentLineNumber,
 					ParentContent:     policyOutput.ParentContent,
 				}
@@ -200,8 +203,10 @@ func writePolicyBreachToString(reportStr *strings.Builder, policyBreach PolicyRe
 	reportStr.WriteString(color.HiBlackString(policyBreach.PolicyDescription + "\n"))
 	reportStr.WriteString("\n")
 	reportStr.WriteString(color.HiBlueString("File: " + underline(policyBreach.Filename+":"+fmt.Sprint(policyBreach.LineNumber)) + "\n"))
-	reportStr.WriteString("\n")
-	reportStr.WriteString(highlightCodeExtract(policyBreach.LineNumber, policyBreach.ParentLineNumber, policyBreach.ParentContent))
+	if !policyBreach.OmitParent {
+		reportStr.WriteString("\n")
+		reportStr.WriteString(highlightCodeExtract(policyBreach.LineNumber, policyBreach.ParentLineNumber, policyBreach.ParentContent))
+	}
 }
 
 func formatSeverity(policySeverity string) string {


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Handle cases where parent is missing when displaying the policies

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [x] I've added test coverage that shows my fix or feature works as expected.
- [x] I've updated or added documentation if required.
- [x] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
