### PR TITLE
fix(policies): update filtering to use policy display IDs

### DIFF
--- a/pkg/commands/process/settings/settings.go
+++ b/pkg/commands/process/settings/settings.go
@@ -135,12 +135,12 @@ func FromOptions(opts flag.Options) (Config, error) {
 	for key := range policies {
 		policy := policies[key]
 
-		if len(opts.PolicyOptions.OnlyPolicy) > 0 && !opts.PolicyOptions.OnlyPolicy[policy.Id] {
+		if len(opts.PolicyOptions.OnlyPolicy) > 0 && !opts.PolicyOptions.OnlyPolicy[policy.DisplayId] {
 			delete(policies, key)
 			continue
 		}
 
-		if opts.PolicyOptions.SkipPolicy[policy.Id] {
+		if opts.PolicyOptions.SkipPolicy[policy.DisplayId] {
 			delete(policies, key)
 			continue
 		}


### PR DESCRIPTION
## Description

Policy filtering now uses display ids (CR-001) instead of internal policy id 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
