### PR TITLE
docs: remove install warning from quickstart

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -13,8 +13,6 @@ Curio is available as a standalone executable binary. The latest release is avai
 
 ### Install Script
 
-:warning: **Not working until public**: Use the [Binary](#binary) instructions in the next section :warning:
-
 This script downloads the Curio binary automatically based on your OS and architecture.
 
 ```bash


### PR DESCRIPTION
## Description
Removes the 'temporary' warning from the quickstart to mirror #268.

Rebuild docs after merging

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
