### PR TITLE
docs: update policy names, descriptions, doc output, and fix IDs

### DIFF
--- a/docs/_data/policies.js
+++ b/docs/_data/policies.js
@@ -1,10 +1,23 @@
 const { readFile } = require("node:fs/promises");
 const yaml = require("js-yaml");
 
+function convertAndSort(obj) {
+  let list = [];
+  for (key in obj) {
+    if (obj.hasOwnProperty(key)) {
+      list.push({
+        ...obj[key],
+      });
+    }
+  }
+  return list.sort((a, b) => (a.display_id > b.display_id ? 1 : -1));
+}
+
 async function fetchFile(location) {
-  return readFile(location, { encoding: "utf8" }).then((file) =>
-    yaml.load(file)
-  );
+  return readFile(location, { encoding: "utf8" }).then((file) => {
+    let out = yaml.load(file);
+    return convertAndSort(out);
+  });
 }
 
 module.exports = async function () {

--- a/docs/reference/policies.njk
+++ b/docs/reference/policies.njk
@@ -12,7 +12,16 @@ Polices are ways to enforce data security best practices across your codebase. C
 Curio includes the following policies by default.
 {% endrenderTemplate %}
 
-{% for key, group in policies %}
-  <h2 id="{{group.name | slugify}}">{{group.name}}</h2>
-  <p>{{group.description}}</p>
+{% for policy in policies %}
+  <h2 id="{{policy.display_id | slugify}}">{{policy.display_id}}: {{policy.name}}</h2>
+  <h3>Description</h3>
+  <p>{{policy.description}}</p>
+  <h3>{{policy.display_id}} configuration files</h3>
+  <ul>
+    {% for item in policy.modules %}
+      <li>
+        <a href="https://github.com/Bearer/curio/tree/main/pkg/commands/process/settings/{{item.path}}">{{item.path}}</a>
+      </li>
+    {% endfor %}
+  </ul>
 {% endfor %}

--- a/integration/flags/.snapshots/TestInitCommand-init
+++ b/integration/flags/.snapshots/TestInitCommand-init
@@ -689,7 +689,7 @@ scan:
             id: application_level_encryption_missing
             display_id: CR-021
             name: Force application-level encryption when processing sensitive data.
-            description: Application-level encryption reduces that applications processing sensitive data can leak viewable data. This policy checks that sensitive data types in records are encrypted.
+            description: Application-level encryption greatly reduces the risk of a data breach or data leak by making data unreadable. This policy checks if sensitive data types found in records are encrypted.
             level: ""
             modules:
                 - path: policies/common.rego
@@ -838,7 +838,7 @@ scan:
             id: ruby_http_get_detection
             display_id: CR-015
             name: Do not send sensitive data as HTTP GET parameters.
-            description: Sensitive data should never be sent as part of the query string in HTTP get requests. This policy checks if sensitive data types are sent as GET parameters.
+            description: Sensitive data should never be sent as part of the query string in HTTP GET requests. This policy checks if sensitive data types are sent as GET parameters.
             level: ""
             modules:
                 - path: policies/common.rego
@@ -986,8 +986,8 @@ scan:
                 policy_failure = data.bearer.insecure_ftp.policy_failure
             id: detect_rails_insecure_ftp
             display_id: CR-008
-            name: Only communicate with secure FTP connections.
-            description: Communication with FTP servers should be done securely in applications that process sensitive data. This policy checks if FTP connections are made securely.
+            name: Only communicate using SFTP connections.
+            description: Communication with FTP servers should be done securely over SFTP in applications that process sensitive data. This policy checks if all FTP connections are made using SFTP.
             level: ""
             modules:
                 - path: policies/common.rego
@@ -1060,8 +1060,8 @@ scan:
                 policy_failure = data.bearer.insecure_ftp_with_data_category.policy_failure
             id: insecure_ftp_with_data_category
             display_id: CR-009
-            name: Only send sensitive data to secure FTP connections.
-            description: Files containing sensitive data should only be sent to secure FTP connections. This policy checks if files created using sensitive data are sent to unsecure FTP connections.
+            name: Only send sensitive data using SFTP connections.
+            description: Files containing sensitive data should only be sent via SFTP connections. This policy checks if files created using sensitive data are sent to over SFTP connections.
             level: ""
             modules:
                 - path: policies/common.rego
@@ -1134,8 +1134,8 @@ scan:
                 policy_failure = data.bearer.insecure_http_get.policy_failure
             id: insecure_http_get
             display_id: CR-013
-            name: Only communicate with secure HTTP connections.
-            description: Applications processing sensitive data should only connect to secure HTTP connections. This policy checks for unsecured HTTP connections.
+            name: Only communicate using HTTPS connections.
+            description: Applications processing sensitive data should only connect using HTTPS connections. This policy checks that all HTTP connections use HTTPS.
             level: ""
             modules:
                 - path: policies/common.rego
@@ -1209,7 +1209,7 @@ scan:
             id: insecure_http_with_data_category
             display_id: CR-014
             name: Only send sensitive data through HTTPS connections.
-            description: Sensitive data sent through HTTP should only be done securely. This policy checks that any transmissions over HTTP that contain sensitive data do so over HTTPS.
+            description: Sensitive data should only be sent through HTTPS. This policy checks that any transmissions over HTTP that contain sensitive data do so over HTTPS.
             level: ""
             modules:
                 - path: policies/common.rego
@@ -1297,7 +1297,7 @@ scan:
             id: detect_rails_insecure_smtp
             display_id: CR-010
             name: Only communicate with secure SMTP connections.
-            description: Secure connections to SMTP help prevent unauthorized actors from viewing transmitted data. This policy checks if SMTP mailer settings are set to only allow secure connections.
+            description: Secure connections using SMTP help prevent unauthorized actors from viewing transmitted data. This policy checks if SMTP mailer settings are set to only allow secure connections.
             level: ""
             modules:
                 - path: policies/common.rego
@@ -1445,7 +1445,7 @@ scan:
             id: detect_ruby_logger
             display_id: CR-001
             name: Do not send sensitive data to loggers.
-            description: Leaking sensitive data to loggers is a common cause of data breaches. This policy looks for instances of sensitive data sent to loggers.
+            description: Leaking sensitive data to loggers is a common cause of data leaks and can lead to data breaches. This policy looks for instances of sensitive data sent to loggers.
             level: ""
             modules:
                 - path: policies/common.rego
@@ -1519,7 +1519,7 @@ scan:
             id: ruby_password_length
             display_id: CR-019
             name: Enforce stronger password requirements.
-            description: Minimum password length should be enforced any time password creation occurs. This policy checks if configurations and validations made for passwords include a secure minimum length.
+            description: Minimum password length should be enforced any time password creation occurs. This policy checks if configurations and validations made for passwords include a minimum length of 8.
             level: ""
             modules:
                 - path: policies/common.rego
@@ -1666,7 +1666,7 @@ scan:
             id: detect_rails_session
             display_id: CR-003
             name: Do not store sensitive data in session cookies.
-            description: Sensitive data should not be stored in the session. This policy looks for any sensitive data stored within the session cookies.
+            description: Sensitive data should not be stored in session cookies. This policy looks for any sensitive data stored within the session cookies.
             level: ""
             modules:
                 - path: policies/common.rego

--- a/integration/flags/.snapshots/TestInitCommand-init
+++ b/integration/flags/.snapshots/TestInitCommand-init
@@ -689,7 +689,7 @@ scan:
             id: application_level_encryption_missing
             display_id: CR-021
             name: Force application-level encryption when processing sensitive data.
-            description: Application level encryption missing. Enable application level encryption to reduce the risk of leaking sensitive data.
+            description: Application-level encryption reduces that applications processing sensitive data can leak viewable data. This policy checks that sensitive data types in records are encrypted.
             level: ""
             modules:
                 - path: policies/common.rego
@@ -764,7 +764,7 @@ scan:
             id: detect_rails_cookies
             display_id: CR-002
             name: Do not store sensitive data in cookies.
-            description: Cookie leaks detected. Avoid storing sensitive data in cookies.
+            description: Storing sensitive data in cookies can lead to a data breach. This policy looks for instances where sensitive data is stored in browser cookies.
             level: ""
             modules:
                 - path: policies/common.rego
@@ -836,9 +836,9 @@ scan:
             query: |
                 policy_failure = data.bearer.http_get_parameters.policy_failure
             id: ruby_http_get_detection
-            display_id: CR-005
-            name: Do not store sensitive data in HTML5 storage
-            description: Sending data as HTTP GET parameters. Avoid sending sensitive data as parameters in GET requests.
+            display_id: CR-015
+            name: Do not send sensitive data as HTTP GET parameters.
+            description: Sensitive data should never be sent as part of the query string in HTTP get requests. This policy checks if sensitive data types are sent as GET parameters.
             level: ""
             modules:
                 - path: policies/common.rego
@@ -911,8 +911,8 @@ scan:
                 policy_failure = data.bearer.insecure_communication.policy_failure
             id: detect_rails_insecure_communication
             display_id: CR-012
-            name: Force HTTPS in applications processing sensitive data.
-            description: Insecure communication in an application processing sensitive data. Ensure communication occurs over SSL.
+            name: Force HTTPS access.
+            description: When applications process sensitive data, they should default to always use SSL when available. This policy checks if force SSL is enabled at the application level.
             level: ""
             modules:
                 - path: policies/common.rego
@@ -985,9 +985,9 @@ scan:
             query: |
                 policy_failure = data.bearer.insecure_ftp.policy_failure
             id: detect_rails_insecure_ftp
-            display_id: CR-009
-            name: Only send sensitive data to FTP connections securely.
-            description: Communication with an insecure FTP server in an application processing sensitive data. Only connect to FTP securely.
+            display_id: CR-008
+            name: Only communicate with secure FTP connections.
+            description: Communication with FTP servers should be done securely in applications that process sensitive data. This policy checks if FTP connections are made securely.
             level: ""
             modules:
                 - path: policies/common.rego
@@ -1059,9 +1059,9 @@ scan:
             query: |
                 policy_failure = data.bearer.insecure_ftp_with_data_category.policy_failure
             id: insecure_ftp_with_data_category
-            display_id: CR-008
-            name: Only communicate with secure FTP connections in applications processing sensitive data.
-            description: Communicating Data Category with an insecure FTP server. Only connect to FTP securely.
+            display_id: CR-009
+            name: Only send sensitive data to secure FTP connections.
+            description: Files containing sensitive data should only be sent to secure FTP connections. This policy checks if files created using sensitive data are sent to unsecure FTP connections.
             level: ""
             modules:
                 - path: policies/common.rego
@@ -1134,8 +1134,8 @@ scan:
                 policy_failure = data.bearer.insecure_http_get.policy_failure
             id: insecure_http_get
             display_id: CR-013
-            name: Avoid unsecured HTTP connections in applications processing sensitive data.
-            description: Communicating using insecure HTTP GET in an application processing sensitive data. Ensure all HTTP communication occurs over HTTPS.
+            name: Only communicate with secure HTTP connections.
+            description: Applications processing sensitive data should only connect to secure HTTP connections. This policy checks for unsecured HTTP connections.
             level: ""
             modules:
                 - path: policies/common.rego
@@ -1207,9 +1207,9 @@ scan:
             query: |
                 policy_failure = data.bearer.insecure_http_with_data_category.policy_failure
             id: insecure_http_with_data_category
-            display_id: CR-015
-            name: Do not pass sensitive data as HTTP GET parameters.
-            description: Communicating Data Category using insecure HTTP. Ensure all HTTP communication occurs over HTTPS.
+            display_id: CR-014
+            name: Only send sensitive data through HTTPS connections.
+            description: Sensitive data sent through HTTP should only be done securely. This policy checks that any transmissions over HTTP that contain sensitive data do so over HTTPS.
             level: ""
             modules:
                 - path: policies/common.rego
@@ -1296,8 +1296,8 @@ scan:
                 policy_failure = data.bearer.insecure_smtp.policy_failure
             id: detect_rails_insecure_smtp
             display_id: CR-010
-            name: Only communicate with secure SMTP connections in applications processing sensitive data.
-            description: Communication using insecure SMTP in an application processing sensitive data. Verify that SMTP settings use OpenSSL or equivalent.
+            name: Only communicate with secure SMTP connections.
+            description: Secure connections to SMTP help prevent unauthorized actors from viewing transmitted data. This policy checks if SMTP mailer settings are set to only allow secure connections.
             level: ""
             modules:
                 - path: policies/common.rego
@@ -1371,7 +1371,7 @@ scan:
             id: detect_rails_jwt
             display_id: CR-004
             name: Do not store sensitive data in JWTs.
-            description: JWT leaks detected. Avoid storing sensitive data in JWTs.
+            description: JWTs are not a secure place to store sensitive data. This policy looks for any sensitive data types saved to a JWT.
             level: ""
             modules:
                 - path: policies/common.rego
@@ -1445,7 +1445,7 @@ scan:
             id: detect_ruby_logger
             display_id: CR-001
             name: Do not send sensitive data to loggers.
-            description: Logger leaks detected. Avoid passing sensitive data to loggers.
+            description: Leaking sensitive data to loggers is a common cause of data breaches. This policy looks for instances of sensitive data sent to loggers.
             level: ""
             modules:
                 - path: policies/common.rego
@@ -1518,8 +1518,8 @@ scan:
                 policy_breach = data.bearer.password_length.policy_breach
             id: ruby_password_length
             display_id: CR-019
-            name: Enforce stronger password requirements in applications processing sensitive data.
-            description: Minimum password length violation detected. Make sure your passwords have sufficient length.
+            name: Enforce stronger password requirements.
+            description: Minimum password length should be enforced any time password creation occurs. This policy checks if configurations and validations made for passwords include a secure minimum length.
             level: ""
             modules:
                 - path: policies/common.rego
@@ -1591,8 +1591,8 @@ scan:
                 policy_failure = data.bearer.third_party_data_category.policy_failure
             id: detect_ruby_third_party_data_send
             display_id: CR-016
-            name: Ensure that no unsecured Third Parties receive sensitive data.
-            description: Sending data in category to third party. Ensure data sent to third party is intended and secured.
+            name: Do not leak sensitive data to third-party loggers.
+            description: 'Sensitive data should not be sent to third party logging libraries or services. This policy checks if sensitive data types are sent to third party loggers. Currently supports: Sentry. '
             level: ""
             modules:
                 - path: policies/common.rego
@@ -1665,8 +1665,8 @@ scan:
                 policy_failure = data.bearer.leakage.policy_failure
             id: detect_rails_session
             display_id: CR-003
-            name: Do not store sensitive data in the session.
-            description: Session leaks detected. Avoid storing sensitive data in the session.
+            name: Do not store sensitive data in session cookies.
+            description: Sensitive data should not be stored in the session. This policy looks for any sensitive data stored within the session cookies.
             level: ""
             modules:
                 - path: policies/common.rego
@@ -1739,8 +1739,8 @@ scan:
                 policy_failure = data.bearer.ssl_certificate_verification_disabled.policy_failure
             id: ssl_certificate_verification_disabled
             display_id: CR-011
-            name: Enable SSL Certificate Verification in applications processing sensitive data.
-            description: SSL certificate verification is disabled in an application processing sensitive data. Enable SSL certificate verification.
+            name: Enable SSL Certificate Verification.
+            description: Applications processing sensitive data should use valid SSL certificates. This policy checks if SSL verification is enabled.
             level: ""
             modules:
                 - path: policies/common.rego
@@ -1814,7 +1814,7 @@ scan:
             id: detect_ruby_weak_encryption_library
             display_id: CR-024
             name: Avoid weak encryption library.
-            description: Weak encryption or hashing library detected. Consider using a different library.
+            description: A weak encryption or hashing library can lead to data breaches and greater security risk. This policy checks for the use of weak encryption and hashing libraries or algorithms.
             level: ""
             modules:
                 - path: policies/common.rego
@@ -2062,8 +2062,8 @@ scan:
                 policy_failure = data.bearer.weak_password_encryption.policy_failure
             id: detect_ruby_weak_encryption
             display_id: CR-023
-            name: Force strong password encryption in applications processing sensitive data.
-            description: Weak encryption or hashing library used to encrypt password. Use a stronger algorithm.
+            name: Force strong password encryption.
+            description: Using a weak encryption or hashing library to encrypt passwords can lead to security breaches and data leaks. This policy checks if weak encryption or hashing libraries are used to encrypt passwords.
             level: ""
             modules:
                 - path: policies/common.rego

--- a/integration/flags/.snapshots/TestReportFlags-report-policies
+++ b/integration/flags/.snapshots/TestReportFlags-report-policies
@@ -1,7 +1,7 @@
 high:
     - policy_name: Do not send sensitive data to loggers.
       policy_display_id: CR-001
-      policy_description: Logger leaks detected. Avoid passing sensitive data to loggers.
+      policy_description: Leaking sensitive data to loggers is a common cause of data breaches. This policy looks for instances of sensitive data sent to loggers.
       line_number: 1
       filename: testdata/policies/users.rb
       category_groups:

--- a/integration/flags/.snapshots/TestReportFlags-report-policies
+++ b/integration/flags/.snapshots/TestReportFlags-report-policies
@@ -1,7 +1,7 @@
 high:
     - policy_name: Do not send sensitive data to loggers.
       policy_display_id: CR-001
-      policy_description: Leaking sensitive data to loggers is a common cause of data breaches. This policy looks for instances of sensitive data sent to loggers.
+      policy_description: Leaking sensitive data to loggers is a common cause of data leaks and can lead to data breaches. This policy looks for instances of sensitive data sent to loggers.
       line_number: 1
       filename: testdata/policies/users.rb
       category_groups:

--- a/integration/policies/.snapshots/TestPolicesWithHealthContext-logger_leaking
+++ b/integration/policies/.snapshots/TestPolicesWithHealthContext-logger_leaking
@@ -1,7 +1,7 @@
 high:
     - policy_name: Do not send sensitive data to loggers.
       policy_display_id: CR-001
-      policy_description: Leaking sensitive data to loggers is a common cause of data breaches. This policy looks for instances of sensitive data sent to loggers.
+      policy_description: Leaking sensitive data to loggers is a common cause of data leaks and can lead to data breaches. This policy looks for instances of sensitive data sent to loggers.
       line_number: 1
       filename: testdata/ruby/logger_leaking.rb
       category_groups:

--- a/integration/policies/.snapshots/TestPolicesWithHealthContext-logger_leaking
+++ b/integration/policies/.snapshots/TestPolicesWithHealthContext-logger_leaking
@@ -1,7 +1,7 @@
 high:
     - policy_name: Do not send sensitive data to loggers.
       policy_display_id: CR-001
-      policy_description: Logger leaks detected. Avoid passing sensitive data to loggers.
+      policy_description: Leaking sensitive data to loggers is a common cause of data breaches. This policy looks for instances of sensitive data sent to loggers.
       line_number: 1
       filename: testdata/ruby/logger_leaking.rb
       category_groups:

--- a/integration/policies/.snapshots/TestPolicesWithHealthContext-sending_data_in_category_to_third_party
+++ b/integration/policies/.snapshots/TestPolicesWithHealthContext-sending_data_in_category_to_third_party
@@ -1,7 +1,7 @@
 high:
-    - policy_name: Ensure that no unsecured Third Parties receive sensitive data.
+    - policy_name: Do not leak sensitive data to third-party loggers.
       policy_display_id: CR-016
-      policy_description: Sending data in category to third party. Ensure data sent to third party is intended and secured.
+      policy_description: 'Sensitive data should not be sent to third party logging libraries or services. This policy checks if sensitive data types are sent to third party loggers. Currently supports: Sentry. '
       line_number: 12
       filename: testdata/ruby/sending_data_in_category_to_third_party.rb
       category_groups:
@@ -15,9 +15,9 @@ high:
           level: "info"
         )
       omit_parent: false
-    - policy_name: Ensure that no unsecured Third Parties receive sensitive data.
+    - policy_name: Do not leak sensitive data to third-party loggers.
       policy_display_id: CR-016
-      policy_description: Sending data in category to third party. Ensure data sent to third party is intended and secured.
+      policy_description: 'Sensitive data should not be sent to third party logging libraries or services. This policy checks if sensitive data types are sent to third party loggers. Currently supports: Sentry. '
       line_number: 18
       filename: testdata/ruby/sending_data_in_category_to_third_party.rb
       category_groups:
@@ -32,9 +32,9 @@ high:
           end
         end
       omit_parent: false
-    - policy_name: Ensure that no unsecured Third Parties receive sensitive data.
+    - policy_name: Do not leak sensitive data to third-party loggers.
       policy_display_id: CR-016
-      policy_description: Sending data in category to third party. Ensure data sent to third party is intended and secured.
+      policy_description: 'Sensitive data should not be sent to third party logging libraries or services. This policy checks if sensitive data types are sent to third party loggers. Currently supports: Sentry. '
       line_number: 24
       filename: testdata/ruby/sending_data_in_category_to_third_party.rb
       category_groups:

--- a/integration/policies/.snapshots/TestPolicies-application_level_encryption_missing_schema_rb
+++ b/integration/policies/.snapshots/TestPolicies-application_level_encryption_missing_schema_rb
@@ -1,7 +1,7 @@
 high:
     - policy_name: Force application-level encryption when processing sensitive data.
       policy_display_id: CR-021
-      policy_description: Application level encryption missing. Enable application level encryption to reduce the risk of leaking sensitive data.
+      policy_description: Application-level encryption reduces that applications processing sensitive data can leak viewable data. This policy checks that sensitive data types in records are encrypted.
       line_number: 3
       filename: testdata/ruby/application_level_encryption_missing/schema_rb/db/schema.rb
       category_groups:
@@ -18,7 +18,7 @@ high:
       omit_parent: false
     - policy_name: Force application-level encryption when processing sensitive data.
       policy_display_id: CR-021
-      policy_description: Application level encryption missing. Enable application level encryption to reduce the risk of leaking sensitive data.
+      policy_description: Application-level encryption reduces that applications processing sensitive data can leak viewable data. This policy checks that sensitive data types in records are encrypted.
       line_number: 4
       filename: testdata/ruby/application_level_encryption_missing/schema_rb/db/schema.rb
       category_groups:
@@ -35,7 +35,7 @@ high:
       omit_parent: false
     - policy_name: Force application-level encryption when processing sensitive data.
       policy_display_id: CR-021
-      policy_description: Application level encryption missing. Enable application level encryption to reduce the risk of leaking sensitive data.
+      policy_description: Application-level encryption reduces that applications processing sensitive data can leak viewable data. This policy checks that sensitive data types in records are encrypted.
       line_number: 5
       filename: testdata/ruby/application_level_encryption_missing/schema_rb/db/schema.rb
       category_groups:

--- a/integration/policies/.snapshots/TestPolicies-application_level_encryption_missing_schema_rb
+++ b/integration/policies/.snapshots/TestPolicies-application_level_encryption_missing_schema_rb
@@ -1,7 +1,7 @@
 high:
     - policy_name: Force application-level encryption when processing sensitive data.
       policy_display_id: CR-021
-      policy_description: Application-level encryption reduces that applications processing sensitive data can leak viewable data. This policy checks that sensitive data types in records are encrypted.
+      policy_description: Application-level encryption greatly reduces the risk of a data breach or data leak by making data unreadable. This policy checks if sensitive data types found in records are encrypted.
       line_number: 3
       filename: testdata/ruby/application_level_encryption_missing/schema_rb/db/schema.rb
       category_groups:
@@ -18,7 +18,7 @@ high:
       omit_parent: false
     - policy_name: Force application-level encryption when processing sensitive data.
       policy_display_id: CR-021
-      policy_description: Application-level encryption reduces that applications processing sensitive data can leak viewable data. This policy checks that sensitive data types in records are encrypted.
+      policy_description: Application-level encryption greatly reduces the risk of a data breach or data leak by making data unreadable. This policy checks if sensitive data types found in records are encrypted.
       line_number: 4
       filename: testdata/ruby/application_level_encryption_missing/schema_rb/db/schema.rb
       category_groups:
@@ -35,7 +35,7 @@ high:
       omit_parent: false
     - policy_name: Force application-level encryption when processing sensitive data.
       policy_display_id: CR-021
-      policy_description: Application-level encryption reduces that applications processing sensitive data can leak viewable data. This policy checks that sensitive data types in records are encrypted.
+      policy_description: Application-level encryption greatly reduces the risk of a data breach or data leak by making data unreadable. This policy checks if sensitive data types found in records are encrypted.
       line_number: 5
       filename: testdata/ruby/application_level_encryption_missing/schema_rb/db/schema.rb
       category_groups:

--- a/integration/policies/.snapshots/TestPolicies-application_level_encryption_missing_structure_sql
+++ b/integration/policies/.snapshots/TestPolicies-application_level_encryption_missing_structure_sql
@@ -1,7 +1,7 @@
 high:
     - policy_name: Force application-level encryption when processing sensitive data.
       policy_display_id: CR-021
-      policy_description: Application-level encryption reduces that applications processing sensitive data can leak viewable data. This policy checks that sensitive data types in records are encrypted.
+      policy_description: Application-level encryption greatly reduces the risk of a data breach or data leak by making data unreadable. This policy checks if sensitive data types found in records are encrypted.
       line_number: 3
       filename: testdata/ruby/application_level_encryption_missing/structure_sql/db/structure.sql
       category_groups:
@@ -19,7 +19,7 @@ high:
       omit_parent: false
     - policy_name: Force application-level encryption when processing sensitive data.
       policy_display_id: CR-021
-      policy_description: Application-level encryption reduces that applications processing sensitive data can leak viewable data. This policy checks that sensitive data types in records are encrypted.
+      policy_description: Application-level encryption greatly reduces the risk of a data breach or data leak by making data unreadable. This policy checks if sensitive data types found in records are encrypted.
       line_number: 4
       filename: testdata/ruby/application_level_encryption_missing/structure_sql/db/structure.sql
       category_groups:

--- a/integration/policies/.snapshots/TestPolicies-application_level_encryption_missing_structure_sql
+++ b/integration/policies/.snapshots/TestPolicies-application_level_encryption_missing_structure_sql
@@ -1,7 +1,7 @@
 high:
     - policy_name: Force application-level encryption when processing sensitive data.
       policy_display_id: CR-021
-      policy_description: Application level encryption missing. Enable application level encryption to reduce the risk of leaking sensitive data.
+      policy_description: Application-level encryption reduces that applications processing sensitive data can leak viewable data. This policy checks that sensitive data types in records are encrypted.
       line_number: 3
       filename: testdata/ruby/application_level_encryption_missing/structure_sql/db/structure.sql
       category_groups:
@@ -19,7 +19,7 @@ high:
       omit_parent: false
     - policy_name: Force application-level encryption when processing sensitive data.
       policy_display_id: CR-021
-      policy_description: Application level encryption missing. Enable application level encryption to reduce the risk of leaking sensitive data.
+      policy_description: Application-level encryption reduces that applications processing sensitive data can leak viewable data. This policy checks that sensitive data types in records are encrypted.
       line_number: 4
       filename: testdata/ruby/application_level_encryption_missing/structure_sql/db/structure.sql
       category_groups:

--- a/integration/policies/.snapshots/TestPolicies-insecure_ftp
+++ b/integration/policies/.snapshots/TestPolicies-insecure_ftp
@@ -1,7 +1,7 @@
 critical:
-    - policy_name: Only send sensitive data to secure FTP connections.
+    - policy_name: Only send sensitive data using SFTP connections.
       policy_display_id: CR-009
-      policy_description: Files containing sensitive data should only be sent to secure FTP connections. This policy checks if files created using sensitive data are sent to unsecure FTP connections.
+      policy_description: Files containing sensitive data should only be sent via SFTP connections. This policy checks if files created using sensitive data are sent to over SFTP connections.
       line_number: 27
       filename: testdata/ruby/insecure_ftp.rb
       category_groups:
@@ -22,9 +22,9 @@ critical:
         end
       omit_parent: false
 medium:
-    - policy_name: Only communicate with secure FTP connections.
+    - policy_name: Only communicate using SFTP connections.
       policy_display_id: CR-008
-      policy_description: Communication with FTP servers should be done securely in applications that process sensitive data. This policy checks if FTP connections are made securely.
+      policy_description: Communication with FTP servers should be done securely over SFTP in applications that process sensitive data. This policy checks if all FTP connections are made using SFTP.
       line_number: 10
       filename: testdata/ruby/insecure_ftp.rb
       category_groups:
@@ -33,9 +33,9 @@ medium:
       parent_line_number: 10
       parent_content: Net::FTP.new("ftp.ruby-lang.org")
       omit_parent: false
-    - policy_name: Only communicate with secure FTP connections.
+    - policy_name: Only communicate using SFTP connections.
       policy_display_id: CR-008
-      policy_description: Communication with FTP servers should be done securely in applications that process sensitive data. This policy checks if FTP connections are made securely.
+      policy_description: Communication with FTP servers should be done securely over SFTP in applications that process sensitive data. This policy checks if all FTP connections are made using SFTP.
       line_number: 17
       filename: testdata/ruby/insecure_ftp.rb
       category_groups:
@@ -50,9 +50,9 @@ medium:
           ftp.getbinaryfile('nif.rb-0.91.gz', 'nif.gz', 1024)
         end
       omit_parent: false
-    - policy_name: Only communicate with secure FTP connections.
+    - policy_name: Only communicate using SFTP connections.
       policy_display_id: CR-008
-      policy_description: Communication with FTP servers should be done securely in applications that process sensitive data. This policy checks if FTP connections are made securely.
+      policy_description: Communication with FTP servers should be done securely over SFTP in applications that process sensitive data. This policy checks if all FTP connections are made using SFTP.
       line_number: 24
       filename: testdata/ruby/insecure_ftp.rb
       category_groups:

--- a/integration/policies/.snapshots/TestPolicies-insecure_ftp
+++ b/integration/policies/.snapshots/TestPolicies-insecure_ftp
@@ -1,7 +1,7 @@
 critical:
-    - policy_name: Only communicate with secure FTP connections in applications processing sensitive data.
-      policy_display_id: CR-008
-      policy_description: Communicating Data Category with an insecure FTP server. Only connect to FTP securely.
+    - policy_name: Only send sensitive data to secure FTP connections.
+      policy_display_id: CR-009
+      policy_description: Files containing sensitive data should only be sent to secure FTP connections. This policy checks if files created using sensitive data are sent to unsecure FTP connections.
       line_number: 27
       filename: testdata/ruby/insecure_ftp.rb
       category_groups:
@@ -22,9 +22,9 @@ critical:
         end
       omit_parent: false
 medium:
-    - policy_name: Only send sensitive data to FTP connections securely.
-      policy_display_id: CR-009
-      policy_description: Communication with an insecure FTP server in an application processing sensitive data. Only connect to FTP securely.
+    - policy_name: Only communicate with secure FTP connections.
+      policy_display_id: CR-008
+      policy_description: Communication with FTP servers should be done securely in applications that process sensitive data. This policy checks if FTP connections are made securely.
       line_number: 10
       filename: testdata/ruby/insecure_ftp.rb
       category_groups:
@@ -33,9 +33,9 @@ medium:
       parent_line_number: 10
       parent_content: Net::FTP.new("ftp.ruby-lang.org")
       omit_parent: false
-    - policy_name: Only send sensitive data to FTP connections securely.
-      policy_display_id: CR-009
-      policy_description: Communication with an insecure FTP server in an application processing sensitive data. Only connect to FTP securely.
+    - policy_name: Only communicate with secure FTP connections.
+      policy_display_id: CR-008
+      policy_description: Communication with FTP servers should be done securely in applications that process sensitive data. This policy checks if FTP connections are made securely.
       line_number: 17
       filename: testdata/ruby/insecure_ftp.rb
       category_groups:
@@ -50,9 +50,9 @@ medium:
           ftp.getbinaryfile('nif.rb-0.91.gz', 'nif.gz', 1024)
         end
       omit_parent: false
-    - policy_name: Only send sensitive data to FTP connections securely.
-      policy_display_id: CR-009
-      policy_description: Communication with an insecure FTP server in an application processing sensitive data. Only connect to FTP securely.
+    - policy_name: Only communicate with secure FTP connections.
+      policy_display_id: CR-008
+      policy_description: Communication with FTP servers should be done securely in applications that process sensitive data. This policy checks if FTP connections are made securely.
       line_number: 24
       filename: testdata/ruby/insecure_ftp.rb
       category_groups:

--- a/integration/policies/.snapshots/TestPolicies-insecure_smtp
+++ b/integration/policies/.snapshots/TestPolicies-insecure_smtp
@@ -1,7 +1,7 @@
 medium:
-    - policy_name: Only communicate with secure SMTP connections in applications processing sensitive data.
+    - policy_name: Only communicate with secure SMTP connections.
       policy_display_id: CR-010
-      policy_description: Communication using insecure SMTP in an application processing sensitive data. Verify that SMTP settings use OpenSSL or equivalent.
+      policy_description: Secure connections to SMTP help prevent unauthorized actors from viewing transmitted data. This policy checks if SMTP mailer settings are set to only allow secure connections.
       line_number: 8
       filename: testdata/ruby/insecure_smtp.rb
       category_groups:
@@ -14,9 +14,9 @@ medium:
           }
         end
       omit_parent: false
-    - policy_name: Only communicate with secure SMTP connections in applications processing sensitive data.
+    - policy_name: Only communicate with secure SMTP connections.
       policy_display_id: CR-010
-      policy_description: Communication using insecure SMTP in an application processing sensitive data. Verify that SMTP settings use OpenSSL or equivalent.
+      policy_description: Secure connections to SMTP help prevent unauthorized actors from viewing transmitted data. This policy checks if SMTP mailer settings are set to only allow secure connections.
       line_number: 14
       filename: testdata/ruby/insecure_smtp.rb
       category_groups:

--- a/integration/policies/.snapshots/TestPolicies-insecure_smtp
+++ b/integration/policies/.snapshots/TestPolicies-insecure_smtp
@@ -1,7 +1,7 @@
 medium:
     - policy_name: Only communicate with secure SMTP connections.
       policy_display_id: CR-010
-      policy_description: Secure connections to SMTP help prevent unauthorized actors from viewing transmitted data. This policy checks if SMTP mailer settings are set to only allow secure connections.
+      policy_description: Secure connections using SMTP help prevent unauthorized actors from viewing transmitted data. This policy checks if SMTP mailer settings are set to only allow secure connections.
       line_number: 8
       filename: testdata/ruby/insecure_smtp.rb
       category_groups:
@@ -16,7 +16,7 @@ medium:
       omit_parent: false
     - policy_name: Only communicate with secure SMTP connections.
       policy_display_id: CR-010
-      policy_description: Secure connections to SMTP help prevent unauthorized actors from viewing transmitted data. This policy checks if SMTP mailer settings are set to only allow secure connections.
+      policy_description: Secure connections using SMTP help prevent unauthorized actors from viewing transmitted data. This policy checks if SMTP mailer settings are set to only allow secure connections.
       line_number: 14
       filename: testdata/ruby/insecure_smtp.rb
       category_groups:

--- a/integration/policies/.snapshots/TestPolicies-logger_leaking
+++ b/integration/policies/.snapshots/TestPolicies-logger_leaking
@@ -1,7 +1,7 @@
 high:
     - policy_name: Do not send sensitive data to loggers.
       policy_display_id: CR-001
-      policy_description: Leaking sensitive data to loggers is a common cause of data breaches. This policy looks for instances of sensitive data sent to loggers.
+      policy_description: Leaking sensitive data to loggers is a common cause of data leaks and can lead to data breaches. This policy looks for instances of sensitive data sent to loggers.
       line_number: 1
       filename: testdata/ruby/logger_leaking.rb
       category_groups:

--- a/integration/policies/.snapshots/TestPolicies-logger_leaking
+++ b/integration/policies/.snapshots/TestPolicies-logger_leaking
@@ -1,7 +1,7 @@
 high:
     - policy_name: Do not send sensitive data to loggers.
       policy_display_id: CR-001
-      policy_description: Logger leaks detected. Avoid passing sensitive data to loggers.
+      policy_description: Leaking sensitive data to loggers is a common cause of data breaches. This policy looks for instances of sensitive data sent to loggers.
       line_number: 1
       filename: testdata/ruby/logger_leaking.rb
       category_groups:

--- a/integration/policies/.snapshots/TestPolicies-ruby_weak_password_encryption
+++ b/integration/policies/.snapshots/TestPolicies-ruby_weak_password_encryption
@@ -1,7 +1,7 @@
 high:
-    - policy_name: Force strong password encryption in applications processing sensitive data.
+    - policy_name: Force strong password encryption.
       policy_display_id: CR-023
-      policy_description: Weak encryption or hashing library used to encrypt password. Use a stronger algorithm.
+      policy_description: Using a weak encryption or hashing library to encrypt passwords can lead to security breaches and data leaks. This policy checks if weak encryption or hashing libraries are used to encrypt passwords.
       line_number: 1
       filename: testdata/ruby/weak_password_encryption.rb
       category_groups:
@@ -9,9 +9,9 @@ high:
       parent_line_number: 1
       parent_content: Digest::SHA1.hexidigest(user.password)
       omit_parent: false
-    - policy_name: Force strong password encryption in applications processing sensitive data.
+    - policy_name: Force strong password encryption.
       policy_display_id: CR-023
-      policy_description: Weak encryption or hashing library used to encrypt password. Use a stronger algorithm.
+      policy_description: Using a weak encryption or hashing library to encrypt passwords can lead to security breaches and data leaks. This policy checks if weak encryption or hashing libraries are used to encrypt passwords.
       line_number: 2
       filename: testdata/ruby/weak_password_encryption.rb
       category_groups:
@@ -19,9 +19,9 @@ high:
       parent_line_number: 2
       parent_content: Digest::MD5.hexdigest(user.password)
       omit_parent: false
-    - policy_name: Force strong password encryption in applications processing sensitive data.
+    - policy_name: Force strong password encryption.
       policy_display_id: CR-023
-      policy_description: Weak encryption or hashing library used to encrypt password. Use a stronger algorithm.
+      policy_description: Using a weak encryption or hashing library to encrypt passwords can lead to security breaches and data leaks. This policy checks if weak encryption or hashing libraries are used to encrypt passwords.
       line_number: 4
       filename: testdata/ruby/weak_password_encryption.rb
       category_groups:
@@ -29,9 +29,9 @@ high:
       parent_line_number: 4
       parent_content: RC4.new("insecure").encrypt(user.password)
       omit_parent: false
-    - policy_name: Force strong password encryption in applications processing sensitive data.
+    - policy_name: Force strong password encryption.
       policy_display_id: CR-023
-      policy_description: Weak encryption or hashing library used to encrypt password. Use a stronger algorithm.
+      policy_description: Using a weak encryption or hashing library to encrypt passwords can lead to security breaches and data leaks. This policy checks if weak encryption or hashing libraries are used to encrypt passwords.
       line_number: 11
       filename: testdata/ruby/weak_password_encryption.rb
       category_groups:
@@ -39,9 +39,9 @@ high:
       parent_line_number: 11
       parent_content: dsa_encrypt.export(cipher, customer.password)
       omit_parent: false
-    - policy_name: Force strong password encryption in applications processing sensitive data.
+    - policy_name: Force strong password encryption.
       policy_display_id: CR-023
-      policy_description: Weak encryption or hashing library used to encrypt password. Use a stronger algorithm.
+      policy_description: Using a weak encryption or hashing library to encrypt passwords can lead to security breaches and data leaks. This policy checks if weak encryption or hashing libraries are used to encrypt passwords.
       line_number: 13
       filename: testdata/ruby/weak_password_encryption.rb
       category_groups:
@@ -49,9 +49,9 @@ high:
       parent_line_number: 13
       parent_content: OpenSSL::PKey::RSA.new(2048).to_pem(cipher, customer.password)
       omit_parent: false
-    - policy_name: Force strong password encryption in applications processing sensitive data.
+    - policy_name: Force strong password encryption.
       policy_display_id: CR-023
-      policy_description: Weak encryption or hashing library used to encrypt password. Use a stronger algorithm.
+      policy_description: Using a weak encryption or hashing library to encrypt passwords can lead to security breaches and data leaks. This policy checks if weak encryption or hashing libraries are used to encrypt passwords.
       line_number: 16
       filename: testdata/ruby/weak_password_encryption.rb
       category_groups:
@@ -62,7 +62,7 @@ high:
 low:
     - policy_name: Avoid weak encryption library.
       policy_display_id: CR-024
-      policy_description: Weak encryption or hashing library detected. Consider using a different library.
+      policy_description: A weak encryption or hashing library can lead to data breaches and greater security risk. This policy checks for the use of weak encryption and hashing libraries or algorithms.
       line_number: 18
       filename: testdata/ruby/weak_password_encryption.rb
       category_groups:
@@ -72,7 +72,7 @@ low:
       omit_parent: false
     - policy_name: Avoid weak encryption library.
       policy_display_id: CR-024
-      policy_description: Weak encryption or hashing library detected. Consider using a different library.
+      policy_description: A weak encryption or hashing library can lead to data breaches and greater security risk. This policy checks for the use of weak encryption and hashing libraries or algorithms.
       line_number: 19
       filename: testdata/ruby/weak_password_encryption.rb
       category_groups:
@@ -82,7 +82,7 @@ low:
       omit_parent: false
     - policy_name: Avoid weak encryption library.
       policy_display_id: CR-024
-      policy_description: Weak encryption or hashing library detected. Consider using a different library.
+      policy_description: A weak encryption or hashing library can lead to data breaches and greater security risk. This policy checks for the use of weak encryption and hashing libraries or algorithms.
       line_number: 20
       filename: testdata/ruby/weak_password_encryption.rb
       category_groups:

--- a/integration/policies/.snapshots/TestPolicies-sending_data_in_category_to_third_party
+++ b/integration/policies/.snapshots/TestPolicies-sending_data_in_category_to_third_party
@@ -1,7 +1,7 @@
 high:
-    - policy_name: Ensure that no unsecured Third Parties receive sensitive data.
+    - policy_name: Do not leak sensitive data to third-party loggers.
       policy_display_id: CR-016
-      policy_description: Sending data in category to third party. Ensure data sent to third party is intended and secured.
+      policy_description: 'Sensitive data should not be sent to third party logging libraries or services. This policy checks if sensitive data types are sent to third party loggers. Currently supports: Sentry. '
       line_number: 12
       filename: testdata/ruby/sending_data_in_category_to_third_party.rb
       category_groups:
@@ -14,9 +14,9 @@ high:
           level: "info"
         )
       omit_parent: false
-    - policy_name: Ensure that no unsecured Third Parties receive sensitive data.
+    - policy_name: Do not leak sensitive data to third-party loggers.
       policy_display_id: CR-016
-      policy_description: Sending data in category to third party. Ensure data sent to third party is intended and secured.
+      policy_description: 'Sensitive data should not be sent to third party logging libraries or services. This policy checks if sensitive data types are sent to third party loggers. Currently supports: Sentry. '
       line_number: 18
       filename: testdata/ruby/sending_data_in_category_to_third_party.rb
       category_groups:
@@ -30,9 +30,9 @@ high:
           end
         end
       omit_parent: false
-    - policy_name: Ensure that no unsecured Third Parties receive sensitive data.
+    - policy_name: Do not leak sensitive data to third-party loggers.
       policy_display_id: CR-016
-      policy_description: Sending data in category to third party. Ensure data sent to third party is intended and secured.
+      policy_description: 'Sensitive data should not be sent to third party logging libraries or services. This policy checks if sensitive data types are sent to third party loggers. Currently supports: Sentry. '
       line_number: 24
       filename: testdata/ruby/sending_data_in_category_to_third_party.rb
       category_groups:

--- a/integration/policies/.snapshots/TestPolicyFlags-only_policy
+++ b/integration/policies/.snapshots/TestPolicyFlags-only_policy
@@ -1,7 +1,7 @@
 high:
     - policy_name: Do not send sensitive data to loggers.
       policy_display_id: CR-001
-      policy_description: Logger leaks detected. Avoid passing sensitive data to loggers.
+      policy_description: Leaking sensitive data to loggers is a common cause of data leaks and can lead to data breaches. This policy looks for instances of sensitive data sent to loggers.
       line_number: 1
       filename: testdata/ruby/logger_leaking.rb
       category_groups:

--- a/pkg/commands/process/settings/policies.yml
+++ b/pkg/commands/process/settings/policies.yml
@@ -1,5 +1,5 @@
 logger_leaks:
-  description: "Logger leaks detected. Avoid passing sensitive data to loggers."
+  description: "Leaking sensitive data to loggers is a common cause of data breaches. This policy looks for instances of sensitive data sent to loggers."
   name: "Do not send sensitive data to loggers."
   display_id: "CR-001"
   id: "detect_ruby_logger"
@@ -11,7 +11,7 @@ logger_leaks:
     - path: policies/leakage.rego
       name: bearer.leakage
 session_leaks:
-  description: "Session leaks detected. Avoid storing sensitive data in the session."
+  description: "Sensitive data should not be stored in the session. This policy looks for any sensitive data stored within the session cookies."
   name: "Do not store sensitive data in session cookies."
   display_id: "CR-003"
   id: "detect_rails_session"
@@ -23,7 +23,7 @@ session_leaks:
     - path: policies/leakage.rego
       name: bearer.leakage
 jwt_leaks:
-  description: "JWT leaks detected. Avoid storing sensitive data in JWTs."
+  description: "JWTs are not a secure place to store sensitive data. This policy looks for any sensitive data types saved to a JWT."
   name: "Do not store sensitive data in JWTs."
   display_id: "CR-004"
   id: "detect_rails_jwt"
@@ -35,7 +35,7 @@ jwt_leaks:
     - path: policies/leakage.rego
       name: bearer.leakage
 cookie_leaks:
-  description: "Cookie leaks detected. Avoid storing sensitive data in cookies."
+  description: "Storing sensitive data in cookies can lead to a data breach. This policy looks for instances where sensitive data is stored in browser cookies."
   name: "Do not store sensitive data in cookies."
   display_id: "CR-002"
   id: "detect_rails_cookies"
@@ -47,7 +47,7 @@ cookie_leaks:
     - path: policies/leakage.rego
       name: bearer.leakage
 ssl_certificate_verification_disabled:
-  description: "SSL certificate verification is disabled in an application processing sensitive data. Enable SSL certificate verification."
+  description: "Applications processing sensitive data should use valid SSL certificates. This policy checks if SSL verification is enabled."
   name: "Enable SSL Certificate Verification."
   display_id: "CR-011"
   id: "ssl_certificate_verification_disabled"
@@ -59,7 +59,7 @@ ssl_certificate_verification_disabled:
     - path: policies/ssl_certificate_verification_disabled.rego
       name: bearer.ssl_certificate_verification_disabled
 application_level_encryption_missing:
-  description: "Application level encryption missing. Enable application level encryption to reduce the risk of leaking sensitive data."
+  description: "Application-level encryption reduces that applications processing sensitive data can leak viewable data. This policy checks that sensitive data types in records are encrypted."
   name: "Force application-level encryption when processing sensitive data."
   display_id: "CR-021"
   id: "application_level_encryption_missing"
@@ -71,7 +71,7 @@ application_level_encryption_missing:
     - path: policies/application_level_encryption.rego
       name: bearer.application_level_encryption
 insecure_smtp_processing_sensitive_data:
-  description: "Communication using insecure SMTP in an application processing sensitive data. Verify that SMTP settings use OpenSSL or equivalent."
+  description: "Secure connections to SMTP help prevent unauthorized actors from viewing transmitted data. This policy checks if SMTP mailer settings are set to only allow secure connections."
   name: "Only communicate with secure SMTP connections."
   display_id: "CR-010"
   id: "detect_rails_insecure_smtp"
@@ -83,9 +83,9 @@ insecure_smtp_processing_sensitive_data:
     - path: policies/insecure_smtp.rego
       name: bearer.insecure_smtp
 http_get_parameters:
-  description: "Sending data as HTTP GET parameters. Avoid sending sensitive data as parameters in GET requests."
-  name: "Do not store sensitive data in HTML5 storage."
-  display_id: "CR-005"
+  description: "Sensitive data should never be sent as part of the query string in HTTP get requests. This policy checks if sensitive data types are sent as GET parameters."
+  name: "Do not send sensitive data as HTTP GET parameters."
+  display_id: "CR-015"
   id: "ruby_http_get_detection"
   query: |
     policy_failure = data.bearer.http_get_parameters.policy_failure
@@ -95,7 +95,7 @@ http_get_parameters:
     - path: policies/http_get_parameters.rego
       name: bearer.http_get_parameters
 insecure_communication_processing_sensitive_data:
-  description: "Insecure communication in an application processing sensitive data. Ensure communication occurs over SSL."
+  description: "When applications process sensitive data, they should default to always use SSL when available. This policy checks if force SSL is enabled at the application level."
   name: "Force HTTPS access."
   display_id: "CR-012"
   id: "detect_rails_insecure_communication"
@@ -107,9 +107,9 @@ insecure_communication_processing_sensitive_data:
     - path: policies/insecure_communication.rego
       name: bearer.insecure_communication
 insecure_ftp_processing_sensitive_data:
-  description: "Communication with an insecure FTP server in an application processing sensitive data. Only connect to FTP securely."
-  name: "Only send sensitive data to secure FTP connections."
-  display_id: "CR-009"
+  description: "Communication with FTP servers should be done securely in applications that process sensitive data. This policy checks if FTP connections are made securely."
+  name: "Only communicate with secure FTP connections."
+  display_id: "CR-008"
   id: "detect_rails_insecure_ftp"
   query: |
     policy_failure = data.bearer.insecure_ftp.policy_failure
@@ -119,9 +119,9 @@ insecure_ftp_processing_sensitive_data:
     - path: policies/insecure_ftp.rego
       name: bearer.insecure_ftp
 insecure_ftp_with_data_category:
-  description: "Communicating Data Category with an insecure FTP server. Only connect to FTP securely."
-  name: "Only communicate with secure FTP connections."
-  display_id: "CR-008"
+  description: "Files containing sensitive data should only be sent to secure FTP connections. This policy checks if files created using sensitive data are sent to unsecure FTP connections."
+  name: "Only send sensitive data to secure FTP connections."
+  display_id: "CR-009"
   id: insecure_ftp_with_data_category
   query: |
     policy_failure = data.bearer.insecure_ftp_with_data_category.policy_failure
@@ -131,8 +131,8 @@ insecure_ftp_with_data_category:
     - path: policies/insecure_ftp_with_data_category.rego
       name: bearer.insecure_ftp_with_data_category
 insecure_http_get:
-  description: "Communicating using insecure HTTP GET in an application processing sensitive data. Ensure all HTTP communication occurs over HTTPS."
-  name: "Only communicate with secure HTTP connections. "
+  description: "Applications processing sensitive data should only connect to secure HTTP connections. This policy checks for unsecured HTTP connections."
+  name: "Only communicate with secure HTTP connections."
   display_id: "CR-013"
   id: insecure_http_get
   query: |
@@ -143,9 +143,9 @@ insecure_http_get:
     - path: policies/insecure_http_get.rego
       name: bearer.insecure_http_get
 insecure_http_with_data_category:
-  description: "Communicating Data Category using insecure HTTP. Ensure all HTTP communication occurs over HTTPS."
-  name: "Do not send sensitive data as HTTP GET parameters."
-  display_id: "CR-015"
+  description: "Sensitive data sent through HTTP should only be done securely. This policy checks that any transmissions over HTTP that contain sensitive data do so over HTTPS."
+  name: "Only send sensitive data through HTTPS connections."
+  display_id: "CR-014"
   id: insecure_http_with_data_category
   query: |
     policy_failure = data.bearer.insecure_http_with_data_category.policy_failure
@@ -155,7 +155,7 @@ insecure_http_with_data_category:
     - path: policies/insecure_http_with_data_category.rego
       name: bearer.insecure_http_with_data_category
 sending_data_in_category_to_third_party:
-  description: "Sending data in category to third party. Ensure data sent to third party is intended and secured."
+  description: "Sensitive data should not be sent to third party logging libraries or services. This policy checks if sensitive data types are sent to third party loggers. Currently supports: Sentry. "
   name: "Do not leak sensitive data to third-party loggers."
   display_id: "CR-016"
   id: "detect_ruby_third_party_data_send"
@@ -167,7 +167,7 @@ sending_data_in_category_to_third_party:
     - path: policies/third_party_data_category.rego
       name: bearer.third_party_data_category
 weak_password_encryption:
-  description: "Weak encryption or hashing library used to encrypt password. Use a stronger algorithm."
+  description: "Using a weak encryption or hashing library to encrypt passwords can lead to security breaches and data leaks. This policy checks if weak encryption or hashing libraries are used to encrypt passwords."
   name: "Force strong password encryption."
   display_id: "CR-023"
   id: "detect_ruby_weak_encryption"
@@ -181,8 +181,8 @@ weak_password_encryption:
     - path: policies/weak_password_encryption.rego
       name: bearer.weak_password_encryption
 password_length:
-  description: "Minimum password length violation detected. Make sure your passwords have sufficient length."
-  name: "Enforce stronger password requirements in applications processing sensitive data."
+  description: "Minimum password length should be enforced any time password creation occurs. This policy checks if configurations and validations made for passwords include a secure minimum length."
+  name: "Enforce stronger password requirements."
   display_id: "CR-019"
   id: "ruby_password_length"
   query: |
@@ -193,7 +193,7 @@ password_length:
     - path: policies/password_length.rego
       name: bearer.password_length
 weak_encryption_library:
-  description: "Weak encryption or hashing library detected. Consider using a different library."
+  description: "A weak encryption or hashing library can lead to data breaches and greater security risk. This policy checks for the use of weak encryption and hashing libraries or algorithms."
   name: "Avoid weak encryption library."
   display_id: "CR-024"
   id: "detect_ruby_weak_encryption_library"

--- a/pkg/commands/process/settings/policies.yml
+++ b/pkg/commands/process/settings/policies.yml
@@ -12,7 +12,7 @@ logger_leaks:
       name: bearer.leakage
 session_leaks:
   description: "Session leaks detected. Avoid storing sensitive data in the session."
-  name: "Do not store sensitive data in the session."
+  name: "Do not store sensitive data in session cookies."
   display_id: "CR-003"
   id: "detect_rails_session"
   query: |
@@ -48,7 +48,7 @@ cookie_leaks:
       name: bearer.leakage
 ssl_certificate_verification_disabled:
   description: "SSL certificate verification is disabled in an application processing sensitive data. Enable SSL certificate verification."
-  name: "Enable SSL Certificate Verification in applications processing sensitive data."
+  name: "Enable SSL Certificate Verification."
   display_id: "CR-011"
   id: "ssl_certificate_verification_disabled"
   query: |
@@ -72,7 +72,7 @@ application_level_encryption_missing:
       name: bearer.application_level_encryption
 insecure_smtp_processing_sensitive_data:
   description: "Communication using insecure SMTP in an application processing sensitive data. Verify that SMTP settings use OpenSSL or equivalent."
-  name: "Only communicate with secure SMTP connections in applications processing sensitive data."
+  name: "Only communicate with secure SMTP connections."
   display_id: "CR-010"
   id: "detect_rails_insecure_smtp"
   query: |
@@ -84,7 +84,7 @@ insecure_smtp_processing_sensitive_data:
       name: bearer.insecure_smtp
 http_get_parameters:
   description: "Sending data as HTTP GET parameters. Avoid sending sensitive data as parameters in GET requests."
-  name: "Do not store sensitive data in HTML5 storage"
+  name: "Do not store sensitive data in HTML5 storage."
   display_id: "CR-005"
   id: "ruby_http_get_detection"
   query: |
@@ -96,7 +96,7 @@ http_get_parameters:
       name: bearer.http_get_parameters
 insecure_communication_processing_sensitive_data:
   description: "Insecure communication in an application processing sensitive data. Ensure communication occurs over SSL."
-  name: "Force HTTPS in applications processing sensitive data."
+  name: "Force HTTPS access."
   display_id: "CR-012"
   id: "detect_rails_insecure_communication"
   query: |
@@ -108,7 +108,7 @@ insecure_communication_processing_sensitive_data:
       name: bearer.insecure_communication
 insecure_ftp_processing_sensitive_data:
   description: "Communication with an insecure FTP server in an application processing sensitive data. Only connect to FTP securely."
-  name: "Only send sensitive data to FTP connections securely."
+  name: "Only send sensitive data to secure FTP connections."
   display_id: "CR-009"
   id: "detect_rails_insecure_ftp"
   query: |
@@ -120,7 +120,7 @@ insecure_ftp_processing_sensitive_data:
       name: bearer.insecure_ftp
 insecure_ftp_with_data_category:
   description: "Communicating Data Category with an insecure FTP server. Only connect to FTP securely."
-  name: "Only communicate with secure FTP connections in applications processing sensitive data."
+  name: "Only communicate with secure FTP connections."
   display_id: "CR-008"
   id: insecure_ftp_with_data_category
   query: |
@@ -132,7 +132,7 @@ insecure_ftp_with_data_category:
       name: bearer.insecure_ftp_with_data_category
 insecure_http_get:
   description: "Communicating using insecure HTTP GET in an application processing sensitive data. Ensure all HTTP communication occurs over HTTPS."
-  name: "Avoid unsecured HTTP connections in applications processing sensitive data."
+  name: "Only communicate with secure HTTP connections. "
   display_id: "CR-013"
   id: insecure_http_get
   query: |
@@ -144,7 +144,7 @@ insecure_http_get:
       name: bearer.insecure_http_get
 insecure_http_with_data_category:
   description: "Communicating Data Category using insecure HTTP. Ensure all HTTP communication occurs over HTTPS."
-  name: "Do not pass sensitive data as HTTP GET parameters."
+  name: "Do not send sensitive data as HTTP GET parameters."
   display_id: "CR-015"
   id: insecure_http_with_data_category
   query: |
@@ -156,7 +156,7 @@ insecure_http_with_data_category:
       name: bearer.insecure_http_with_data_category
 sending_data_in_category_to_third_party:
   description: "Sending data in category to third party. Ensure data sent to third party is intended and secured."
-  name: "Ensure that no unsecured Third Parties receive sensitive data."
+  name: "Do not leak sensitive data to third-party loggers."
   display_id: "CR-016"
   id: "detect_ruby_third_party_data_send"
   query: |
@@ -168,7 +168,7 @@ sending_data_in_category_to_third_party:
       name: bearer.third_party_data_category
 weak_password_encryption:
   description: "Weak encryption or hashing library used to encrypt password. Use a stronger algorithm."
-  name: "Force strong password encryption in applications processing sensitive data."
+  name: "Force strong password encryption."
   display_id: "CR-023"
   id: "detect_ruby_weak_encryption"
   query: |

--- a/pkg/commands/process/settings/policies.yml
+++ b/pkg/commands/process/settings/policies.yml
@@ -1,5 +1,5 @@
 logger_leaks:
-  description: "Leaking sensitive data to loggers is a common cause of data breaches. This policy looks for instances of sensitive data sent to loggers."
+  description: "Leaking sensitive data to loggers is a common cause of data leaks and can lead to data breaches. This policy looks for instances of sensitive data sent to loggers."
   name: "Do not send sensitive data to loggers."
   display_id: "CR-001"
   id: "detect_ruby_logger"
@@ -11,7 +11,7 @@ logger_leaks:
     - path: policies/leakage.rego
       name: bearer.leakage
 session_leaks:
-  description: "Sensitive data should not be stored in the session. This policy looks for any sensitive data stored within the session cookies."
+  description: "Sensitive data should not be stored in session cookies. This policy looks for any sensitive data stored within the session cookies."
   name: "Do not store sensitive data in session cookies."
   display_id: "CR-003"
   id: "detect_rails_session"
@@ -59,7 +59,7 @@ ssl_certificate_verification_disabled:
     - path: policies/ssl_certificate_verification_disabled.rego
       name: bearer.ssl_certificate_verification_disabled
 application_level_encryption_missing:
-  description: "Application-level encryption reduces that applications processing sensitive data can leak viewable data. This policy checks that sensitive data types in records are encrypted."
+  description: "Application-level encryption greatly reduces the risk of a data breach or data leak by making data unreadable. This policy checks if sensitive data types found in records are encrypted."
   name: "Force application-level encryption when processing sensitive data."
   display_id: "CR-021"
   id: "application_level_encryption_missing"
@@ -71,7 +71,7 @@ application_level_encryption_missing:
     - path: policies/application_level_encryption.rego
       name: bearer.application_level_encryption
 insecure_smtp_processing_sensitive_data:
-  description: "Secure connections to SMTP help prevent unauthorized actors from viewing transmitted data. This policy checks if SMTP mailer settings are set to only allow secure connections."
+  description: "Secure connections using SMTP help prevent unauthorized actors from viewing transmitted data. This policy checks if SMTP mailer settings are set to only allow secure connections."
   name: "Only communicate with secure SMTP connections."
   display_id: "CR-010"
   id: "detect_rails_insecure_smtp"
@@ -83,7 +83,7 @@ insecure_smtp_processing_sensitive_data:
     - path: policies/insecure_smtp.rego
       name: bearer.insecure_smtp
 http_get_parameters:
-  description: "Sensitive data should never be sent as part of the query string in HTTP get requests. This policy checks if sensitive data types are sent as GET parameters."
+  description: "Sensitive data should never be sent as part of the query string in HTTP GET requests. This policy checks if sensitive data types are sent as GET parameters."
   name: "Do not send sensitive data as HTTP GET parameters."
   display_id: "CR-015"
   id: "ruby_http_get_detection"
@@ -107,8 +107,8 @@ insecure_communication_processing_sensitive_data:
     - path: policies/insecure_communication.rego
       name: bearer.insecure_communication
 insecure_ftp_processing_sensitive_data:
-  description: "Communication with FTP servers should be done securely in applications that process sensitive data. This policy checks if FTP connections are made securely."
-  name: "Only communicate with secure FTP connections."
+  description: "Communication with FTP servers should be done securely over SFTP in applications that process sensitive data. This policy checks if all FTP connections are made using SFTP."
+  name: "Only communicate using SFTP connections."
   display_id: "CR-008"
   id: "detect_rails_insecure_ftp"
   query: |
@@ -119,8 +119,8 @@ insecure_ftp_processing_sensitive_data:
     - path: policies/insecure_ftp.rego
       name: bearer.insecure_ftp
 insecure_ftp_with_data_category:
-  description: "Files containing sensitive data should only be sent to secure FTP connections. This policy checks if files created using sensitive data are sent to unsecure FTP connections."
-  name: "Only send sensitive data to secure FTP connections."
+  description: "Files containing sensitive data should only be sent via SFTP connections. This policy checks if files created using sensitive data are sent to over SFTP connections."
+  name: "Only send sensitive data using SFTP connections."
   display_id: "CR-009"
   id: insecure_ftp_with_data_category
   query: |
@@ -131,8 +131,8 @@ insecure_ftp_with_data_category:
     - path: policies/insecure_ftp_with_data_category.rego
       name: bearer.insecure_ftp_with_data_category
 insecure_http_get:
-  description: "Applications processing sensitive data should only connect to secure HTTP connections. This policy checks for unsecured HTTP connections."
-  name: "Only communicate with secure HTTP connections."
+  description: "Applications processing sensitive data should only connect using HTTPS connections. This policy checks that all HTTP connections use HTTPS."
+  name: "Only communicate using HTTPS connections."
   display_id: "CR-013"
   id: insecure_http_get
   query: |
@@ -143,7 +143,7 @@ insecure_http_get:
     - path: policies/insecure_http_get.rego
       name: bearer.insecure_http_get
 insecure_http_with_data_category:
-  description: "Sensitive data sent through HTTP should only be done securely. This policy checks that any transmissions over HTTP that contain sensitive data do so over HTTPS."
+  description: "Sensitive data should only be sent through HTTPS. This policy checks that any transmissions over HTTP that contain sensitive data do so over HTTPS."
   name: "Only send sensitive data through HTTPS connections."
   display_id: "CR-014"
   id: insecure_http_with_data_category
@@ -181,7 +181,7 @@ weak_password_encryption:
     - path: policies/weak_password_encryption.rego
       name: bearer.weak_password_encryption
 password_length:
-  description: "Minimum password length should be enforced any time password creation occurs. This policy checks if configurations and validations made for passwords include a secure minimum length."
+  description: "Minimum password length should be enforced any time password creation occurs. This policy checks if configurations and validations made for passwords include a minimum length of 8."
   name: "Enforce stronger password requirements."
   display_id: "CR-019"
   id: "ruby_password_length"


### PR DESCRIPTION
## Description
This should probably be a couple of PRs, but the parts depend on one another.
- Updates policy names to reflect the new format. Synced with the existing notion policies list.
- Add new descriptions to each policy for docs. These should be clear until future decisions are made on larger-scale explanation/fix formats for policy docs.
- Updates policy file parsing to sort `policies.yml` by display_id (CR-001, CR-002, etc).
- Updates policy doc page to display new information and accept links to specific policies by ID (curio.sh/reference/policies/#cr-001 for example) (see image)
- Fixes mismatched CR IDs. A few policies did not match the ID assigned to them. Changed to reflect notion list (source of truth)

<img width="910" alt="CleanShot 2022-12-14 at 13 55 26@2x" src="https://user-images.githubusercontent.com/1649672/207723439-4a6a9607-42da-4ed8-af06-5f2494689555.png">


## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
