### PR TITLE
feat(scan): cache and reuse the latest report to produce the dataflow…

### DIFF
--- a/integration/flags/.snapshots/TestInitCommand
+++ b/integration/flags/.snapshots/TestInitCommand
@@ -681,6 +681,7 @@ scan:
     debug: false
     disable-domain-resolution: true
     domain-resolution-timeout: 3s
+    force: false
     internal-domains: []
     policies:
         application_level_encryption_missing:
@@ -743,11 +744,15 @@ scan:
 
                     policy_failure contains item if {
                         datatype = input.dataflow.data_types[_]
+                        datatype.name != "Unique Identifier"
+
                         detector = datatype.detectors[_]
                         location = detector.locations[_]
 
                         location.stored
+
                         not location.encrypted
+
 
                         item := {
                             "category_groups": data.bearer.common.groups_for_datatype(datatype),

--- a/integration/flags/.snapshots/TestMetadataFlags-help-scan
+++ b/integration/flags/.snapshots/TestMetadataFlags-help-scan
@@ -23,6 +23,7 @@ Scan Flags
       --debug                                Enable debug logs
       --disable-domain-resolution            Do not attempt to resolve detected domains during classification (default false), e.g. --disable-domain-resolution=true (default true)
       --domain-resolution-timeout duration   Set timeout when attempting to resolve detected domains during classification (default 3 seconds), e.g. --domain-resolution-timeout=3s (default 3s)
+      --force                                Disable the cache and runs the detections again
       --internal-domains strings             Define regular expressions for better classification of private or unreachable domains e.g. --internal-domains="*.my-company.com,private.sh"
       --quiet                                Suppress non-essential messages
       --skip-path strings                    Specify the comma separated files and directories to skip. Supports * syntax, e.g. --skip-path users/*.go,users/admin.sql

--- a/integration/flags/.snapshots/TestMetadataFlags-scan-help
+++ b/integration/flags/.snapshots/TestMetadataFlags-scan-help
@@ -23,6 +23,7 @@ Scan Flags
       --debug                                Enable debug logs
       --disable-domain-resolution            Do not attempt to resolve detected domains during classification (default false), e.g. --disable-domain-resolution=true (default true)
       --domain-resolution-timeout duration   Set timeout when attempting to resolve detected domains during classification (default 3 seconds), e.g. --domain-resolution-timeout=3s (default 3s)
+      --force                                Disable the cache and runs the detections again
       --internal-domains strings             Define regular expressions for better classification of private or unreachable domains e.g. --internal-domains="*.my-company.com,private.sh"
       --quiet                                Suppress non-essential messages
       --skip-path strings                    Specify the comma separated files and directories to skip. Supports * syntax, e.g. --skip-path users/*.go,users/admin.sql

--- a/integration/internal/testhelper/testhelper.go
+++ b/integration/internal/testhelper/testhelper.go
@@ -79,7 +79,9 @@ func RunTests(t *testing.T, tests []TestCase) {
 			arguments := test.arguments
 
 			if !test.displayStdErr {
-				arguments = append(arguments, "--quiet")
+				arguments = append(arguments, "--quiet", "--force")
+			} else {
+				arguments = append(arguments, "--force")
 			}
 
 			combinedOutput, err := executeApp(arguments)

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -5,18 +5,21 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
+	"strings"
 
+	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 
 	"golang.org/x/xerrors"
 
+	"github.com/bearer/curio/cmd/curio/build"
 	"github.com/bearer/curio/pkg/commands/process/balancer"
 	"github.com/bearer/curio/pkg/commands/process/settings"
 	"github.com/bearer/curio/pkg/commands/process/worker/work"
 	"github.com/bearer/curio/pkg/flag"
 	reportoutput "github.com/bearer/curio/pkg/report/output"
 	outputhandler "github.com/bearer/curio/pkg/util/output"
-	"github.com/bearer/curio/pkg/util/tmpfile"
 
 	"github.com/bearer/curio/pkg/types"
 )
@@ -46,8 +49,9 @@ type Runner interface {
 }
 
 type runner struct {
-	balancer   *balancer.Monitor
-	reportPath string
+	balancer       *balancer.Monitor
+	reportPath     string
+	reuseDetection bool
 }
 
 // NewRunner initializes Runner that provides scanning functionalities.
@@ -55,7 +59,38 @@ func NewRunner(ctx context.Context, scanSettings settings.Config) Runner {
 	r := &runner{}
 
 	r.balancer = balancer.New(scanSettings)
-	r.reportPath = tmpfile.Create(os.TempDir(), ".jsonl")
+	cmd := exec.Command("git", "-C", scanSettings.Scan.Target, "rev-parse", "HEAD")
+	sha, err := cmd.Output()
+
+	if err != nil {
+		log.Debug().Msgf("error getting git sha %s", err.Error())
+		sha = []byte(uuid.NewString())
+	}
+
+	path := os.TempDir() + strings.TrimSuffix(string(sha), "\n") + "-" + build.CommitSHA + ".jsonl"
+	r.reportPath = path
+
+	if _, err := os.Stat(path); err == nil {
+		if !scanSettings.Scan.Force {
+			r.reuseDetection = true
+			log.Debug().Msgf("reuse detection for %s", path)
+
+			return r
+		} else {
+			err := os.Remove(path)
+			if err != nil {
+				log.Debug().Msgf("couldn't remove report path %s, %s", path, err.Error())
+			}
+		}
+	}
+
+	log.Debug().Msgf("creating report %s", path)
+	reportPath, err := os.Create(path)
+
+	if err != nil {
+		log.Debug().Msgf("failed to create path %s, %s", path, err.Error())
+	}
+	log.Debug().Msgf("successfully created reportPath %s", reportPath.Name())
 
 	return r
 }
@@ -80,21 +115,21 @@ func (r *runner) ScanRepository(ctx context.Context, opts flag.Options) (types.R
 }
 
 func (r *runner) scanArtifact(ctx context.Context, opts flag.Options) (types.Report, error) {
-	task := r.balancer.ScheduleTask(work.ProcessRequest{
-		Repository: work.Repository{
-			Dir:               opts.Target,
-			PreviousCommitSHA: "",
-			CommitSHA:         "",
-		},
-		FilePath: r.reportPath,
-	})
-	result := <-task.Done
+	if !r.reuseDetection {
+		task := r.balancer.ScheduleTask(work.ProcessRequest{
+			Repository: work.Repository{
+				Dir:               opts.Target,
+				PreviousCommitSHA: "",
+				CommitSHA:         "",
+			},
+			FilePath: r.reportPath,
+		})
+		result := <-task.Done
 
-	if result.Error != nil {
-		return types.Report{}, result.Error
+		if result.Error != nil {
+			return types.Report{}, result.Error
+		}
 	}
-
-	log.Debug().Msgf("report location: %s", r.reportPath)
 
 	return types.Report{
 		Path: r.reportPath,

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -79,18 +79,19 @@ func NewRunner(ctx context.Context, scanSettings settings.Config) Runner {
 		} else {
 			err := os.Remove(path)
 			if err != nil {
-				log.Debug().Msgf("couldn't remove report path %s, %s", path, err.Error())
+				log.Error().Msgf("couldn't remove report path %s, %s", path, err.Error())
 			}
 		}
 	}
 
 	log.Debug().Msgf("creating report %s", path)
-	reportPath, err := os.Create(path)
+	pathCreated, err := os.Create(path)
 
 	if err != nil {
-		log.Debug().Msgf("failed to create path %s, %s", path, err.Error())
+		log.Error().Msgf("failed to create path %s, %s, %#v", path, err.Error(), pathCreated)
 	}
-	log.Debug().Msgf("successfully created reportPath %s", reportPath.Name())
+
+	log.Debug().Msgf("successfully created reportPath %s", path)
 
 	return r
 }

--- a/pkg/commands/process/settings/policies/application_level_encryption.rego
+++ b/pkg/commands/process/settings/policies/application_level_encryption.rego
@@ -6,11 +6,15 @@ import future.keywords
 
 policy_failure contains item if {
     datatype = input.dataflow.data_types[_]
+    datatype.name != "Unique Identifier"
+
     detector = datatype.detectors[_]
     location = detector.locations[_]
 
     location.stored
+
     not location.encrypted
+
 
     item := {
         "category_groups": data.bearer.common.groups_for_datatype(datatype),

--- a/pkg/detectors/custom/custom.go
+++ b/pkg/detectors/custom/custom.go
@@ -4,7 +4,7 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"regexp"
 	"sort"
@@ -126,7 +126,7 @@ func (detector *Detector) ProcessFile(file *file.FileInfo, dir *file.Path, repor
 			if err != nil {
 				return false, err
 			}
-			fileBytes, err := ioutil.ReadAll(f)
+			fileBytes, err := io.ReadAll(f)
 			if err != nil {
 				return false, err
 			}

--- a/pkg/detectors/internal/testhelper/testhelper.go
+++ b/pkg/detectors/internal/testhelper/testhelper.go
@@ -75,13 +75,13 @@ func RegistrationFor(detectorType reportdetectors.Type) []detectors.InitializedD
 }
 
 type InMemoryReport struct {
-	CustomDetections []detections.Detection
-	Detections       []*detections.Detection
-	Dependencies     []*detections.Detection
-	Frameworks       []*detections.FrameworkDetection
-	Errors           []*detections.ErrorDetection
-	SecretLeaks      []*detections.Detection
-	CreateView       []*detections.Detection
+	CustomDetections        []detections.Detection
+	Detections              []*detections.Detection
+	Dependencies            []*detections.Detection
+	Frameworks              []*detections.FrameworkDetection
+	Errors                  []*detections.ErrorDetection
+	SecretLeaks             []*detections.Detection
+	CreateView              []*detections.Detection
 	SchemaGroupDetectorType reportdetectors.Type
 	SchemaGroupObjectName   string
 }
@@ -213,8 +213,4 @@ func (report *InMemoryReport) AddError(filePath string, err error) {
 		Message: err.Error(),
 		File:    filePath,
 	})
-}
-
-func (report *InMemoryReport) AddFillerLine() {
-
 }

--- a/pkg/detectors/rails/personal_data/personal_data.go
+++ b/pkg/detectors/rails/personal_data/personal_data.go
@@ -54,6 +54,11 @@ func ExtractFromDatabaseSchema(
 		columnName := stripQuotes(columnNode.Content())
 		columnTypeNode := captures["type"]
 		columnType := columnTypeNode.Content()
+
+		if columnType == "index" {
+			return nil
+		}
+
 		ruleNode := captures["rule"]
 
 		objectUUID := uuidHolder.Assign(tableNode.ID(), idGenerator)
@@ -61,12 +66,12 @@ func ExtractFromDatabaseSchema(
 
 		transformedObjectName := pluralizer.Singular(strings.ToLower(tableName))
 		currentSchema := schema.Schema{
-			ObjectName:      tableName,
-			ObjectUUID:      objectUUID,
-			FieldName:       columnName,
-			FieldUUID:       fieldUUID,
-			FieldType:       columnType,
-			SimpleFieldType: convertToSimpleType(columnType),
+			ObjectName:            tableName,
+			ObjectUUID:            objectUUID,
+			FieldName:             columnName,
+			FieldUUID:             fieldUUID,
+			FieldType:             columnType,
+			SimpleFieldType:       convertToSimpleType(columnType),
 			TransformedObjectName: transformedObjectName,
 		}
 

--- a/pkg/flag/scan_flags.go
+++ b/pkg/flag/scan_flags.go
@@ -54,6 +54,12 @@ var (
 		Value:      false,
 		Usage:      "Suppress non-essential messages",
 	}
+	ForceFlag = Flag{
+		Name:       "force",
+		ConfigName: "scan.force",
+		Value:      false,
+		Usage:      "Disable the cache and runs the detections again",
+	}
 )
 
 type ScanFlagGroup struct {
@@ -64,6 +70,7 @@ type ScanFlagGroup struct {
 	InternalDomainsFlag         *Flag
 	ContextFlag                 *Flag
 	QuietFlag                   *Flag
+	ForceFlag                   *Flag
 }
 
 type ScanOptions struct {
@@ -75,6 +82,7 @@ type ScanOptions struct {
 	InternalDomains         []string      `mapstructure:"internal-domains" json:"internal-domains" yaml:"internal-domains"`
 	Context                 Context       `mapstructure:"context" json:"context" yaml:"context"`
 	Quiet                   bool          `mapstructure:"quiet" json:"quiet" yaml:"quiet"`
+	Force                   bool          `mapstructure:"force" json:"force" yaml:"force"`
 }
 
 func NewScanFlagGroup() *ScanFlagGroup {
@@ -86,6 +94,7 @@ func NewScanFlagGroup() *ScanFlagGroup {
 		InternalDomainsFlag:         &InternalDomainsFlag,
 		ContextFlag:                 &ContextFlag,
 		QuietFlag:                   &QuietFlag,
+		ForceFlag:                   &ForceFlag,
 	}
 }
 
@@ -102,6 +111,7 @@ func (f *ScanFlagGroup) Flags() []*Flag {
 		f.InternalDomainsFlag,
 		f.ContextFlag,
 		f.QuietFlag,
+		f.ForceFlag,
 	}
 }
 
@@ -119,6 +129,7 @@ func (f *ScanFlagGroup) ToOptions(args []string) (ScanOptions, error) {
 		InternalDomains:         getStringSlice(f.InternalDomainsFlag),
 		Context:                 getContext(f.ContextFlag),
 		Quiet:                   getBool(f.QuietFlag),
+		Force:                   getBool(f.ForceFlag),
 		Target:                  target,
 	}, nil
 }

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -23,7 +23,6 @@ type Report interface {
 	AddFramework(detectorType detectors.Type, frameworkType frameworks.Type, data interface{}, source source.Source)
 	AddDependency(detectorType detectors.Type, dependency dependencies.Dependency, source source.Source)
 	AddSecretLeak(secret secret.Secret, source source.Source)
-	AddFillerLine()
 	AddError(filePath string, err error)
 }
 

--- a/pkg/report/writer/detectors.go
+++ b/pkg/report/writer/detectors.go
@@ -260,12 +260,6 @@ func (report *Detectors) AddError(filePath string, err error) {
 	})
 }
 
-func (report *Detectors) AddFillerLine() {
-	report.Add(&detections.Detection{
-		Type: detections.TypeFiller,
-	})
-}
-
 func (report *Detectors) Add(data interface{}) {
 	detectionsToAdd := []interface{}{data}
 


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Stores and keep the results of the previous scan (so that we can customize the policies and get the results real quick after)
Introduces the new option `--force` to reset the cache

Also:
- fixes an issue with the application level encryption missing 
  - we shouldn't use Unique Identifier here
- exclude `t.index` from the schema_rb detector

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
