### PR TITLE
fix: ensure ids are added to detections for policy reports

### DIFF
--- a/pkg/report/output/output.go
+++ b/pkg/report/output/output.go
@@ -74,24 +74,14 @@ func getReportOutput(report types.Report, config settings.Config) (any, error) {
 	case flag.ReportDataFlow:
 		return getDataflow(report, config, false)
 	case flag.ReportPolicies:
-		dataflow, err := getDataflow(report, config, true)
-		if err != nil {
-			return nil, err
-		}
-
-		return policies.GetOutput(dataflow, config)
+		return getPolicyReportOutput(report, config)
 	case flag.ReportStats:
 		lineOfCodeOutput, err := stats.GoclocDetectorOutput(config.Scan.Target)
 		if err != nil {
 			return nil, err
 		}
 
-		detectorsOutput, err := detectors.GetOutput(report)
-		if err != nil {
-			return nil, err
-		}
-
-		dataflowOutput, err := dataflow.GetOutput(detectorsOutput, config, true)
+		dataflowOutput, err := getDataflow(report, config, true)
 		if err != nil {
 			return nil, err
 		}
@@ -103,12 +93,7 @@ func getReportOutput(report types.Report, config settings.Config) (any, error) {
 }
 
 func getPolicyReportOutput(report types.Report, config settings.Config) (map[string][]policies.PolicyResult, error) {
-	detections, err := detectors.GetOutput(report)
-	if err != nil {
-		return nil, err
-	}
-
-	dataflow, err := dataflow.GetOutput(detections, config, true)
+	dataflow, err := getDataflow(report, config, true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Ensure that ids are added to detections when generating policy reports. 

We were adding ids in some codepaths but not others (eg. YAML/JSON reports worked but not the default/text report).

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [x] I've added test coverage that shows my fix or feature works as expected.
- [x] I've updated or added documentation if required.
- [x] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
