### PR TITLE
docs: add supported language page to docs

### DIFF
--- a/docs/_data/nav.js
+++ b/docs/_data/nav.js
@@ -25,6 +25,7 @@ module.exports = [
       { name: "Commands", url: "/reference/commands/" },
       { name: "Data Types", url: "/reference/datatypes/" },
       { name: "Policies", url: "/reference/policies/" },
+      { name: "Supported Languages", url: "/reference/supported-languages/" },
     ],
   },
 ];

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -6,11 +6,13 @@ permalink: "/"
 
 # Curio
 
-Welcome to the Curio documentation. Curio is a static code analysis tool (SAST) dedicated to data security. It scans your source code to discover sensitive data flows (PHI, PII, PD as well as Data stores, internal and external APIs) and data security risks (leaks, missing encryption, third-party sharing etc).
+Welcome to the Curio documentation. Curio is a static code analysis tool (SAST) dedicated to data security. It scans your source code to [discover sensitive data](/explanations/discovery-and-classification) flows (PHI, PII, PD as well as Data stores, internal and external APIs) and data security risks (leaks, missing encryption, third-party sharing etc).
 
 ## Getting started
 
-New to Curio? Check out the [quickstart](/quickstart/) to scan your first project. Ready to dive in? Check the [command reference](/reference/commands/) to configure Curio to your needs.
+New to Curio? Check out the [quickstart](/quickstart/) to scan your first project. 
+
+Ready to dive in? Curio's [reports](/explanations/reports/) are your path to analyzing data security risks in your application. Check the [supported languages](/reference/supported-languages/), then view the [command reference](/reference/commands/) to configure Curio to your needs.
 
 
 ## Explanations
@@ -27,3 +29,4 @@ Coming soon...
 - [Commands](/reference/commands/)
 - [Supported Data Types](/reference/datatypes/)
 - [Built-in Policies](/reference/policies/)
+- [Supported Languages](/reference/supported-languages/)

--- a/docs/explanations/reports.md
+++ b/docs/explanations/reports.md
@@ -44,6 +44,8 @@ MEDIUM: 2 (Insecure SMTP, Insecure FTP)
 LOW: 0
 ```
 
+Policy reports are [currently available](/reference/supported-languages/) for Ruby projects, with Javascript/Typescript coming soon and more languages to follow.
+
 To run your first policy report, run `curio scan` with the `--report policies` flag.
 
 ## Data Flow Report

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -5,7 +5,7 @@ layout: layouts/doc.njk
 
 # Quick Start
 
-Discover data security risks and vulnerabilities in only a few minutes. In this guide you will install Curio, run a scan on a local project, and view the results of a policy report. Let's get started!
+Discover data security risks and vulnerabilities in only a few minutes. In this guide you will install Curio, run a scan on a local project, and view the results of a [policy report](/explanations/reports/#policy-report). Let's get started!
 
 ## Installation
 

--- a/docs/reference/supported-languages.md
+++ b/docs/reference/supported-languages.md
@@ -1,0 +1,27 @@
+---
+title: Supported Languages
+layout: layouts/doc.njk
+---
+
+# Supported languages
+
+Curio currently fully supports Ruby, while JavaScript/TypeScript support is coming soon. Additional languages listed below are supported only for the Data Flow Report features for now.
+
+| Languages       | Data Flow Report | Policy Report |
+| --------------- | ---------------- | ------------- |
+| Ruby            | ✅                | ✅             |
+| JavaScript / TS | ✅                | Coming soon   |
+| PHP             | ✅                | Coming later  |
+| Java            | ✅                | Coming later  |
+| C#              | ✅                | Coming later  |
+| Go              | ✅                | Coming later  |
+| Python          | ✅                | Coming later  |
+
+In addition, Curio also supports these common structured data file formats:
+
+| Format   | Support |
+| -------- | ------- |
+| SQL      | ✅       |
+| OpenAPI  | ✅       |
+| GraphQL  | ✅       |
+| Protobuf | ✅       |


### PR DESCRIPTION
## Description
- Adds a 'supported languages' page to the documentation. It exists in the github readme, but was missing from the docs.
- Adds inter-linking of resources to make moving between documents easier.

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
