### PR TITLE
fix: Detect CREATE TABLE statements without schema prefix

### DIFF
--- a/integration/flags/.snapshots/TestInitCommand-init
+++ b/integration/flags/.snapshots/TestInitCommand-init
@@ -285,6 +285,11 @@ scan:
                       <$COLUMN>
                     )
                   filters: []
+                - pattern: |
+                    CREATE TABLE $TABLE_NAME (
+                      <$COLUMN>
+                    )
+                  filters: []
             root_singularize: true
             root_lowercase: true
             metavars: {}

--- a/pkg/commands/process/settings/custom_detector.yml
+++ b/pkg/commands/process/settings/custom_detector.yml
@@ -189,6 +189,10 @@ detect_sql_create_public_table:
       CREATE TABLE public.$TABLE_NAME (
         <$COLUMN>
       )
+    - |
+      CREATE TABLE $TABLE_NAME (
+        <$COLUMN>
+      )
   param_parenting: true
   root_singularize: true
   root_lowercase: true

--- a/pkg/detectors/custom/.snapshots/TestSQLCreateTableMySQLJSON
+++ b/pkg/detectors/custom/.snapshots/TestSQLCreateTableMySQLJSON
@@ -1,0 +1,92 @@
+[
+	{
+		"type": "custom",
+		"detector_type": "detect_sql_create_table",
+		"source": {
+			"filename": "structure.sql",
+			"language": "SQL",
+			"language_type": "data",
+			"line_number": 3,
+			"column_number": 8,
+			"text": null
+		},
+		"value": {
+			"object_name": "users",
+			"field_name": "id",
+			"field_type": "integer",
+			"field_type_simple": "number"
+		}
+	},
+	{
+		"type": "custom",
+		"detector_type": "detect_sql_create_table",
+		"source": {
+			"filename": "structure.sql",
+			"language": "SQL",
+			"language_type": "data",
+			"line_number": 4,
+			"column_number": 8,
+			"text": null
+		},
+		"value": {
+			"object_name": "users",
+			"field_name": "class_id",
+			"field_type": "integer",
+			"field_type_simple": "number"
+		}
+	},
+	{
+		"type": "custom",
+		"detector_type": "detect_sql_create_table",
+		"source": {
+			"filename": "structure.sql",
+			"language": "SQL",
+			"language_type": "data",
+			"line_number": 5,
+			"column_number": 8,
+			"text": null
+		},
+		"value": {
+			"object_name": "users",
+			"field_name": "type",
+			"field_type": "char",
+			"field_type_simple": "string"
+		}
+	},
+	{
+		"type": "custom",
+		"detector_type": "detect_sql_create_table",
+		"source": {
+			"filename": "structure.sql",
+			"language": "SQL",
+			"language_type": "data",
+			"line_number": 6,
+			"column_number": 8,
+			"text": null
+		},
+		"value": {
+			"object_name": "users",
+			"field_name": "created_at",
+			"field_type": "timestamp",
+			"field_type_simple": "date"
+		}
+	},
+	{
+		"type": "custom",
+		"detector_type": "detect_sql_create_table",
+		"source": {
+			"filename": "structure.sql",
+			"language": "SQL",
+			"language_type": "data",
+			"line_number": 7,
+			"column_number": 8,
+			"text": null
+		},
+		"value": {
+			"object_name": "users",
+			"field_name": "updated_at",
+			"field_type": "timestamp",
+			"field_type_simple": "date"
+		}
+	}
+]

--- a/pkg/detectors/custom/custom_test.go
+++ b/pkg/detectors/custom/custom_test.go
@@ -35,6 +35,9 @@ var configSQLCreateFunction []byte
 //go:embed testdata/config/sql_create_table.yml
 var configSQLCreateTable []byte
 
+//go:embed testdata/config/sql_create_table_mysql.yml
+var configSQLCreateTableMySQL []byte
+
 //go:embed testdata/config/sql_create_trigger.yml
 var configSQLCreateTrigger []byte
 
@@ -91,6 +94,10 @@ func TestSQLCreateFunctionJSON(t *testing.T) {
 }
 func TestSQLCreateTableJSON(t *testing.T) {
 	result := runTest(configSQLCreateTable, filepath.Join("testdata", "sql", "create_table"), t)
+	cupaloy.SnapshotT(t, result)
+}
+func TestSQLCreateTableMySQLJSON(t *testing.T) {
+	result := runTest(configSQLCreateTableMySQL, filepath.Join("testdata", "sql", "create_table_mysql"), t)
 	cupaloy.SnapshotT(t, result)
 }
 

--- a/pkg/detectors/custom/testdata/config/sql_create_table_mysql.yml
+++ b/pkg/detectors/custom/testdata/config/sql_create_table_mysql.yml
@@ -1,0 +1,9 @@
+detect_sql_create_table:
+  patterns:
+    - |
+      CREATE TABLE $TABLE_NAME (
+        <$COLUMN>
+      )
+  param_parenting: true
+  languages:
+    - sql

--- a/pkg/detectors/custom/testdata/sql/create_table_mysql/structure.sql
+++ b/pkg/detectors/custom/testdata/sql/create_table_mysql/structure.sql
@@ -1,0 +1,8 @@
+-- MySQL CREATE TABLE statement
+CREATE TABLE users (
+       id integer NOT NULL,
+       class_id integer,
+       type char(255) NOT NULL,
+       created_at timestamp NOT NULL,
+       updated_at timestamp NOT NULL
+);


### PR DESCRIPTION
## Description

Previously, we would only detect `CREATE TABLE` statements where the table name is qualified by the `public.` schema prefix. This prefix will not always be present, even for PostgreSQL; it will certainly not be present for MySQL.

## Checklist

- [X] I've added test coverage that shows my fix or feature works as expected.
- [X] I've updated or added documentation if required.
- [X] I've included usage information in the description if CLI behavior was updated or added.
- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
