### PR TITLE
fix: Incorrect context in policy report for app-level encryption

### DIFF
--- a/integration/flags/.snapshots/TestInitCommand-init
+++ b/integration/flags/.snapshots/TestInitCommand-init
@@ -544,8 +544,8 @@ scan:
                             "severity": data.bearer.common.severity_of_datatype(datatype),
                             "filename": location.filename,
                             "line_number": location.line_number,
-                            "parent_line_number": detector.parent.line_number,
-                            "parent_content": detector.parent.content
+                            "parent_line_number": location.parent.line_number,
+                            "parent_content": location.parent.content
                         }
                     }
         cookie_leaks:

--- a/integration/flags/.snapshots/TestReportFlags-report-dataflow-verified-by
+++ b/integration/flags/.snapshots/TestReportFlags-report-dataflow-verified-by
@@ -11,6 +11,18 @@ data_types:
                   filename: user.rb
                   line_number: 2
               stored: true
+              parent:
+                line_number: 1
+                content: |-
+                    CREATE TABLE public.Users (
+                      id bigint NOT NULL,
+                      first_name character varying NOT NULL,
+                      last_name character varying NOT NULL,
+                      email character varying NOT NULL,
+                      tanker_encrypted_date_of_birth character varying NOT NULL,
+                      city character varying NOT NULL,
+                      country character varying NOT NULL,
+                    )
         - name: ruby
           locations:
             - filename: testdata/verified_by/user.rb
@@ -22,6 +34,18 @@ data_types:
             - filename: testdata/verified_by/schema.sql
               line_number: 6
               stored: true
+              parent:
+                line_number: 1
+                content: |-
+                    CREATE TABLE public.Users (
+                      id bigint NOT NULL,
+                      first_name character varying NOT NULL,
+                      last_name character varying NOT NULL,
+                      email character varying NOT NULL,
+                      tanker_encrypted_date_of_birth character varying NOT NULL,
+                      city character varying NOT NULL,
+                      country character varying NOT NULL,
+                    )
     - name: Email Address
       detectors:
         - name: detect_sql_create_public_table
@@ -34,6 +58,18 @@ data_types:
                   filename: user.rb
                   line_number: 2
               stored: true
+              parent:
+                line_number: 1
+                content: |-
+                    CREATE TABLE public.Users (
+                      id bigint NOT NULL,
+                      first_name character varying NOT NULL,
+                      last_name character varying NOT NULL,
+                      email character varying NOT NULL,
+                      tanker_encrypted_date_of_birth character varying NOT NULL,
+                      city character varying NOT NULL,
+                      country character varying NOT NULL,
+                    )
         - name: ruby
           locations:
             - filename: testdata/verified_by/user.rb
@@ -45,6 +81,18 @@ data_types:
             - filename: testdata/verified_by/schema.sql
               line_number: 3
               stored: true
+              parent:
+                line_number: 1
+                content: |-
+                    CREATE TABLE public.Users (
+                      id bigint NOT NULL,
+                      first_name character varying NOT NULL,
+                      last_name character varying NOT NULL,
+                      email character varying NOT NULL,
+                      tanker_encrypted_date_of_birth character varying NOT NULL,
+                      city character varying NOT NULL,
+                      country character varying NOT NULL,
+                    )
     - name: Lastname
       detectors:
         - name: detect_sql_create_public_table
@@ -52,6 +100,18 @@ data_types:
             - filename: testdata/verified_by/schema.sql
               line_number: 4
               stored: true
+              parent:
+                line_number: 1
+                content: |-
+                    CREATE TABLE public.Users (
+                      id bigint NOT NULL,
+                      first_name character varying NOT NULL,
+                      last_name character varying NOT NULL,
+                      email character varying NOT NULL,
+                      tanker_encrypted_date_of_birth character varying NOT NULL,
+                      city character varying NOT NULL,
+                      country character varying NOT NULL,
+                    )
     - name: Physical Address
       detectors:
         - name: detect_sql_create_public_table
@@ -64,6 +124,18 @@ data_types:
                   filename: user.rb
                   line_number: 2
               stored: true
+              parent:
+                line_number: 1
+                content: |-
+                    CREATE TABLE public.Users (
+                      id bigint NOT NULL,
+                      first_name character varying NOT NULL,
+                      last_name character varying NOT NULL,
+                      email character varying NOT NULL,
+                      tanker_encrypted_date_of_birth character varying NOT NULL,
+                      city character varying NOT NULL,
+                      country character varying NOT NULL,
+                    )
         - name: ruby
           locations:
             - filename: testdata/verified_by/user.rb

--- a/integration/policies/.snapshots/TestPolicies-application_level_encryption_missing_schema_rb
+++ b/integration/policies/.snapshots/TestPolicies-application_level_encryption_missing_schema_rb
@@ -1,6 +1,23 @@
 high:
     - policy_name: Application level encryption missing
       policy_description: Application level encryption missing. Enable application level encryption to reduce the risk of leaking sensitive data.
+      line_number: 3
+      filename: testdata/ruby/application_level_encryption_missing/schema_rb/db/schema.rb
+      category_groups:
+        - PHI
+        - PII
+      parent_line_number: 2
+      parent_content: |-
+        create_table "users", force: :cascade do |t|
+            t.string "email", null: false
+            t.string "name"
+            t.string "encrypted_password", null: false
+            t.datetime "created_at", null: false
+            t.datetime "updated_at", null: false
+          end
+      omit_parent: false
+    - policy_name: Application level encryption missing
+      policy_description: Application level encryption missing. Enable application level encryption to reduce the risk of leaking sensitive data.
       line_number: 4
       filename: testdata/ruby/application_level_encryption_missing/schema_rb/db/schema.rb
       category_groups:

--- a/pkg/commands/process/settings/policies/application_level_encryption.rego
+++ b/pkg/commands/process/settings/policies/application_level_encryption.rego
@@ -17,7 +17,7 @@ policy_breach contains item if {
         "severity": data.bearer.common.severity_of_datatype(datatype),
         "filename": location.filename,
         "line_number": location.line_number,
-        "parent_line_number": detector.parent.line_number,
-        "parent_content": detector.parent.content
+        "parent_line_number": location.parent.line_number,
+        "parent_content": location.parent.content
     }
 }

--- a/pkg/detectors/graphql/graphql.go
+++ b/pkg/detectors/graphql/graphql.go
@@ -87,6 +87,10 @@ func (detector *detector) ExtractFromSchema(
 			SimpleFieldType: convertType(fieldType),
 		}
 
+		if report.SchemaGroupShouldClose(objectName) {
+			report.SchemaGroupEnd(detector.idGenerator)
+		}
+
 		if !report.SchemaGroupIsOpen() {
 			source := objectNode.Source(true)
 			report.SchemaGroupBegin(

--- a/pkg/detectors/internal/testhelper/testhelper.go
+++ b/pkg/detectors/internal/testhelper/testhelper.go
@@ -83,6 +83,7 @@ type InMemoryReport struct {
 	SecretLeaks      []*detections.Detection
 	CreateView       []*detections.Detection
 	SchemaGroupDetectorType reportdetectors.Type
+	SchemaGroupObjectName   string
 }
 
 func (report *InMemoryReport) AddDetection(
@@ -106,10 +107,15 @@ func (report *InMemoryReport) AddDetection(
 
 func (report *InMemoryReport) SchemaGroupBegin(detectorType reportdetectors.Type, node *parser.Node, schema schema.Schema, source *source.Source, parent *parser.Node) {
 	report.SchemaGroupDetectorType = detectorType
+	report.SchemaGroupObjectName = schema.ObjectName
 }
 
 func (report *InMemoryReport) SchemaGroupIsOpen() bool {
 	return report.SchemaGroupDetectorType != ""
+}
+
+func (report *InMemoryReport) SchemaGroupShouldClose(tableName string) bool {
+	return tableName != report.SchemaGroupObjectName
 }
 
 func (report *InMemoryReport) SchemaGroupAddItem(node *parser.Node, schema schema.Schema, source *source.Source) {
@@ -123,6 +129,7 @@ func (report *InMemoryReport) SchemaGroupAddItem(node *parser.Node, schema schem
 
 func (report *InMemoryReport) SchemaGroupEnd(idGenerator nodeid.Generator) {
 	report.SchemaGroupDetectorType = ""
+	report.SchemaGroupObjectName = ""
 }
 
 func (report *InMemoryReport) AddDataType(

--- a/pkg/detectors/openapi/reportadder/reportadder.go
+++ b/pkg/detectors/openapi/reportadder/reportadder.go
@@ -49,19 +49,23 @@ func AddSchema(file *file.FileInfo, report reporttypes.Report, foundValues map[p
 		node := sortableSchema.Key
 		schema := sortableSchema.Value
 
+		objectName := stringutil.StripQuotes(schema.Value.ObjectName)
+
 		schema.Source.Language = file.Language
 		schema.Source.LanguageType = file.LanguageTypeString()
 		schema.Value.FieldName = stringutil.StripQuotes(schema.Value.FieldName)
 		schema.Value.FieldType = stringutil.StripQuotes(schema.Value.FieldType)
-		schema.Value.ObjectName = stringutil.StripQuotes(schema.Value.ObjectName)
+		schema.Value.ObjectName = objectName
 		schema.Value.SimpleFieldType = convertSchema(schema.Value.FieldType)
 
+		if report.SchemaGroupShouldClose(objectName) {
+			report.SchemaGroupEnd(idGenerator)
+		}
+
 		if !report.SchemaGroupIsOpen() {
-			// @todo FIXME: Transition to new API
-			var objectNode *parser.Node
 			report.SchemaGroupBegin(
 				detectors.DetectorOpenAPI,
-				objectNode,
+				nil,
 				schema.Value,
 				&schema.Source,
 				nil,

--- a/pkg/detectors/proto/proto.go
+++ b/pkg/detectors/proto/proto.go
@@ -90,6 +90,10 @@ func (detector *detector) ExtractFromSchema(
 			SimpleFieldType: convertToSimpleType(columnType),
 		}
 
+		if report.SchemaGroupShouldClose(objectName) {
+			report.SchemaGroupEnd(detector.idGenerator)
+		}
+
 		if !report.SchemaGroupIsOpen() {
 			source := objectNode.Source(true)
 			report.SchemaGroupBegin(

--- a/pkg/detectors/rails/personal_data/personal_data.go
+++ b/pkg/detectors/rails/personal_data/personal_data.go
@@ -69,6 +69,11 @@ func ExtractFromDatabaseSchema(
 			SimpleFieldType: convertToSimpleType(columnType),
 			TransformedObjectName: transformedObjectName,
 		}
+
+		if report.SchemaGroupShouldClose(tableName) {
+			report.SchemaGroupEnd(idGenerator)
+		}
+
 		if !report.SchemaGroupIsOpen() {
 			source := tableNode.Source(false)
 			report.SchemaGroupBegin(

--- a/pkg/detectors/sql/create_table/create_table.go
+++ b/pkg/detectors/sql/create_table/create_table.go
@@ -97,6 +97,11 @@ func Detect(file *file.FileInfo, report reporttypes.Report, idGenerator nodeid.G
 				FieldType:       columnType,
 				SimpleFieldType: util.ConvertToSimpleType(columnType),
 			}
+
+			if report.SchemaGroupShouldClose(tableName) {
+				report.SchemaGroupEnd(idGenerator)
+			}
+
 			if !report.SchemaGroupIsOpen() {
 				source := tableNode.Source(true)
 				report.SchemaGroupBegin(

--- a/pkg/report/output/dataflow/types/datatypes.go
+++ b/pkg/report/output/dataflow/types/datatypes.go
@@ -1,6 +1,8 @@
 package types
 
-import "github.com/bearer/curio/pkg/report/schema"
+import (
+	"github.com/bearer/curio/pkg/report/schema"
+)
 
 type Datatype struct {
 	UUID         string             `json:"uuid,omitempty" yaml:"uuid,omitempty"`
@@ -20,7 +22,8 @@ type DatatypeLocation struct {
 	LineNumber int                  `json:"line_number" yaml:"line_number"`
 	Encrypted  *bool                `json:"encrypted,omitempty" yaml:"encrypted,omitempty"`
 	VerifiedBy []DatatypeVerifiedBy `json:"verified_by,omitempty" yaml:"verified_by,omitempty"`
-	Stored      *bool               `json:"stored,omitempty" yaml:"stored,omitempty"`
+	Stored     *bool                `json:"stored,omitempty" yaml:"stored,omitempty"`
+	Parent     *schema.Parent       `json:"parent,omitempty" yaml:"parent,omitempty"`
 }
 
 type DatatypeVerifiedBy struct {

--- a/pkg/report/schema/schema.go
+++ b/pkg/report/schema/schema.go
@@ -39,6 +39,7 @@ type Parent struct {
 type ReportSchema interface {
 	SchemaGroupBegin(detectorType detectors.Type, node *parser.Node, schema Schema, source *source.Source, parent *parser.Node)
 	SchemaGroupIsOpen() bool
+	SchemaGroupShouldClose(tableName string) bool
 	SchemaGroupAddItem(node *parser.Node, schema Schema, source *source.Source)
 	SchemaGroupEnd(idGenerator nodeid.Generator)
 }


### PR DESCRIPTION
## Description

The policy for "application-level encryption missing" incorrectly reports context from `schema.rb` instead of `structure.sql`.

## Checklist

- [X] I've added test coverage that shows my fix or feature works as expected.
- [X] I've updated or added documentation if required.
- [X] I've included usage information in the description if CLI behavior was updated or added.
- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
