### PR TITLE
ci: simplify release output

### DIFF
--- a/goreleaser/release.yaml
+++ b/goreleaser/release.yaml
@@ -1,11 +1,5 @@
 builds:
   - skip: true
-changelog:
-  sort: asc
-  filters:
-    exclude:
-      - "^docs:"
-      - "^test:"
 release:
   draft: true
   mode: append
@@ -13,10 +7,3 @@ release:
     - glob: ./curio-build/**/*
     - glob: ./curio-build/checksums.txt
   name_template: "Release {{.Tag}}"
-  header: |
-    # What's Changed
-    ## 🚀 Features
-    ## 🎄 Enhancements
-    ## 🎠 Community
-    ## New Contributors
-    ## Code Diff


### PR DESCRIPTION
## Description
Prefer githubs auto generated release notes this allows more flexablity with tag ranges etc and seems adequate for now.

This PR reduces the output from goreleaser but leaves it in place incase we want to expand things in the future

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
