### PR TITLE
doc: remove license for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@
 
   [![GitHub Release][release-img]][release]
   [![Test][test-img]][test]
-  ![GitHub](https://img.shields.io/github/license/bearer/curio)
   [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
   [![Discord](https://img.shields.io/discord/1042147477765242973?label=discord)][discord]
 


### PR DESCRIPTION
Elastic doesn't seem to be supported as of today by GitHub

## Description
<!-- What does this PR do and how does it -->

Removing License badge for now since it is not supported by GitHub as of today.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
