### PR TITLE
feat: add policy for communicating data category with insecure FTP

### DIFF
--- a/integration/custom_detectors/.snapshots/TestCustomDetectors-ftp
+++ b/integration/custom_detectors/.snapshots/TestCustomDetectors-ftp
@@ -1,0 +1,88 @@
+data_types:
+    - name: Email Address
+      detectors:
+        - name: ruby
+          locations:
+            - filename: testdata/ruby/ftp.rb
+              line_number: 7
+    - name: Ethnic Origin
+      detectors:
+        - name: ruby
+          locations:
+            - filename: testdata/ruby/ftp.rb
+              line_number: 27
+risks:
+    - detector_id: detect_rails_insecure_ftp_data
+      data_types:
+        - name: Ethnic Origin
+          stored: false
+          locations:
+            - filename: testdata/ruby/ftp.rb
+              line_number: 27
+              parent:
+                line_number: 24
+                content: |-
+                    Net::FTP.open("ftp.site.com") do |ftp|
+                      file = Tempfile.new("user_data")
+                      begin
+                        file << { user: { ethnicity: "martian" } }.to_json
+                        file.close
+
+                        ftp.puttextfile(file.path, "/users/123.json")
+                      ensure
+                        file.close!
+                      end
+                    end
+    - detector_id: detect_rails_insecure_ftp
+      locations:
+        - filename: testdata/ruby/ftp.rb
+          line_number: 2
+          parent:
+            line_number: 2
+            content: |-
+                Net::FTP.open("ftp.site.com") do |ftp|
+                  ftp.puttextfile("no_data.txt", "/no_data.txt")
+                end
+          content: |
+            Net::FTP.open()
+        - filename: testdata/ruby/ftp.rb
+          line_number: 10
+          parent:
+            line_number: 10
+            content: |-
+                Net::FTP.open("ftp.site.com") do |ftp|
+                  file = Tempfile.new("user_data")
+                  begin
+                    file << user.to_json
+                    file.close
+
+                    ftp.puttextfile(file.path, "/users/123.json")
+                  ensure
+                    file.close!
+                  end
+                end
+          content: |
+            Net::FTP.open()
+        - filename: testdata/ruby/ftp.rb
+          line_number: 24
+          parent:
+            line_number: 24
+            content: |-
+                Net::FTP.open("ftp.site.com") do |ftp|
+                  file = Tempfile.new("user_data")
+                  begin
+                    file << { user: { ethnicity: "martian" } }.to_json
+                    file.close
+
+                    ftp.puttextfile(file.path, "/users/123.json")
+                  ensure
+                    file.close!
+                  end
+                end
+          content: |
+            Net::FTP.open()
+components: []
+
+
+--
+

--- a/integration/custom_detectors/.snapshots/TestCustomDetectors-ruby_http_detection
+++ b/integration/custom_detectors/.snapshots/TestCustomDetectors-ruby_http_detection
@@ -30,6 +30,10 @@ data_types:
             - filename: testdata/ruby/ruby_http_detection.rb
               line_number: 35
             - filename: testdata/ruby/ruby_http_detection.rb
+              line_number: 40
+            - filename: testdata/ruby/ruby_http_detection.rb
+              line_number: 43
+            - filename: testdata/ruby/ruby_http_detection.rb
               line_number: 45
             - filename: testdata/ruby/ruby_http_detection.rb
               line_number: 47
@@ -38,15 +42,27 @@ data_types:
             - filename: testdata/ruby/ruby_http_detection.rb
               line_number: 54
             - filename: testdata/ruby/ruby_http_detection.rb
+              line_number: 59
+            - filename: testdata/ruby/ruby_http_detection.rb
+              line_number: 66
+            - filename: testdata/ruby/ruby_http_detection.rb
               line_number: 71
+            - filename: testdata/ruby/ruby_http_detection.rb
+              line_number: 73
+            - filename: testdata/ruby/ruby_http_detection.rb
+              line_number: 75
             - filename: testdata/ruby/ruby_http_detection.rb
               line_number: 80
             - filename: testdata/ruby/ruby_http_detection.rb
               line_number: 82
             - filename: testdata/ruby/ruby_http_detection.rb
+              line_number: 84
+            - filename: testdata/ruby/ruby_http_detection.rb
               line_number: 89
             - filename: testdata/ruby/ruby_http_detection.rb
               line_number: 91
+            - filename: testdata/ruby/ruby_http_detection.rb
+              line_number: 106
             - filename: testdata/ruby/ruby_http_detection.rb
               line_number: 108
             - filename: testdata/ruby/ruby_http_detection.rb
@@ -67,6 +83,20 @@ data_types:
               line_number: 26
             - filename: testdata/ruby/ruby_http_detection.rb
               line_number: 35
+            - filename: testdata/ruby/ruby_http_detection.rb
+              line_number: 40
+            - filename: testdata/ruby/ruby_http_detection.rb
+              line_number: 43
+            - filename: testdata/ruby/ruby_http_detection.rb
+              line_number: 60
+            - filename: testdata/ruby/ruby_http_detection.rb
+              line_number: 66
+            - filename: testdata/ruby/ruby_http_detection.rb
+              line_number: 75
+            - filename: testdata/ruby/ruby_http_detection.rb
+              line_number: 84
+            - filename: testdata/ruby/ruby_http_detection.rb
+              line_number: 106
 risks:
     - detector_id: ruby_http_get_detection
       data_types:
@@ -131,6 +161,11 @@ risks:
               parent:
                 line_number: 71
                 content: HTTP.get("http://my.api.com/users/search?first_name=#{user_2.first_name}")
+            - filename: testdata/ruby/ruby_http_detection.rb
+              line_number: 73
+              parent:
+                line_number: 73
+                content: 'HTTP.get("https://my.api.com/users/search", params: { user_8: { first_name: "John" } })'
             - filename: testdata/ruby/ruby_http_detection.rb
               line_number: 80
               parent:
@@ -207,6 +242,31 @@ risks:
               parent:
                 line_number: 35
                 content: 'RestClient.post("http://my.api.com/users/create", { user_6: { first_name: "John", last_name: "Doe" } })'
+            - filename: testdata/ruby/ruby_http_detection.rb
+              line_number: 43
+              parent:
+                line_number: 43
+                content: 'Typhoeus.post("http://my.api.com/users/create", { body: { user_8: { first_name: "John", last_name: "Doe" } } })'
+            - filename: testdata/ruby/ruby_http_detection.rb
+              line_number: 66
+              parent:
+                line_number: 66
+                content: 'HTTParty.post("http://my.api.com/users/create", { body: { user: { first_name: "John", last_name: "Doe" } } })'
+            - filename: testdata/ruby/ruby_http_detection.rb
+              line_number: 75
+              parent:
+                line_number: 75
+                content: 'HTTP.post("http://my.api.com/users/create", form: { user_9: { first_name: "John", last_name: "Doe" } })'
+            - filename: testdata/ruby/ruby_http_detection.rb
+              line_number: 84
+              parent:
+                line_number: 84
+                content: 'Excon.post("http://my.api.com/users/create", body: { user_10: { first_name: "John", last_name: "Doe" } })'
+            - filename: testdata/ruby/ruby_http_detection.rb
+              line_number: 106
+              parent:
+                line_number: 106
+                content: 'HTTPX.post("http://my.api.com/users/create", json: { user_12: { first_name: "John", last_name: "Doe" } })'
         - name: Lastname
           stored: false
           locations:
@@ -235,6 +295,31 @@ risks:
               parent:
                 line_number: 35
                 content: 'RestClient.post("http://my.api.com/users/create", { user_6: { first_name: "John", last_name: "Doe" } })'
+            - filename: testdata/ruby/ruby_http_detection.rb
+              line_number: 43
+              parent:
+                line_number: 43
+                content: 'Typhoeus.post("http://my.api.com/users/create", { body: { user_8: { first_name: "John", last_name: "Doe" } } })'
+            - filename: testdata/ruby/ruby_http_detection.rb
+              line_number: 66
+              parent:
+                line_number: 66
+                content: 'HTTParty.post("http://my.api.com/users/create", { body: { user: { first_name: "John", last_name: "Doe" } } })'
+            - filename: testdata/ruby/ruby_http_detection.rb
+              line_number: 75
+              parent:
+                line_number: 75
+                content: 'HTTP.post("http://my.api.com/users/create", form: { user_9: { first_name: "John", last_name: "Doe" } })'
+            - filename: testdata/ruby/ruby_http_detection.rb
+              line_number: 84
+              parent:
+                line_number: 84
+                content: 'Excon.post("http://my.api.com/users/create", body: { user_10: { first_name: "John", last_name: "Doe" } })'
+            - filename: testdata/ruby/ruby_http_detection.rb
+              line_number: 106
+              parent:
+                line_number: 106
+                content: 'HTTPX.post("http://my.api.com/users/create", json: { user_12: { first_name: "John", last_name: "Doe" } })'
     - detector_id: ruby_http_get_insecure
       locations:
         - filename: testdata/ruby/ruby_http_detection.rb

--- a/integration/custom_detectors/custom_detectors_test.go
+++ b/integration/custom_detectors/custom_detectors_test.go
@@ -20,6 +20,7 @@ func TestCustomDetectors(t *testing.T) {
 		newScanTest("ruby", "detect_rails_session", "detect_rails_session.rb"),
 		newScanTest("ruby", "detect_rails_cookies", "detect_rails_cookies.rb"),
 		newScanTest("ruby", "detect_ruby_logger", "detect_ruby_logger.rb"),
+		newScanTest("ruby", "ftp", "ftp.rb"),
 		newScanTest("ruby", "ruby_file_detection", "ruby_file_detection.rb"),
 		newScanTest("ruby", "ssl_certificate_verification_disabled", "ssl_certificate_verification_disabled.rb"),
 		newScanTest("ruby", "ruby_http_detection", "ruby_http_detection.rb"),

--- a/integration/custom_detectors/testdata/ruby/ftp.rb
+++ b/integration/custom_detectors/testdata/ruby/ftp.rb
@@ -1,0 +1,34 @@
+# No data type detection expected
+Net::FTP.open("ftp.site.com") do |ftp|
+  ftp.puttextfile("no_data.txt", "/no_data.txt")
+end
+
+
+user = { email: "dave@example.com" }
+
+# Expecting data type detection (but not working yet)
+Net::FTP.open("ftp.site.com") do |ftp|
+  file = Tempfile.new("user_data")
+  begin
+    file << user.to_json
+    file.close
+
+    ftp.puttextfile(file.path, "/users/123.json")
+  ensure
+    file.close!
+  end
+end
+
+
+# Expecting data type detection
+Net::FTP.open("ftp.site.com") do |ftp|
+  file = Tempfile.new("user_data")
+  begin
+    file << { user: { ethnicity: "martian" } }.to_json
+    file.close
+
+    ftp.puttextfile(file.path, "/users/123.json")
+  ensure
+    file.close!
+  end
+end

--- a/integration/flags/.snapshots/TestInitCommand-init
+++ b/integration/flags/.snapshots/TestInitCommand-init
@@ -103,6 +103,25 @@ scan:
             stored: false
             detect_presence: true
             omit_parent: false
+        detect_rails_insecure_ftp_data:
+            disabled: false
+            type: risk
+            languages:
+                - ruby
+            param_parenting: false
+            processors: []
+            patterns:
+                - pattern: |
+                    Net::FTP.open do
+                      $ANYTHING
+                    end
+                  filters: []
+            root_singularize: false
+            root_lowercase: false
+            metavars: {}
+            stored: false
+            detect_presence: false
+            omit_parent: false
         detect_rails_insecure_smtp:
             disabled: false
             type: risk
@@ -817,6 +836,79 @@ scan:
                         item := {
                             "category_groups": data.bearer.common.groups_for_datatypes(input.dataflow.data_types),
                             "severity": "medium",
+                            "filename": location.filename,
+                            "line_number": location.line_number,
+                            "parent_line_number": location.parent.line_number,
+                            "parent_content": location.parent.content
+                        }
+                    }
+        insecure_ftp_with_data_category:
+            query: |
+                policy_breach = data.bearer.insecure_ftp_with_data_category.policy_breach
+            id: insecure_ftp_with_data_category
+            name: Insecure FTP with Data Category
+            description: Communicating Data Category with an insecure FTP server. Only connect to FTP securely.
+            level: ""
+            modules:
+                - path: policies/common.rego
+                  name: bearer.common
+                  content: |
+                    package bearer.common
+
+                    import future.keywords
+
+                    sensitive_data_group_uuid := "f6a0c071-5908-4420-bac2-bba28d41223e"
+                    personal_data_group_uuid := "e1d3135b-3c0f-4b55-abce-19f27a26cbb3"
+
+                    severity_of_datatype(data_type) := "critical" if {
+                        some category in input.data_categories
+                        category.uuid == data_type.category_uuid
+
+                        some group in category.groups
+                        group.uuid == sensitive_data_group_uuid
+                    }
+
+                    severity_of_datatype(data_type) := "high" if {
+                        some category in input.data_categories
+                        category.uuid == data_type.category_uuid
+
+                        some group in category.groups
+                        group.uuid == personal_data_group_uuid
+
+                        every group_1 in category.groups {
+                            group_1.uuid != sensitive_data_group_uuid
+                        }
+                    }
+
+                    groups_for_datatype(data_type) := x if {
+                        some category in input.data_categories
+                        category.uuid == data_type.category_uuid
+
+                        x := {name | name := category.groups[_].name}
+                    }
+
+                    groups_for_datatypes(data_types) := groups if {
+                        groups := {name | name := groups_for_datatype(data_types[_])[_]}
+                    }
+                - path: policies/insecure_ftp_with_data_category.rego
+                  name: bearer.insecure_ftp_with_data_category
+                  content: |
+                    package bearer.insecure_ftp_with_data_category
+
+                    import data.bearer.common
+
+                    import future.keywords
+
+                    policy_breach contains item if {
+                        some risk in input.dataflow.risks
+                        risk.detector_id == "detect_rails_insecure_ftp_data"
+
+                        data_type = risk.data_types[_]
+                        location = data_type.locations[_]
+
+                        item := {
+                            "category_groups": data.bearer.common.groups_for_datatype(data_type),
+                            "severity": data.bearer.common.severity_of_datatype(data_type),
                             "filename": location.filename,
                             "line_number": location.line_number,
                             "parent_line_number": location.parent.line_number,

--- a/integration/policies/.snapshots/TestPolicies-insecure_ftp
+++ b/integration/policies/.snapshots/TestPolicies-insecure_ftp
@@ -1,3 +1,25 @@
+critical:
+    - policy_name: Insecure FTP with Data Category
+      policy_description: Communicating Data Category with an insecure FTP server. Only connect to FTP securely.
+      line_number: 27
+      filename: testdata/ruby/insecure_ftp.rb
+      category_groups:
+        - PII
+        - Sensitive personal data
+      parent_line_number: 24
+      parent_content: |-
+        Net::FTP.open("ftp.site.com") do |ftp|
+          file = Tempfile.new("user_data")
+          begin
+            file << { user: { ethnicity: "martian" } }.to_json
+            file.close
+
+            ftp.puttextfile(file.path, "/users/123.json")
+          ensure
+            file.close!
+          end
+        end
+      omit_parent: false
 medium:
     - policy_name: Insecure FTP
       policy_description: Communication with insecure FTP in an application processing sensitive data
@@ -6,6 +28,7 @@ medium:
       category_groups:
         - PHI
         - PII
+        - Sensitive personal data
       parent_line_number: 10
       parent_content: Net::FTP.new("ftp.ruby-lang.org")
       omit_parent: false
@@ -16,6 +39,7 @@ medium:
       category_groups:
         - PHI
         - PII
+        - Sensitive personal data
       parent_line_number: 17
       parent_content: |-
         Net::FTP.open('example.com') do |ftp|
@@ -23,6 +47,28 @@ medium:
           files = ftp.chdir('pub/lang/ruby/contrib')
           files = ftp.list('n*')
           ftp.getbinaryfile('nif.rb-0.91.gz', 'nif.gz', 1024)
+        end
+      omit_parent: false
+    - policy_name: Insecure FTP
+      policy_description: Communication with insecure FTP in an application processing sensitive data
+      line_number: 24
+      filename: testdata/ruby/insecure_ftp.rb
+      category_groups:
+        - PHI
+        - PII
+        - Sensitive personal data
+      parent_line_number: 24
+      parent_content: |-
+        Net::FTP.open("ftp.site.com") do |ftp|
+          file = Tempfile.new("user_data")
+          begin
+            file << { user: { ethnicity: "martian" } }.to_json
+            file.close
+
+            ftp.puttextfile(file.path, "/users/123.json")
+          ensure
+            file.close!
+          end
         end
       omit_parent: false
 

--- a/integration/policies/testdata/ruby/insecure_ftp.rb
+++ b/integration/policies/testdata/ruby/insecure_ftp.rb
@@ -21,6 +21,18 @@ Net::FTP.open('example.com') do |ftp|
   ftp.getbinaryfile('nif.rb-0.91.gz', 'nif.gz', 1024)
 end
 
+Net::FTP.open("ftp.site.com") do |ftp|
+  file = Tempfile.new("user_data")
+  begin
+    file << { user: { ethnicity: "martian" } }.to_json
+    file.close
+
+    ftp.puttextfile(file.path, "/users/123.json")
+  ensure
+    file.close!
+  end
+end
+
 ## Not detected
 require "net/sftp"
 

--- a/pkg/commands/process/settings/custom_detector.yml
+++ b/pkg/commands/process/settings/custom_detector.yml
@@ -241,6 +241,15 @@ detect_rails_insecure_ftp:
   languages:
     - ruby
   detect_presence: true
+detect_rails_insecure_ftp_data:
+  type: "risk"
+  patterns:
+    - |
+      Net::FTP.open do
+        $ANYTHING
+      end
+  languages:
+    - ruby
 detect_ruby_third_party_data_send:
   type: "risk"
   patterns:

--- a/pkg/commands/process/settings/policies.yml
+++ b/pkg/commands/process/settings/policies.yml
@@ -108,6 +108,17 @@ insecure_ftp_processing_sensitive_data:
       name: bearer.common
     - path: policies/insecure_ftp.rego
       name: bearer.insecure_ftp
+insecure_ftp_with_data_category:
+  description: "Communicating Data Category with an insecure FTP server. Only connect to FTP securely."
+  name: "Insecure FTP with Data Category"
+  id: insecure_ftp_with_data_category
+  query: |
+    policy_breach = data.bearer.insecure_ftp_with_data_category.policy_breach
+  modules:
+    - path: policies/common.rego
+      name: bearer.common
+    - path: policies/insecure_ftp_with_data_category.rego
+      name: bearer.insecure_ftp_with_data_category
 insecure_http_get:
   description: "Communicating with insecure HTTP GET in an application processing sensitive data"
   name: "Insecure HTTP GET"

--- a/pkg/commands/process/settings/policies/insecure_ftp_with_data_category.rego
+++ b/pkg/commands/process/settings/policies/insecure_ftp_with_data_category.rego
@@ -1,0 +1,22 @@
+package bearer.insecure_ftp_with_data_category
+
+import data.bearer.common
+
+import future.keywords
+
+policy_breach contains item if {
+    some risk in input.dataflow.risks
+    risk.detector_id == "detect_rails_insecure_ftp_data"
+
+    data_type = risk.data_types[_]
+    location = data_type.locations[_]
+
+    item := {
+        "category_groups": data.bearer.common.groups_for_datatype(data_type),
+        "severity": data.bearer.common.severity_of_datatype(data_type),
+        "filename": location.filename,
+        "line_number": location.line_number,
+        "parent_line_number": location.parent.line_number,
+        "parent_content": location.parent.content
+    }
+}

--- a/pkg/detectors/ruby/datatype/properties.go
+++ b/pkg/detectors/ruby/datatype/properties.go
@@ -149,7 +149,7 @@ func addProperties(node *parser.Node, helperDatatypes map[parser.NodeID]*schemad
 					}
 				}
 			}
-		} else if parentNode.Type() == "argument_list" || parentNode.Type() == "program" {
+		} else {
 			// add child properties
 			for i := 0; i < hashNode.ChildCount(); i++ {
 				pair := hashNode.Child(i)
@@ -199,7 +199,6 @@ func addProperties(node *parser.Node, helperDatatypes map[parser.NodeID]*schemad
 						Properties: make(map[string]schemadatatype.DataTypable),
 					}
 				}
-
 			}
 		}
 	}


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Adds a new policy for detecting communication of a data category with an insecure FTP server.

Also removes a restriction on finding properties/data types from hashes with arbitrary parents. This fixes a few HTTP cases.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [x] I've added test coverage that shows my fix or feature works as expected.
- [x] I've updated or added documentation if required.
- [x] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
