### PR TITLE
chore: Re-order option groups in CLI scan help output

### DIFF
--- a/integration/flags/.snapshots/TestMetadataFlags-help-scan
+++ b/integration/flags/.snapshots/TestMetadataFlags-help-scan
@@ -9,6 +9,15 @@ Examples:
   $ curio scan /path/to/your_project
 
 
+Report Flags
+  -f, --format string   Specify report format (json, yaml)
+      --output string   Specify the output path for the report.
+      --report string   Specify the type of report (detectors, dataflow, policies, stats). (default "policies")
+
+Policy Flags
+      --only-policy strings   Specify the comma-separated ids of the policies you would like to run. Skips all other policies.
+      --skip-policy strings   Specify the comma-separated ids of the policies you would like to skip. Runs all other policies.
+
 Scan Flags
       --context string                       Expand context of schema classification e.g., --context=health, to include data types particular to health
       --debug                                Enable debug logs
@@ -18,9 +27,8 @@ Scan Flags
       --quiet                                Suppress non-essential messages
       --skip-path strings                    Specify the comma separated files and directories to skip. Supports * syntax, e.g. --skip-path users/*.go,users/admin.sql
 
-Policy Flags
-      --only-policy strings   Specify the comma-separated ids of the policies you would like to run. Skips all other policies.
-      --skip-policy strings   Specify the comma-separated ids of the policies you would like to skip. Runs all other policies.
+General Flags
+      --config-file string   Load configuration from the specified path.
 
 Worker Flags
       --existing-worker string              Specify the URL of an existing worker.
@@ -33,14 +41,6 @@ Worker Flags
       --timeout-file-second-per-bytes int   number of file size bytes producing a second of timeout assigned to scanning a file (default 10000)
       --timeout-worker-online duration      Maximum time to wait for a worker process to come online. (default 1m0s)
       --workers int                         The number of processing workers to spawn. (default 1)
-
-Report Flags
-  -f, --format string   Specify report format (json, yaml)
-      --output string   Specify the output path for the report.
-      --report string   Specify the type of report (detectors, dataflow, policies, stats). (default "policies")
-
-General Flags
-      --config-file string   Load configuration from the specified path.
 
 
 --

--- a/integration/flags/.snapshots/TestMetadataFlags-scan-help
+++ b/integration/flags/.snapshots/TestMetadataFlags-scan-help
@@ -9,6 +9,15 @@ Examples:
   $ curio scan /path/to/your_project
 
 
+Report Flags
+  -f, --format string   Specify report format (json, yaml)
+      --output string   Specify the output path for the report.
+      --report string   Specify the type of report (detectors, dataflow, policies, stats). (default "policies")
+
+Policy Flags
+      --only-policy strings   Specify the comma-separated ids of the policies you would like to run. Skips all other policies.
+      --skip-policy strings   Specify the comma-separated ids of the policies you would like to skip. Runs all other policies.
+
 Scan Flags
       --context string                       Expand context of schema classification e.g., --context=health, to include data types particular to health
       --debug                                Enable debug logs
@@ -18,9 +27,8 @@ Scan Flags
       --quiet                                Suppress non-essential messages
       --skip-path strings                    Specify the comma separated files and directories to skip. Supports * syntax, e.g. --skip-path users/*.go,users/admin.sql
 
-Policy Flags
-      --only-policy strings   Specify the comma-separated ids of the policies you would like to run. Skips all other policies.
-      --skip-policy strings   Specify the comma-separated ids of the policies you would like to skip. Runs all other policies.
+General Flags
+      --config-file string   Load configuration from the specified path.
 
 Worker Flags
       --existing-worker string              Specify the URL of an existing worker.
@@ -33,14 +41,6 @@ Worker Flags
       --timeout-file-second-per-bytes int   number of file size bytes producing a second of timeout assigned to scanning a file (default 10000)
       --timeout-worker-online duration      Maximum time to wait for a worker process to come online. (default 1m0s)
       --workers int                         The number of processing workers to spawn. (default 1)
-
-Report Flags
-  -f, --format string   Specify report format (json, yaml)
-      --output string   Specify the output path for the report.
-      --report string   Specify the type of report (detectors, dataflow, policies, stats). (default "policies")
-
-General Flags
-      --config-file string   Load configuration from the specified path.
 
 
 --

--- a/pkg/flag/options.go
+++ b/pkg/flag/options.go
@@ -150,26 +150,26 @@ func getDuration(flag *Flag) time.Duration {
 func (f *Flags) groups() []FlagGroup {
 	var groups []FlagGroup
 	// This order affects the usage message, so they are sorted by frequency of use.
-	if f.ScanFlagGroup != nil {
-		groups = append(groups, f.ScanFlagGroup)
-	}
-	if f.ProcessFlagGroup != nil {
-		groups = append(groups, f.ProcessFlagGroup)
+	if f.ReportFlagGroup != nil {
+		groups = append(groups, f.ReportFlagGroup)
 	}
 	if f.PolicyFlagGroup != nil {
 		groups = append(groups, f.PolicyFlagGroup)
 	}
-	if f.RepoFlagGroup != nil {
-		groups = append(groups, f.RepoFlagGroup)
+	if f.ScanFlagGroup != nil {
+		groups = append(groups, f.ScanFlagGroup)
+	}
+	if f.GeneralFlagGroup != nil {
+		groups = append(groups, f.GeneralFlagGroup)
 	}
 	if f.WorkerFlagGroup != nil {
 		groups = append(groups, f.WorkerFlagGroup)
 	}
-	if f.ReportFlagGroup != nil {
-		groups = append(groups, f.ReportFlagGroup)
+	if f.ProcessFlagGroup != nil {
+		groups = append(groups, f.ProcessFlagGroup)
 	}
-	if f.GeneralFlagGroup != nil {
-		groups = append(groups, f.GeneralFlagGroup)
+	if f.RepoFlagGroup != nil {
+		groups = append(groups, f.RepoFlagGroup)
 	}
 
 	return groups


### PR DESCRIPTION
## Description

Tweak the order of the flag groups in the scan help output, for better usability.

## Checklist

- [X] I've added test coverage that shows my fix or feature works as expected.
- [X] I've updated or added documentation if required.
- [X] I've included usage information in the description if CLI behavior was updated or added.
- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
