### PR TITLE
fix: Include correct indentation in first line of policy breach context

### DIFF
--- a/integration/flags/.snapshots/TestInitCommand-init
+++ b/integration/flags/.snapshots/TestInitCommand-init
@@ -82,7 +82,7 @@ scan:
             metavars: {}
             stored: false
             detect_presence: true
-            omit_parent: true
+            omit_parent: false
         detect_rails_insecure_ftp:
             disabled: false
             type: risk
@@ -149,7 +149,7 @@ scan:
             metavars: {}
             stored: false
             detect_presence: true
-            omit_parent: true
+            omit_parent: false
         detect_rails_jwt:
             disabled: false
             type: risk
@@ -768,7 +768,9 @@ scan:
                           "severity": "medium",
                           "filename": location.filename,
                           "line_number": location.line_number,
-                          "omit_parent": true
+                          "omit_parent": true,
+                          "parent_line_number": location.parent.line_number,
+                          "parent_content": location.parent.content,
                         }
                     }
         insecure_ftp_processing_sensitive_data:
@@ -1146,7 +1148,9 @@ scan:
                             "severity": "medium",
                             "filename": location.filename,
                             "line_number": location.line_number,
-                            "omit_parent": true
+                            "omit_parent": true,
+                            "parent_line_number": location.parent.line_number,
+                            "parent_content": location.parent.content,
                         }
                     }
         jwt_leaks:

--- a/integration/policies/.snapshots/TestPolicies-insecure_communication
+++ b/integration/policies/.snapshots/TestPolicies-insecure_communication
@@ -5,6 +5,11 @@ medium:
       filename: testdata/ruby/insecure_communication.rb
       category_groups:
         - PII
+      parent_line_number: 8
+      parent_content: |-
+        Rails.application.configure do
+          config.force_ssl = false
+        end
       omit_parent: true
 
 

--- a/integration/policies/.snapshots/TestPolicies-insecure_smtp
+++ b/integration/policies/.snapshots/TestPolicies-insecure_smtp
@@ -5,6 +5,13 @@ medium:
       filename: testdata/ruby/insecure_smtp.rb
       category_groups:
         - PII
+      parent_line_number: 8
+      parent_content: |-
+        Rails.application.configure do
+          config.action_mailer.smtp_settings = {
+            openssl_verify_mode: OpenSSL::SSL::VERIFY_NONE
+          }
+        end
       omit_parent: true
     - policy_name: Insecure SMTP
       policy_description: Communication using insecure SMTP in an application processing sensitive data. Verify that SMTP settings use OpenSSL or equivalent.
@@ -12,6 +19,13 @@ medium:
       filename: testdata/ruby/insecure_smtp.rb
       category_groups:
         - PII
+      parent_line_number: 14
+      parent_content: |-
+        Rails.application.configure do
+          config.action_mailer.smtp_settings = {
+            openssl_verify_mode: "none"
+          }
+        end
       omit_parent: true
 
 

--- a/pkg/commands/process/settings/custom_detector.yml
+++ b/pkg/commands/process/settings/custom_detector.yml
@@ -224,7 +224,6 @@ detect_rails_insecure_smtp:
   languages:
     - ruby
   detect_presence: true
-  omit_parent: true
 detect_rails_insecure_communication:
   type: "risk"
   patterns:
@@ -235,7 +234,6 @@ detect_rails_insecure_communication:
   languages:
     - ruby
   detect_presence: true
-  omit_parent: true
 detect_rails_insecure_ftp:
   type: "risk"
   patterns:

--- a/pkg/commands/process/settings/policies/insecure_communication.rego
+++ b/pkg/commands/process/settings/policies/insecure_communication.rego
@@ -16,6 +16,8 @@ policy_breach contains item if {
       "severity": "medium",
       "filename": location.filename,
       "line_number": location.line_number,
-      "omit_parent": true
+      "omit_parent": true,
+      "parent_line_number": location.parent.line_number,
+      "parent_content": location.parent.content,
     }
 }

--- a/pkg/commands/process/settings/policies/insecure_smtp.rego
+++ b/pkg/commands/process/settings/policies/insecure_smtp.rego
@@ -16,6 +16,8 @@ policy_breach contains item if {
         "severity": "medium",
         "filename": location.filename,
         "line_number": location.line_number,
-        "omit_parent": true
+        "omit_parent": true,
+        "parent_line_number": location.parent.line_number,
+        "parent_content": location.parent.content,
     }
 }

--- a/pkg/util/file/file.go
+++ b/pkg/util/file/file.go
@@ -1,6 +1,7 @@
 package file
 
 import (
+	"bufio"
 	"io"
 	"os"
 	"path/filepath"
@@ -302,4 +303,27 @@ func EnsureFileExists(filePath string) *os.File {
 	}
 
 	return file
+}
+
+func ReadFileSingleLine(filePath string, lineNumber int) (string, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	lineCounter := 1
+	for scanner.Scan() {
+		if lineCounter == lineNumber {
+			return scanner.Text(), nil
+		}
+		lineCounter++
+	}
+
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+
+	return "", nil
 }


### PR DESCRIPTION
## Description

Previously, we would omit any and all content that precedes the match, on the first line of the match context. In particular, if the first line of a match has initial whitespace, then this would be trimmed in the output.

Unfortunately, in order to reconstruct the first line fully, we must re-read it from the originating file. This is done using a
line scanner, to avoid reading the entire file into memory. Nevertheless, this is sub-optimal; in the future, it may be worthwhile improving on this implementation.

Also: show only a single-line code extract, when the policy dictates that parent context be omitted.

### Screenshots

#### Before

![Before](https://user-images.githubusercontent.com/132732/207268523-07397f6a-bd92-47e9-a367-e7ecadcad622.png)

#### After

![After](https://user-images.githubusercontent.com/132732/207268574-dec8acbc-2896-4226-bc64-4a70fba91df7.png)

## Checklist

- [X] I've added test coverage that shows my fix or feature works as expected.
- [X] I've updated or added documentation if required.
- [X] I've included usage information in the description if CLI behavior was updated or added.
- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
