### PR TITLE
chore: sign darwin binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,15 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: 1.18
+      - name: Setup Gon
+        run: brew install mitchellh/gon/gon
+      - name: Import Code-Signing Certificates
+        uses: Apple-Actions/import-codesign-certs@v1
+        with:
+          # The certificates in a PKCS12 file encoded as a base64 string
+          p12-file-base64: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_P12_BASE64 }}
+          # The password used to import the PKCS12 file.
+          p12-password: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_PASSWORD }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:
@@ -80,14 +89,18 @@ jobs:
           args: release --skip-publish -f ./goreleaser/darwin.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AC_USERNAME: ${{ secrets.AC_USERNAME }}
+          AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
       - name: Upload
         uses: actions/upload-artifact@v3
         with:
           name: curio-darwin
-          path: dist/curio*
+          path: |
+            dist/curio*.tar.gz
+            dist/curio*checksums.txt
 
   publish:
-    needs: [tag, build-darwin, build-linux]
+    needs: [tag, build-linux, build-darwin]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -112,8 +125,8 @@ jobs:
       - name: Merge checksum file
         run: |
           cd ./curio-build
-          cat ./darwin/curio*checksums.txt >> checksums.txt
           cat ./linux/curio*checksums.txt >> checksums.txt
+          cat ./darwin/curio*checksums.txt >> checksums.txt
           rm ./darwin/curio*checksums.txt
           rm ./linux/curio*checksums.txt
       - name: Release

--- a/goreleaser/darwin.yaml
+++ b/goreleaser/darwin.yaml
@@ -1,9 +1,12 @@
+project_name: curio
+
 before:
   hooks:
     - go mod tidy
     - go generate ./...
+
 builds:
-  - id: "darwin"
+  - id: curio-macos-build
     main: ./cmd/curio
     binary: curio
     env:
@@ -11,14 +14,45 @@ builds:
     goos:
       - darwin
     goarch:
-      - arm64
       - amd64
+      - arm64
     ldflags:
       - -s -w
       - -X "github.com/bearer/curio/cmd/curio/build.Version={{.Version}}"
       - -X "github.com/bearer/curio/cmd/curio/build.CommitSHA={{.Commit}}"
+    hooks:
+      post:
+        - |
+          sh -c '
+          fn=dist/curio-macos-build_{{.Target}}/gon.hcl
+          cat >"$fn" <<EOF
+          source = ["dist/curio-macos-build_{{.Target}}/{{.Name}}"]
+
+          bundle_id = "com.bearer.curio"
+
+          apple_id {
+            password = "@env:AC_PASSWORD"
+          }
+
+          sign {
+            application_identity = "Developer ID Application: Bearer Inc (5T2VP4YAG8)"
+          }
+
+          zip {
+            output_path = "curio_{{.Target}}.zip"
+          }
+          EOF
+          '
+        - "gon -log-level=debug 'dist/curio-macos-build_{{.Target}}/gon.hcl'"
+
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
+
+archives:
+  - id: macos-archive
+    builds:
+      - curio-macos-build
+
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Sign Darwin binaries to avoid having to approve the binary when running it

```bash
❯ codesign -dv --verbose=4 curio
Executable=/Users/cfabianski/Downloads/curio-darwin-5/curio_0.15.4-next_darwin_arm64/curio
Identifier=curio
Format=Mach-O thin (arm64)
CodeDirectory v=20500 size=457969 flags=0x10000(runtime) hashes=14306+2 location=embedded
VersionPlatform=1
VersionMin=786432
VersionSDK=787200
Hash type=sha256 size=32
CandidateCDHash sha256=2b3908ae4be5abac28c8fc4c1bb62d4991e81cb2
CandidateCDHashFull sha256=2b3908ae4be5abac28c8fc4c1bb62d4991e81cb210a7891f42e47c438e8a8c41
Hash choices=sha256
CMSDigest=2b3908ae4be5abac28c8fc4c1bb62d4991e81cb210a7891f42e47c438e8a8c41
CMSDigestType=2
Executable Segment base=0
Executable Segment limit=42745856
Executable Segment flags=0x1
Page size=4096
CDHash=2b3908ae4be5abac28c8fc4c1bb62d4991e81cb2
Signature size=8969
Authority=Developer ID Application: Bearer Inc (5T2VP4YAG8)
Authority=Developer ID Certification Authority
Authority=Apple Root CA
Timestamp=13 Dec 2022 at 12:06:14
Info.plist=not bound
TeamIdentifier=5T2VP4YAG8
Runtime Version=12.3.0
Sealed Resources=none
Internal requirements count=1 size=168
```

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
