### PR TITLE
fix: make progress output smaller to reduce wrapping issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,21 +22,34 @@ Curio is a static code analysis tool (SAST) that scans your source code to disco
 [Explore the docs](https://curio.sh) - [Getting Started](#rocket-getting-started) - [FAQ](#question-faqs) - [Report Bug](https://github.com/Bearer/curio/issues/new/choose) - [Discord Community][discord]
 
 ```
-Scanning target... 100% [===============] (7481/7481, 22 files/s) [5m44s]
+Scanning target ./example-project
+ └ 100% [===============] (3305/3305, 115 files/s) [28s]
 
 Policy Report
 
 =====================================
 Policy list:
 
+- JWT leaking
+- Insecure communication
+- Insecure HTTP with Data Category
 - Logger leaking
+- Cookie leaking
+- Insecure SMTP
+- HTTP GET parameters
+- Insecure FTP with Data Category
+- Session leaking
+- Insecure FTP
+- Third-party data category exposure
+- SSL certificate verification disabled
 - Application level encryption missing
+- Insecure HTTP GET
 
 =====================================
 
 SUCCESS
 
-2 policies were run and no breaches were detected.
+14 policies were run and no breaches were detected.
 
 ```
 

--- a/pkg/commands/process/balancer/worker.go
+++ b/pkg/commands/process/balancer/worker.go
@@ -78,7 +78,7 @@ func (worker *Worker) Start() {
 	}
 
 	if !worker.config.Scan.Quiet {
-		output.StdErrLogger().Msgf("Target %s", worker.config.Scan.Target)
+		output.StdErrLogger().Msgf("Scanning target %s", worker.config.Scan.Target)
 	}
 	bar := output.GetProgressBar(len(worker.FileList), worker.config)
 

--- a/pkg/util/output/progress_bar.go
+++ b/pkg/util/output/progress_bar.go
@@ -11,6 +11,7 @@ func GetProgressBar(filesLength int, config settings.Config) *progressbar.Progre
 		progressbar.OptionSetVisibility(!hideProgress),
 		progressbar.OptionSetWriter(errorWriter),
 		progressbar.OptionShowCount(),
+		progressbar.OptionSetWidth(15),
 		progressbar.OptionEnableColorCodes(false),
 		progressbar.OptionShowElapsedTimeOnFinish(),
 		progressbar.OptionOnCompletion(func() {
@@ -18,7 +19,7 @@ func GetProgressBar(filesLength int, config settings.Config) *progressbar.Progre
 		}),
 		progressbar.OptionShowIts(),
 		progressbar.OptionSetItsString("files"),
-		progressbar.OptionSetDescription("Scanning target..."),
+		progressbar.OptionSetDescription(" └"),
 		progressbar.OptionSetTheme(progressbar.Theme{
 			Saucer:        "=",
 			SaucerHead:    ">",


### PR DESCRIPTION
## Description
Progress bar was quite long and was common to run into wrapping issues. 

Moved scanning to line above and reduced overall length of the bar 

<img width="460" alt="Screenshot 2022-12-09 at 13 59 34" src="https://user-images.githubusercontent.com/699436/206721523-b25994db-fa72-47a4-b67a-2d139856aac6.png">


<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
