### PR TITLE
feat: Add external service count to policies report placeholder output

### DIFF
--- a/pkg/report/output/dataflow/components/components.go
+++ b/pkg/report/output/dataflow/components/components.go
@@ -1,6 +1,8 @@
 package components
 
 import (
+	"strings"
+
 	"github.com/bearer/curio/pkg/report/output/dataflow/types"
 
 	dependenciesclassification "github.com/bearer/curio/pkg/classification/dependencies"
@@ -16,9 +18,10 @@ type Holder struct {
 }
 
 type component struct {
-	name      string
-	uuid      string
-	detectors map[string]*detector // group detectors by detectorName
+	name           string
+	component_type string
+	uuid           string
+	detectors      map[string]*detector // group detectors by detectorName
 }
 
 type detector struct {
@@ -38,15 +41,35 @@ func New(isInternal bool) *Holder {
 	}
 }
 
+func getComponentType(classificationReason string) string {
+	if strings.HasPrefix(classificationReason, "internal_domain_") {
+		return "internal_service"
+	}
+
+	if strings.HasPrefix(classificationReason, "recipe_match") {
+		return "external_service"
+	}
+
+	return ""
+}
+
 func (holder *Holder) AddInterface(classifiedDetection interfaceclassification.ClassifiedInterface) error {
 	if classifiedDetection.Classification == nil {
 		return nil
 	}
 
+	componentType := getComponentType(classifiedDetection.Classification.Decision.Reason)
+
+	componentUUID := classifiedDetection.Classification.RecipeUUID
+	if componentUUID == "" {
+		componentUUID = classifiedDetection.Classification.Name()
+	}
+
 	if classifiedDetection.Classification.Decision.State == classify.Valid {
 		holder.addComponent(
 			classifiedDetection.Classification.Name(),
-			classifiedDetection.Classification.RecipeUUID,
+			componentType,
+			componentUUID,
 			string(classifiedDetection.DetectorType),
 			classifiedDetection.Source.Filename,
 			*classifiedDetection.Source.LineNumber,
@@ -61,10 +84,18 @@ func (holder *Holder) AddDependency(classifiedDetection dependenciesclassificati
 		return nil
 	}
 
+	componentType := getComponentType(classifiedDetection.Classification.Decision.Reason)
+
+	componentUUID := classifiedDetection.Classification.RecipeUUID
+	if componentUUID == "" {
+		componentUUID = classifiedDetection.Classification.RecipeName
+	}
+
 	if classifiedDetection.Classification.Decision.State == classify.Valid {
 		holder.addComponent(
 			classifiedDetection.Classification.RecipeName,
-			classifiedDetection.Classification.RecipeUUID,
+			componentType,
+			componentUUID,
 			string(classifiedDetection.DetectorType),
 			classifiedDetection.Source.Filename,
 			*classifiedDetection.Source.LineNumber,
@@ -79,9 +110,12 @@ func (holder *Holder) AddFramework(classifiedDetection frameworkclassification.C
 		return nil
 	}
 
+	componentType := getComponentType(classifiedDetection.Classification.Decision.Reason)
+
 	if classifiedDetection.Classification.Decision.State == classify.Valid {
 		holder.addComponent(
 			classifiedDetection.Classification.RecipeName,
+			componentType,
 			classifiedDetection.Classification.RecipeUUID,
 			string(classifiedDetection.DetectorType),
 			classifiedDetection.Source.Filename,
@@ -93,7 +127,7 @@ func (holder *Holder) AddFramework(classifiedDetection frameworkclassification.C
 }
 
 // addComponent adds component to hash list and at the same time blocks duplicates
-func (holder *Holder) addComponent(componentName string, componentUUID string, detectorName string, fileName string, lineNumber int) {
+func (holder *Holder) addComponent(componentName string, componentType string, componentUUID string, detectorName string, fileName string, lineNumber int) {
 	// create component entry if it doesn't exist
 	if _, exists := holder.components[componentUUID]; !exists {
 		var uuid string
@@ -101,9 +135,10 @@ func (holder *Holder) addComponent(componentName string, componentUUID string, d
 			uuid = componentUUID
 		}
 		holder.components[componentUUID] = &component{
-			name:      componentName,
-			uuid:      uuid,
-			detectors: make(map[string]*detector),
+			name:           componentName,
+			component_type: componentType,
+			uuid:           uuid,
+			detectors:      make(map[string]*detector),
 		}
 	}
 
@@ -137,6 +172,7 @@ func (holder *Holder) ToDataFlow() []types.Component {
 	for _, targetComponent := range availableComponents {
 		constructedComponent := types.Component{
 			Name:      targetComponent.name,
+			Type:      targetComponent.component_type,
 			UUID:      targetComponent.uuid,
 			Locations: make([]types.ComponentLocation, 0),
 		}

--- a/pkg/report/output/dataflow/components/components.go
+++ b/pkg/report/output/dataflow/components/components.go
@@ -86,16 +86,11 @@ func (holder *Holder) AddDependency(classifiedDetection dependenciesclassificati
 
 	componentType := getComponentType(classifiedDetection.Classification.Decision.Reason)
 
-	componentUUID := classifiedDetection.Classification.RecipeUUID
-	if componentUUID == "" {
-		componentUUID = classifiedDetection.Classification.RecipeName
-	}
-
 	if classifiedDetection.Classification.Decision.State == classify.Valid {
 		holder.addComponent(
 			classifiedDetection.Classification.RecipeName,
 			componentType,
-			componentUUID,
+			classifiedDetection.Classification.RecipeUUID,
 			string(classifiedDetection.DetectorType),
 			classifiedDetection.Source.Filename,
 			*classifiedDetection.Source.LineNumber,

--- a/pkg/report/output/dataflow/components/components_test.go
+++ b/pkg/report/output/dataflow/components/components_test.go
@@ -79,8 +79,8 @@ func TestDataflowComponents(t *testing.T) {
 		},
 		{
 			Name: "multiple detections - deterministic output",
-			FileContent: `{	"detector_type": "ruby", "type": "interface_classified", "source": {"filename": "billing.rb", "line_number": 2}, "classification": { "Decision": { "state": "valid" }, "recipe_name": "Stripe", "recipe_match": true}}
-{"detector_type": "gemfile-lock", "type": "dependency_classified", "source": {"filename": "Gemfile.lock", "line_number": 258}, "classification": { "Decision": { "state": "valid" }, "recipe_name": "Stripe", "recipe_match": true}}`,
+			FileContent: `{	"detector_type": "ruby", "type": "interface_classified", "source": {"filename": "billing.rb", "line_number": 2}, "classification": { "Decision": { "state": "valid" }, "recipe_name": "Stripe", "recipe_uuid": "123-abc", "recipe_match": true}}
+{"detector_type": "gemfile-lock", "type": "dependency_classified", "source": {"filename": "Gemfile.lock", "line_number": 258}, "classification": { "Decision": { "state": "valid" }, "recipe_name": "Stripe", "recipe_uuid": "123-abc", "recipe_match": true}}`,
 			Want: []types.Component{
 				{
 					Name: "Stripe",

--- a/pkg/report/output/dataflow/types/components.go
+++ b/pkg/report/output/dataflow/types/components.go
@@ -2,6 +2,7 @@ package types
 
 type Component struct {
 	Name      string              `json:"name" yaml:"name"`
+	Type      string              `json:"type" yaml:"type"`
 	UUID      string              `json:"uuid,omitempty" yaml:"uuid,omitempty"`
 	Locations []ComponentLocation `json:"locations" yaml:"locations"`
 }

--- a/pkg/report/output/stats/stats.go
+++ b/pkg/report/output/stats/stats.go
@@ -72,8 +72,11 @@ func GetOutput(inputgocloc *gocloc.Result, inputDataflow *dataflow.DataFlow, con
 	numberOfExternalAPIs := 0
 	numberOfInternalAPIs := 0
 	for _, component := range inputDataflow.Components {
-		if strings.HasPrefix(component.Name, "http://") || strings.HasPrefix(component.Name, "https://") {
+		if component.Type == "internal_service" {
 			numberOfInternalAPIs++
+		}
+		if component.Type == "external_service" {
+			numberOfExternalAPIs++
 		}
 
 		// @todo FIXME: Collect statistics for data stores
@@ -168,14 +171,14 @@ Though this doesn’t mean the curious bear comes empty-handed, it found:
 	if statistics.NumberOfExternalAPIs != 0 {
 		outputStr.WriteString(fmt.Sprintf(
 			`
-- %d external API(s).`,
+- %d external service(s).`,
 			statistics.NumberOfExternalAPIs))
 	}
 
 	if statistics.NumberOfInternalAPIs != 0 {
 		outputStr.WriteString(fmt.Sprintf(
 			`
-- %d internal API(s).`,
+- %d internal URL(s).`,
 			statistics.NumberOfInternalAPIs))
 	}
 


### PR DESCRIPTION
## Description

This uses the newly-exposed component type in the dataflow report; when the component type is `"external_service"`, then we count the component as an external API.

Also change the previous internal service counting scheme to use the new mechanism.

**Note**

This also changes the titles for some list items in the output, to reduce the potential for confusion:

* "external API(s)" -> "external service(s)"
* "internal API(s)" -> "internal URL(s)"

### Screenshots

![Screenshot_2022-12-15_15-14-39](https://user-images.githubusercontent.com/132732/207897308-a5de0fc3-8064-4491-9644-39938307f8d2.png)


## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [X] I've updated or added documentation if required.
- [X] I've included usage information in the description if CLI behavior was updated or added.
- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
