### PR TITLE
fix: fix bad flag examples

### DIFF
--- a/docs/_data/curio_scan.yaml
+++ b/docs/_data/curio_scan.yaml
@@ -13,15 +13,15 @@ options:
     - name: disable-domain-resolution
       default_value: "true"
       usage: |
-        Do not attempt to resolve detected domains during classification (default false), e.g. --disable-domain-resolution=true
+        Do not attempt to resolve detected domains during classification
     - name: domain-resolution-timeout
       default_value: 3s
       usage: |
-        Set timeout when attempting to resolve detected domains during classification (default 3 seconds), e.g. --domain-resolution-timeout=3s
+        Set timeout when attempting to resolve detected domains during classification, e.g. --domain-resolution-timeout=3s
     - name: existing-worker
       usage: Specify the URL of an existing worker.
     - name: file-size-max
-      default_value: "100000"
+      default_value: "2000000"
       usage: Ignore files larger than the specified value.
     - name: files-to-batch
       default_value: "1"
@@ -36,7 +36,7 @@ options:
     - name: internal-domains
       default_value: '[]'
       usage: |
-        Define regular expressions for better classification of private or unreachable domains e.g. --internal-domains="*.my-company.com,private.sh"
+        Define regular expressions for better classification of private or unreachable domains e.g. --internal-domains=".*.my-company.com,private.sh"
     - name: memory-max
       default_value: "800000000"
       usage: |

--- a/integration/flags/.snapshots/TestMetadataFlags-help-scan
+++ b/integration/flags/.snapshots/TestMetadataFlags-help-scan
@@ -21,10 +21,10 @@ Policy Flags
 Scan Flags
       --context string                       Expand context of schema classification e.g., --context=health, to include data types particular to health
       --debug                                Enable debug logs
-      --disable-domain-resolution            Do not attempt to resolve detected domains during classification (default false), e.g. --disable-domain-resolution=true (default true)
-      --domain-resolution-timeout duration   Set timeout when attempting to resolve detected domains during classification (default 3 seconds), e.g. --domain-resolution-timeout=3s (default 3s)
+      --disable-domain-resolution            Do not attempt to resolve detected domains during classification (default true)
+      --domain-resolution-timeout duration   Set timeout when attempting to resolve detected domains during classification, e.g. --domain-resolution-timeout=3s (default 3s)
       --force                                Disable the cache and runs the detections again
-      --internal-domains strings             Define regular expressions for better classification of private or unreachable domains e.g. --internal-domains="*.my-company.com,private.sh"
+      --internal-domains strings             Define regular expressions for better classification of private or unreachable domains e.g. --internal-domains=".*.my-company.com,private.sh"
       --quiet                                Suppress non-essential messages
       --skip-path strings                    Specify the comma separated files and directories to skip. Supports * syntax, e.g. --skip-path users/*.go,users/admin.sql
 

--- a/integration/flags/.snapshots/TestMetadataFlags-scan-help
+++ b/integration/flags/.snapshots/TestMetadataFlags-scan-help
@@ -21,10 +21,10 @@ Policy Flags
 Scan Flags
       --context string                       Expand context of schema classification e.g., --context=health, to include data types particular to health
       --debug                                Enable debug logs
-      --disable-domain-resolution            Do not attempt to resolve detected domains during classification (default false), e.g. --disable-domain-resolution=true (default true)
-      --domain-resolution-timeout duration   Set timeout when attempting to resolve detected domains during classification (default 3 seconds), e.g. --domain-resolution-timeout=3s (default 3s)
+      --disable-domain-resolution            Do not attempt to resolve detected domains during classification (default true)
+      --domain-resolution-timeout duration   Set timeout when attempting to resolve detected domains during classification, e.g. --domain-resolution-timeout=3s (default 3s)
       --force                                Disable the cache and runs the detections again
-      --internal-domains strings             Define regular expressions for better classification of private or unreachable domains e.g. --internal-domains="*.my-company.com,private.sh"
+      --internal-domains strings             Define regular expressions for better classification of private or unreachable domains e.g. --internal-domains=".*.my-company.com,private.sh"
       --quiet                                Suppress non-essential messages
       --skip-path strings                    Specify the comma separated files and directories to skip. Supports * syntax, e.g. --skip-path users/*.go,users/admin.sql
 

--- a/integration/flags/metadata_flags_test.go
+++ b/integration/flags/metadata_flags_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func newMetadataTest(name string, arguments []string) testhelper.TestCase {
-	return testhelper.NewTestCase(name, arguments, testhelper.TestCaseOptions{DisplayStdErr: true})
+	return testhelper.NewTestCase(name, arguments, testhelper.TestCaseOptions{DisplayStdErr: true, IgnoreForce: true})
 }
 
 func TestMetadataFlags(t *testing.T) {

--- a/integration/internal/testhelper/testhelper.go
+++ b/integration/internal/testhelper/testhelper.go
@@ -15,10 +15,12 @@ type TestCase struct {
 	shouldSucceed bool
 	options       TestCaseOptions
 	displayStdErr bool
+	ignoreForce   bool
 }
 
 type TestCaseOptions struct {
 	DisplayStdErr bool
+	IgnoreForce   bool
 }
 
 func NewTestCase(name string, arguments []string, options TestCaseOptions) TestCase {
@@ -28,6 +30,7 @@ func NewTestCase(name string, arguments []string, options TestCaseOptions) TestC
 		shouldSucceed: true,
 		options:       options,
 		displayStdErr: options.DisplayStdErr,
+		ignoreForce:   options.IgnoreForce,
 	}
 }
 
@@ -79,8 +82,10 @@ func RunTests(t *testing.T, tests []TestCase) {
 			arguments := test.arguments
 
 			if !test.displayStdErr {
-				arguments = append(arguments, "--quiet", "--force")
-			} else {
+				arguments = append(arguments, "--quiet")
+			}
+
+			if !test.ignoreForce {
 				arguments = append(arguments, "--force")
 			}
 

--- a/pkg/flag/scan_flags.go
+++ b/pkg/flag/scan_flags.go
@@ -28,19 +28,19 @@ var (
 		Name:       "disable-domain-resolution",
 		ConfigName: "scan.disable-domain-resolution",
 		Value:      true,
-		Usage:      "Do not attempt to resolve detected domains during classification (default false), e.g. --disable-domain-resolution=true",
+		Usage:      "Do not attempt to resolve detected domains during classification",
 	}
 	DomainResolutionTimeoutFlag = Flag{
 		Name:       "domain-resolution-timeout",
 		ConfigName: "scan.domain-resolution-timeout",
 		Value:      3 * time.Second,
-		Usage:      "Set timeout when attempting to resolve detected domains during classification (default 3 seconds), e.g. --domain-resolution-timeout=3s",
+		Usage:      "Set timeout when attempting to resolve detected domains during classification, e.g. --domain-resolution-timeout=3s",
 	}
 	InternalDomainsFlag = Flag{
 		Name:       "internal-domains",
 		ConfigName: "scan.internal-domains",
 		Value:      []string{},
-		Usage:      "Define regular expressions for better classification of private or unreachable domains e.g. --internal-domains=\"*.my-company.com,private.sh\"",
+		Usage:      "Define regular expressions for better classification of private or unreachable domains e.g. --internal-domains=\".*.my-company.com,private.sh\"",
 	}
 	ContextFlag = Flag{
 		Name:       "context",


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Fixing some outdated flag docs - we were giving default values in the description that weren't ideal
Also fixed bad example for internal domain (invalid regex)

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
