### PR TITLE
fix: Disable policy report entirely unless Ruby language detected

### DIFF
--- a/pkg/report/output/output.go
+++ b/pkg/report/output/output.go
@@ -161,14 +161,19 @@ func anySupportedLanguagesPresent(inputgocloc *gocloc.Result, config settings.Co
 		foundLanguages[strings.ToLower(language.Name)] = true
 	}
 
-	for foundLanguage := range foundLanguages {
-		for ruleLanguage := range ruleLanguages {
-			if foundLanguage == ruleLanguage {
-				log.Debug().Msgf("Found a language for which policies are applicable: %s", foundLanguage)
-				return true, nil
-			}
-		}
+	_, rubyPresent := foundLanguages["ruby"]
+	if rubyPresent {
+		return true, nil
 	}
+
+	// for foundLanguage := range foundLanguages {
+	//	for ruleLanguage := range ruleLanguages {
+	//		if foundLanguage == ruleLanguage {
+	//			log.Debug().Msgf("Found a language for which policies are applicable: %s", foundLanguage)
+	//			return true, nil
+	//		}
+	//	}
+	// }
 
 	log.Debug().Msg("No language found for which policies are applicable")
 	return false, nil


### PR DESCRIPTION
## Description

Even though we have policies that support SQL, we do not want to run these in non-Ruby projects.

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [X] I've updated or added documentation if required.
- [X] I've included usage information in the description if CLI behavior was updated or added.
- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
