### PR TITLE
fix: dont show config load when no config given

### DIFF
--- a/pkg/commands/scan.go
+++ b/pkg/commands/scan.go
@@ -66,7 +66,7 @@ func NewScanCommand() *cobra.Command {
 				return xerrors.Errorf("flag error: %w", err)
 			}
 
-			if !options.Quiet {
+			if !options.Quiet && configPath != "" {
 				output.StdErrLogger().Msgf("Loaded %s configuration file", configPath)
 			}
 


### PR DESCRIPTION
## Description

Currently you get `Loaded  configuration file` when no file is given this PR hides the message when no config is set

<!-- What does this PR do and how does it -->

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
