### PR TITLE
feat(policies): add weak encryption policy

### DIFF
--- a/integration/custom_detectors/.snapshots/TestCustomDetectors-ruby_weak_encryption_library
+++ b/integration/custom_detectors/.snapshots/TestCustomDetectors-ruby_weak_encryption_library
@@ -1,0 +1,73 @@
+data_types:
+    - name: Email Address
+      detectors:
+        - name: ruby
+          locations:
+            - filename: testdata/ruby/weak_encryption_library.rb
+              line_number: 2
+    - name: Firstname
+      detectors:
+        - name: ruby
+          locations:
+            - filename: testdata/ruby/weak_encryption_library.rb
+              line_number: 3
+    - name: Gender identity
+      detectors:
+        - name: ruby
+          locations:
+            - filename: testdata/ruby/weak_encryption_library.rb
+              line_number: 6
+    - name: Physical Address
+      detectors:
+        - name: ruby
+          locations:
+            - filename: testdata/ruby/weak_encryption_library.rb
+              line_number: 4
+risks:
+    - detector_id: detect_ruby_weak_encryption
+      data_types:
+        - name: Email Address
+          stored: false
+          locations:
+            - filename: testdata/ruby/weak_encryption_library.rb
+              line_number: 2
+              parent:
+                line_number: 2
+                content: Digest::SHA1.hexidigest(user.email)
+        - name: Firstname
+          stored: false
+          locations:
+            - filename: testdata/ruby/weak_encryption_library.rb
+              line_number: 3
+              parent:
+                line_number: 3
+                content: Digest::MD5.hexdigest(user.first_name)
+    - detector_id: encrypt_method_call
+      data_types:
+        - name: Physical Address
+          stored: false
+          locations:
+            - filename: testdata/ruby/weak_encryption_library.rb
+              line_number: 4
+              parent:
+                line_number: 4
+                content: RC4.new("insecure").encrypt(user.address)
+    - detector_id: ruby_blowfish_method_call
+      data_types:
+        - name: Gender identity
+          stored: false
+          locations:
+            - filename: testdata/ruby/weak_encryption_library.rb
+              line_number: 6
+              parent:
+                line_number: 6
+                content: Crypt::Blowfish.new("insecure").encrypt_block({ |u| user.gender_identity })
+components: []
+
+
+--
+Processing Detectors
+Finished processing Detectors
+Processing Dataflow
+Finished processing Dataflow
+

--- a/integration/custom_detectors/.snapshots/TestCustomDetectors-ruby_weak_encryption_library
+++ b/integration/custom_detectors/.snapshots/TestCustomDetectors-ruby_weak_encryption_library
@@ -66,8 +66,4 @@ components: []
 
 
 --
-Processing Detectors
-Finished processing Detectors
-Processing Dataflow
-Finished processing Dataflow
 

--- a/integration/custom_detectors/custom_detectors_test.go
+++ b/integration/custom_detectors/custom_detectors_test.go
@@ -26,6 +26,7 @@ func TestCustomDetectors(t *testing.T) {
 		newScanTest("ruby", "ruby_http_detection", "ruby_http_detection.rb"),
 		newScanTest("ruby", "ruby_weak_password_encryption", "weak_password_encryption.rb"),
 		newScanTest("ruby", "detect_password_length", "detect_password_length.rb"),
+		newScanTest("ruby", "ruby_weak_encryption_library", "weak_encryption_library.rb"),
 	}
 
 	testhelper.RunTests(t, tests)

--- a/integration/custom_detectors/testdata/ruby/weak_encryption_library.rb
+++ b/integration/custom_detectors/testdata/ruby/weak_encryption_library.rb
@@ -1,0 +1,6 @@
+# Detected
+Digest::SHA1.hexidigest(user.email)
+Digest::MD5.hexdigest(user.first_name)
+RC4.new("insecure").encrypt(user.address)
+
+Crypt::Blowfish.new("insecure").encrypt_block({ |u| user.gender_identity })

--- a/integration/flags/.snapshots/TestInitCommand-init
+++ b/integration/flags/.snapshots/TestInitCommand-init
@@ -1517,8 +1517,8 @@ scan:
             query: |
                 policy_breach = data.bearer.password_length.policy_breach
             id: ruby_password_length
-            display_id: ""
-            name: Password length
+            display_id: CR-019
+            name: Enforce stronger password requirements in applications processing sensitive data.
             description: Minimum password length violation detected. Make sure your passwords have sufficient length.
             level: ""
             modules:
@@ -1808,6 +1808,255 @@ scan:
                         "parent_content": location.parent.content
                       }
                     }
+        weak_encryption_library:
+            query: |
+                policy_failure = data.bearer.weak_encryption_library.policy_failure
+            id: detect_ruby_weak_encryption_library
+            display_id: CR-024
+            name: Avoid weak encryption library.
+            description: Weak encryption or hashing library detected. Consider using a different library.
+            level: ""
+            modules:
+                - path: policies/common.rego
+                  name: bearer.common
+                  content: |
+                    package bearer.common
+
+                    import future.keywords
+
+                    sensitive_data_group_uuid := "f6a0c071-5908-4420-bac2-bba28d41223e"
+                    personal_data_group_uuid := "e1d3135b-3c0f-4b55-abce-19f27a26cbb3"
+
+                    severity_of_datatype(data_type) := "critical" if {
+                        some category in input.data_categories
+                        category.uuid == data_type.category_uuid
+
+                        some group in category.groups
+                        group.uuid == sensitive_data_group_uuid
+                    }
+
+                    severity_of_datatype(data_type) := "high" if {
+                        some category in input.data_categories
+                        category.uuid == data_type.category_uuid
+
+                        some group in category.groups
+                        group.uuid == personal_data_group_uuid
+
+                        every group_1 in category.groups {
+                            group_1.uuid != sensitive_data_group_uuid
+                        }
+                    }
+
+                    groups_for_datatype(data_type) := x if {
+                        some category in input.data_categories
+                        category.uuid == data_type.category_uuid
+
+                        x := {name | name := category.groups[_].name}
+                    }
+
+                    groups_for_datatypes(data_types) := groups if {
+                        groups := {name | name := groups_for_datatype(data_types[_])[_]}
+                    }
+                - path: policies/encryption_common.rego
+                  name: bearer.encryption_common
+                  content: |-
+                    package bearer.encryption_common
+
+                    import future.keywords
+
+                    password_uuid := "02bb0d3a-2c8c-4842-be1c-c057f0dccd63"
+
+                    files_with_password_encryption_calls contains item if {
+                      some detector in input.dataflow.risks
+                      detector.detector_id in [
+                        "ruby_openssl_pkey_rsa_method_call",
+                        "ruby_openssl_pkey_method_call",
+                        "ruby_blowfish_method_call",
+                        "encrypt_method_call"
+                      ]
+
+                      data_type = detector.data_types[_]
+                      data_type.uuid == password_uuid
+
+                      location = detector.locations[_]
+
+                      item := location.filename
+                    }
+
+                    rc4_files contains item if {
+                      some detector in input.dataflow.risks
+                      detector.detector_id == "initialize_ruby_rc4_encryption"
+
+                      location = detector.locations[_]
+
+                      item := location.filename
+                    }
+
+                    blowfish_files contains item if {
+                      some detector in input.dataflow.risks
+                      detector.detector_id == "initialize_ruby_blowfish_encryption"
+
+                      location = detector.locations[_]
+
+                      item := location.filename
+                    }
+
+                    openssl_pkey_rsa_files contains item if {
+                      some detector in input.dataflow.risks
+                      detector.detector_id == "initialize_ruby_openssl_pkey_rsa_encryption"
+
+                      location = detector.locations[_]
+
+                      item := location.filename
+                    }
+
+                    openssl_pkey_dsa_files contains item if {
+                      some detector in input.dataflow.risks
+                      detector.detector_id == "initialize_ruby_openssl_pkey_dsa_encryption"
+
+                      location = detector.locations[_]
+
+                      item := location.filename
+                    }
+                - path: policies/weak_encryption_library.rego
+                  name: bearer.weak_encryption_library
+                  content: |
+                    package bearer.weak_encryption_library
+
+                    import data.bearer.common
+                    import data.bearer.encryption_common
+
+                    import future.keywords
+
+                    password_uuid := "02bb0d3a-2c8c-4842-be1c-c057f0dccd63"
+
+                    # openssl pkey rsa encryption
+                    policy_failure contains item if {
+                        some detector in input.dataflow.risks
+                        detector.detector_id in ["ruby_openssl_pkey_rsa_method_call", "ruby_openssl_pkey_method_call"]
+
+                        data_type = detector.data_types[_]
+                        data_type.uuid != data.bearer.encryption_common.password_uuid
+
+                        location = data_type.locations[_]
+                        location.filename in data.bearer.encryption_common.openssl_pkey_rsa_files
+
+                        item := {
+                            "category_groups": data.bearer.common.groups_for_datatype(data_type),
+                            "severity": "low",
+                            "filename": location.filename,
+                            "line_number": location.line_number,
+                            "parent_line_number": location.parent.line_number,
+                            "parent_content": location.parent.content
+                        }
+                    }
+
+                    # openssl pkey dsa encryption
+                    policy_failure contains item if {
+                        some detector in input.dataflow.risks
+                        detector.detector_id in ["ruby_openssl_pkey_dsa_method_call", "ruby_openssl_pkey_method_call"]
+
+                        data_type = detector.data_types[_]
+                        data_type.uuid != data.bearer.encryption_common.password_uuid
+
+                        location = data_type.locations[_]
+                        location.filename in data.bearer.encryption_common.openssl_pkey_dsa_files
+
+                        item := {
+                            "category_groups": data.bearer.common.groups_for_datatype(data_type),
+                            "severity": "low",
+                            "filename": location.filename,
+                            "line_number": location.line_number,
+                            "parent_line_number": location.parent.line_number,
+                            "parent_content": location.parent.content
+                        }
+                    }
+
+                    # blowfish encryption
+                    policy_failure contains item if {
+                        some detector in input.dataflow.risks
+                        detector.detector_id == "ruby_blowfish_method_call"
+
+                        data_type = detector.data_types[_]
+                        data_type.uuid != data.bearer.encryption_common.password_uuid
+
+                        location = data_type.locations[_]
+                        location.filename in data.bearer.encryption_common.blowfish_files
+
+                        item := {
+                            "category_groups": data.bearer.common.groups_for_datatype(data_type),
+                            "severity": "low",
+                            "filename": location.filename,
+                            "line_number": location.line_number,
+                            "parent_line_number": location.parent.line_number,
+                            "parent_content": location.parent.content
+                        }
+                    }
+
+                    # rc4 encryption
+                    policy_failure contains item if {
+                        some detector in input.dataflow.risks
+                        detector.detector_id == "encrypt_method_call"
+
+                        data_type = detector.data_types[_]
+                        data_type.uuid != data.bearer.encryption_common.password_uuid
+
+                        location = data_type.locations[_]
+                        location.filename in data.bearer.encryption_common.rc4_files
+
+                        item := {
+                            "category_groups": data.bearer.common.groups_for_datatype(data_type),
+                            "severity": "low",
+                            "filename": location.filename,
+                            "line_number": location.line_number,
+                            "parent_line_number": location.parent.line_number,
+                            "parent_content": location.parent.content
+                        }
+                    }
+
+                    policy_failure contains item if {
+                        some detector in input.dataflow.risks
+                        detector.detector_id in [
+                          "initialize_ruby_rc4_encryption",
+                          "initialize_ruby_blowfish_encryption",
+                          "initialize_ruby_openssl_pkey_rsa_encryption",
+                          "initialize_ruby_openssl_pkey_dsa_encryption",
+                        ]
+
+                        data_type = detector.data_types[_]
+                        location = data_type.locations[_]
+                        # NOT in a file with an encryption method call
+                        not location in data.bearer.encryption_common.files_with_password_encryption_calls
+
+                        item := {
+                            "category_groups": data.bearer.common.groups_for_datatype(data_type),
+                            "severity": "low",
+                            "filename": location.filename,
+                            "line_number": location.line_number,
+                            "parent_line_number": location.parent.line_number,
+                            "parent_content": location.parent.content
+                        }
+                    }
+
+                    policy_failure contains item if {
+                        some detector in input.dataflow.risks
+                        detector.detector_id == "detect_ruby_weak_encryption"
+
+                        # NOT password data type
+                        data_type = detector.data_types[_]
+                        data_type.uuid != data.bearer.encryption_common.password_uuid
+
+                        location = data_type.locations[_]
+
+                        item := {
+                            "category_groups": data.bearer.common.groups_for_datatype(data_type),
+                            "severity": "low",
+                            "filename": location.filename,
+                            "line_number": location.line_number,
+                            "parent_line_number": location.parent.line_number,
+                            "parent_content": location.parent.content
+                        }
+                    }
         weak_password_encryption:
             query: |
                 policy_failure = data.bearer.weak_password_encryption.policy_failure
@@ -1864,6 +2113,25 @@ scan:
 
                     import future.keywords
 
+                    password_uuid := "02bb0d3a-2c8c-4842-be1c-c057f0dccd63"
+
+                    files_with_password_encryption_calls contains item if {
+                      some detector in input.dataflow.risks
+                      detector.detector_id in [
+                        "ruby_openssl_pkey_rsa_method_call",
+                        "ruby_openssl_pkey_method_call",
+                        "ruby_blowfish_method_call",
+                        "encrypt_method_call"
+                      ]
+
+                      data_type = detector.data_types[_]
+                      data_type.uuid == password_uuid
+
+                      location = detector.locations[_]
+
+                      item := location.filename
+                    }
+
                     rc4_files contains item if {
                       some detector in input.dataflow.risks
                       detector.detector_id == "initialize_ruby_rc4_encryption"
@@ -1909,15 +2177,13 @@ scan:
 
                     import future.keywords
 
-                    password_uuid := "02bb0d3a-2c8c-4842-be1c-c057f0dccd63"
-
                     # openssl pkey rsa encryption
                     policy_failure contains item if {
                         some detector in input.dataflow.risks
                         detector.detector_id in ["ruby_openssl_pkey_rsa_method_call", "ruby_openssl_pkey_method_call"]
 
                         data_type = detector.data_types[_]
-                        data_type.uuid == password_uuid
+                        data_type.uuid == data.bearer.encryption_common.password_uuid
 
                         location = data_type.locations[_]
                         location.filename in data.bearer.encryption_common.openssl_pkey_rsa_files
@@ -1938,7 +2204,7 @@ scan:
                         detector.detector_id in ["ruby_openssl_pkey_dsa_method_call", "ruby_openssl_pkey_method_call"]
 
                         data_type = detector.data_types[_]
-                        data_type.uuid == password_uuid
+                        data_type.uuid == data.bearer.encryption_common.password_uuid
 
                         location = data_type.locations[_]
                         location.filename in data.bearer.encryption_common.openssl_pkey_dsa_files
@@ -1959,7 +2225,7 @@ scan:
                         detector.detector_id == "ruby_blowfish_method_call"
 
                         data_type = detector.data_types[_]
-                        data_type.uuid == password_uuid
+                        data_type.uuid == data.bearer.encryption_common.password_uuid
 
                         location = data_type.locations[_]
                         location.filename in data.bearer.encryption_common.blowfish_files
@@ -1980,7 +2246,7 @@ scan:
                         detector.detector_id == "encrypt_method_call"
 
                         data_type = detector.data_types[_]
-                        data_type.uuid == password_uuid
+                        data_type.uuid == data.bearer.encryption_common.password_uuid
 
                         location = data_type.locations[_]
                         location.filename in data.bearer.encryption_common.rc4_files
@@ -2000,7 +2266,7 @@ scan:
                         detector.detector_id == input.policy_id
 
                         data_type = detector.data_types[_]
-                        data_type.uuid == password_uuid
+                        data_type.uuid == data.bearer.encryption_common.password_uuid
 
                         location = data_type.locations[_]
                         item := {

--- a/integration/policies/.snapshots/TestPolicies-ruby_weak_password_encryption
+++ b/integration/policies/.snapshots/TestPolicies-ruby_weak_password_encryption
@@ -59,6 +59,37 @@ high:
       parent_line_number: 16
       parent_content: rc4_encrypt.encrypt!(customer.password)
       omit_parent: false
+low:
+    - policy_name: Avoid weak encryption library.
+      policy_display_id: CR-024
+      policy_description: Weak encryption or hashing library detected. Consider using a different library.
+      line_number: 18
+      filename: testdata/ruby/weak_password_encryption.rb
+      category_groups:
+        - PII
+      parent_line_number: 18
+      parent_content: Digest::SHA1.hexidigest(user.email)
+      omit_parent: false
+    - policy_name: Avoid weak encryption library.
+      policy_display_id: CR-024
+      policy_description: Weak encryption or hashing library detected. Consider using a different library.
+      line_number: 19
+      filename: testdata/ruby/weak_password_encryption.rb
+      category_groups:
+        - PII
+      parent_line_number: 19
+      parent_content: Digest::MD5.hexdigest(user.first_name)
+      omit_parent: false
+    - policy_name: Avoid weak encryption library.
+      policy_display_id: CR-024
+      policy_description: Weak encryption or hashing library detected. Consider using a different library.
+      line_number: 20
+      filename: testdata/ruby/weak_password_encryption.rb
+      category_groups:
+        - PII
+      parent_line_number: 20
+      parent_content: RC4.new("insecure").encrypt(user.address)
+      omit_parent: false
 
 
 --

--- a/pkg/commands/process/settings/policies.yml
+++ b/pkg/commands/process/settings/policies.yml
@@ -182,7 +182,8 @@ weak_password_encryption:
       name: bearer.weak_password_encryption
 password_length:
   description: "Minimum password length violation detected. Make sure your passwords have sufficient length."
-  name: "Password length"
+  name: "Enforce stronger password requirements in applications processing sensitive data."
+  display_id: "CR-019"
   id: "ruby_password_length"
   query: |
     policy_breach = data.bearer.password_length.policy_breach
@@ -191,3 +192,17 @@ password_length:
       name: bearer.common
     - path: policies/password_length.rego
       name: bearer.password_length
+weak_encryption_library:
+  description: "Weak encryption or hashing library detected. Consider using a different library."
+  name: "Avoid weak encryption library."
+  display_id: "CR-024"
+  id: "detect_ruby_weak_encryption_library"
+  query: |
+    policy_failure = data.bearer.weak_encryption_library.policy_failure
+  modules:
+    - path: policies/common.rego
+      name: bearer.common
+    - path: policies/encryption_common.rego
+      name: bearer.encryption_common
+    - path: policies/weak_encryption_library.rego
+      name: bearer.weak_encryption_library

--- a/pkg/commands/process/settings/policies/encryption_common.rego
+++ b/pkg/commands/process/settings/policies/encryption_common.rego
@@ -2,6 +2,25 @@ package bearer.encryption_common
 
 import future.keywords
 
+password_uuid := "02bb0d3a-2c8c-4842-be1c-c057f0dccd63"
+
+files_with_password_encryption_calls contains item if {
+  some detector in input.dataflow.risks
+  detector.detector_id in [
+    "ruby_openssl_pkey_rsa_method_call",
+    "ruby_openssl_pkey_method_call",
+    "ruby_blowfish_method_call",
+    "encrypt_method_call"
+  ]
+
+  data_type = detector.data_types[_]
+  data_type.uuid == password_uuid
+
+  location = detector.locations[_]
+
+  item := location.filename
+}
+
 rc4_files contains item if {
   some detector in input.dataflow.risks
   detector.detector_id == "initialize_ruby_rc4_encryption"

--- a/pkg/commands/process/settings/policies/weak_encryption_library.rego
+++ b/pkg/commands/process/settings/policies/weak_encryption_library.rego
@@ -13,7 +13,7 @@ policy_failure contains item if {
     detector.detector_id in ["ruby_openssl_pkey_rsa_method_call", "ruby_openssl_pkey_method_call"]
 
     data_type = detector.data_types[_]
-    data_type.uuid != password_uuid
+    data_type.uuid != data.bearer.encryption_common.password_uuid
 
     location = data_type.locations[_]
     location.filename in data.bearer.encryption_common.openssl_pkey_rsa_files
@@ -34,7 +34,7 @@ policy_failure contains item if {
     detector.detector_id in ["ruby_openssl_pkey_dsa_method_call", "ruby_openssl_pkey_method_call"]
 
     data_type = detector.data_types[_]
-    data_type.uuid != password_uuid
+    data_type.uuid != data.bearer.encryption_common.password_uuid
 
     location = data_type.locations[_]
     location.filename in data.bearer.encryption_common.openssl_pkey_dsa_files
@@ -55,7 +55,7 @@ policy_failure contains item if {
     detector.detector_id == "ruby_blowfish_method_call"
 
     data_type = detector.data_types[_]
-    data_type.uuid != password_uuid
+    data_type.uuid != data.bearer.encryption_common.password_uuid
 
     location = data_type.locations[_]
     location.filename in data.bearer.encryption_common.blowfish_files
@@ -76,7 +76,7 @@ policy_failure contains item if {
     detector.detector_id == "encrypt_method_call"
 
     data_type = detector.data_types[_]
-    data_type.uuid != password_uuid
+    data_type.uuid != data.bearer.encryption_common.password_uuid
 
     location = data_type.locations[_]
     location.filename in data.bearer.encryption_common.rc4_files
@@ -121,7 +121,7 @@ policy_failure contains item if {
 
     # NOT password data type
     data_type = detector.data_types[_]
-    data_type.uuid != password_uuid
+    data_type.uuid != data.bearer.encryption_common.password_uuid
 
     location = data_type.locations[_]
 

--- a/pkg/commands/process/settings/policies/weak_encryption_library.rego
+++ b/pkg/commands/process/settings/policies/weak_encryption_library.rego
@@ -1,0 +1,136 @@
+package bearer.weak_encryption_library
+
+import data.bearer.common
+import data.bearer.encryption_common
+
+import future.keywords
+
+password_uuid := "02bb0d3a-2c8c-4842-be1c-c057f0dccd63"
+
+# openssl pkey rsa encryption
+policy_failure contains item if {
+    some detector in input.dataflow.risks
+    detector.detector_id in ["ruby_openssl_pkey_rsa_method_call", "ruby_openssl_pkey_method_call"]
+
+    data_type = detector.data_types[_]
+    data_type.uuid != password_uuid
+
+    location = data_type.locations[_]
+    location.filename in data.bearer.encryption_common.openssl_pkey_rsa_files
+
+    item := {
+        "category_groups": data.bearer.common.groups_for_datatype(data_type),
+        "severity": "low",
+        "filename": location.filename,
+        "line_number": location.line_number,
+        "parent_line_number": location.parent.line_number,
+        "parent_content": location.parent.content
+    }
+}
+
+# openssl pkey dsa encryption
+policy_failure contains item if {
+    some detector in input.dataflow.risks
+    detector.detector_id in ["ruby_openssl_pkey_dsa_method_call", "ruby_openssl_pkey_method_call"]
+
+    data_type = detector.data_types[_]
+    data_type.uuid != password_uuid
+
+    location = data_type.locations[_]
+    location.filename in data.bearer.encryption_common.openssl_pkey_dsa_files
+
+    item := {
+        "category_groups": data.bearer.common.groups_for_datatype(data_type),
+        "severity": "low",
+        "filename": location.filename,
+        "line_number": location.line_number,
+        "parent_line_number": location.parent.line_number,
+        "parent_content": location.parent.content
+    }
+}
+
+# blowfish encryption
+policy_failure contains item if {
+    some detector in input.dataflow.risks
+    detector.detector_id == "ruby_blowfish_method_call"
+
+    data_type = detector.data_types[_]
+    data_type.uuid != password_uuid
+
+    location = data_type.locations[_]
+    location.filename in data.bearer.encryption_common.blowfish_files
+
+    item := {
+        "category_groups": data.bearer.common.groups_for_datatype(data_type),
+        "severity": "low",
+        "filename": location.filename,
+        "line_number": location.line_number,
+        "parent_line_number": location.parent.line_number,
+        "parent_content": location.parent.content
+    }
+}
+
+# rc4 encryption
+policy_failure contains item if {
+    some detector in input.dataflow.risks
+    detector.detector_id == "encrypt_method_call"
+
+    data_type = detector.data_types[_]
+    data_type.uuid != password_uuid
+
+    location = data_type.locations[_]
+    location.filename in data.bearer.encryption_common.rc4_files
+
+    item := {
+        "category_groups": data.bearer.common.groups_for_datatype(data_type),
+        "severity": "low",
+        "filename": location.filename,
+        "line_number": location.line_number,
+        "parent_line_number": location.parent.line_number,
+        "parent_content": location.parent.content
+    }
+}
+
+policy_failure contains item if {
+    some detector in input.dataflow.risks
+    detector.detector_id in [
+      "initialize_ruby_rc4_encryption",
+      "initialize_ruby_blowfish_encryption",
+      "initialize_ruby_openssl_pkey_rsa_encryption",
+      "initialize_ruby_openssl_pkey_dsa_encryption",
+    ]
+
+    data_type = detector.data_types[_]
+    location = data_type.locations[_]
+    # NOT in a file with an encryption method call
+    not location in data.bearer.encryption_common.files_with_password_encryption_calls
+
+    item := {
+        "category_groups": data.bearer.common.groups_for_datatype(data_type),
+        "severity": "low",
+        "filename": location.filename,
+        "line_number": location.line_number,
+        "parent_line_number": location.parent.line_number,
+        "parent_content": location.parent.content
+    }
+}
+
+policy_failure contains item if {
+    some detector in input.dataflow.risks
+    detector.detector_id == "detect_ruby_weak_encryption"
+
+    # NOT password data type
+    data_type = detector.data_types[_]
+    data_type.uuid != password_uuid
+
+    location = data_type.locations[_]
+
+    item := {
+        "category_groups": data.bearer.common.groups_for_datatype(data_type),
+        "severity": "low",
+        "filename": location.filename,
+        "line_number": location.line_number,
+        "parent_line_number": location.parent.line_number,
+        "parent_content": location.parent.content
+    }
+}

--- a/pkg/commands/process/settings/policies/weak_password_encryption.rego
+++ b/pkg/commands/process/settings/policies/weak_password_encryption.rego
@@ -5,15 +5,13 @@ import data.bearer.encryption_common
 
 import future.keywords
 
-password_uuid := "02bb0d3a-2c8c-4842-be1c-c057f0dccd63"
-
 # openssl pkey rsa encryption
 policy_failure contains item if {
     some detector in input.dataflow.risks
     detector.detector_id in ["ruby_openssl_pkey_rsa_method_call", "ruby_openssl_pkey_method_call"]
 
     data_type = detector.data_types[_]
-    data_type.uuid == password_uuid
+    data_type.uuid == data.bearer.encryption_common.password_uuid
 
     location = data_type.locations[_]
     location.filename in data.bearer.encryption_common.openssl_pkey_rsa_files
@@ -34,7 +32,7 @@ policy_failure contains item if {
     detector.detector_id in ["ruby_openssl_pkey_dsa_method_call", "ruby_openssl_pkey_method_call"]
 
     data_type = detector.data_types[_]
-    data_type.uuid == password_uuid
+    data_type.uuid == data.bearer.encryption_common.password_uuid
 
     location = data_type.locations[_]
     location.filename in data.bearer.encryption_common.openssl_pkey_dsa_files
@@ -55,7 +53,7 @@ policy_failure contains item if {
     detector.detector_id == "ruby_blowfish_method_call"
 
     data_type = detector.data_types[_]
-    data_type.uuid == password_uuid
+    data_type.uuid == data.bearer.encryption_common.password_uuid
 
     location = data_type.locations[_]
     location.filename in data.bearer.encryption_common.blowfish_files
@@ -76,7 +74,7 @@ policy_failure contains item if {
     detector.detector_id == "encrypt_method_call"
 
     data_type = detector.data_types[_]
-    data_type.uuid == password_uuid
+    data_type.uuid == data.bearer.encryption_common.password_uuid
 
     location = data_type.locations[_]
     location.filename in data.bearer.encryption_common.rc4_files
@@ -96,7 +94,7 @@ policy_failure contains item if {
     detector.detector_id == input.policy_id
 
     data_type = detector.data_types[_]
-    data_type.uuid == password_uuid
+    data_type.uuid == data.bearer.encryption_common.password_uuid
 
     location = data_type.locations[_]
     item := {


### PR DESCRIPTION
## Description

An extension to https://github.com/Bearer/curio/pull/215

Give policy failure with low severity if we detect a weak encryption library being used for a data type that it not a password

Example

Code

```
cipher = OpenSSL::Cipher.new('aes-128-cbc')
dsa_encrypt = OpenSSL::PKey::DSA.new(2048)
dsa_encrypt.export(cipher, customer.first_name)
```

Policy report

![Screenshot 2022-12-14 at 10 24 17](https://user-images.githubusercontent.com/4560746/207543806-26f6928c-f6ff-4a30-b17f-5ee9feed3894.png)



<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
