### PR TITLE
docs: fix policy id slugs for anchor links

### DIFF
--- a/docs/reference/policies.njk
+++ b/docs/reference/policies.njk
@@ -13,7 +13,7 @@ Curio includes the following policies by default.
 {% endrenderTemplate %}
 
 {% for policy in policies %}
-  <h2 id="{{policy.display_id | slugify}}">{{policy.display_id}}: {{policy.name}}</h2>
+  <h2 id="{{policy.display_id}}">{{policy.display_id}}: {{policy.name}}</h2>
   <h3>Description</h3>
   <p>{{policy.description}}</p>
   <h3>{{policy.display_id}} configuration files</h3>


### PR DESCRIPTION
## Description
Browsers are fussy about case sensitivity with the in-page anchors. Stops policy page from slugifying policy display IDs so URLs from CLI work as expected.
## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
