### PR TITLE
fix(policies): replace policy failure name by policy id in report

### DIFF
--- a/integration/flags/.snapshots/TestInitCommand-init
+++ b/integration/flags/.snapshots/TestInitCommand-init
@@ -603,6 +603,7 @@ scan:
             query: |
                 policy_failure = data.bearer.application_level_encryption.policy_failure
             id: application_level_encryption_missing
+            display_id: CR-021
             name: Application level encryption missing
             description: Application level encryption missing. Enable application level encryption to reduce the risk of leaking sensitive data.
             level: ""
@@ -677,6 +678,7 @@ scan:
             query: |
                 policy_failure = data.bearer.leakage.policy_failure
             id: detect_rails_cookies
+            display_id: CR-002
             name: Cookie leaking
             description: Cookie leaks detected. Avoid storing sensitive data in cookies.
             level: ""
@@ -750,6 +752,7 @@ scan:
             query: |
                 policy_failure = data.bearer.http_get_parameters.policy_failure
             id: ruby_http_get_detection
+            display_id: CR-005
             name: HTTP GET parameters
             description: Sending data as HTTP GET parameters. Avoid sending sensitive data as parameters in GET requests.
             level: ""
@@ -823,6 +826,7 @@ scan:
             query: |
                 policy_failure = data.bearer.insecure_communication.policy_failure
             id: detect_rails_insecure_communication
+            display_id: CR-012
             name: Insecure communication
             description: Insecure communication in an application processing sensitive data. Ensure communication occurs over SSL.
             level: ""
@@ -897,6 +901,7 @@ scan:
             query: |
                 policy_failure = data.bearer.insecure_ftp.policy_failure
             id: detect_rails_insecure_ftp
+            display_id: CR-009
             name: Insecure FTP
             description: Communication with an insecure FTP server in an application processing sensitive data. Only connect to FTP securely.
             level: ""
@@ -970,6 +975,7 @@ scan:
             query: |
                 policy_failure = data.bearer.insecure_ftp_with_data_category.policy_failure
             id: insecure_ftp_with_data_category
+            display_id: CR-008
             name: Insecure FTP with Data Category
             description: Communicating Data Category with an insecure FTP server. Only connect to FTP securely.
             level: ""
@@ -1043,6 +1049,7 @@ scan:
             query: |
                 policy_failure = data.bearer.insecure_http_get.policy_failure
             id: insecure_http_get
+            display_id: CR-013
             name: Insecure HTTP GET
             description: Communicating using insecure HTTP GET in an application processing sensitive data. Ensure all HTTP communication occurs over HTTPS.
             level: ""
@@ -1116,6 +1123,7 @@ scan:
             query: |
                 policy_failure = data.bearer.insecure_http_with_data_category.policy_failure
             id: insecure_http_with_data_category
+            display_id: CR-015
             name: Insecure HTTP with Data Category
             description: Communicating Data Category using insecure HTTP. Ensure all HTTP communication occurs over HTTPS.
             level: ""
@@ -1203,6 +1211,7 @@ scan:
             query: |
                 policy_failure = data.bearer.insecure_smtp.policy_failure
             id: detect_rails_insecure_smtp
+            display_id: CR-010
             name: Insecure SMTP
             description: Communication using insecure SMTP in an application processing sensitive data. Verify that SMTP settings use OpenSSL or equivalent.
             level: ""
@@ -1276,6 +1285,7 @@ scan:
             query: |
                 policy_failure = data.bearer.leakage.policy_failure
             id: detect_rails_jwt
+            display_id: CR-004
             name: JWT leaking
             description: JWT leaks detected. Avoid storing sensitive data in JWTs.
             level: ""
@@ -1349,6 +1359,7 @@ scan:
             query: |
                 policy_failure = data.bearer.leakage.policy_failure
             id: detect_ruby_logger
+            display_id: CR-001
             name: Logger leaking
             description: Logger leaks detected. Avoid passing sensitive data to loggers.
             level: ""
@@ -1422,6 +1433,7 @@ scan:
             query: |
                 policy_failure = data.bearer.third_party_data_category.policy_failure
             id: detect_ruby_third_party_data_send
+            display_id: CR-016
             name: Third-party data category exposure
             description: Sending data in category to third party. Ensure data sent to third party is intended and secured.
             level: ""
@@ -1495,6 +1507,7 @@ scan:
             query: |
                 policy_failure = data.bearer.leakage.policy_failure
             id: detect_rails_session
+            display_id: CR-003
             name: Session leaking
             description: Session leaks detected. Avoid storing sensitive data in the session.
             level: ""
@@ -1568,6 +1581,7 @@ scan:
             query: |
                 policy_failure = data.bearer.ssl_certificate_verification_disabled.policy_failure
             id: ssl_certificate_verification_disabled
+            display_id: CR-011
             name: SSL certificate verification disabled
             description: SSL certificate verification is disabled in an application processing sensitive data. Enable SSL certificate verification.
             level: ""
@@ -1641,6 +1655,7 @@ scan:
             query: |
                 policy_failure = data.bearer.weak_password_encryption.policy_failure
             id: detect_ruby_weak_encryption
+            display_id: CR-023
             name: Weak password encryption
             description: Weak encryption or hashing library used to encrypt password. Use a stronger algorithm.
             level: ""

--- a/integration/flags/.snapshots/TestInitCommand-init
+++ b/integration/flags/.snapshots/TestInitCommand-init
@@ -604,7 +604,7 @@ scan:
                 policy_failure = data.bearer.application_level_encryption.policy_failure
             id: application_level_encryption_missing
             display_id: CR-021
-            name: Application level encryption missing
+            name: Force application-level encryption when processing sensitive data.
             description: Application level encryption missing. Enable application level encryption to reduce the risk of leaking sensitive data.
             level: ""
             modules:
@@ -679,7 +679,7 @@ scan:
                 policy_failure = data.bearer.leakage.policy_failure
             id: detect_rails_cookies
             display_id: CR-002
-            name: Cookie leaking
+            name: Do not store sensitive data in cookies.
             description: Cookie leaks detected. Avoid storing sensitive data in cookies.
             level: ""
             modules:
@@ -753,7 +753,7 @@ scan:
                 policy_failure = data.bearer.http_get_parameters.policy_failure
             id: ruby_http_get_detection
             display_id: CR-005
-            name: HTTP GET parameters
+            name: Do not store sensitive data in HTML5 storage
             description: Sending data as HTTP GET parameters. Avoid sending sensitive data as parameters in GET requests.
             level: ""
             modules:
@@ -827,7 +827,7 @@ scan:
                 policy_failure = data.bearer.insecure_communication.policy_failure
             id: detect_rails_insecure_communication
             display_id: CR-012
-            name: Insecure communication
+            name: Force HTTPS in applications processing sensitive data.
             description: Insecure communication in an application processing sensitive data. Ensure communication occurs over SSL.
             level: ""
             modules:
@@ -902,7 +902,7 @@ scan:
                 policy_failure = data.bearer.insecure_ftp.policy_failure
             id: detect_rails_insecure_ftp
             display_id: CR-009
-            name: Insecure FTP
+            name: Only send sensitive data to FTP connections securely.
             description: Communication with an insecure FTP server in an application processing sensitive data. Only connect to FTP securely.
             level: ""
             modules:
@@ -976,7 +976,7 @@ scan:
                 policy_failure = data.bearer.insecure_ftp_with_data_category.policy_failure
             id: insecure_ftp_with_data_category
             display_id: CR-008
-            name: Insecure FTP with Data Category
+            name: Only communicate with secure FTP connections in applications processing sensitive data.
             description: Communicating Data Category with an insecure FTP server. Only connect to FTP securely.
             level: ""
             modules:
@@ -1050,7 +1050,7 @@ scan:
                 policy_failure = data.bearer.insecure_http_get.policy_failure
             id: insecure_http_get
             display_id: CR-013
-            name: Insecure HTTP GET
+            name: Avoid unsecured HTTP connections in applications processing sensitive data.
             description: Communicating using insecure HTTP GET in an application processing sensitive data. Ensure all HTTP communication occurs over HTTPS.
             level: ""
             modules:
@@ -1124,7 +1124,7 @@ scan:
                 policy_failure = data.bearer.insecure_http_with_data_category.policy_failure
             id: insecure_http_with_data_category
             display_id: CR-015
-            name: Insecure HTTP with Data Category
+            name: Do not pass sensitive data as HTTP GET parameters.
             description: Communicating Data Category using insecure HTTP. Ensure all HTTP communication occurs over HTTPS.
             level: ""
             modules:
@@ -1212,7 +1212,7 @@ scan:
                 policy_failure = data.bearer.insecure_smtp.policy_failure
             id: detect_rails_insecure_smtp
             display_id: CR-010
-            name: Insecure SMTP
+            name: Only communicate with secure SMTP connections in applications processing sensitive data.
             description: Communication using insecure SMTP in an application processing sensitive data. Verify that SMTP settings use OpenSSL or equivalent.
             level: ""
             modules:
@@ -1286,7 +1286,7 @@ scan:
                 policy_failure = data.bearer.leakage.policy_failure
             id: detect_rails_jwt
             display_id: CR-004
-            name: JWT leaking
+            name: Do not store sensitive data in JWTs.
             description: JWT leaks detected. Avoid storing sensitive data in JWTs.
             level: ""
             modules:
@@ -1360,7 +1360,7 @@ scan:
                 policy_failure = data.bearer.leakage.policy_failure
             id: detect_ruby_logger
             display_id: CR-001
-            name: Logger leaking
+            name: Do not send sensitive data to loggers.
             description: Logger leaks detected. Avoid passing sensitive data to loggers.
             level: ""
             modules:
@@ -1434,7 +1434,7 @@ scan:
                 policy_failure = data.bearer.third_party_data_category.policy_failure
             id: detect_ruby_third_party_data_send
             display_id: CR-016
-            name: Third-party data category exposure
+            name: Ensure that no unsecured Third Parties receive sensitive data.
             description: Sending data in category to third party. Ensure data sent to third party is intended and secured.
             level: ""
             modules:
@@ -1508,7 +1508,7 @@ scan:
                 policy_failure = data.bearer.leakage.policy_failure
             id: detect_rails_session
             display_id: CR-003
-            name: Session leaking
+            name: Do not store sensitive data in the session.
             description: Session leaks detected. Avoid storing sensitive data in the session.
             level: ""
             modules:
@@ -1582,7 +1582,7 @@ scan:
                 policy_failure = data.bearer.ssl_certificate_verification_disabled.policy_failure
             id: ssl_certificate_verification_disabled
             display_id: CR-011
-            name: SSL certificate verification disabled
+            name: Enable SSL Certificate Verification in applications processing sensitive data.
             description: SSL certificate verification is disabled in an application processing sensitive data. Enable SSL certificate verification.
             level: ""
             modules:
@@ -1656,7 +1656,7 @@ scan:
                 policy_failure = data.bearer.weak_password_encryption.policy_failure
             id: detect_ruby_weak_encryption
             display_id: CR-023
-            name: Weak password encryption
+            name: Force strong password encryption in applications processing sensitive data.
             description: Weak encryption or hashing library used to encrypt password. Use a stronger algorithm.
             level: ""
             modules:

--- a/integration/flags/.snapshots/TestReportFlags-report-policies
+++ b/integration/flags/.snapshots/TestReportFlags-report-policies
@@ -1,5 +1,5 @@
 high:
-    - policy_name: Logger leaking
+    - policy_name: Do not send sensitive data to loggers.
       policy_display_id: CR-001
       policy_description: Logger leaks detected. Avoid passing sensitive data to loggers.
       line_number: 1

--- a/integration/flags/.snapshots/TestReportFlags-report-policies
+++ b/integration/flags/.snapshots/TestReportFlags-report-policies
@@ -1,5 +1,6 @@
 high:
     - policy_name: Logger leaking
+      policy_display_id: CR-001
       policy_description: Logger leaks detected. Avoid passing sensitive data to loggers.
       line_number: 1
       filename: testdata/policies/users.rb

--- a/integration/policies/.snapshots/TestPolicesWithHealthContext-logger_leaking
+++ b/integration/policies/.snapshots/TestPolicesWithHealthContext-logger_leaking
@@ -1,5 +1,5 @@
 high:
-    - policy_name: Logger leaking
+    - policy_name: Do not send sensitive data to loggers.
       policy_display_id: CR-001
       policy_description: Logger leaks detected. Avoid passing sensitive data to loggers.
       line_number: 1

--- a/integration/policies/.snapshots/TestPolicesWithHealthContext-logger_leaking
+++ b/integration/policies/.snapshots/TestPolicesWithHealthContext-logger_leaking
@@ -1,5 +1,6 @@
 high:
     - policy_name: Logger leaking
+      policy_display_id: CR-001
       policy_description: Logger leaks detected. Avoid passing sensitive data to loggers.
       line_number: 1
       filename: testdata/ruby/logger_leaking.rb

--- a/integration/policies/.snapshots/TestPolicesWithHealthContext-sending_data_in_category_to_third_party
+++ b/integration/policies/.snapshots/TestPolicesWithHealthContext-sending_data_in_category_to_third_party
@@ -1,5 +1,6 @@
 high:
     - policy_name: Third-party data category exposure
+      policy_display_id: CR-016
       policy_description: Sending data in category to third party. Ensure data sent to third party is intended and secured.
       line_number: 12
       filename: testdata/ruby/sending_data_in_category_to_third_party.rb
@@ -15,6 +16,7 @@ high:
         )
       omit_parent: false
     - policy_name: Third-party data category exposure
+      policy_display_id: CR-016
       policy_description: Sending data in category to third party. Ensure data sent to third party is intended and secured.
       line_number: 18
       filename: testdata/ruby/sending_data_in_category_to_third_party.rb
@@ -31,6 +33,7 @@ high:
         end
       omit_parent: false
     - policy_name: Third-party data category exposure
+      policy_display_id: CR-016
       policy_description: Sending data in category to third party. Ensure data sent to third party is intended and secured.
       line_number: 24
       filename: testdata/ruby/sending_data_in_category_to_third_party.rb

--- a/integration/policies/.snapshots/TestPolicesWithHealthContext-sending_data_in_category_to_third_party
+++ b/integration/policies/.snapshots/TestPolicesWithHealthContext-sending_data_in_category_to_third_party
@@ -1,5 +1,5 @@
 high:
-    - policy_name: Third-party data category exposure
+    - policy_name: Ensure that no unsecured Third Parties receive sensitive data.
       policy_display_id: CR-016
       policy_description: Sending data in category to third party. Ensure data sent to third party is intended and secured.
       line_number: 12
@@ -15,7 +15,7 @@ high:
           level: "info"
         )
       omit_parent: false
-    - policy_name: Third-party data category exposure
+    - policy_name: Ensure that no unsecured Third Parties receive sensitive data.
       policy_display_id: CR-016
       policy_description: Sending data in category to third party. Ensure data sent to third party is intended and secured.
       line_number: 18
@@ -32,7 +32,7 @@ high:
           end
         end
       omit_parent: false
-    - policy_name: Third-party data category exposure
+    - policy_name: Ensure that no unsecured Third Parties receive sensitive data.
       policy_display_id: CR-016
       policy_description: Sending data in category to third party. Ensure data sent to third party is intended and secured.
       line_number: 24

--- a/integration/policies/.snapshots/TestPolicies-application_level_encryption_missing_schema_rb
+++ b/integration/policies/.snapshots/TestPolicies-application_level_encryption_missing_schema_rb
@@ -1,5 +1,6 @@
 high:
     - policy_name: Application level encryption missing
+      policy_display_id: CR-021
       policy_description: Application level encryption missing. Enable application level encryption to reduce the risk of leaking sensitive data.
       line_number: 3
       filename: testdata/ruby/application_level_encryption_missing/schema_rb/db/schema.rb
@@ -16,6 +17,7 @@ high:
           end
       omit_parent: false
     - policy_name: Application level encryption missing
+      policy_display_id: CR-021
       policy_description: Application level encryption missing. Enable application level encryption to reduce the risk of leaking sensitive data.
       line_number: 4
       filename: testdata/ruby/application_level_encryption_missing/schema_rb/db/schema.rb
@@ -32,6 +34,7 @@ high:
           end
       omit_parent: false
     - policy_name: Application level encryption missing
+      policy_display_id: CR-021
       policy_description: Application level encryption missing. Enable application level encryption to reduce the risk of leaking sensitive data.
       line_number: 5
       filename: testdata/ruby/application_level_encryption_missing/schema_rb/db/schema.rb

--- a/integration/policies/.snapshots/TestPolicies-application_level_encryption_missing_schema_rb
+++ b/integration/policies/.snapshots/TestPolicies-application_level_encryption_missing_schema_rb
@@ -1,5 +1,5 @@
 high:
-    - policy_name: Application level encryption missing
+    - policy_name: Force application-level encryption when processing sensitive data.
       policy_display_id: CR-021
       policy_description: Application level encryption missing. Enable application level encryption to reduce the risk of leaking sensitive data.
       line_number: 3
@@ -16,7 +16,7 @@ high:
             t.datetime "updated_at", null: false
           end
       omit_parent: false
-    - policy_name: Application level encryption missing
+    - policy_name: Force application-level encryption when processing sensitive data.
       policy_display_id: CR-021
       policy_description: Application level encryption missing. Enable application level encryption to reduce the risk of leaking sensitive data.
       line_number: 4
@@ -33,7 +33,7 @@ high:
             t.datetime "updated_at", null: false
           end
       omit_parent: false
-    - policy_name: Application level encryption missing
+    - policy_name: Force application-level encryption when processing sensitive data.
       policy_display_id: CR-021
       policy_description: Application level encryption missing. Enable application level encryption to reduce the risk of leaking sensitive data.
       line_number: 5

--- a/integration/policies/.snapshots/TestPolicies-application_level_encryption_missing_structure_sql
+++ b/integration/policies/.snapshots/TestPolicies-application_level_encryption_missing_structure_sql
@@ -1,5 +1,5 @@
 high:
-    - policy_name: Application level encryption missing
+    - policy_name: Force application-level encryption when processing sensitive data.
       policy_display_id: CR-021
       policy_description: Application level encryption missing. Enable application level encryption to reduce the risk of leaking sensitive data.
       line_number: 3
@@ -17,7 +17,7 @@ high:
           email character varying DEFAULT ''::character varying NOT NULL
         )
       omit_parent: false
-    - policy_name: Application level encryption missing
+    - policy_name: Force application-level encryption when processing sensitive data.
       policy_display_id: CR-021
       policy_description: Application level encryption missing. Enable application level encryption to reduce the risk of leaking sensitive data.
       line_number: 4

--- a/integration/policies/.snapshots/TestPolicies-application_level_encryption_missing_structure_sql
+++ b/integration/policies/.snapshots/TestPolicies-application_level_encryption_missing_structure_sql
@@ -1,5 +1,6 @@
 high:
     - policy_name: Application level encryption missing
+      policy_display_id: CR-021
       policy_description: Application level encryption missing. Enable application level encryption to reduce the risk of leaking sensitive data.
       line_number: 3
       filename: testdata/ruby/application_level_encryption_missing/structure_sql/db/structure.sql
@@ -17,6 +18,7 @@ high:
         )
       omit_parent: false
     - policy_name: Application level encryption missing
+      policy_display_id: CR-021
       policy_description: Application level encryption missing. Enable application level encryption to reduce the risk of leaking sensitive data.
       line_number: 4
       filename: testdata/ruby/application_level_encryption_missing/structure_sql/db/structure.sql

--- a/integration/policies/.snapshots/TestPolicies-insecure_ftp
+++ b/integration/policies/.snapshots/TestPolicies-insecure_ftp
@@ -1,5 +1,6 @@
 critical:
     - policy_name: Insecure FTP with Data Category
+      policy_display_id: CR-008
       policy_description: Communicating Data Category with an insecure FTP server. Only connect to FTP securely.
       line_number: 27
       filename: testdata/ruby/insecure_ftp.rb
@@ -22,6 +23,7 @@ critical:
       omit_parent: false
 medium:
     - policy_name: Insecure FTP
+      policy_display_id: CR-009
       policy_description: Communication with an insecure FTP server in an application processing sensitive data. Only connect to FTP securely.
       line_number: 10
       filename: testdata/ruby/insecure_ftp.rb
@@ -32,6 +34,7 @@ medium:
       parent_content: Net::FTP.new("ftp.ruby-lang.org")
       omit_parent: false
     - policy_name: Insecure FTP
+      policy_display_id: CR-009
       policy_description: Communication with an insecure FTP server in an application processing sensitive data. Only connect to FTP securely.
       line_number: 17
       filename: testdata/ruby/insecure_ftp.rb
@@ -48,6 +51,7 @@ medium:
         end
       omit_parent: false
     - policy_name: Insecure FTP
+      policy_display_id: CR-009
       policy_description: Communication with an insecure FTP server in an application processing sensitive data. Only connect to FTP securely.
       line_number: 24
       filename: testdata/ruby/insecure_ftp.rb

--- a/integration/policies/.snapshots/TestPolicies-insecure_ftp
+++ b/integration/policies/.snapshots/TestPolicies-insecure_ftp
@@ -1,5 +1,5 @@
 critical:
-    - policy_name: Insecure FTP with Data Category
+    - policy_name: Only communicate with secure FTP connections in applications processing sensitive data.
       policy_display_id: CR-008
       policy_description: Communicating Data Category with an insecure FTP server. Only connect to FTP securely.
       line_number: 27
@@ -22,7 +22,7 @@ critical:
         end
       omit_parent: false
 medium:
-    - policy_name: Insecure FTP
+    - policy_name: Only send sensitive data to FTP connections securely.
       policy_display_id: CR-009
       policy_description: Communication with an insecure FTP server in an application processing sensitive data. Only connect to FTP securely.
       line_number: 10
@@ -33,7 +33,7 @@ medium:
       parent_line_number: 10
       parent_content: Net::FTP.new("ftp.ruby-lang.org")
       omit_parent: false
-    - policy_name: Insecure FTP
+    - policy_name: Only send sensitive data to FTP connections securely.
       policy_display_id: CR-009
       policy_description: Communication with an insecure FTP server in an application processing sensitive data. Only connect to FTP securely.
       line_number: 17
@@ -50,7 +50,7 @@ medium:
           ftp.getbinaryfile('nif.rb-0.91.gz', 'nif.gz', 1024)
         end
       omit_parent: false
-    - policy_name: Insecure FTP
+    - policy_name: Only send sensitive data to FTP connections securely.
       policy_display_id: CR-009
       policy_description: Communication with an insecure FTP server in an application processing sensitive data. Only connect to FTP securely.
       line_number: 24

--- a/integration/policies/.snapshots/TestPolicies-insecure_smtp
+++ b/integration/policies/.snapshots/TestPolicies-insecure_smtp
@@ -1,5 +1,5 @@
 medium:
-    - policy_name: Insecure SMTP
+    - policy_name: Only communicate with secure SMTP connections in applications processing sensitive data.
       policy_display_id: CR-010
       policy_description: Communication using insecure SMTP in an application processing sensitive data. Verify that SMTP settings use OpenSSL or equivalent.
       line_number: 8
@@ -14,7 +14,7 @@ medium:
           }
         end
       omit_parent: false
-    - policy_name: Insecure SMTP
+    - policy_name: Only communicate with secure SMTP connections in applications processing sensitive data.
       policy_display_id: CR-010
       policy_description: Communication using insecure SMTP in an application processing sensitive data. Verify that SMTP settings use OpenSSL or equivalent.
       line_number: 14

--- a/integration/policies/.snapshots/TestPolicies-insecure_smtp
+++ b/integration/policies/.snapshots/TestPolicies-insecure_smtp
@@ -1,5 +1,6 @@
 medium:
     - policy_name: Insecure SMTP
+      policy_display_id: CR-010
       policy_description: Communication using insecure SMTP in an application processing sensitive data. Verify that SMTP settings use OpenSSL or equivalent.
       line_number: 8
       filename: testdata/ruby/insecure_smtp.rb
@@ -14,6 +15,7 @@ medium:
         end
       omit_parent: false
     - policy_name: Insecure SMTP
+      policy_display_id: CR-010
       policy_description: Communication using insecure SMTP in an application processing sensitive data. Verify that SMTP settings use OpenSSL or equivalent.
       line_number: 14
       filename: testdata/ruby/insecure_smtp.rb

--- a/integration/policies/.snapshots/TestPolicies-logger_leaking
+++ b/integration/policies/.snapshots/TestPolicies-logger_leaking
@@ -1,5 +1,5 @@
 high:
-    - policy_name: Logger leaking
+    - policy_name: Do not send sensitive data to loggers.
       policy_display_id: CR-001
       policy_description: Logger leaks detected. Avoid passing sensitive data to loggers.
       line_number: 1

--- a/integration/policies/.snapshots/TestPolicies-logger_leaking
+++ b/integration/policies/.snapshots/TestPolicies-logger_leaking
@@ -1,5 +1,6 @@
 high:
     - policy_name: Logger leaking
+      policy_display_id: CR-001
       policy_description: Logger leaks detected. Avoid passing sensitive data to loggers.
       line_number: 1
       filename: testdata/ruby/logger_leaking.rb

--- a/integration/policies/.snapshots/TestPolicies-ruby_weak_password_encryption
+++ b/integration/policies/.snapshots/TestPolicies-ruby_weak_password_encryption
@@ -1,5 +1,5 @@
 high:
-    - policy_name: Weak password encryption
+    - policy_name: Force strong password encryption in applications processing sensitive data.
       policy_display_id: CR-023
       policy_description: Weak encryption or hashing library used to encrypt password. Use a stronger algorithm.
       line_number: 1
@@ -9,7 +9,7 @@ high:
       parent_line_number: 1
       parent_content: Digest::SHA1.hexidigest(user.password)
       omit_parent: false
-    - policy_name: Weak password encryption
+    - policy_name: Force strong password encryption in applications processing sensitive data.
       policy_display_id: CR-023
       policy_description: Weak encryption or hashing library used to encrypt password. Use a stronger algorithm.
       line_number: 2
@@ -19,7 +19,7 @@ high:
       parent_line_number: 2
       parent_content: Digest::MD5.hexdigest(user.password)
       omit_parent: false
-    - policy_name: Weak password encryption
+    - policy_name: Force strong password encryption in applications processing sensitive data.
       policy_display_id: CR-023
       policy_description: Weak encryption or hashing library used to encrypt password. Use a stronger algorithm.
       line_number: 4
@@ -29,7 +29,7 @@ high:
       parent_line_number: 4
       parent_content: RC4.new("insecure").encrypt(user.password)
       omit_parent: false
-    - policy_name: Weak password encryption
+    - policy_name: Force strong password encryption in applications processing sensitive data.
       policy_display_id: CR-023
       policy_description: Weak encryption or hashing library used to encrypt password. Use a stronger algorithm.
       line_number: 11
@@ -39,7 +39,7 @@ high:
       parent_line_number: 11
       parent_content: dsa_encrypt.export(cipher, customer.password)
       omit_parent: false
-    - policy_name: Weak password encryption
+    - policy_name: Force strong password encryption in applications processing sensitive data.
       policy_display_id: CR-023
       policy_description: Weak encryption or hashing library used to encrypt password. Use a stronger algorithm.
       line_number: 13
@@ -49,7 +49,7 @@ high:
       parent_line_number: 13
       parent_content: OpenSSL::PKey::RSA.new(2048).to_pem(cipher, customer.password)
       omit_parent: false
-    - policy_name: Weak password encryption
+    - policy_name: Force strong password encryption in applications processing sensitive data.
       policy_display_id: CR-023
       policy_description: Weak encryption or hashing library used to encrypt password. Use a stronger algorithm.
       line_number: 16

--- a/integration/policies/.snapshots/TestPolicies-ruby_weak_password_encryption
+++ b/integration/policies/.snapshots/TestPolicies-ruby_weak_password_encryption
@@ -1,5 +1,6 @@
 high:
     - policy_name: Weak password encryption
+      policy_display_id: CR-023
       policy_description: Weak encryption or hashing library used to encrypt password. Use a stronger algorithm.
       line_number: 1
       filename: testdata/ruby/weak_password_encryption.rb
@@ -9,6 +10,7 @@ high:
       parent_content: Digest::SHA1.hexidigest(user.password)
       omit_parent: false
     - policy_name: Weak password encryption
+      policy_display_id: CR-023
       policy_description: Weak encryption or hashing library used to encrypt password. Use a stronger algorithm.
       line_number: 2
       filename: testdata/ruby/weak_password_encryption.rb
@@ -18,6 +20,7 @@ high:
       parent_content: Digest::MD5.hexdigest(user.password)
       omit_parent: false
     - policy_name: Weak password encryption
+      policy_display_id: CR-023
       policy_description: Weak encryption or hashing library used to encrypt password. Use a stronger algorithm.
       line_number: 4
       filename: testdata/ruby/weak_password_encryption.rb
@@ -27,6 +30,7 @@ high:
       parent_content: RC4.new("insecure").encrypt(user.password)
       omit_parent: false
     - policy_name: Weak password encryption
+      policy_display_id: CR-023
       policy_description: Weak encryption or hashing library used to encrypt password. Use a stronger algorithm.
       line_number: 11
       filename: testdata/ruby/weak_password_encryption.rb
@@ -36,6 +40,7 @@ high:
       parent_content: dsa_encrypt.export(cipher, customer.password)
       omit_parent: false
     - policy_name: Weak password encryption
+      policy_display_id: CR-023
       policy_description: Weak encryption or hashing library used to encrypt password. Use a stronger algorithm.
       line_number: 13
       filename: testdata/ruby/weak_password_encryption.rb
@@ -45,6 +50,7 @@ high:
       parent_content: OpenSSL::PKey::RSA.new(2048).to_pem(cipher, customer.password)
       omit_parent: false
     - policy_name: Weak password encryption
+      policy_display_id: CR-023
       policy_description: Weak encryption or hashing library used to encrypt password. Use a stronger algorithm.
       line_number: 16
       filename: testdata/ruby/weak_password_encryption.rb

--- a/integration/policies/.snapshots/TestPolicies-sending_data_in_category_to_third_party
+++ b/integration/policies/.snapshots/TestPolicies-sending_data_in_category_to_third_party
@@ -1,5 +1,5 @@
 high:
-    - policy_name: Third-party data category exposure
+    - policy_name: Ensure that no unsecured Third Parties receive sensitive data.
       policy_display_id: CR-016
       policy_description: Sending data in category to third party. Ensure data sent to third party is intended and secured.
       line_number: 12
@@ -14,7 +14,7 @@ high:
           level: "info"
         )
       omit_parent: false
-    - policy_name: Third-party data category exposure
+    - policy_name: Ensure that no unsecured Third Parties receive sensitive data.
       policy_display_id: CR-016
       policy_description: Sending data in category to third party. Ensure data sent to third party is intended and secured.
       line_number: 18
@@ -30,7 +30,7 @@ high:
           end
         end
       omit_parent: false
-    - policy_name: Third-party data category exposure
+    - policy_name: Ensure that no unsecured Third Parties receive sensitive data.
       policy_display_id: CR-016
       policy_description: Sending data in category to third party. Ensure data sent to third party is intended and secured.
       line_number: 24

--- a/integration/policies/.snapshots/TestPolicies-sending_data_in_category_to_third_party
+++ b/integration/policies/.snapshots/TestPolicies-sending_data_in_category_to_third_party
@@ -1,5 +1,6 @@
 high:
     - policy_name: Third-party data category exposure
+      policy_display_id: CR-016
       policy_description: Sending data in category to third party. Ensure data sent to third party is intended and secured.
       line_number: 12
       filename: testdata/ruby/sending_data_in_category_to_third_party.rb
@@ -14,6 +15,7 @@ high:
         )
       omit_parent: false
     - policy_name: Third-party data category exposure
+      policy_display_id: CR-016
       policy_description: Sending data in category to third party. Ensure data sent to third party is intended and secured.
       line_number: 18
       filename: testdata/ruby/sending_data_in_category_to_third_party.rb
@@ -29,6 +31,7 @@ high:
         end
       omit_parent: false
     - policy_name: Third-party data category exposure
+      policy_display_id: CR-016
       policy_description: Sending data in category to third party. Ensure data sent to third party is intended and secured.
       line_number: 24
       filename: testdata/ruby/sending_data_in_category_to_third_party.rb

--- a/pkg/commands/process/settings/policies.yml
+++ b/pkg/commands/process/settings/policies.yml
@@ -1,6 +1,6 @@
 logger_leaks:
   description: "Logger leaks detected. Avoid passing sensitive data to loggers."
-  name: "Logger leaking"
+  name: "Do not send sensitive data to loggers."
   display_id: "CR-001"
   id: "detect_ruby_logger"
   query: |
@@ -12,7 +12,7 @@ logger_leaks:
       name: bearer.leakage
 session_leaks:
   description: "Session leaks detected. Avoid storing sensitive data in the session."
-  name: "Session leaking"
+  name: "Do not store sensitive data in the session."
   display_id: "CR-003"
   id: "detect_rails_session"
   query: |
@@ -24,7 +24,7 @@ session_leaks:
       name: bearer.leakage
 jwt_leaks:
   description: "JWT leaks detected. Avoid storing sensitive data in JWTs."
-  name: "JWT leaking"
+  name: "Do not store sensitive data in JWTs."
   display_id: "CR-004"
   id: "detect_rails_jwt"
   query: |
@@ -36,7 +36,7 @@ jwt_leaks:
       name: bearer.leakage
 cookie_leaks:
   description: "Cookie leaks detected. Avoid storing sensitive data in cookies."
-  name: "Cookie leaking"
+  name: "Do not store sensitive data in cookies."
   display_id: "CR-002"
   id: "detect_rails_cookies"
   query: |
@@ -48,7 +48,7 @@ cookie_leaks:
       name: bearer.leakage
 ssl_certificate_verification_disabled:
   description: "SSL certificate verification is disabled in an application processing sensitive data. Enable SSL certificate verification."
-  name: "SSL certificate verification disabled"
+  name: "Enable SSL Certificate Verification in applications processing sensitive data."
   display_id: "CR-011"
   id: "ssl_certificate_verification_disabled"
   query: |
@@ -60,7 +60,7 @@ ssl_certificate_verification_disabled:
       name: bearer.ssl_certificate_verification_disabled
 application_level_encryption_missing:
   description: "Application level encryption missing. Enable application level encryption to reduce the risk of leaking sensitive data."
-  name: "Application level encryption missing"
+  name: "Force application-level encryption when processing sensitive data."
   display_id: "CR-021"
   id: "application_level_encryption_missing"
   query: |
@@ -72,7 +72,7 @@ application_level_encryption_missing:
       name: bearer.application_level_encryption
 insecure_smtp_processing_sensitive_data:
   description: "Communication using insecure SMTP in an application processing sensitive data. Verify that SMTP settings use OpenSSL or equivalent."
-  name: "Insecure SMTP"
+  name: "Only communicate with secure SMTP connections in applications processing sensitive data."
   display_id: "CR-010"
   id: "detect_rails_insecure_smtp"
   query: |
@@ -84,7 +84,7 @@ insecure_smtp_processing_sensitive_data:
       name: bearer.insecure_smtp
 http_get_parameters:
   description: "Sending data as HTTP GET parameters. Avoid sending sensitive data as parameters in GET requests."
-  name: "HTTP GET parameters"
+  name: "Do not store sensitive data in HTML5 storage"
   display_id: "CR-005"
   id: "ruby_http_get_detection"
   query: |
@@ -96,7 +96,7 @@ http_get_parameters:
       name: bearer.http_get_parameters
 insecure_communication_processing_sensitive_data:
   description: "Insecure communication in an application processing sensitive data. Ensure communication occurs over SSL."
-  name: "Insecure communication"
+  name: "Force HTTPS in applications processing sensitive data."
   display_id: "CR-012"
   id: "detect_rails_insecure_communication"
   query: |
@@ -108,7 +108,7 @@ insecure_communication_processing_sensitive_data:
       name: bearer.insecure_communication
 insecure_ftp_processing_sensitive_data:
   description: "Communication with an insecure FTP server in an application processing sensitive data. Only connect to FTP securely."
-  name: "Insecure FTP"
+  name: "Only send sensitive data to FTP connections securely."
   display_id: "CR-009"
   id: "detect_rails_insecure_ftp"
   query: |
@@ -120,7 +120,7 @@ insecure_ftp_processing_sensitive_data:
       name: bearer.insecure_ftp
 insecure_ftp_with_data_category:
   description: "Communicating Data Category with an insecure FTP server. Only connect to FTP securely."
-  name: "Insecure FTP with Data Category"
+  name: "Only communicate with secure FTP connections in applications processing sensitive data."
   display_id: "CR-008"
   id: insecure_ftp_with_data_category
   query: |
@@ -132,7 +132,7 @@ insecure_ftp_with_data_category:
       name: bearer.insecure_ftp_with_data_category
 insecure_http_get:
   description: "Communicating using insecure HTTP GET in an application processing sensitive data. Ensure all HTTP communication occurs over HTTPS."
-  name: "Insecure HTTP GET"
+  name: "Avoid unsecured HTTP connections in applications processing sensitive data."
   display_id: "CR-013"
   id: insecure_http_get
   query: |
@@ -144,7 +144,7 @@ insecure_http_get:
       name: bearer.insecure_http_get
 insecure_http_with_data_category:
   description: "Communicating Data Category using insecure HTTP. Ensure all HTTP communication occurs over HTTPS."
-  name: "Insecure HTTP with Data Category"
+  name: "Do not pass sensitive data as HTTP GET parameters."
   display_id: "CR-015"
   id: insecure_http_with_data_category
   query: |
@@ -156,7 +156,7 @@ insecure_http_with_data_category:
       name: bearer.insecure_http_with_data_category
 sending_data_in_category_to_third_party:
   description: "Sending data in category to third party. Ensure data sent to third party is intended and secured."
-  name: "Third-party data category exposure"
+  name: "Ensure that no unsecured Third Parties receive sensitive data."
   display_id: "CR-016"
   id: "detect_ruby_third_party_data_send"
   query: |
@@ -168,7 +168,7 @@ sending_data_in_category_to_third_party:
       name: bearer.third_party_data_category
 weak_password_encryption:
   description: "Weak encryption or hashing library used to encrypt password. Use a stronger algorithm."
-  name: "Weak password encryption"
+  name: "Force strong password encryption in applications processing sensitive data."
   display_id: "CR-023"
   id: "detect_ruby_weak_encryption"
   query: |

--- a/pkg/commands/process/settings/policies.yml
+++ b/pkg/commands/process/settings/policies.yml
@@ -1,6 +1,7 @@
 logger_leaks:
   description: "Logger leaks detected. Avoid passing sensitive data to loggers."
   name: "Logger leaking"
+  display_id: "CR-001"
   id: "detect_ruby_logger"
   query: |
     policy_failure = data.bearer.leakage.policy_failure
@@ -12,6 +13,7 @@ logger_leaks:
 session_leaks:
   description: "Session leaks detected. Avoid storing sensitive data in the session."
   name: "Session leaking"
+  display_id: "CR-003"
   id: "detect_rails_session"
   query: |
     policy_failure = data.bearer.leakage.policy_failure
@@ -23,6 +25,7 @@ session_leaks:
 jwt_leaks:
   description: "JWT leaks detected. Avoid storing sensitive data in JWTs."
   name: "JWT leaking"
+  display_id: "CR-004"
   id: "detect_rails_jwt"
   query: |
     policy_failure = data.bearer.leakage.policy_failure
@@ -34,6 +37,7 @@ jwt_leaks:
 cookie_leaks:
   description: "Cookie leaks detected. Avoid storing sensitive data in cookies."
   name: "Cookie leaking"
+  display_id: "CR-002"
   id: "detect_rails_cookies"
   query: |
     policy_failure = data.bearer.leakage.policy_failure
@@ -45,6 +49,7 @@ cookie_leaks:
 ssl_certificate_verification_disabled:
   description: "SSL certificate verification is disabled in an application processing sensitive data. Enable SSL certificate verification."
   name: "SSL certificate verification disabled"
+  display_id: "CR-011"
   id: "ssl_certificate_verification_disabled"
   query: |
     policy_failure = data.bearer.ssl_certificate_verification_disabled.policy_failure
@@ -56,6 +61,7 @@ ssl_certificate_verification_disabled:
 application_level_encryption_missing:
   description: "Application level encryption missing. Enable application level encryption to reduce the risk of leaking sensitive data."
   name: "Application level encryption missing"
+  display_id: "CR-021"
   id: "application_level_encryption_missing"
   query: |
     policy_failure = data.bearer.application_level_encryption.policy_failure
@@ -67,6 +73,7 @@ application_level_encryption_missing:
 insecure_smtp_processing_sensitive_data:
   description: "Communication using insecure SMTP in an application processing sensitive data. Verify that SMTP settings use OpenSSL or equivalent."
   name: "Insecure SMTP"
+  display_id: "CR-010"
   id: "detect_rails_insecure_smtp"
   query: |
     policy_failure = data.bearer.insecure_smtp.policy_failure
@@ -78,6 +85,7 @@ insecure_smtp_processing_sensitive_data:
 http_get_parameters:
   description: "Sending data as HTTP GET parameters. Avoid sending sensitive data as parameters in GET requests."
   name: "HTTP GET parameters"
+  display_id: "CR-005"
   id: "ruby_http_get_detection"
   query: |
     policy_failure = data.bearer.http_get_parameters.policy_failure
@@ -89,6 +97,7 @@ http_get_parameters:
 insecure_communication_processing_sensitive_data:
   description: "Insecure communication in an application processing sensitive data. Ensure communication occurs over SSL."
   name: "Insecure communication"
+  display_id: "CR-012"
   id: "detect_rails_insecure_communication"
   query: |
     policy_failure = data.bearer.insecure_communication.policy_failure
@@ -100,6 +109,7 @@ insecure_communication_processing_sensitive_data:
 insecure_ftp_processing_sensitive_data:
   description: "Communication with an insecure FTP server in an application processing sensitive data. Only connect to FTP securely."
   name: "Insecure FTP"
+  display_id: "CR-009"
   id: "detect_rails_insecure_ftp"
   query: |
     policy_failure = data.bearer.insecure_ftp.policy_failure
@@ -111,6 +121,7 @@ insecure_ftp_processing_sensitive_data:
 insecure_ftp_with_data_category:
   description: "Communicating Data Category with an insecure FTP server. Only connect to FTP securely."
   name: "Insecure FTP with Data Category"
+  display_id: "CR-008"
   id: insecure_ftp_with_data_category
   query: |
     policy_failure = data.bearer.insecure_ftp_with_data_category.policy_failure
@@ -122,6 +133,7 @@ insecure_ftp_with_data_category:
 insecure_http_get:
   description: "Communicating using insecure HTTP GET in an application processing sensitive data. Ensure all HTTP communication occurs over HTTPS."
   name: "Insecure HTTP GET"
+  display_id: "CR-013"
   id: insecure_http_get
   query: |
     policy_failure = data.bearer.insecure_http_get.policy_failure
@@ -133,6 +145,7 @@ insecure_http_get:
 insecure_http_with_data_category:
   description: "Communicating Data Category using insecure HTTP. Ensure all HTTP communication occurs over HTTPS."
   name: "Insecure HTTP with Data Category"
+  display_id: "CR-015"
   id: insecure_http_with_data_category
   query: |
     policy_failure = data.bearer.insecure_http_with_data_category.policy_failure
@@ -144,6 +157,7 @@ insecure_http_with_data_category:
 sending_data_in_category_to_third_party:
   description: "Sending data in category to third party. Ensure data sent to third party is intended and secured."
   name: "Third-party data category exposure"
+  display_id: "CR-016"
   id: "detect_ruby_third_party_data_send"
   query: |
     policy_failure = data.bearer.third_party_data_category.policy_failure
@@ -155,6 +169,7 @@ sending_data_in_category_to_third_party:
 weak_password_encryption:
   description: "Weak encryption or hashing library used to encrypt password. Use a stronger algorithm."
   name: "Weak password encryption"
+  display_id: "CR-023"
   id: "detect_ruby_weak_encryption"
   query: |
     policy_failure = data.bearer.weak_password_encryption.policy_failure

--- a/pkg/commands/process/settings/settings.go
+++ b/pkg/commands/process/settings/settings.go
@@ -33,6 +33,7 @@ type Modules []*PolicyModule
 type Policy struct {
 	Query       string      `mapstructure:"query" json:"query" yaml:"query"`
 	Id          string      `mapstructure:"id" json:"id" yaml:"id"`
+	DisplayId   string      `mapstructure:"display_id" json:"display_id" yaml:"display_id"`
 	Name        string      `mapstructure:"name" json:"name" yaml:"name"`
 	Description string      `mapstructure:"description" json:"description" yaml:"description"`
 	Level       PolicyLevel `mapstructure:"level" json:"level" yaml:"level"`

--- a/pkg/report/output/policies/policies.go
+++ b/pkg/report/output/policies/policies.go
@@ -158,11 +158,11 @@ func BuildReportString(policyResults map[string][]PolicyResult, policies map[str
 
 func writePolicyListToString(reportStr *strings.Builder, policies map[string]*settings.Policy) {
 	// list policies that were run
-	reportStr.WriteString("\nPolicy list: \n\n")
+	reportStr.WriteString("\nPolicy checks: \n\n")
 	policyList := []string{}
 	for key := range policies {
 		policy := policies[key]
-		policyList = append(policyList, color.HiBlackString("- "+policy.DisplayId+" "+policy.Name+"\n"))
+		policyList = append(policyList, color.HiBlackString("- "+policy.Name+" ["+policy.DisplayId+"]\n"))
 	}
 
 	sort.Strings(policyList)
@@ -192,9 +192,7 @@ func writeSummaryToString(
 	totalCount := criticalCount + highCount + mediumCount + lowCount
 
 	reportStr.WriteString("\n\n")
-	reportStr.WriteString(color.RedString("Policy failures detected\n\n"))
-	reportStr.WriteString(fmt.Sprint(policyCount) + " policies were run ")
-	reportStr.WriteString("and " + fmt.Sprint(totalCount) + " failures were detected.\n\n")
+	reportStr.WriteString(color.RedString(fmt.Sprint(policyCount) + " policies, " + fmt.Sprint(totalCount) + " failures\n\n"))
 
 	// critical count
 	reportStr.WriteString(formatSeverity(settings.LevelCritical) + fmt.Sprint(criticalCount))
@@ -225,14 +223,15 @@ func writeSummaryToString(
 		reportStr.WriteString(" (" + strings.Join(policyIds, ", ") + ")")
 	}
 
-	reportStr.WriteString("\n\n")
+	reportStr.WriteString("\n")
 }
 
 func writePolicyFailureToString(reportStr *strings.Builder, policyFailure PolicyResult, policySeverity string) {
 	reportStr.WriteString("\n\n")
 	reportStr.WriteString(formatSeverity(policySeverity))
-	reportStr.WriteString(policyFailure.PolicyName + "\n\n")
-	reportStr.WriteString(color.HiBlackString("https://curio.sh/reference/policies/" + policyFailure.PolicyDisplayId + "\n"))
+	reportStr.WriteString(policyFailure.PolicyName + " [" + policyFailure.PolicyDisplayId + "]" + "\n")
+	reportStr.WriteString(color.HiBlackString("https://curio.sh/reference/policies\n"))
+	// reportStr.WriteString(color.HiBlackString("https://curio.sh/reference/policies/#" + policyFailure.PolicyDisplayId + "\n"))
 	reportStr.WriteString("\n")
 	reportStr.WriteString(color.HiBlueString("File: " + underline(policyFailure.Filename+":"+fmt.Sprint(policyFailure.LineNumber)) + "\n"))
 

--- a/pkg/report/output/policies/policies.go
+++ b/pkg/report/output/policies/policies.go
@@ -231,8 +231,8 @@ func writeSummaryToString(
 func writePolicyFailureToString(reportStr *strings.Builder, policyFailure PolicyResult, policySeverity string) {
 	reportStr.WriteString("\n\n")
 	reportStr.WriteString(formatSeverity(policySeverity))
-	reportStr.WriteString(policyFailure.PolicyName + " policy failure with " + strings.Join(policyFailure.CategoryGroups, ", ") + "\n")
-	reportStr.WriteString(color.HiBlackString(policyFailure.PolicyDescription + "\n"))
+	reportStr.WriteString(policyFailure.PolicyName + "\n\n")
+	reportStr.WriteString(color.HiBlackString("https://curio.sh/reference/policies/" + policyFailure.PolicyDisplayId + "\n"))
 	reportStr.WriteString("\n")
 	reportStr.WriteString(color.HiBlueString("File: " + underline(policyFailure.Filename+":"+fmt.Sprint(policyFailure.LineNumber)) + "\n"))
 


### PR DESCRIPTION
## Description
* Add "display id" to policies
* Show display id in policy failure list (and not policy name)
* Include display id in policy listing at top of report

Example # 1 
![Screenshot 2022-12-14 at 12 52 48](https://user-images.githubusercontent.com/4560746/207577679-4127fcfc-5a42-4c0b-93b6-05f8b4eee72f.png)

Example # 2 - with multiple failures (ordering)

![Screenshot 2022-12-14 at 12 53 49](https://user-images.githubusercontent.com/4560746/207577730-e2bac7ac-38b7-4b58-a557-b98b3ae01fc0.png)


<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
