### PR TITLE
feat: Consolation message for codebases where no policies supported

### DIFF
--- a/pkg/report/output/output.go
+++ b/pkg/report/output/output.go
@@ -40,9 +40,9 @@ func ReportPolicies(report types.Report, output *zerolog.Event, config settings.
 	}
 
 	if !reportSupported {
-		placeholderStr, err2 := getPlaceholderOutput(report, config, lineOfCodeOutput)
-		if err2 != nil {
-			err = err2
+		var placeholderStr *strings.Builder
+		placeholderStr, err = getPlaceholderOutput(report, config, lineOfCodeOutput)
+		if err != nil {
 			return
 		}
 

--- a/pkg/report/output/stats/stats.go
+++ b/pkg/report/output/stats/stats.go
@@ -1,20 +1,41 @@
 package stats
 
 import (
+	"fmt"
+	"strings"
+
+	"github.com/bearer/curio/pkg/classification/db"
 	"github.com/bearer/curio/pkg/commands/process/settings"
+
+	// reportdetectors "github.com/bearer/curio/pkg/report/detectors"
 	"github.com/bearer/curio/pkg/report/output/dataflow"
+	"github.com/bearer/curio/pkg/util/maputil"
 	"github.com/hhatto/gocloc"
+	"github.com/fatih/color"
 )
 
 type DataType struct {
-	Name        string `json:"name" yaml:"name"`
-	Occurrences int    `json:"occurrences" yaml:"occurrences"`
+	Name         string `json:"name" yaml:"name"`
+	CategoryUUID string `json:"-" yaml:"-"`
+	Encrypted    bool   `json:"-" yaml:"-"`
+	Occurrences  int    `json:"occurrences" yaml:"occurrences"`
+}
+
+type DataStore struct {
+	Name                       string `json:"name" yaml:"name"`
+	NumberOfDataTypes          int `json:"number_of_data_types" yaml:"number_of_data_types"`
+	NumberOfEncryptedDataTypes int `json:"number_of_encrypted_data_types" yaml:"number_of_encrypted_data_types"`
 }
 
 type Stats struct {
-	NumberOfLines     int32      `json:"number_of_lines" yaml:"number_of_lines"`
-	NumberOfDataTypes int        `json:"number_of_data_types" yaml:"number_of_data_types"`
-	DataTypes         []DataType `json:"data_types" yaml:"data_types"`
+	NumberOfLines        int32            `json:"number_of_lines" yaml:"number_of_lines"`
+	NumberOfDataTypes    int              `json:"number_of_data_types" yaml:"number_of_data_types"`
+	DataTypes            []DataType       `json:"data_types" yaml:"data_types"`
+	DataStores           []DataStore      `json:"-" yaml:"-"`
+	NumberOfExternalAPIs int              `json:"-" yaml:"-"`
+	NumberOfInternalAPIs int              `json:"-" yaml:"-"`
+	Languages            map[string]int32 `json:"-" yaml:"-"`
+	DataGroups           []string         `json:"-" yaml:"-"`
 }
 
 func GetOutput(inputgocloc *gocloc.Result, inputDataflow *dataflow.DataFlow, config settings.Config) (*Stats, error) {
@@ -27,15 +48,142 @@ func GetOutput(inputgocloc *gocloc.Result, inputDataflow *dataflow.DataFlow, con
 			occurrences += len(detector.Locations)
 		}
 
+		encrypted := false
+	outer:
+		for _, detector := range data_type.Detectors {
+			for _, location := range detector.Locations {
+				if location.Encrypted != nil && *location.Encrypted {
+					encrypted = true
+					break outer
+				}
+			}
+		}
+
 		data_types = append(data_types, DataType{
-			Name:        data_type.Name,
-			Occurrences: occurrences,
+			Name:         data_type.Name,
+			CategoryUUID: data_type.CategoryUUID,
+			Encrypted:    encrypted,
+			Occurrences:  occurrences,
 		})
 	}
 
+	dataGroupNames := getDataGroupNames(config, data_types)
+
+	dataStores := []DataStore{}
+	numberOfExternalAPIs := 0
+	numberOfInternalAPIs := 0
+	for _, component := range inputDataflow.Components {
+		if strings.HasPrefix(component.Name, "http://") || strings.HasPrefix(component.Name, "https://") {
+			numberOfInternalAPIs++
+		}
+
+		// @todo FIXME: Collect statistics for data stores
+
+		// detectors := []string{}
+		// for _, location := range component.Locations {
+		//	detectors = append(detectors, location.Detector)
+		// }
+
+		// for _, detector := range detectors {
+		//	if detector == string(reportdetectors.DetectorSQL) {
+		//		dataStores = append(dataStores, DataStore{
+		//			Name: "",
+		//			NumberOfDataTypes: 0,
+		//			NumberOfEncryptedDataTypes: 0,
+		//		})
+		//	}
+		// }
+	}
+
+	languages := map[string]int32{}
+	for _, language := range inputgocloc.Languages {
+		languages[language.Name] = language.Code
+	}
+
 	return &Stats{
-		NumberOfLines:     inputgocloc.Total.Code,
-		NumberOfDataTypes: numberOfDataTypesFound,
-		DataTypes:         data_types,
+		NumberOfLines:        inputgocloc.Total.Code,
+		NumberOfDataTypes:    numberOfDataTypesFound,
+		DataTypes:            data_types,
+		DataStores:           dataStores,
+		NumberOfExternalAPIs: numberOfExternalAPIs,
+		NumberOfInternalAPIs: numberOfInternalAPIs,
+		Languages:            languages,
+		DataGroups:           dataGroupNames,
 	}, nil
+}
+
+func getDataGroupNames(config settings.Config, dataTypes []DataType) []string {
+	dataCategories := db.DefaultWithContext(config.Scan.Context).DataCategories
+	dataGroups := make(map[string]bool)
+	for _, dataType := range dataTypes {
+		for _, category := range dataCategories {
+			if category.UUID == dataType.CategoryUUID {
+				for _, group := range category.Groups {
+					dataGroups[group.Name] = true
+				}
+				break
+			}
+		}
+	}
+
+	return maputil.SortedStringKeys(dataGroups)
+}
+
+func GetPlaceholderOutput(inputgocloc *gocloc.Result, inputDataflow *dataflow.DataFlow, config settings.Config) (outputStr *strings.Builder, err error) {
+	outputStr = &strings.Builder{}
+	statistics, err := GetOutput(inputgocloc, inputDataflow, config)
+
+	totalDataTypeOccurrences := 0
+	for _, dataType := range statistics.DataTypes {
+		totalDataTypeOccurrences += dataType.Occurrences
+	}
+
+	supportURL := "https://curio.sh/explanations/reports/"
+	outputStr.WriteString(fmt.Sprintf(`
+The policy report is not yet available for your stack. Learn more at %s
+
+Though this doesn’t mean the curious bear comes empty-handed, it found:
+
+- %d unique data type(s), representing %d occurrences, including %s.`,
+		supportURL,
+		statistics.NumberOfDataTypes,
+		totalDataTypeOccurrences,
+		strings.Join(statistics.DataGroups, ", ")))
+
+	if len(statistics.DataStores) != 0 {
+		totalDataStoreDataTypes := 0
+		totalDataStoreEncryptedDataTypes := 0
+		for _, dataStore := range statistics.DataStores {
+			totalDataStoreDataTypes += dataStore.NumberOfDataTypes
+			totalDataStoreEncryptedDataTypes += dataStore.NumberOfEncryptedDataTypes
+		}
+
+		outputStr.WriteString(fmt.Sprintf(
+			`
+- %d database(s) storing %d data type(s) including %d encrypted data type(s).`,
+			len(statistics.DataStores),
+			totalDataStoreDataTypes,
+			totalDataStoreEncryptedDataTypes))
+	}
+
+	if statistics.NumberOfExternalAPIs != 0 {
+		outputStr.WriteString(fmt.Sprintf(
+			`
+- %d external API(s).`,
+			statistics.NumberOfExternalAPIs))
+	}
+
+	if statistics.NumberOfInternalAPIs != 0 {
+		outputStr.WriteString(fmt.Sprintf(
+			`
+- %d internal API(s).`,
+			statistics.NumberOfInternalAPIs))
+	}
+
+	suggestedCommand := color.New(color.Italic).Sprintf("curio scan --report dataflow")
+	outputStr.WriteString(fmt.Sprintf(`
+
+Run the data flow report if you want the full output using: %s`, suggestedCommand))
+
+	return
 }

--- a/pkg/report/output/stats/stats.go
+++ b/pkg/report/output/stats/stats.go
@@ -7,7 +7,6 @@ import (
 	"github.com/bearer/curio/pkg/classification/db"
 	"github.com/bearer/curio/pkg/commands/process/settings"
 
-	// reportdetectors "github.com/bearer/curio/pkg/report/detectors"
 	"github.com/bearer/curio/pkg/report/output/dataflow"
 	"github.com/bearer/curio/pkg/util/maputil"
 	"github.com/hhatto/gocloc"


### PR DESCRIPTION
## Description

When a codebase is such &mdash; by virtue of languages, technologies, etc. present &mdash; that no policies are applicable, then we should show a message summarizing what we detected.

### Limitations

In this initial implementation, the following features are missing.

* No warning icon/emoji displayed
* No count of database, and associated data type counts, displayed
* No count of external APIs displayed
* Internal API counting is implemented, but only in a rudimentary manner: components whose name string begins with either `"http://"` or `"https://"` are counted as internal APIs

### Screenshot

![Screenshot_2022-12-15_10-21-01](https://user-images.githubusercontent.com/132732/207835556-5cc712e5-d345-4fb9-8b3f-694af355f685.png)

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [X] I've updated or added documentation if required.
- [X] I've included usage information in the description if CLI behavior was updated or added.
- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
