### PR TITLE
feat: Add database information to policies report placeholder output

### DIFF
--- a/pkg/classification/db/db.go
+++ b/pkg/classification/db/db.go
@@ -43,6 +43,7 @@ type Recipe struct {
 	URLS     []string  `json:"urls" yaml:"urls"`
 	Name     string    `json:"name" yaml:"name"`
 	Type     string    `json:"type" yaml:"type"`
+	SubType  string    `json:"sub_type" yaml:"sub_type"`
 	Packages []Package `json:"packages" yaml:"packages"`
 	UUID     string    `json:"uuid" yaml:"uuid"`
 }

--- a/pkg/classification/db/recipes/abbyy_cloud_ocr_sdk.json
+++ b/pkg/classification/db/recipes/abbyy_cloud_ocr_sdk.json
@@ -9,5 +9,6 @@
     "https://cloud.ocrsdk.com"
   ],
   "packages": [],
-  "uuid": "5e82da9f-8ba8-4956-b0ae-185724785eca"
+  "uuid": "5e82da9f-8ba8-4956-b0ae-185724785eca",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/abtasty.json
+++ b/pkg/classification/db/recipes/abtasty.json
@@ -6,5 +6,6 @@
     "https://try.abtasty.com"
   ],
   "packages": [],
-  "uuid": "fc6dd834-feb7-4c23-8c02-9239e0b0fea2"
+  "uuid": "fc6dd834-feb7-4c23-8c02-9239e0b0fea2",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/active_directory.json
+++ b/pkg/classification/db/recipes/active_directory.json
@@ -10,5 +10,6 @@
       "package_manager": "npm"
     }
   ],
-  "uuid": "5da94a12-9635-409b-a7ae-7e9a892578bd"
+  "uuid": "5da94a12-9635-409b-a7ae-7e9a892578bd",
+  "sub_type": "database"
 }

--- a/pkg/classification/db/recipes/activecampaign.json
+++ b/pkg/classification/db/recipes/activecampaign.json
@@ -12,5 +12,6 @@
       "package_manager": "packagist"
     }
   ],
-  "uuid": "afaa1456-989f-4672-b4a5-976f1316fc9e"
+  "uuid": "afaa1456-989f-4672-b4a5-976f1316fc9e",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/adictiz.json
+++ b/pkg/classification/db/recipes/adictiz.json
@@ -6,5 +6,6 @@
     "https://api.adictiz.com"
   ],
   "packages": [],
-  "uuid": "8ac17d90-1489-4d6b-98be-a2a8ac167616"
+  "uuid": "8ac17d90-1489-4d6b-98be-a2a8ac167616",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/adjust.json
+++ b/pkg/classification/db/recipes/adjust.json
@@ -6,5 +6,6 @@
     "https://api.adjust.com"
   ],
   "packages": [],
-  "uuid": "1545189b-bfbb-4233-9baa-f734fc04a78b"
+  "uuid": "1545189b-bfbb-4233-9baa-f734fc04a78b",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/adobe_campaign_neolane.json
+++ b/pkg/classification/db/recipes/adobe_campaign_neolane.json
@@ -10,5 +10,6 @@
       "package_manager": "nuget"
     }
   ],
-  "uuid": "d3b1bf1b-f2b0-497a-85e2-9627fc0eedc1"
+  "uuid": "d3b1bf1b-f2b0-497a-85e2-9627fc0eedc1",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/adobe_scene7.json
+++ b/pkg/classification/db/recipes/adobe_scene7.json
@@ -6,5 +6,6 @@
     "https://*.scene7.com"
   ],
   "packages": [],
-  "uuid": "e465626b-e35a-4aa4-bb9b-bb9270fbbc47"
+  "uuid": "e465626b-e35a-4aa4-bb9b-bb9270fbbc47",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/adotmob.json
+++ b/pkg/classification/db/recipes/adotmob.json
@@ -7,5 +7,6 @@
     "https://tracker.adotmob.com"
   ],
   "packages": [],
-  "uuid": "af99b1dc-ba20-40a4-a2b0-ffdbdb52be16"
+  "uuid": "af99b1dc-ba20-40a4-a2b0-ffdbdb52be16",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/adroll.json
+++ b/pkg/classification/db/recipes/adroll.json
@@ -6,5 +6,6 @@
     "https://*.adroll.com"
   ],
   "packages": [],
-  "uuid": "524be664-02b3-4da3-9cc6-6a8ff3c53a81"
+  "uuid": "524be664-02b3-4da3-9cc6-6a8ff3c53a81",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/adyen.json
+++ b/pkg/classification/db/recipes/adyen.json
@@ -12,5 +12,6 @@
     "https://checkout-test.adyen.com"
   ],
   "packages": [],
-  "uuid": "d050650e-f863-4ed8-9342-3a54b32335b8"
+  "uuid": "d050650e-f863-4ed8-9342-3a54b32335b8",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/aerospike.json
+++ b/pkg/classification/db/recipes/aerospike.json
@@ -10,5 +10,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "04acee0b-17a2-4c53-83c4-2a37204e487e"
+  "uuid": "04acee0b-17a2-4c53-83c4-2a37204e487e",
+  "sub_type": "database"
 }

--- a/pkg/classification/db/recipes/airbrake.json
+++ b/pkg/classification/db/recipes/airbrake.json
@@ -33,5 +33,6 @@
       "package_manager": "npm"
     }
   ],
-  "uuid": "d5a2adb3-de91-40a8-bf34-3421527183b8"
+  "uuid": "d5a2adb3-de91-40a8-bf34-3421527183b8",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/airtable.json
+++ b/pkg/classification/db/recipes/airtable.json
@@ -17,5 +17,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "a7357734-41c7-4497-af13-32336335f2db"
+  "uuid": "a7357734-41c7-4497-af13-32336335f2db",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/alexa_com.json
+++ b/pkg/classification/db/recipes/alexa_com.json
@@ -6,5 +6,6 @@
     "https://data.alexa.com"
   ],
   "packages": [],
-  "uuid": "54d4b954-fc9b-4492-b21a-ee37e458b879"
+  "uuid": "54d4b954-fc9b-4492-b21a-ee37e458b879",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/algolia.json
+++ b/pkg/classification/db/recipes/algolia.json
@@ -67,5 +67,6 @@
       "package_manager": "npm"
     }
   ],
-  "uuid": "c1176caf-170c-48e8-807e-acb537ff4aec"
+  "uuid": "c1176caf-170c-48e8-807e-acb537ff4aec",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/alibaba_cloud_apis.json
+++ b/pkg/classification/db/recipes/alibaba_cloud_apis.json
@@ -27,5 +27,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "4e6fddd2-34c7-46b7-83c4-e53b638a4acf"
+  "uuid": "4e6fddd2-34c7-46b7-83c4-e53b638a4acf",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/alloy.json
+++ b/pkg/classification/db/recipes/alloy.json
@@ -6,5 +6,6 @@
     "https://alloy.co/v1/"
   ],
   "packages": [],
-  "uuid": "feb9ea94-aabf-4fe8-bde5-a11aea8b4e99"
+  "uuid": "feb9ea94-aabf-4fe8-bde5-a11aea8b4e99",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/almerys.json
+++ b/pkg/classification/db/recipes/almerys.json
@@ -7,5 +7,6 @@
     "https://rec.edi.b2bi.almerys.com"
   ],
   "packages": [],
-  "uuid": "e4e7cb02-b442-45ed-9dcd-3cbbaff1925f"
+  "uuid": "e4e7cb02-b442-45ed-9dcd-3cbbaff1925f",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/alpaca.json
+++ b/pkg/classification/db/recipes/alpaca.json
@@ -6,5 +6,6 @@
     "https://api.alpaca.markets"
   ],
   "packages": [],
-  "uuid": "f4392c0c-1c58-48e5-a7a6-fefe11483274"
+  "uuid": "f4392c0c-1c58-48e5-a7a6-fefe11483274",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/amazon_aws_apis.json
+++ b/pkg/classification/db/recipes/amazon_aws_apis.json
@@ -43,5 +43,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "1fc214b7-854e-42fb-8824-b6c22187938f"
+  "uuid": "1fc214b7-854e-42fb-8824-b6c22187938f",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/ambassador.json
+++ b/pkg/classification/db/recipes/ambassador.json
@@ -10,5 +10,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "3b1d8641-4ed0-4315-9389-5d0e2e6dce4e"
+  "uuid": "3b1d8641-4ed0-4315-9389-5d0e2e6dce4e",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/amc_theater.json
+++ b/pkg/classification/db/recipes/amc_theater.json
@@ -6,5 +6,6 @@
     "https://api.amctheatres.com"
   ],
   "packages": [],
-  "uuid": "f5175ce6-603c-4393-a64e-2500b11b40b4"
+  "uuid": "f5175ce6-603c-4393-a64e-2500b11b40b4",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/ameli.json
+++ b/pkg/classification/db/recipes/ameli.json
@@ -7,5 +7,6 @@
     "https://services-ps.ameli.fr/lps"
   ],
   "packages": [],
-  "uuid": "0767b306-3ee8-426a-b63a-44355add6f27"
+  "uuid": "0767b306-3ee8-426a-b63a-44355add6f27",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/amplitude.json
+++ b/pkg/classification/db/recipes/amplitude.json
@@ -15,5 +15,6 @@
       "package_manager": "npm"
     }
   ],
-  "uuid": "c2ebeaa2-480b-4dc5-a6a4-360c0b79e842"
+  "uuid": "c2ebeaa2-480b-4dc5-a6a4-360c0b79e842",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/apache_airflow.json
+++ b/pkg/classification/db/recipes/apache_airflow.json
@@ -10,5 +10,6 @@
       "package_manager": "pypi"
     }
   ],
-  "uuid": "b7bcad55-c748-49fc-abcb-6b0dc9881787"
+  "uuid": "b7bcad55-c748-49fc-abcb-6b0dc9881787",
+  "sub_type": "message_bus"
 }

--- a/pkg/classification/db/recipes/apache_beam.json
+++ b/pkg/classification/db/recipes/apache_beam.json
@@ -50,5 +50,6 @@
       "package_manager": "maven"
     }
   ],
-  "uuid": "868baac0-35f1-432d-bfde-e9416a987c4d"
+  "uuid": "868baac0-35f1-432d-bfde-e9416a987c4d",
+  "sub_type": "message_bus"
 }

--- a/pkg/classification/db/recipes/apache_hbase.json
+++ b/pkg/classification/db/recipes/apache_hbase.json
@@ -10,5 +10,6 @@
       "package_manager": "maven"
     }
   ],
-  "uuid": "ee048325-9ebe-4306-9f48-c300e27af849"
+  "uuid": "ee048325-9ebe-4306-9f48-c300e27af849",
+  "sub_type": "database"
 }

--- a/pkg/classification/db/recipes/apache_kafka.json
+++ b/pkg/classification/db/recipes/apache_kafka.json
@@ -180,5 +180,6 @@
       "package_manager": "maven"
     }
   ],
-  "uuid": "749d874f-c6ad-478a-b7b2-bd28f48da6ad"
+  "uuid": "749d874f-c6ad-478a-b7b2-bd28f48da6ad",
+  "sub_type": "message_bus"
 }

--- a/pkg/classification/db/recipes/apache_spark.json
+++ b/pkg/classification/db/recipes/apache_spark.json
@@ -20,5 +20,6 @@
       "package_manager": "maven"
     }
   ],
-  "uuid": "4041aa6e-78f9-4f60-b141-507637f384ee"
+  "uuid": "4041aa6e-78f9-4f60-b141-507637f384ee",
+  "sub_type": "database"
 }

--- a/pkg/classification/db/recipes/apollographql.json
+++ b/pkg/classification/db/recipes/apollographql.json
@@ -8,5 +8,6 @@
     "https://schema-reporting.api.apollographql.com"
   ],
   "packages": [],
-  "uuid": "17045718-a5ba-48fb-bd34-ab33c0a62bfa"
+  "uuid": "17045718-a5ba-48fb-bd34-ab33c0a62bfa",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/appbase.json
+++ b/pkg/classification/db/recipes/appbase.json
@@ -6,5 +6,6 @@
     "https://api.appbase.io"
   ],
   "packages": [],
-  "uuid": "ac4faf1f-01c1-427e-97e1-f8d865fc8722"
+  "uuid": "ac4faf1f-01c1-427e-97e1-f8d865fc8722",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/appdynamics.json
+++ b/pkg/classification/db/recipes/appdynamics.json
@@ -13,5 +13,6 @@
       "package_manager": "npm"
     }
   ],
-  "uuid": "391da1c2-e7d6-46fa-afc9-d0d0cefdca5c"
+  "uuid": "391da1c2-e7d6-46fa-afc9-d0d0cefdca5c",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/apple.json
+++ b/pkg/classification/db/recipes/apple.json
@@ -14,5 +14,6 @@
     "https://api.storekit-sandbox.itunes.apple.com"
   ],
   "packages": [],
-  "uuid": "e61910ab-fb33-4b55-948e-6ffe189c230c"
+  "uuid": "e61910ab-fb33-4b55-948e-6ffe189c230c",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/apple_pay.json
+++ b/pkg/classification/db/recipes/apple_pay.json
@@ -7,5 +7,6 @@
     "https://apple-pay-gateway.apple.com"
   ],
   "packages": [],
-  "uuid": "3907b935-0197-4fb0-a836-e6fbb597fd9d"
+  "uuid": "3907b935-0197-4fb0-a836-e6fbb597fd9d",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/appveyor.json
+++ b/pkg/classification/db/recipes/appveyor.json
@@ -6,5 +6,6 @@
     "https://ci.appveyor.com/api"
   ],
   "packages": [],
-  "uuid": "7bf38449-7638-4f73-896d-ff46954b0e80"
+  "uuid": "7bf38449-7638-4f73-896d-ff46954b0e80",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/aquasec.json
+++ b/pkg/classification/db/recipes/aquasec.json
@@ -6,5 +6,6 @@
     "https://api.aquasec.com"
   ],
   "packages": [],
-  "uuid": "42b63325-c431-44b0-8b2b-b48e68bf26fb"
+  "uuid": "42b63325-c431-44b0-8b2b-b48e68bf26fb",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/asana.json
+++ b/pkg/classification/db/recipes/asana.json
@@ -12,5 +12,6 @@
       "package_manager": "rubygems"
     }
   ],
-  "uuid": "d818d702-67d9-43b8-bc61-095055fd7055"
+  "uuid": "d818d702-67d9-43b8-bc61-095055fd7055",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/assurcard.json
+++ b/pkg/classification/db/recipes/assurcard.json
@@ -9,5 +9,6 @@
     "https://testinsurer.assurcard.be"
   ],
   "packages": [],
-  "uuid": "25c4fef8-b90b-47dd-b322-f4ed55fbb9dc"
+  "uuid": "25c4fef8-b90b-47dd-b322-f4ed55fbb9dc",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/athos_worldline.json
+++ b/pkg/classification/db/recipes/athos_worldline.json
@@ -12,5 +12,6 @@
     "https://acqsim.test.sips-atos.com"
   ],
   "packages": [],
-  "uuid": "a2e4023c-a098-420b-bcdb-0bb6630cd9bf"
+  "uuid": "a2e4023c-a098-420b-bcdb-0bb6630cd9bf",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/atinternet.json
+++ b/pkg/classification/db/recipes/atinternet.json
@@ -7,5 +7,6 @@
     "https://api.atinternet.io"
   ],
   "packages": [],
-  "uuid": "e014169c-3f2a-42bf-9dcb-c0236bb99d5b"
+  "uuid": "e014169c-3f2a-42bf-9dcb-c0236bb99d5b",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/atlassian_cloud.json
+++ b/pkg/classification/db/recipes/atlassian_cloud.json
@@ -19,5 +19,6 @@
       "package_manager": "rubygems"
     }
   ],
-  "uuid": "3ba7ec95-6936-49ed-b4d7-eafffb5233b9"
+  "uuid": "3ba7ec95-6936-49ed-b4d7-eafffb5233b9",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/auth0.json
+++ b/pkg/classification/db/recipes/auth0.json
@@ -47,5 +47,6 @@
       "package_manager": "rubygems"
     }
   ],
-  "uuid": "2a8392d5-7013-41ab-833d-64fd2cffcba6"
+  "uuid": "2a8392d5-7013-41ab-833d-64fd2cffcba6",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/aws_athena.json
+++ b/pkg/classification/db/recipes/aws_athena.json
@@ -25,5 +25,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "475b237b-6837-4d1f-ac9e-2ab80574f40c"
+  "uuid": "475b237b-6837-4d1f-ac9e-2ab80574f40c",
+  "sub_type": "datalake"
 }

--- a/pkg/classification/db/recipes/aws_dynamodb.json
+++ b/pkg/classification/db/recipes/aws_dynamodb.json
@@ -25,5 +25,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "11f8b440-d1ca-40d7-8a2d-2b8caa7c7fad"
+  "uuid": "11f8b440-d1ca-40d7-8a2d-2b8caa7c7fad",
+  "sub_type": "database"
 }

--- a/pkg/classification/db/recipes/aws_key_management_service_kms.json
+++ b/pkg/classification/db/recipes/aws_key_management_service_kms.json
@@ -30,5 +30,6 @@
       "package_manager": "maven"
     }
   ],
-  "uuid": "e163685a-bf96-4dd4-a1db-0ccdaf1dbc3e"
+  "uuid": "e163685a-bf96-4dd4-a1db-0ccdaf1dbc3e",
+  "sub_type": "object_storage"
 }

--- a/pkg/classification/db/recipes/aws_kinesis.json
+++ b/pkg/classification/db/recipes/aws_kinesis.json
@@ -15,5 +15,6 @@
       "package_manager": "maven"
     }
   ],
-  "uuid": "8feff8fb-432e-4213-b5dd-9358ebcfb5b5"
+  "uuid": "8feff8fb-432e-4213-b5dd-9358ebcfb5b5",
+  "sub_type": "message_bus"
 }

--- a/pkg/classification/db/recipes/aws_redshift.json
+++ b/pkg/classification/db/recipes/aws_redshift.json
@@ -30,5 +30,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "3a49be11-d8a7-4f63-ba4d-542320f3c580"
+  "uuid": "3a49be11-d8a7-4f63-ba4d-542320f3c580",
+  "sub_type": "database"
 }

--- a/pkg/classification/db/recipes/aws_s3.json
+++ b/pkg/classification/db/recipes/aws_s3.json
@@ -48,5 +48,6 @@
       "package_manager": "npm"
     }
   ],
-  "uuid": "4e5a3a3a-47cd-4b0e-b0a6-fa30a0a62499"
+  "uuid": "4e5a3a3a-47cd-4b0e-b0a6-fa30a0a62499",
+  "sub_type": "object_storage"
 }

--- a/pkg/classification/db/recipes/aws_s3_glacier.json
+++ b/pkg/classification/db/recipes/aws_s3_glacier.json
@@ -25,5 +25,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "31c32157-d398-4dd9-98be-9ec28a8103c2"
+  "uuid": "31c32157-d398-4dd9-98be-9ec28a8103c2",
+  "sub_type": "object_storage"
 }

--- a/pkg/classification/db/recipes/aws_sqs.json
+++ b/pkg/classification/db/recipes/aws_sqs.json
@@ -20,5 +20,6 @@
       "package_manager": "maven"
     }
   ],
-  "uuid": "27c833e8-298b-4c71-a7cf-c1943779f485"
+  "uuid": "27c833e8-298b-4c71-a7cf-c1943779f485",
+  "sub_type": "message_bus"
 }

--- a/pkg/classification/db/recipes/azure_cognitive_search.json
+++ b/pkg/classification/db/recipes/azure_cognitive_search.json
@@ -10,5 +10,6 @@
       "package_manager": "nuget"
     }
   ],
-  "uuid": "efb12c61-a48f-4193-a2ce-08807b4c2e07"
+  "uuid": "efb12c61-a48f-4193-a2ce-08807b4c2e07",
+  "sub_type": "search_engine"
 }

--- a/pkg/classification/db/recipes/azure_cosmos_db.json
+++ b/pkg/classification/db/recipes/azure_cosmos_db.json
@@ -10,5 +10,6 @@
       "package_manager": "nuget"
     }
   ],
-  "uuid": "610197d6-7d20-41b4-9e45-dda645165b0b"
+  "uuid": "610197d6-7d20-41b4-9e45-dda645165b0b",
+  "sub_type": "database"
 }

--- a/pkg/classification/db/recipes/azure_key_vault.json
+++ b/pkg/classification/db/recipes/azure_key_vault.json
@@ -15,5 +15,6 @@
       "package_manager": "rubygems"
     }
   ],
-  "uuid": "96950467-4e02-474f-8e44-3029359075e7"
+  "uuid": "96950467-4e02-474f-8e44-3029359075e7",
+  "sub_type": "database"
 }

--- a/pkg/classification/db/recipes/azure_service_bus.json
+++ b/pkg/classification/db/recipes/azure_service_bus.json
@@ -10,5 +10,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "235e9ec8-0884-4bfc-8238-f8047b4f8663"
+  "uuid": "235e9ec8-0884-4bfc-8238-f8047b4f8663",
+  "sub_type": "message_bus"
 }

--- a/pkg/classification/db/recipes/azure_storage.json
+++ b/pkg/classification/db/recipes/azure_storage.json
@@ -90,5 +90,6 @@
       "package_manager": "nuget"
     }
   ],
-  "uuid": "f0f43ee7-7f6b-4572-aaa0-6b207146912b"
+  "uuid": "f0f43ee7-7f6b-4572-aaa0-6b207146912b",
+  "sub_type": "object_storage"
 }

--- a/pkg/classification/db/recipes/badgerdb.json
+++ b/pkg/classification/db/recipes/badgerdb.json
@@ -10,5 +10,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "128ba4b0-a8e6-4264-bde4-79cf618ee20e"
+  "uuid": "128ba4b0-a8e6-4264-bde4-79cf618ee20e",
+  "sub_type": "database"
 }

--- a/pkg/classification/db/recipes/bamboohr.json
+++ b/pkg/classification/db/recipes/bamboohr.json
@@ -6,5 +6,6 @@
     "https://api.bamboohr.com"
   ],
   "packages": [],
-  "uuid": "5fff4ef9-78fd-4119-9549-f638ea042a3a"
+  "uuid": "5fff4ef9-78fd-4119-9549-f638ea042a3a",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/bambuser.json
+++ b/pkg/classification/db/recipes/bambuser.json
@@ -6,5 +6,6 @@
     "https://api.bambuser.com"
   ],
   "packages": [],
-  "uuid": "6fe6417f-583b-47e1-9702-9e52487af977"
+  "uuid": "6fe6417f-583b-47e1-9702-9e52487af977",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/bank_of_apis_natwest_rbs.json
+++ b/pkg/classification/db/recipes/bank_of_apis_natwest_rbs.json
@@ -18,5 +18,6 @@
     "https://api.natwest.com"
   ],
   "packages": [],
-  "uuid": "ada271a8-4f20-45c4-9032-8ab97ca770bc"
+  "uuid": "ada271a8-4f20-45c4-9032-8ab97ca770bc",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/barclays.json
+++ b/pkg/classification/db/recipes/barclays.json
@@ -8,5 +8,6 @@
     "https://dataservices.secure.barclays.co.uk"
   ],
   "packages": [],
-  "uuid": "2680e873-0e32-4df1-9bc9-9e4ed41205c1"
+  "uuid": "2680e873-0e32-4df1-9bc9-9e4ed41205c1",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/basecamp.json
+++ b/pkg/classification/db/recipes/basecamp.json
@@ -12,5 +12,6 @@
       "package_manager": "rubygems"
     }
   ],
-  "uuid": "7734452e-1ab6-45c5-8975-cba4ec741ea4"
+  "uuid": "7734452e-1ab6-45c5-8975-cba4ec741ea4",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/bigcommerce.json
+++ b/pkg/classification/db/recipes/bigcommerce.json
@@ -8,5 +8,6 @@
     "https://mybigcommerce.com/api"
   ],
   "packages": [],
-  "uuid": "361dece7-aeab-419e-8621-3b5894b2ba7f"
+  "uuid": "361dece7-aeab-419e-8621-3b5894b2ba7f",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/bintray_jfrog.json
+++ b/pkg/classification/db/recipes/bintray_jfrog.json
@@ -6,5 +6,6 @@
     "https://api.bintray.com"
   ],
   "packages": [],
-  "uuid": "de9b9d2f-30fb-4bd8-a87a-c6d46269026a"
+  "uuid": "de9b9d2f-30fb-4bd8-a87a-c6d46269026a",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/bitbucket.json
+++ b/pkg/classification/db/recipes/bitbucket.json
@@ -17,5 +17,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "fdf90f2b-930a-4bd8-93ff-d2acdf4d6032"
+  "uuid": "fdf90f2b-930a-4bd8-93ff-d2acdf4d6032",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/bitly.json
+++ b/pkg/classification/db/recipes/bitly.json
@@ -7,5 +7,6 @@
     "https://api-ssl.bitly.com"
   ],
   "packages": [],
-  "uuid": "7887766b-8ced-42e2-8812-3a1d397af0fa"
+  "uuid": "7887766b-8ced-42e2-8812-3a1d397af0fa",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/bitrise.json
+++ b/pkg/classification/db/recipes/bitrise.json
@@ -6,5 +6,6 @@
     "https://api.bitrise.io"
   ],
   "packages": [],
-  "uuid": "cea8c6bb-2804-484d-98fe-2d8cc39057de"
+  "uuid": "cea8c6bb-2804-484d-98fe-2d8cc39057de",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/blackfire.json
+++ b/pkg/classification/db/recipes/blackfire.json
@@ -10,5 +10,6 @@
       "package_manager": "packagist"
     }
   ],
-  "uuid": "7fa6b706-85de-4085-8728-c68aa1b12b1e"
+  "uuid": "7fa6b706-85de-4085-8728-c68aa1b12b1e",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/boltdb.json
+++ b/pkg/classification/db/recipes/boltdb.json
@@ -30,5 +30,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "2ae64d6a-36cf-4fd2-982e-31b248605f6a"
+  "uuid": "2ae64d6a-36cf-4fd2-982e-31b248605f6a",
+  "sub_type": "database"
 }

--- a/pkg/classification/db/recipes/box.json
+++ b/pkg/classification/db/recipes/box.json
@@ -17,5 +17,6 @@
       "package_manager": "npm"
     }
   ],
-  "uuid": "c2d24a00-32a7-445f-819c-1f881e7b7372"
+  "uuid": "c2d24a00-32a7-445f-819c-1f881e7b7372",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/braze.json
+++ b/pkg/classification/db/recipes/braze.json
@@ -9,5 +9,6 @@
     "https://rest.*.braze.com"
   ],
   "packages": [],
-  "uuid": "8590b330-fd42-438b-a016-383260360844"
+  "uuid": "8590b330-fd42-438b-a016-383260360844",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/brightbox.json
+++ b/pkg/classification/db/recipes/brightbox.json
@@ -6,5 +6,6 @@
     "https://api.*.brightbox.com"
   ],
   "packages": [],
-  "uuid": "d00a92c8-bc14-4e40-baab-55751bafeaf8"
+  "uuid": "d00a92c8-bc14-4e40-baab-55751bafeaf8",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/browserstack.json
+++ b/pkg/classification/db/recipes/browserstack.json
@@ -6,5 +6,6 @@
     "https://api.browserstack.com"
   ],
   "packages": [],
-  "uuid": "bf4bc4fb-2609-42e1-9885-f428f469ef86"
+  "uuid": "bf4bc4fb-2609-42e1-9885-f428f469ef86",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/bugsnag.json
+++ b/pkg/classification/db/recipes/bugsnag.json
@@ -25,5 +25,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "7ee828de-b2de-4b7e-a93a-f1a084ca59d1"
+  "uuid": "7ee828de-b2de-4b7e-a93a-f1a084ca59d1",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/buntdb.json
+++ b/pkg/classification/db/recipes/buntdb.json
@@ -10,5 +10,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "ef021a10-943b-4199-9590-803a0ce70e29"
+  "uuid": "ef021a10-943b-4199-9590-803a0ce70e29",
+  "sub_type": "key_value_cache"
 }

--- a/pkg/classification/db/recipes/calendly.json
+++ b/pkg/classification/db/recipes/calendly.json
@@ -8,5 +8,6 @@
     "https://api.calendly.com"
   ],
   "packages": [],
-  "uuid": "bdce54a8-5070-41de-8556-3f2742fb84ff"
+  "uuid": "bdce54a8-5070-41de-8556-3f2742fb84ff",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/cashplus.json
+++ b/pkg/classification/db/recipes/cashplus.json
@@ -12,5 +12,6 @@
     "https://cashplus.com"
   ],
   "packages": [],
-  "uuid": "68bca703-5a6f-435f-9876-6bd7ff9d0f60"
+  "uuid": "68bca703-5a6f-435f-9876-6bd7ff9d0f60",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/cassandara.json
+++ b/pkg/classification/db/recipes/cassandara.json
@@ -25,5 +25,6 @@
       "package_manager": "npm"
     }
   ],
-  "uuid": "71c72ffc-c462-4b2d-97eb-129114801114"
+  "uuid": "71c72ffc-c462-4b2d-97eb-129114801114",
+  "sub_type": "database"
 }

--- a/pkg/classification/db/recipes/centrify.json
+++ b/pkg/classification/db/recipes/centrify.json
@@ -10,5 +10,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "fba3b838-20fa-4a40-9e3e-b6c3a40c708a"
+  "uuid": "fba3b838-20fa-4a40-9e3e-b6c3a40c708a",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/chargebee.json
+++ b/pkg/classification/db/recipes/chargebee.json
@@ -6,5 +6,6 @@
     "https://chargebee.com/api"
   ],
   "packages": [],
-  "uuid": "b4365c78-819e-4901-a9e7-b5e716593def"
+  "uuid": "b4365c78-819e-4901-a9e7-b5e716593def",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/chargify.json
+++ b/pkg/classification/db/recipes/chargify.json
@@ -6,5 +6,6 @@
     "https://js.chargify.com"
   ],
   "packages": [],
-  "uuid": "fefd1ff1-dd3a-49dc-a8d7-5e9e58f29061"
+  "uuid": "fefd1ff1-dd3a-49dc-a8d7-5e9e58f29061",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/checkout_com.json
+++ b/pkg/classification/db/recipes/checkout_com.json
@@ -7,5 +7,6 @@
     "https://api.checkout.com"
   ],
   "packages": [],
-  "uuid": "968ed200-35c8-42cc-a37e-d2b586750522"
+  "uuid": "968ed200-35c8-42cc-a37e-d2b586750522",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/circleci.json
+++ b/pkg/classification/db/recipes/circleci.json
@@ -6,5 +6,6 @@
     "https://circleci.com/api"
   ],
   "packages": [],
-  "uuid": "48075eda-bdf2-4e43-b8fb-ecd173e20766"
+  "uuid": "48075eda-bdf2-4e43-b8fb-ecd173e20766",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/cirrus_ci.json
+++ b/pkg/classification/db/recipes/cirrus_ci.json
@@ -6,5 +6,6 @@
     "https://api.cirrus-ci.com"
   ],
   "packages": [],
-  "uuid": "b334f203-7f53-40be-8787-3eeb285d30c8"
+  "uuid": "b334f203-7f53-40be-8787-3eeb285d30c8",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/clearbit.json
+++ b/pkg/classification/db/recipes/clearbit.json
@@ -34,5 +34,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "d18fea8d-8ccc-49cc-8e7c-af05e30bdce9"
+  "uuid": "d18fea8d-8ccc-49cc-8e7c-af05e30bdce9",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/clickhouse.json
+++ b/pkg/classification/db/recipes/clickhouse.json
@@ -25,5 +25,6 @@
       "package_manager": "pypi"
     }
   ],
-  "uuid": "c7181945-dcfc-4af2-86d9-4c66d2cfedcd"
+  "uuid": "c7181945-dcfc-4af2-86d9-4c66d2cfedcd",
+  "sub_type": "database"
 }

--- a/pkg/classification/db/recipes/clickup.json
+++ b/pkg/classification/db/recipes/clickup.json
@@ -6,5 +6,6 @@
     "https://api.clickup.com"
   ],
   "packages": [],
-  "uuid": "7d0cde63-1e4c-46d5-95c9-158690730341"
+  "uuid": "7d0cde63-1e4c-46d5-95c9-158690730341",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/clodo.json
+++ b/pkg/classification/db/recipes/clodo.json
@@ -6,5 +6,6 @@
     "https://api.clodo.ru"
   ],
   "packages": [],
-  "uuid": "192ba856-8107-4b3b-8612-7e436e6f6ddf"
+  "uuid": "192ba856-8107-4b3b-8612-7e436e6f6ddf",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/cloudflare.json
+++ b/pkg/classification/db/recipes/cloudflare.json
@@ -12,5 +12,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "dd77bb6c-c4f2-4128-baca-b9ec77ca4481"
+  "uuid": "dd77bb6c-c4f2-4128-baca-b9ec77ca4481",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/cloudinary.json
+++ b/pkg/classification/db/recipes/cloudinary.json
@@ -18,5 +18,6 @@
       "package_manager": "npm"
     }
   ],
-  "uuid": "6467a192-7025-4c09-996e-2456ca5d884b"
+  "uuid": "6467a192-7025-4c09-996e-2456ca5d884b",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/cloudwatch.json
+++ b/pkg/classification/db/recipes/cloudwatch.json
@@ -40,5 +40,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "e03d0ecf-71d9-495f-ae27-0d5016ac7980"
+  "uuid": "e03d0ecf-71d9-495f-ae27-0d5016ac7980",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/cockroachdb.json
+++ b/pkg/classification/db/recipes/cockroachdb.json
@@ -20,5 +20,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "081ef44f-493b-4ed8-807c-334cdffedb79"
+  "uuid": "081ef44f-493b-4ed8-807c-334cdffedb79",
+  "sub_type": "database"
 }

--- a/pkg/classification/db/recipes/companies_house_gov_uk.json
+++ b/pkg/classification/db/recipes/companies_house_gov_uk.json
@@ -7,5 +7,6 @@
     "https://api.companieshouse.gov.uk"
   ],
   "packages": [],
-  "uuid": "5be996ca-b007-4174-a9aa-fb3b69697d59"
+  "uuid": "5be996ca-b007-4174-a9aa-fb3b69697d59",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/complyadvantage.json
+++ b/pkg/classification/db/recipes/complyadvantage.json
@@ -6,5 +6,6 @@
     "https://api.complyadvantage.com"
   ],
   "packages": [],
-  "uuid": "a11ff385-4eae-42d7-af88-fd8b8e3e0efb"
+  "uuid": "a11ff385-4eae-42d7-af88-fd8b8e3e0efb",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/contentful.json
+++ b/pkg/classification/db/recipes/contentful.json
@@ -10,5 +10,6 @@
     "https://preview.contentful.com"
   ],
   "packages": [],
-  "uuid": "d57faf83-4a86-4356-8a9f-6392d645a730"
+  "uuid": "d57faf83-4a86-4356-8a9f-6392d645a730",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/cookiebot_com.json
+++ b/pkg/classification/db/recipes/cookiebot_com.json
@@ -6,5 +6,6 @@
     "https://consent.cookiebot.com/api"
   ],
   "packages": [],
-  "uuid": "db0eed28-e96d-4d70-be90-395fe2522ef2"
+  "uuid": "db0eed28-e96d-4d70-be90-395fe2522ef2",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/copper.json
+++ b/pkg/classification/db/recipes/copper.json
@@ -6,5 +6,6 @@
     "https://api.prosperworks.com"
   ],
   "packages": [],
-  "uuid": "8b0a84b7-a7de-4477-a52a-7d54da796e1b"
+  "uuid": "8b0a84b7-a7de-4477-a52a-7d54da796e1b",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/couchbase.json
+++ b/pkg/classification/db/recipes/couchbase.json
@@ -40,5 +40,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "1b152f28-a00f-4bb4-bbd1-6281fec8272b"
+  "uuid": "1b152f28-a00f-4bb4-bbd1-6281fec8272b",
+  "sub_type": "database"
 }

--- a/pkg/classification/db/recipes/crmgang.json
+++ b/pkg/classification/db/recipes/crmgang.json
@@ -6,5 +6,6 @@
     "https://api.crmgang.com"
   ],
   "packages": [],
-  "uuid": "0068ae26-d24e-464d-87f2-03b55a58d678"
+  "uuid": "0068ae26-d24e-464d-87f2-03b55a58d678",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/customer.json
+++ b/pkg/classification/db/recipes/customer.json
@@ -8,5 +8,6 @@
     "https://track.customer.io/api"
   ],
   "packages": [],
-  "uuid": "864f73ed-4f27-4587-8c5c-d10fc28c6ad2"
+  "uuid": "864f73ed-4f27-4587-8c5c-d10fc28c6ad2",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/dalenys.json
+++ b/pkg/classification/db/recipes/dalenys.json
@@ -6,5 +6,6 @@
     "https://*.dalenys.com"
   ],
   "packages": [],
-  "uuid": "fe876ee8-2abb-4fe7-a5f9-1c5ad5cd0de2"
+  "uuid": "fe876ee8-2abb-4fe7-a5f9-1c5ad5cd0de2",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/databricks.json
+++ b/pkg/classification/db/recipes/databricks.json
@@ -10,5 +10,6 @@
       "package_manager": "pypi"
     }
   ],
-  "uuid": "12b94e84-ba8a-4dca-83d6-8b778f2f0177"
+  "uuid": "12b94e84-ba8a-4dca-83d6-8b778f2f0177",
+  "sub_type": "datalake"
 }

--- a/pkg/classification/db/recipes/datadog.json
+++ b/pkg/classification/db/recipes/datadog.json
@@ -85,5 +85,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "1fc5f10d-490f-48b9-b901-e0813804c781"
+  "uuid": "1fc5f10d-490f-48b9-b901-e0813804c781",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/datadome.json
+++ b/pkg/classification/db/recipes/datadome.json
@@ -13,5 +13,6 @@
       "package_manager": "nuget"
     }
   ],
-  "uuid": "07ecbb23-0fbf-4d0d-a656-2799baac40fe"
+  "uuid": "07ecbb23-0fbf-4d0d-a656-2799baac40fe",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/debounce.json
+++ b/pkg/classification/db/recipes/debounce.json
@@ -6,5 +6,6 @@
     "https://api.debounce.io"
   ],
   "packages": [],
-  "uuid": "e9b89ac7-f8f4-410a-9f27-aaffc49ced6d"
+  "uuid": "e9b89ac7-f8f4-410a-9f27-aaffc49ced6d",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/demdex_adobe.json
+++ b/pkg/classification/db/recipes/demdex_adobe.json
@@ -6,5 +6,6 @@
     "https://api.demdex.net"
   ],
   "packages": [],
-  "uuid": "e779c7a6-b3e6-44d9-abd6-46f681c6cb58"
+  "uuid": "e779c7a6-b3e6-44d9-abd6-46f681c6cb58",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/digitalocean.json
+++ b/pkg/classification/db/recipes/digitalocean.json
@@ -4,5 +4,6 @@
   "type": "external_service",
   "urls": [],
   "packages": [],
-  "uuid": "d617fbd2-cbbf-4e70-91e3-4a955e8bb171"
+  "uuid": "d617fbd2-cbbf-4e70-91e3-4a955e8bb171",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/digitalocean_apis.json
+++ b/pkg/classification/db/recipes/digitalocean_apis.json
@@ -12,5 +12,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "9953be23-9b90-4e49-b8fd-2cb74ae29a4c"
+  "uuid": "9953be23-9b90-4e49-b8fd-2cb74ae29a4c",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/discord.json
+++ b/pkg/classification/db/recipes/discord.json
@@ -37,5 +37,6 @@
       "package_manager": "rubygems"
     }
   ],
-  "uuid": "dfc822d6-92f0-4ac1-ab99-13b6cae5f222"
+  "uuid": "dfc822d6-92f0-4ac1-ab99-13b6cae5f222",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/disk.json
+++ b/pkg/classification/db/recipes/disk.json
@@ -4,5 +4,6 @@
   "type": "data_store",
   "urls": [],
   "packages": [],
-  "uuid": "39747024-c306-4a95-a0df-7e585a33a86f"
+  "uuid": "39747024-c306-4a95-a0df-7e585a33a86f",
+  "sub_type": "flat_file"
 }

--- a/pkg/classification/db/recipes/dmp.json
+++ b/pkg/classification/db/recipes/dmp.json
@@ -6,5 +6,6 @@
     "https://lps2.dmp.gouv.fr/si-dmp-server/*"
   ],
   "packages": [],
-  "uuid": "f819829d-6608-440a-8f54-7273e5eb5d16"
+  "uuid": "f819829d-6608-440a-8f54-7273e5eb5d16",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/dnsimple.json
+++ b/pkg/classification/db/recipes/dnsimple.json
@@ -12,5 +12,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "57a5b8af-8666-4a76-9e16-b8c3436caae6"
+  "uuid": "57a5b8af-8666-4a76-9e16-b8c3436caae6",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/dnsmadeeasy.json
+++ b/pkg/classification/db/recipes/dnsmadeeasy.json
@@ -7,5 +7,6 @@
     "https://api.dnsmadeeasy.com"
   ],
   "packages": [],
-  "uuid": "8838b6ee-9db4-408b-9ba8-eec5c6c893ec"
+  "uuid": "8838b6ee-9db4-408b-9ba8-eec5c6c893ec",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/docusign.json
+++ b/pkg/classification/db/recipes/docusign.json
@@ -7,5 +7,6 @@
     "https://docusign.net/restapi"
   ],
   "packages": [],
-  "uuid": "eba0f4bc-3e35-46af-a0a7-fbce5a41ca5b"
+  "uuid": "eba0f4bc-3e35-46af-a0a7-fbce5a41ca5b",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/dossier_pharmaceutique.json
+++ b/pkg/classification/db/recipes/dossier_pharmaceutique.json
@@ -6,5 +6,6 @@
     "http://ws-fac.dossier-pharmaceutique.fr"
   ],
   "packages": [],
-  "uuid": "6b35773c-fd76-440f-bc84-03b23e26bde4"
+  "uuid": "6b35773c-fd76-440f-bc84-03b23e26bde4",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/dreamhost.json
+++ b/pkg/classification/db/recipes/dreamhost.json
@@ -6,5 +6,6 @@
     "https://api.dreamhost.com"
   ],
   "packages": [],
-  "uuid": "78102417-52f7-40c7-99ee-ac84986e5171"
+  "uuid": "78102417-52f7-40c7-99ee-ac84986e5171",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/drift.json
+++ b/pkg/classification/db/recipes/drift.json
@@ -7,5 +7,6 @@
     "https://driftapi.com"
   ],
   "packages": [],
-  "uuid": "a256be05-3a8f-4fe7-9b53-3b4a29e018e7"
+  "uuid": "a256be05-3a8f-4fe7-9b53-3b4a29e018e7",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/dropbox.json
+++ b/pkg/classification/db/recipes/dropbox.json
@@ -43,5 +43,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "c937ba62-9652-46b1-a9d4-ebda12ff3cb9"
+  "uuid": "c937ba62-9652-46b1-a9d4-ebda12ff3cb9",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/dropcontact.json
+++ b/pkg/classification/db/recipes/dropcontact.json
@@ -6,5 +6,6 @@
     "https://api.dropcontact.io"
   ],
   "packages": [],
-  "uuid": "faaaec71-40e5-4b72-8624-b0e903d70d07"
+  "uuid": "faaaec71-40e5-4b72-8624-b0e903d70d07",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/dyn_oracle.json
+++ b/pkg/classification/db/recipes/dyn_oracle.json
@@ -7,5 +7,6 @@
     "https://api-v4.dynect.net"
   ],
   "packages": [],
-  "uuid": "4d70c5f4-087a-478d-8983-00cf5e9cfb98"
+  "uuid": "4d70c5f4-087a-478d-8983-00cf5e9cfb98",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/easypost.json
+++ b/pkg/classification/db/recipes/easypost.json
@@ -6,5 +6,6 @@
     "https://api.easypost.com"
   ],
   "packages": [],
-  "uuid": "69b0b60c-23ae-4955-8094-9ced959ffa29"
+  "uuid": "69b0b60c-23ae-4955-8094-9ced959ffa29",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/edgecast.json
+++ b/pkg/classification/db/recipes/edgecast.json
@@ -6,5 +6,6 @@
     "https://api.edgecast.com"
   ],
   "packages": [],
-  "uuid": "1fd78c5c-ecbe-4aaf-ade6-b39f8b649f1e"
+  "uuid": "1fd78c5c-ecbe-4aaf-ade6-b39f8b649f1e",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/elastic.json
+++ b/pkg/classification/db/recipes/elastic.json
@@ -63,5 +63,6 @@
       "package_manager": "pypi"
     }
   ],
-  "uuid": "e56e4e80-adab-4afb-915a-f1760b8f9631"
+  "uuid": "e56e4e80-adab-4afb-915a-f1760b8f9631",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/elasticsearch.json
+++ b/pkg/classification/db/recipes/elasticsearch.json
@@ -160,5 +160,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "911eed55-46f6-4324-ab55-ca11acfe562e"
+  "uuid": "911eed55-46f6-4324-ab55-ca11acfe562e",
+  "sub_type": "database"
 }

--- a/pkg/classification/db/recipes/emburse.json
+++ b/pkg/classification/db/recipes/emburse.json
@@ -6,5 +6,6 @@
     "https://api.emburse.com"
   ],
   "packages": [],
-  "uuid": "aa5dceaa-c507-46a8-8151-eef566492dc2"
+  "uuid": "aa5dceaa-c507-46a8-8151-eef566492dc2",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/enboarder.json
+++ b/pkg/classification/db/recipes/enboarder.json
@@ -7,5 +7,6 @@
     "https://enboarder.com/restapi"
   ],
   "packages": [],
-  "uuid": "80344ac3-1e35-4c1b-90bd-4b4c39498a7c"
+  "uuid": "80344ac3-1e35-4c1b-90bd-4b4c39498a7c",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/envoy.json
+++ b/pkg/classification/db/recipes/envoy.json
@@ -6,5 +6,6 @@
     "https://api.envoy.com"
   ],
   "packages": [],
-  "uuid": "64bcc7c1-ce82-4fee-b676-7cbc1a0981d0"
+  "uuid": "64bcc7c1-ce82-4fee-b676-7cbc1a0981d0",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/esante_gouv.json
+++ b/pkg/classification/db/recipes/esante_gouv.json
@@ -7,5 +7,6 @@
     "http://wallet.esw.esante.gouv.fr"
   ],
   "packages": [],
-  "uuid": "af33534a-877b-472f-851c-29f2a677a90f"
+  "uuid": "af33534a-877b-472f-851c-29f2a677a90f",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/essendex.json
+++ b/pkg/classification/db/recipes/essendex.json
@@ -12,5 +12,6 @@
       "package_manager": "packagist"
     }
   ],
-  "uuid": "3b6eb622-d245-4f9c-9004-5df4534bf0e6"
+  "uuid": "3b6eb622-d245-4f9c-9004-5df4534bf0e6",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/etcd.json
+++ b/pkg/classification/db/recipes/etcd.json
@@ -25,5 +25,6 @@
       "package_manager": "pypi"
     }
   ],
-  "uuid": "198d458d-c732-4a22-8399-3e2213ef2371"
+  "uuid": "198d458d-c732-4a22-8399-3e2213ef2371",
+  "sub_type": "database"
 }

--- a/pkg/classification/db/recipes/exoscale_cloud_apis.json
+++ b/pkg/classification/db/recipes/exoscale_cloud_apis.json
@@ -15,5 +15,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "a935df2b-319a-48ea-918c-b3c09d0922e3"
+  "uuid": "a935df2b-319a-48ea-918c-b3c09d0922e3",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/expensify.json
+++ b/pkg/classification/db/recipes/expensify.json
@@ -6,5 +6,6 @@
     "https://integrations.expensify.com/Integration-Server"
   ],
   "packages": [],
-  "uuid": "ef9c9488-0c59-419f-98db-45bddfd692b5"
+  "uuid": "ef9c9488-0c59-419f-98db-45bddfd692b5",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/facebook.json
+++ b/pkg/classification/db/recipes/facebook.json
@@ -45,5 +45,6 @@
       "package_manager": "packagist"
     }
   ],
-  "uuid": "50fd14cc-91e0-443a-95fa-fed159da5380"
+  "uuid": "50fd14cc-91e0-443a-95fa-fed159da5380",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/fauna.json
+++ b/pkg/classification/db/recipes/fauna.json
@@ -15,5 +15,6 @@
       "package_manager": "npm"
     }
   ],
-  "uuid": "95a0c7d4-d3ad-497d-a3ba-3c3d8a5bf89a"
+  "uuid": "95a0c7d4-d3ad-497d-a3ba-3c3d8a5bf89a",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/firebase.json
+++ b/pkg/classification/db/recipes/firebase.json
@@ -20,5 +20,6 @@
       "package_manager": "npm"
     }
   ],
-  "uuid": "8fdcb3b8-89eb-4f85-bdfc-460823d1d108"
+  "uuid": "8fdcb3b8-89eb-4f85-bdfc-460823d1d108",
+  "sub_type": "database"
 }

--- a/pkg/classification/db/recipes/firebird.json
+++ b/pkg/classification/db/recipes/firebird.json
@@ -10,5 +10,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "124c973c-291c-4599-94f8-cecaa892c9d1"
+  "uuid": "124c973c-291c-4599-94f8-cecaa892c9d1",
+  "sub_type": "database"
 }

--- a/pkg/classification/db/recipes/fluentd.json
+++ b/pkg/classification/db/recipes/fluentd.json
@@ -10,5 +10,6 @@
       "package_manager": "npm"
     }
   ],
-  "uuid": "b4620736-5d38-49f8-b6f1-b334ec93cfe0"
+  "uuid": "b4620736-5d38-49f8-b6f1-b334ec93cfe0",
+  "sub_type": "message_bus"
 }

--- a/pkg/classification/db/recipes/forestadmin.json
+++ b/pkg/classification/db/recipes/forestadmin.json
@@ -6,5 +6,6 @@
     "https://api.forestadmin.com"
   ],
   "packages": [],
-  "uuid": "fa8f7ed9-b1c3-40ec-98c8-5c9ac089e1a6"
+  "uuid": "fa8f7ed9-b1c3-40ec-98c8-5c9ac089e1a6",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/fountain.json
+++ b/pkg/classification/db/recipes/fountain.json
@@ -6,5 +6,6 @@
     "https://api.fountain.com"
   ],
   "packages": [],
-  "uuid": "c0fba763-19cc-496c-819c-3bad20c8a0e3"
+  "uuid": "c0fba763-19cc-496c-819c-3bad20c8a0e3",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/france_billet.json
+++ b/pkg/classification/db/recipes/france_billet.json
@@ -6,5 +6,6 @@
     "https://billetweb.fr/api"
   ],
   "packages": [],
-  "uuid": "c2d64406-aa0f-4029-8ed8-1c6b1ce549e8"
+  "uuid": "c2d64406-aa0f-4029-8ed8-1c6b1ce549e8",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/freshworks.json
+++ b/pkg/classification/db/recipes/freshworks.json
@@ -11,5 +11,6 @@
     "https://freshdesk.com/api"
   ],
   "packages": [],
-  "uuid": "364c8f99-a1fe-4d79-b3ad-edcd8676eec3"
+  "uuid": "364c8f99-a1fe-4d79-b3ad-edcd8676eec3",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/front.json
+++ b/pkg/classification/db/recipes/front.json
@@ -8,5 +8,6 @@
     "https://chat-assets.frontapp.com/"
   ],
   "packages": [],
-  "uuid": "4c83b690-94ad-4a72-8169-a6ab43588de5"
+  "uuid": "4c83b690-94ad-4a72-8169-a6ab43588de5",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/ftp_sftp.json
+++ b/pkg/classification/db/recipes/ftp_sftp.json
@@ -40,5 +40,6 @@
       "package_manager": "packagist"
     }
   ],
-  "uuid": "811b84ce-faae-4980-85d1-177f270ac4a1"
+  "uuid": "811b84ce-faae-4980-85d1-177f270ac4a1",
+  "sub_type": "shared_folders"
 }

--- a/pkg/classification/db/recipes/galileo.json
+++ b/pkg/classification/db/recipes/galileo.json
@@ -7,5 +7,6 @@
     "https://sandbox-api.gpsrv.com"
   ],
   "packages": [],
-  "uuid": "5b77c78b-62ad-4a63-85f6-44dd9f126379"
+  "uuid": "5b77c78b-62ad-4a63-85f6-44dd9f126379",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/gandi.json
+++ b/pkg/classification/db/recipes/gandi.json
@@ -7,5 +7,6 @@
     "https://api.gandi.net"
   ],
   "packages": [],
-  "uuid": "b2808b65-bc4d-4837-b587-5b8c38208953"
+  "uuid": "b2808b65-bc4d-4837-b587-5b8c38208953",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/geckoboard.json
+++ b/pkg/classification/db/recipes/geckoboard.json
@@ -12,5 +12,6 @@
       "package_manager": "rubygems"
     }
   ],
-  "uuid": "de694e95-87ce-4164-99c4-0bb854282a26"
+  "uuid": "de694e95-87ce-4164-99c4-0bb854282a26",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/gfycat.json
+++ b/pkg/classification/db/recipes/gfycat.json
@@ -6,5 +6,6 @@
     "https://api.gfycat.com"
   ],
   "packages": [],
-  "uuid": "1c5d6b67-85f4-41a3-b6b9-5c2dff414af2"
+  "uuid": "1c5d6b67-85f4-41a3-b6b9-5c2dff414af2",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/gitea.json
+++ b/pkg/classification/db/recipes/gitea.json
@@ -10,5 +10,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "f7e16e43-8073-4cd6-8670-2eb9f75b7c7e"
+  "uuid": "f7e16e43-8073-4cd6-8670-2eb9f75b7c7e",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/github.json
+++ b/pkg/classification/db/recipes/github.json
@@ -62,5 +62,6 @@
       "package_manager": "npm"
     }
   ],
-  "uuid": "f92a8cf0-3524-4319-9dec-3406066c0119"
+  "uuid": "f92a8cf0-3524-4319-9dec-3406066c0119",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/gitlab.json
+++ b/pkg/classification/db/recipes/gitlab.json
@@ -42,5 +42,6 @@
       "package_manager": "packagist"
     }
   ],
-  "uuid": "326d233c-f513-4310-ad7f-2a96a3a7a2dc"
+  "uuid": "326d233c-f513-4310-ad7f-2a96a3a7a2dc",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/glesys.json
+++ b/pkg/classification/db/recipes/glesys.json
@@ -6,5 +6,6 @@
     "https://api.glesys.com"
   ],
   "packages": [],
-  "uuid": "eb4120e6-d5a7-4e2d-a352-b5471327679e"
+  "uuid": "eb4120e6-d5a7-4e2d-a352-b5471327679e",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/gocardless.json
+++ b/pkg/classification/db/recipes/gocardless.json
@@ -10,5 +10,6 @@
     "https://connect-sandbox.gocardless.com"
   ],
   "packages": [],
-  "uuid": "45d741a5-24f5-4943-9932-91b94d607f0c"
+  "uuid": "45d741a5-24f5-4943-9932-91b94d607f0c",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/google_ads.json
+++ b/pkg/classification/db/recipes/google_ads.json
@@ -24,5 +24,6 @@
       "package_manager": "maven"
     }
   ],
-  "uuid": "4af91aef-2c9f-4643-b1a7-d24865520b5c"
+  "uuid": "4af91aef-2c9f-4643-b1a7-d24865520b5c",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/google_analytics.json
+++ b/pkg/classification/db/recipes/google_analytics.json
@@ -23,5 +23,6 @@
       "package_manager": "npm"
     }
   ],
-  "uuid": "ecf4694f-3271-4894-a54e-e72b0a16a8f0"
+  "uuid": "ecf4694f-3271-4894-a54e-e72b0a16a8f0",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/google_cloud_apis.json
+++ b/pkg/classification/db/recipes/google_cloud_apis.json
@@ -182,5 +182,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "fdeb2b0f-fdc8-49f9-871a-c7d5d384abdd"
+  "uuid": "fdeb2b0f-fdc8-49f9-871a-c7d5d384abdd",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/google_cloud_bigquery.json
+++ b/pkg/classification/db/recipes/google_cloud_bigquery.json
@@ -120,5 +120,6 @@
       "package_manager": "packagist"
     }
   ],
-  "uuid": "2c6da556-2622-471b-80cd-0ecefa73db61"
+  "uuid": "2c6da556-2622-471b-80cd-0ecefa73db61",
+  "sub_type": "datalake"
 }

--- a/pkg/classification/db/recipes/google_cloud_bigtable.json
+++ b/pkg/classification/db/recipes/google_cloud_bigtable.json
@@ -25,5 +25,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "0b6a3389-d3f1-46a2-b99c-af06343d7aa9"
+  "uuid": "0b6a3389-d3f1-46a2-b99c-af06343d7aa9",
+  "sub_type": "database"
 }

--- a/pkg/classification/db/recipes/google_cloud_dataflow.json
+++ b/pkg/classification/db/recipes/google_cloud_dataflow.json
@@ -10,5 +10,6 @@
       "package_manager": "maven"
     }
   ],
-  "uuid": "bb5382df-97ab-48a6-915d-c6fa0c4db5ee"
+  "uuid": "bb5382df-97ab-48a6-915d-c6fa0c4db5ee",
+  "sub_type": "message_bus"
 }

--- a/pkg/classification/db/recipes/google_cloud_datastore.json
+++ b/pkg/classification/db/recipes/google_cloud_datastore.json
@@ -20,5 +20,6 @@
       "package_manager": "pypi"
     }
   ],
-  "uuid": "021606b8-9fef-45a8-b57b-9095dcc96a75"
+  "uuid": "021606b8-9fef-45a8-b57b-9095dcc96a75",
+  "sub_type": "database"
 }

--- a/pkg/classification/db/recipes/google_cloud_firestore.json
+++ b/pkg/classification/db/recipes/google_cloud_firestore.json
@@ -10,5 +10,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "63202bac-af18-4c67-92f9-a6b4a8bb8211"
+  "uuid": "63202bac-af18-4c67-92f9-a6b4a8bb8211",
+  "sub_type": "database"
 }

--- a/pkg/classification/db/recipes/google_cloud_key_management.json
+++ b/pkg/classification/db/recipes/google_cloud_key_management.json
@@ -15,5 +15,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "bba91239-46e2-4167-acbf-aa96a231234e"
+  "uuid": "bba91239-46e2-4167-acbf-aa96a231234e",
+  "sub_type": "database"
 }

--- a/pkg/classification/db/recipes/google_cloud_pub_sub.json
+++ b/pkg/classification/db/recipes/google_cloud_pub_sub.json
@@ -30,5 +30,6 @@
       "package_manager": "rubygems"
     }
   ],
-  "uuid": "4f9955fb-23b7-4f3e-ab5f-134afa22940b"
+  "uuid": "4f9955fb-23b7-4f3e-ab5f-134afa22940b",
+  "sub_type": "message_bus"
 }

--- a/pkg/classification/db/recipes/google_cloud_secret_manager.json
+++ b/pkg/classification/db/recipes/google_cloud_secret_manager.json
@@ -15,5 +15,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "4084a657-c78f-4979-a59b-894a996a361d"
+  "uuid": "4084a657-c78f-4979-a59b-894a996a361d",
+  "sub_type": "database"
 }

--- a/pkg/classification/db/recipes/google_cloud_spanner.json
+++ b/pkg/classification/db/recipes/google_cloud_spanner.json
@@ -20,5 +20,6 @@
       "package_manager": "maven"
     }
   ],
-  "uuid": "4f76d9ef-77e1-42f7-ac04-11147c151a82"
+  "uuid": "4f76d9ef-77e1-42f7-ac04-11147c151a82",
+  "sub_type": "database"
 }

--- a/pkg/classification/db/recipes/google_cloud_storage.json
+++ b/pkg/classification/db/recipes/google_cloud_storage.json
@@ -60,5 +60,6 @@
       "package_manager": "nuget"
     }
   ],
-  "uuid": "3a154582-174f-4ef7-90a2-f654435c23cb"
+  "uuid": "3a154582-174f-4ef7-90a2-f654435c23cb",
+  "sub_type": "object_storage"
 }

--- a/pkg/classification/db/recipes/google_maps.json
+++ b/pkg/classification/db/recipes/google_maps.json
@@ -37,5 +37,6 @@
       "package_manager": "npm"
     }
   ],
-  "uuid": "2cd538ec-0763-42ab-9c6c-444f1285aa52"
+  "uuid": "2cd538ec-0763-42ab-9c6c-444f1285aa52",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/google_recaptcha.json
+++ b/pkg/classification/db/recipes/google_recaptcha.json
@@ -17,5 +17,6 @@
       "package_manager": "rubygems"
     }
   ],
-  "uuid": "a0a4e3ff-0efa-437f-88a1-dde415eb3790"
+  "uuid": "a0a4e3ff-0efa-437f-88a1-dde415eb3790",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/google_service_apis.json
+++ b/pkg/classification/db/recipes/google_service_apis.json
@@ -152,5 +152,6 @@
       "package_manager": "nuget"
     }
   ],
-  "uuid": "602f6d0b-b28e-4c6d-bf72-0a75e3d47bc1"
+  "uuid": "602f6d0b-b28e-4c6d-bf72-0a75e3d47bc1",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/google_spreadsheets.json
+++ b/pkg/classification/db/recipes/google_spreadsheets.json
@@ -14,5 +14,6 @@
       "package_manager": "pypi"
     }
   ],
-  "uuid": "ebe2e05e-bc56-4204-9329-d9b8d3cf1837"
+  "uuid": "ebe2e05e-bc56-4204-9329-d9b8d3cf1837",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/google_tag_manager.json
+++ b/pkg/classification/db/recipes/google_tag_manager.json
@@ -13,5 +13,6 @@
       "package_manager": "maven"
     }
   ],
-  "uuid": "ed26c7c7-436b-450e-bfda-9c553fe81de6"
+  "uuid": "ed26c7c7-436b-450e-bfda-9c553fe81de6",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/google_workspace_apis.json
+++ b/pkg/classification/db/recipes/google_workspace_apis.json
@@ -19,5 +19,6 @@
       "package_manager": "rubygems"
     }
   ],
-  "uuid": "fcf6a2de-0bdd-4fe9-b1a7-696b947128df"
+  "uuid": "fcf6a2de-0bdd-4fe9-b1a7-696b947128df",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/gouv_fr_data.json
+++ b/pkg/classification/db/recipes/gouv_fr_data.json
@@ -6,5 +6,6 @@
     "https://data.gouv.fr/api"
   ],
   "packages": [],
-  "uuid": "42e4e730-37a9-4bf3-b89e-1abbb930b2db"
+  "uuid": "42e4e730-37a9-4bf3-b89e-1abbb930b2db",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/gravatar.json
+++ b/pkg/classification/db/recipes/gravatar.json
@@ -13,5 +13,6 @@
       "package_manager": "npm"
     }
   ],
-  "uuid": "4bcb5ed3-ecbe-43dd-890a-926291c96c11"
+  "uuid": "4bcb5ed3-ecbe-43dd-890a-926291c96c11",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/gravity_payments.json
+++ b/pkg/classification/db/recipes/gravity_payments.json
@@ -6,5 +6,6 @@
     "https://api.gravitypayments.com"
   ],
   "packages": [],
-  "uuid": "c37c083c-8ef7-4a68-9931-157334510182"
+  "uuid": "c37c083c-8ef7-4a68-9931-157334510182",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/greenhouse.json
+++ b/pkg/classification/db/recipes/greenhouse.json
@@ -6,5 +6,6 @@
     "https://boards-api.greenhouse.io"
   ],
   "packages": [],
-  "uuid": "a74f179f-60e6-4b51-a4b0-b495df22f0d2"
+  "uuid": "a74f179f-60e6-4b51-a4b0-b495df22f0d2",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/hashicorp_vault.json
+++ b/pkg/classification/db/recipes/hashicorp_vault.json
@@ -30,5 +30,6 @@
       "package_manager": "npm"
     }
   ],
-  "uuid": "a5a1840d-e6cc-4757-b1eb-0682844b2226"
+  "uuid": "a5a1840d-e6cc-4757-b1eb-0682844b2226",
+  "sub_type": "database"
 }

--- a/pkg/classification/db/recipes/have_i_been_pwned.json
+++ b/pkg/classification/db/recipes/have_i_been_pwned.json
@@ -7,5 +7,6 @@
     "https://haveibeenpwned.com/api"
   ],
   "packages": [],
-  "uuid": "572eb51d-8e7e-415e-8a56-d5fd87bc8121"
+  "uuid": "572eb51d-8e7e-415e-8a56-d5fd87bc8121",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/heap.json
+++ b/pkg/classification/db/recipes/heap.json
@@ -7,5 +7,6 @@
     "https://cdn.heapanalytics.com/js"
   ],
   "packages": [],
-  "uuid": "ed1d7ebc-e584-4b8e-9c2e-cdd53564308c"
+  "uuid": "ed1d7ebc-e584-4b8e-9c2e-cdd53564308c",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/hellosign.json
+++ b/pkg/classification/db/recipes/hellosign.json
@@ -6,5 +6,6 @@
     "https://api.hellosign.com"
   ],
   "packages": [],
-  "uuid": "0906c4ab-0df3-48d7-aa83-5cda588d158c"
+  "uuid": "0906c4ab-0df3-48d7-aa83-5cda588d158c",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/heroku.json
+++ b/pkg/classification/db/recipes/heroku.json
@@ -32,5 +32,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "6cabd765-14ac-428b-b8ee-98b91e385a08"
+  "uuid": "6cabd765-14ac-428b-b8ee-98b91e385a08",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/hiscox.json
+++ b/pkg/classification/db/recipes/hiscox.json
@@ -9,5 +9,6 @@
     "https://hiscoxukpartners-test.azure-api.net"
   ],
   "packages": [],
-  "uuid": "3f72ee9d-db86-40ff-8e81-acac848b0073"
+  "uuid": "3f72ee9d-db86-40ff-8e81-acac848b0073",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/hmrc_gov_uk.json
+++ b/pkg/classification/db/recipes/hmrc_gov_uk.json
@@ -9,5 +9,6 @@
     "https://test-transaction-engine.tax.service.gov.uk"
   ],
   "packages": [],
-  "uuid": "051b0da2-e8f7-4af7-aa17-800961bff5e8"
+  "uuid": "051b0da2-e8f7-4af7-aa17-800961bff5e8",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/honeybadger.json
+++ b/pkg/classification/db/recipes/honeybadger.json
@@ -7,5 +7,6 @@
     "https://app.honeybadger.io/v2/"
   ],
   "packages": [],
-  "uuid": "a5ac3dba-19ea-426c-9184-88d7153d5cc5"
+  "uuid": "a5ac3dba-19ea-426c-9184-88d7153d5cc5",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/hotjar.json
+++ b/pkg/classification/db/recipes/hotjar.json
@@ -12,5 +12,6 @@
       "package_manager": "npm"
     }
   ],
-  "uuid": "f8979dfd-cff1-4869-870d-be529fbf308f"
+  "uuid": "f8979dfd-cff1-4869-870d-be529fbf308f",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/hubspot.json
+++ b/pkg/classification/db/recipes/hubspot.json
@@ -39,5 +39,6 @@
       "package_manager": "packagist"
     }
   ],
-  "uuid": "49450731-7f88-4a6a-8b7c-f396f8915258"
+  "uuid": "49450731-7f88-4a6a-8b7c-f396f8915258",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/hugging_face.json
+++ b/pkg/classification/db/recipes/hugging_face.json
@@ -8,5 +8,6 @@
     "https://huggingface.co"
   ],
   "packages": [],
-  "uuid": "b6d81504-7282-45a1-a8ac-3256622f40db"
+  "uuid": "b6d81504-7282-45a1-a8ac-3256622f40db",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/hunter.json
+++ b/pkg/classification/db/recipes/hunter.json
@@ -6,5 +6,6 @@
     "https://api.hunter.io"
   ],
   "packages": [],
-  "uuid": "cf67436e-1b9f-441f-9dc8-dc2a5b8fe7da"
+  "uuid": "cf67436e-1b9f-441f-9dc8-dc2a5b8fe7da",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/hypersql.json
+++ b/pkg/classification/db/recipes/hypersql.json
@@ -10,5 +10,6 @@
       "package_manager": "maven"
     }
   ],
-  "uuid": "2c275588-e1aa-4aee-bc9c-de0e641eadb4"
+  "uuid": "2c275588-e1aa-4aee-bc9c-de0e641eadb4",
+  "sub_type": "database"
 }

--- a/pkg/classification/db/recipes/iagility.json
+++ b/pkg/classification/db/recipes/iagility.json
@@ -6,5 +6,6 @@
     "https://iagility.smsizer.com/api/*"
   ],
   "packages": [],
-  "uuid": "936de652-fcd4-42b6-ba02-7eb1e22865aa"
+  "uuid": "936de652-fcd4-42b6-ba02-7eb1e22865aa",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/iban.json
+++ b/pkg/classification/db/recipes/iban.json
@@ -6,5 +6,6 @@
     "https://api.iban.com"
   ],
   "packages": [],
-  "uuid": "69857cae-a5cf-4ac3-ad02-c495ed69e70b"
+  "uuid": "69857cae-a5cf-4ac3-ad02-c495ed69e70b",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/ibm_db2.json
+++ b/pkg/classification/db/recipes/ibm_db2.json
@@ -4,5 +4,6 @@
   "type": "data_store",
   "urls": [],
   "packages": [],
-  "uuid": "b9bbbbb8-cb8b-4ffb-997f-e0d1e9050a96"
+  "uuid": "b9bbbbb8-cb8b-4ffb-997f-e0d1e9050a96",
+  "sub_type": "database"
 }

--- a/pkg/classification/db/recipes/iceberg_technology.json
+++ b/pkg/classification/db/recipes/iceberg_technology.json
@@ -9,5 +9,6 @@
     "https://api.iceberg.com"
   ],
   "packages": [],
-  "uuid": "dee7e8f0-41ce-4795-97ff-c2c9946f8359"
+  "uuid": "dee7e8f0-41ce-4795-97ff-c2c9946f8359",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/influxdb.json
+++ b/pkg/classification/db/recipes/influxdb.json
@@ -40,5 +40,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "f7ede608-54d5-4345-a2ba-60a4bc70189f"
+  "uuid": "f7ede608-54d5-4345-a2ba-60a4bc70189f",
+  "sub_type": "database"
 }

--- a/pkg/classification/db/recipes/instagram.json
+++ b/pkg/classification/db/recipes/instagram.json
@@ -6,5 +6,6 @@
     "https://api.instagram.com"
   ],
   "packages": [],
-  "uuid": "5761d35a-0af9-42d7-94c2-f70a602482d1"
+  "uuid": "5761d35a-0af9-42d7-94c2-f70a602482d1",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/instana.json
+++ b/pkg/classification/db/recipes/instana.json
@@ -6,5 +6,6 @@
     "https://instana.io/api"
   ],
   "packages": [],
-  "uuid": "4b05bba6-d8ff-45fc-9378-6ed180304689"
+  "uuid": "4b05bba6-d8ff-45fc-9378-6ed180304689",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/intercom.json
+++ b/pkg/classification/db/recipes/intercom.json
@@ -33,5 +33,6 @@
       "package_manager": "pypi"
     }
   ],
-  "uuid": "342c74d9-2ff4-4009-b648-644b7092bf25"
+  "uuid": "342c74d9-2ff4-4009-b648-644b7092bf25",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/intuit.json
+++ b/pkg/classification/db/recipes/intuit.json
@@ -27,5 +27,6 @@
       "package_manager": "rubygems"
     }
   ],
-  "uuid": "20f6f8a1-ec4c-4a39-9c41-9824c94d9656"
+  "uuid": "20f6f8a1-ec4c-4a39-9c41-9824c94d9656",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/ipdata.json
+++ b/pkg/classification/db/recipes/ipdata.json
@@ -6,5 +6,6 @@
     "https://api.ipdata.co"
   ],
   "packages": [],
-  "uuid": "b23eadc7-629b-444e-aa03-b547c59761be"
+  "uuid": "b23eadc7-629b-444e-aa03-b547c59761be",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/ipify_org.json
+++ b/pkg/classification/db/recipes/ipify_org.json
@@ -6,5 +6,6 @@
     "https://api.ipify.org"
   ],
   "packages": [],
-  "uuid": "278a12e1-2e88-4a4e-80d3-f8c4f1048e3c"
+  "uuid": "278a12e1-2e88-4a4e-80d3-f8c4f1048e3c",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/ipregistry.json
+++ b/pkg/classification/db/recipes/ipregistry.json
@@ -6,5 +6,6 @@
     "https://api.ipregistry.co"
   ],
   "packages": [],
-  "uuid": "c2e582e5-c799-4f92-a670-2402f661354c"
+  "uuid": "c2e582e5-c799-4f92-a670-2402f661354c",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/iproov.json
+++ b/pkg/classification/db/recipes/iproov.json
@@ -6,5 +6,6 @@
     "https://eu.rp.secure.iproov.me"
   ],
   "packages": [],
-  "uuid": "ed87b530-bffb-4838-835c-84240e66507e"
+  "uuid": "ed87b530-bffb-4838-835c-84240e66507e",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/ipstack.json
+++ b/pkg/classification/db/recipes/ipstack.json
@@ -6,5 +6,6 @@
     "https://api.ipstack.com"
   ],
   "packages": [],
-  "uuid": "a0254047-0200-4b6c-b4ea-d2efb27d2b7b"
+  "uuid": "a0254047-0200-4b6c-b4ea-d2efb27d2b7b",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/iris_openbooks_freeagent.json
+++ b/pkg/classification/db/recipes/iris_openbooks_freeagent.json
@@ -6,5 +6,6 @@
     "https://admin.irisopenbooks.co.uk"
   ],
   "packages": [],
-  "uuid": "78d064d7-8535-4644-9174-366ce48b3348"
+  "uuid": "78d064d7-8535-4644-9174-366ce48b3348",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/izberg_marketplace.json
+++ b/pkg/classification/db/recipes/izberg_marketplace.json
@@ -6,5 +6,6 @@
     "https://api.izberg.me"
   ],
   "packages": [],
-  "uuid": "d20e6b2f-a27c-4abb-9fd4-75565424c964"
+  "uuid": "d20e6b2f-a27c-4abb-9fd4-75565424c964",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/jfrog.json
+++ b/pkg/classification/db/recipes/jfrog.json
@@ -6,5 +6,6 @@
     "https://*.jfrog.io"
   ],
   "packages": [],
-  "uuid": "6b0cea07-d1c1-4573-9200-599f167898eb"
+  "uuid": "6b0cea07-d1c1-4573-9200-599f167898eb",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/jsdelivr.json
+++ b/pkg/classification/db/recipes/jsdelivr.json
@@ -6,5 +6,6 @@
     "https://api.jsdelivr.com"
   ],
   "packages": [],
-  "uuid": "e94a329c-96da-4906-925e-077db0ca28cc"
+  "uuid": "e94a329c-96da-4906-925e-077db0ca28cc",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/jumio.json
+++ b/pkg/classification/db/recipes/jumio.json
@@ -7,5 +7,6 @@
     "https://netverify.com/api"
   ],
   "packages": [],
-  "uuid": "8315b8ef-bf9e-4292-bb7b-6a55ca6a721b"
+  "uuid": "8315b8ef-bf9e-4292-bb7b-6a55ca6a721b",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/klarna.json
+++ b/pkg/classification/db/recipes/klarna.json
@@ -8,5 +8,6 @@
     "https://api.klarna.com"
   ],
   "packages": [],
-  "uuid": "bd069ac5-fb0d-41eb-8908-124b4b11be81"
+  "uuid": "bd069ac5-fb0d-41eb-8908-124b4b11be81",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/la_poste.json
+++ b/pkg/classification/db/recipes/la_poste.json
@@ -7,5 +7,6 @@
     "https://api.laposte.fr"
   ],
   "packages": [],
-  "uuid": "a9788351-127c-42e2-87b4-06f6d6fb209a"
+  "uuid": "a9788351-127c-42e2-87b4-06f6d6fb209a",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/launchdarkly.json
+++ b/pkg/classification/db/recipes/launchdarkly.json
@@ -6,5 +6,6 @@
     "https://app.launchdarkly.com/api/"
   ],
   "packages": [],
-  "uuid": "37009f8e-21ac-4d83-983b-b3809e7cb319"
+  "uuid": "37009f8e-21ac-4d83-983b-b3809e7cb319",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/lengow.json
+++ b/pkg/classification/db/recipes/lengow.json
@@ -9,5 +9,6 @@
     "https://api.lengow.net"
   ],
   "packages": [],
-  "uuid": "5bbf514a-6036-4282-ae9e-7d92becd7f32"
+  "uuid": "5bbf514a-6036-4282-ae9e-7d92becd7f32",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/lets_enhance.json
+++ b/pkg/classification/db/recipes/lets_enhance.json
@@ -6,5 +6,6 @@
     "https://api.letsenhance.io"
   ],
   "packages": [],
-  "uuid": "ee7951bb-f3ae-4143-a273-8ccaba3a0f49"
+  "uuid": "ee7951bb-f3ae-4143-a273-8ccaba3a0f49",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/leveldb.json
+++ b/pkg/classification/db/recipes/leveldb.json
@@ -10,5 +10,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "2690be23-9c8e-4a47-a78a-0e2008c5315a"
+  "uuid": "2690be23-9c8e-4a47-a78a-0e2008c5315a",
+  "sub_type": "database"
 }

--- a/pkg/classification/db/recipes/lever.json
+++ b/pkg/classification/db/recipes/lever.json
@@ -7,5 +7,6 @@
     "https://api.lever.co"
   ],
   "packages": [],
-  "uuid": "214b8d02-5a10-48a8-8d5b-1c780ecf2fb8"
+  "uuid": "214b8d02-5a10-48a8-8d5b-1c780ecf2fb8",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/lightstep.json
+++ b/pkg/classification/db/recipes/lightstep.json
@@ -12,5 +12,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "b24a08aa-ea78-4ea7-bab0-dfff529d1e6e"
+  "uuid": "b24a08aa-ea78-4ea7-bab0-dfff529d1e6e",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/linkedin.json
+++ b/pkg/classification/db/recipes/linkedin.json
@@ -7,5 +7,6 @@
     "https://api.linkedin.com"
   ],
   "packages": [],
-  "uuid": "0e1c1075-16c0-467e-9e71-65d83f3157bb"
+  "uuid": "0e1c1075-16c0-467e-9e71-65d83f3157bb",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/liquid_web_cloud_apis.json
+++ b/pkg/classification/db/recipes/liquid_web_cloud_apis.json
@@ -17,5 +17,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "b2884f53-1cc9-4de7-a2ee-c6e1cb54c37c"
+  "uuid": "b2884f53-1cc9-4de7-a2ee-c6e1cb54c37c",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/logrocket.json
+++ b/pkg/classification/db/recipes/logrocket.json
@@ -12,5 +12,6 @@
       "package_manager": "npm"
     }
   ],
-  "uuid": "ac3f9271-1212-436b-85c3-c01a52b71a19"
+  "uuid": "ac3f9271-1212-436b-85c3-c01a52b71a19",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/logz_io.json
+++ b/pkg/classification/db/recipes/logz_io.json
@@ -7,5 +7,6 @@
     "https://api-*.logz.io"
   ],
   "packages": [],
-  "uuid": "b8240fe0-248c-4685-9d94-84e05e6cc761"
+  "uuid": "b8240fe0-248c-4685-9d94-84e05e6cc761",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/mabaya.json
+++ b/pkg/classification/db/recipes/mabaya.json
@@ -6,5 +6,6 @@
     "https://manage-api.mabaya.com"
   ],
   "packages": [],
-  "uuid": "03ee8fbc-5f33-4c6e-b9e0-296b477a3aed"
+  "uuid": "03ee8fbc-5f33-4c6e-b9e0-296b477a3aed",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/mailchimp.json
+++ b/pkg/classification/db/recipes/mailchimp.json
@@ -58,5 +58,6 @@
       "package_manager": "packagist"
     }
   ],
-  "uuid": "6bf43020-4354-4044-818e-610e8e691d1a"
+  "uuid": "6bf43020-4354-4044-818e-610e8e691d1a",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/mailjet.json
+++ b/pkg/classification/db/recipes/mailjet.json
@@ -12,5 +12,6 @@
       "package_manager": "rubygems"
     }
   ],
-  "uuid": "80ff09d3-78a2-4d5a-a843-f68c460ce289"
+  "uuid": "80ff09d3-78a2-4d5a-a843-f68c460ce289",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/mangopay.json
+++ b/pkg/classification/db/recipes/mangopay.json
@@ -18,5 +18,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "e1662fc3-1481-4d4a-8fd1-979cfc22dc37"
+  "uuid": "e1662fc3-1481-4d4a-8fd1-979cfc22dc37",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/mapbox.json
+++ b/pkg/classification/db/recipes/mapbox.json
@@ -6,5 +6,6 @@
     "https://api.mapbox.com"
   ],
   "packages": [],
-  "uuid": "a868d872-5ae1-4107-b24d-d3481839f141"
+  "uuid": "a868d872-5ae1-4107-b24d-d3481839f141",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/mariadb.json
+++ b/pkg/classification/db/recipes/mariadb.json
@@ -35,5 +35,6 @@
       "package_manager": "rubygems"
     }
   ],
-  "uuid": "873dde6f-ddd3-4689-b818-7877392c1aea"
+  "uuid": "873dde6f-ddd3-4689-b818-7877392c1aea",
+  "sub_type": "database"
 }

--- a/pkg/classification/db/recipes/marketo.json
+++ b/pkg/classification/db/recipes/marketo.json
@@ -7,5 +7,6 @@
     "https://mktorest.com/rest"
   ],
   "packages": [],
-  "uuid": "05879227-1116-4be9-9e1a-c665dc41958d"
+  "uuid": "05879227-1116-4be9-9e1a-c665dc41958d",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/maxmind.json
+++ b/pkg/classification/db/recipes/maxmind.json
@@ -8,5 +8,6 @@
     "https://minfraud.maxmind.com/minfraud"
   ],
   "packages": [],
-  "uuid": "3086a2a6-0606-4544-a7d8-0417e54116ef"
+  "uuid": "3086a2a6-0606-4544-a7d8-0417e54116ef",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/memcached.json
+++ b/pkg/classification/db/recipes/memcached.json
@@ -60,5 +60,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "42908ccc-4f0f-419e-9ba0-f25121fd15b7"
+  "uuid": "42908ccc-4f0f-419e-9ba0-f25121fd15b7",
+  "sub_type": "key_value_cache"
 }

--- a/pkg/classification/db/recipes/message_bus.json
+++ b/pkg/classification/db/recipes/message_bus.json
@@ -55,5 +55,6 @@
       "package_manager": "packagist"
     }
   ],
-  "uuid": "30becb85-cb58-4f4f-bbc4-d9111385a95c"
+  "uuid": "30becb85-cb58-4f4f-bbc4-d9111385a95c",
+  "sub_type": "message_bus"
 }

--- a/pkg/classification/db/recipes/mettle.json
+++ b/pkg/classification/db/recipes/mettle.json
@@ -8,5 +8,6 @@
     "https://api.openbanking.prd-mettle.co.uk"
   ],
   "packages": [],
-  "uuid": "90622b2f-1660-41cf-b697-8ce395c1ffe4"
+  "uuid": "90622b2f-1660-41cf-b697-8ce395c1ffe4",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/microsoft.json
+++ b/pkg/classification/db/recipes/microsoft.json
@@ -7,5 +7,6 @@
     "https://graph.microsoft.com"
   ],
   "packages": [],
-  "uuid": "5ff99297-f4af-47cf-9004-36fdb84c78e6"
+  "uuid": "5ff99297-f4af-47cf-9004-36fdb84c78e6",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/microsoft_azure_apis.json
+++ b/pkg/classification/db/recipes/microsoft_azure_apis.json
@@ -58,5 +58,6 @@
       "package_manager": "nuget"
     }
   ],
-  "uuid": "427f0af3-3364-4a91-b62e-6c1a0a93fce6"
+  "uuid": "427f0af3-3364-4a91-b62e-6c1a0a93fce6",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/microsoft_sql_server.json
+++ b/pkg/classification/db/recipes/microsoft_sql_server.json
@@ -85,5 +85,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "e4db4505-b837-4b76-9184-c3cec3b5e522"
+  "uuid": "e4db4505-b837-4b76-9184-c3cec3b5e522",
+  "sub_type": "database"
 }

--- a/pkg/classification/db/recipes/microsoft_teams.json
+++ b/pkg/classification/db/recipes/microsoft_teams.json
@@ -17,5 +17,6 @@
       "package_manager": "packagist"
     }
   ],
-  "uuid": "6cecbba3-e157-4401-85fc-4b31e7cad609"
+  "uuid": "6cecbba3-e157-4401-85fc-4b31e7cad609",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/mirakl.json
+++ b/pkg/classification/db/recipes/mirakl.json
@@ -10,5 +10,6 @@
       "package_manager": "packagist"
     }
   ],
-  "uuid": "a1f0de2b-55a1-4848-b8a2-2c61bed8b737"
+  "uuid": "a1f0de2b-55a1-4848-b8a2-2c61bed8b737",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/mixpanel.json
+++ b/pkg/classification/db/recipes/mixpanel.json
@@ -20,5 +20,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "5ca35c2c-7b66-4ed1-a45a-b2556f88749f"
+  "uuid": "5ca35c2c-7b66-4ed1-a45a-b2556f88749f",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/monday.json
+++ b/pkg/classification/db/recipes/monday.json
@@ -6,5 +6,6 @@
     "https://api.monday.com"
   ],
   "packages": [],
-  "uuid": "242a391c-5c7d-4ba4-9d7f-3089eb0f76ed"
+  "uuid": "242a391c-5c7d-4ba4-9d7f-3089eb0f76ed",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/mondial_relay.json
+++ b/pkg/classification/db/recipes/mondial_relay.json
@@ -6,5 +6,6 @@
     "https://api.mondialrelay.com"
   ],
   "packages": [],
-  "uuid": "1d9c00f2-7eb2-44fb-9dcd-0d50bec584ec"
+  "uuid": "1d9c00f2-7eb2-44fb-9dcd-0d50bec584ec",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/mongodb.json
+++ b/pkg/classification/db/recipes/mongodb.json
@@ -155,5 +155,6 @@
       "package_manager": "maven"
     }
   ],
-  "uuid": "be62dea4-2b19-4e33-8092-6751aaa6430b"
+  "uuid": "be62dea4-2b19-4e33-8092-6751aaa6430b",
+  "sub_type": "database"
 }

--- a/pkg/classification/db/recipes/mux.json
+++ b/pkg/classification/db/recipes/mux.json
@@ -9,5 +9,6 @@
     "https://api.mux.com/video"
   ],
   "packages": [],
-  "uuid": "ebd4ef05-37f9-49a3-8fbf-a26071f7ee13"
+  "uuid": "ebd4ef05-37f9-49a3-8fbf-a26071f7ee13",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/mysql.json
+++ b/pkg/classification/db/recipes/mysql.json
@@ -110,5 +110,6 @@
       "package_manager": "packagist"
     }
   ],
-  "uuid": "ffa70264-2b19-445d-a5c9-be82b64fe750"
+  "uuid": "ffa70264-2b19-445d-a5c9-be82b64fe750",
+  "sub_type": "database"
 }

--- a/pkg/classification/db/recipes/name_com.json
+++ b/pkg/classification/db/recipes/name_com.json
@@ -12,5 +12,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "d1d21271-c8c5-4775-9d98-20796be029de"
+  "uuid": "d1d21271-c8c5-4775-9d98-20796be029de",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/namesilo.json
+++ b/pkg/classification/db/recipes/namesilo.json
@@ -12,5 +12,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "c55afa49-8f97-4208-aa0a-eb4fdad16a6f"
+  "uuid": "c55afa49-8f97-4208-aa0a-eb4fdad16a6f",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/nativex_mobvista.json
+++ b/pkg/classification/db/recipes/nativex_mobvista.json
@@ -6,5 +6,6 @@
     "https://3s.mobvista.com"
   ],
   "packages": [],
-  "uuid": "11503f35-8d4a-47db-ac98-be3b1b014ca6"
+  "uuid": "11503f35-8d4a-47db-ac98-be3b1b014ca6",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/neo4j.json
+++ b/pkg/classification/db/recipes/neo4j.json
@@ -45,5 +45,6 @@
       "package_manager": "rubygems"
     }
   ],
-  "uuid": "27f59acd-c638-4681-acfb-3aa64c862c28"
+  "uuid": "27f59acd-c638-4681-acfb-3aa64c862c28",
+  "sub_type": "database"
 }

--- a/pkg/classification/db/recipes/nethunt_crm.json
+++ b/pkg/classification/db/recipes/nethunt_crm.json
@@ -6,5 +6,6 @@
     "https://nethunt.com/api/v1/zapier"
   ],
   "packages": [],
-  "uuid": "ed6216a4-0081-466e-a291-0db8109ded00"
+  "uuid": "ed6216a4-0081-466e-a291-0db8109ded00",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/netlify.json
+++ b/pkg/classification/db/recipes/netlify.json
@@ -6,5 +6,6 @@
     "https://api.netlify.com"
   ],
   "packages": [],
-  "uuid": "64e2a73d-81eb-407b-a6ef-a02dfb13fefb"
+  "uuid": "64e2a73d-81eb-407b-a6ef-a02dfb13fefb",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/new_relic.json
+++ b/pkg/classification/db/recipes/new_relic.json
@@ -40,5 +40,6 @@
       "package_manager": "maven"
     }
   ],
-  "uuid": "895291fe-f457-4326-8113-c0cf1426084b"
+  "uuid": "895291fe-f457-4326-8113-c0cf1426084b",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/nightfall.json
+++ b/pkg/classification/db/recipes/nightfall.json
@@ -7,5 +7,6 @@
     "https://radar.nightfall.ai/api"
   ],
   "packages": [],
-  "uuid": "0a4ad1f9-a542-41ce-a722-d559af93bb5b"
+  "uuid": "0a4ad1f9-a542-41ce-a722-d559af93bb5b",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/nimble.json
+++ b/pkg/classification/db/recipes/nimble.json
@@ -6,5 +6,6 @@
     "https://api.nimble.com"
   ],
   "packages": [],
-  "uuid": "d8015191-e83d-4c37-bac3-0ac429b7b4d9"
+  "uuid": "d8015191-e83d-4c37-bac3-0ac429b7b4d9",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/nodemailer.json
+++ b/pkg/classification/db/recipes/nodemailer.json
@@ -6,5 +6,6 @@
     "https://api.nodemailer.com"
   ],
   "packages": [],
-  "uuid": "930bdbcc-d4b4-4fdc-a09a-d7ce61e296b2"
+  "uuid": "930bdbcc-d4b4-4fdc-a09a-d7ce61e296b2",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/nuxeo.json
+++ b/pkg/classification/db/recipes/nuxeo.json
@@ -20,5 +20,6 @@
       "package_manager": "maven"
     }
   ],
-  "uuid": "8a7016a6-dc0c-4559-ae0c-4cae38ea063d"
+  "uuid": "8a7016a6-dc0c-4559-ae0c-4cae38ea063d",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/nylas.json
+++ b/pkg/classification/db/recipes/nylas.json
@@ -6,5 +6,6 @@
     "https://api.nylas.com"
   ],
   "packages": [],
-  "uuid": "0adcdf60-21c0-4d1f-9703-723e4ade37e7"
+  "uuid": "0adcdf60-21c0-4d1f-9703-723e4ade37e7",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/ocrolus.json
+++ b/pkg/classification/db/recipes/ocrolus.json
@@ -6,5 +6,6 @@
     "https://api.ocrolus.com"
   ],
   "packages": [],
-  "uuid": "7d3a8bd1-2110-407e-a35a-d5c0ed5e5c39"
+  "uuid": "7d3a8bd1-2110-407e-a35a-d5c0ed5e5c39",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/okta.json
+++ b/pkg/classification/db/recipes/okta.json
@@ -18,5 +18,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "807f7e5f-63ac-426d-9b6e-fcd3b4325f66"
+  "uuid": "807f7e5f-63ac-426d-9b6e-fcd3b4325f66",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/oney.json
+++ b/pkg/classification/db/recipes/oney.json
@@ -7,5 +7,6 @@
     "https://api-staging.oney.io"
   ],
   "packages": [],
-  "uuid": "481bec69-5726-4015-a3e4-ff9b299250fa"
+  "uuid": "481bec69-5726-4015-a3e4-ff9b299250fa",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/onfido.json
+++ b/pkg/classification/db/recipes/onfido.json
@@ -19,5 +19,6 @@
       "package_manager": "npm"
     }
   ],
-  "uuid": "b87f9797-f6bd-4beb-ac7a-06afdaa07e2d"
+  "uuid": "b87f9797-f6bd-4beb-ac7a-06afdaa07e2d",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/openstack_object_storage.json
+++ b/pkg/classification/db/recipes/openstack_object_storage.json
@@ -10,5 +10,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "35038191-e5ea-4a4b-b316-eaee40e13c5a"
+  "uuid": "35038191-e5ea-4a4b-b316-eaee40e13c5a",
+  "sub_type": "object_storage"
 }

--- a/pkg/classification/db/recipes/opentok.json
+++ b/pkg/classification/db/recipes/opentok.json
@@ -18,5 +18,6 @@
       "package_manager": "npm"
     }
   ],
-  "uuid": "655dc0a1-647d-4708-872d-03450d97f79b"
+  "uuid": "655dc0a1-647d-4708-872d-03450d97f79b",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/openweather.json
+++ b/pkg/classification/db/recipes/openweather.json
@@ -6,5 +6,6 @@
     "https://api.openweathermap.org"
   ],
   "packages": [],
-  "uuid": "f9d149a2-c519-48b9-a634-7ed1bdd9081e"
+  "uuid": "f9d149a2-c519-48b9-a634-7ed1bdd9081e",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/optimizely.json
+++ b/pkg/classification/db/recipes/optimizely.json
@@ -6,5 +6,6 @@
     "https://cdn.optimizely.com"
   ],
   "packages": [],
-  "uuid": "344c5c72-e7c0-46e7-b970-d3002504da09"
+  "uuid": "344c5c72-e7c0-46e7-b970-d3002504da09",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/oracle.json
+++ b/pkg/classification/db/recipes/oracle.json
@@ -25,5 +25,6 @@
       "package_manager": "nuget"
     }
   ],
-  "uuid": "80886e2a-ee2c-423d-98bc-0a3d743787b4"
+  "uuid": "80886e2a-ee2c-423d-98bc-0a3d743787b4",
+  "sub_type": "database"
 }

--- a/pkg/classification/db/recipes/ovh_cloud_apis.json
+++ b/pkg/classification/db/recipes/ovh_cloud_apis.json
@@ -17,5 +17,6 @@
       "package_manager": "npm"
     }
   ],
-  "uuid": "6f1734c6-7eab-410a-a858-781e79439e4f"
+  "uuid": "6f1734c6-7eab-410a-a858-781e79439e4f",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/ozone_open_banking_sandbox.json
+++ b/pkg/classification/db/recipes/ozone_open_banking_sandbox.json
@@ -8,5 +8,6 @@
     "https://ob19-auth1-ui.o3bank.co.uk"
   ],
   "packages": [],
-  "uuid": "5814e8d3-2723-4590-b308-b4cd1e6fdee7"
+  "uuid": "5814e8d3-2723-4590-b308-b4cd1e6fdee7",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/pagerduty.json
+++ b/pkg/classification/db/recipes/pagerduty.json
@@ -17,5 +17,6 @@
       "package_manager": "rubygems"
     }
   ],
-  "uuid": "125900d0-de02-4839-baf2-eeac1a94fd96"
+  "uuid": "125900d0-de02-4839-baf2-eeac1a94fd96",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/pandadoc.json
+++ b/pkg/classification/db/recipes/pandadoc.json
@@ -6,5 +6,6 @@
     "https://api.pandadoc.com"
   ],
   "packages": [],
-  "uuid": "214c3327-fa63-4f1d-b6d8-24128e776137"
+  "uuid": "214c3327-fa63-4f1d-b6d8-24128e776137",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/payfit.json
+++ b/pkg/classification/db/recipes/payfit.json
@@ -10,5 +10,6 @@
     "https://api.payfit.io"
   ],
   "packages": [],
-  "uuid": "8a99c328-019d-408a-927e-c9d00b79e34e"
+  "uuid": "8a99c328-019d-408a-927e-c9d00b79e34e",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/payline.json
+++ b/pkg/classification/db/recipes/payline.json
@@ -7,5 +7,6 @@
     "https://payment.payline.com"
   ],
   "packages": [],
-  "uuid": "5c8af3d9-ea59-4723-8246-69cedda69082"
+  "uuid": "5c8af3d9-ea59-4723-8246-69cedda69082",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/paylocity.json
+++ b/pkg/classification/db/recipes/paylocity.json
@@ -6,5 +6,6 @@
     "https://api.paylocity.com/api"
   ],
   "packages": [],
-  "uuid": "eefaabf0-3440-4fe5-abf0-ff040eb830e1"
+  "uuid": "eefaabf0-3440-4fe5-abf0-ff040eb830e1",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/payoneer.json
+++ b/pkg/classification/db/recipes/payoneer.json
@@ -9,5 +9,6 @@
     "https://api.payoneer.com"
   ],
   "packages": [],
-  "uuid": "6de3441c-52aa-464c-9392-0b0c480223de"
+  "uuid": "6de3441c-52aa-464c-9392-0b0c480223de",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/paypal.json
+++ b/pkg/classification/db/recipes/paypal.json
@@ -60,5 +60,6 @@
       "package_manager": "npm"
     }
   ],
-  "uuid": "3e73327b-3b0b-4927-a782-954b4b832252"
+  "uuid": "3e73327b-3b0b-4927-a782-954b4b832252",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/payu.json
+++ b/pkg/classification/db/recipes/payu.json
@@ -17,5 +17,6 @@
       "package_manager": "packagist"
     }
   ],
-  "uuid": "a3274cd2-23b0-474a-86f8-e658f9d87ae3"
+  "uuid": "a3274cd2-23b0-474a-86f8-e658f9d87ae3",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/phrase.json
+++ b/pkg/classification/db/recipes/phrase.json
@@ -23,5 +23,6 @@
       "package_manager": "npm"
     }
   ],
-  "uuid": "f790753a-776f-4dea-96e1-2f62afb65f91"
+  "uuid": "f790753a-776f-4dea-96e1-2f62afb65f91",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/pipedrive.json
+++ b/pkg/classification/db/recipes/pipedrive.json
@@ -7,5 +7,6 @@
     "https://pipedrive.com/api"
   ],
   "packages": [],
-  "uuid": "5858620b-a97e-421b-99d3-7487dd48662f"
+  "uuid": "5858620b-a97e-421b-99d3-7487dd48662f",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/pipeliner.json
+++ b/pkg/classification/db/recipes/pipeliner.json
@@ -6,5 +6,6 @@
     "https://pipelinersales.com/api"
   ],
   "packages": [],
-  "uuid": "520c97de-1548-4d39-adef-3314ffc2eb67"
+  "uuid": "520c97de-1548-4d39-adef-3314ffc2eb67",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/plaid.json
+++ b/pkg/classification/db/recipes/plaid.json
@@ -7,5 +7,6 @@
     "https://sandbox.plaid.com"
   ],
   "packages": [],
-  "uuid": "d52feb7f-c121-4228-8f1e-48f35dc61feb"
+  "uuid": "d52feb7f-c121-4228-8f1e-48f35dc61feb",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/porkbun.json
+++ b/pkg/classification/db/recipes/porkbun.json
@@ -12,5 +12,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "e28200a6-ed39-425c-a7db-a63915e46b1d"
+  "uuid": "e28200a6-ed39-425c-a7db-a63915e46b1d",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/postgresql.json
+++ b/pkg/classification/db/recipes/postgresql.json
@@ -115,5 +115,6 @@
       "package_manager": "pypi"
     }
   ],
-  "uuid": "428ff7dd-22ea-4e80-8755-84c70cf460db"
+  "uuid": "428ff7dd-22ea-4e80-8755-84c70cf460db",
+  "sub_type": "database"
 }

--- a/pkg/classification/db/recipes/posthog.json
+++ b/pkg/classification/db/recipes/posthog.json
@@ -42,5 +42,6 @@
       "package_manager": "npm"
     }
   ],
-  "uuid": "db798605-ffc1-4d03-8b89-4698e9e1b83e"
+  "uuid": "db798605-ffc1-4d03-8b89-4698e9e1b83e",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/postmark.json
+++ b/pkg/classification/db/recipes/postmark.json
@@ -6,5 +6,6 @@
     "https://api.postmarkapp.com"
   ],
   "packages": [],
-  "uuid": "5d62c01f-619e-4249-96cc-c64dd7cbe0aa"
+  "uuid": "5d62c01f-619e-4249-96cc-c64dd7cbe0aa",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/prestashop.json
+++ b/pkg/classification/db/recipes/prestashop.json
@@ -8,5 +8,6 @@
     "https://api.prestashop.com"
   ],
   "packages": [],
-  "uuid": "07dd4bdf-3fa4-4578-9357-57d8be6a1594"
+  "uuid": "07dd4bdf-3fa4-4578-9357-57d8be6a1594",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/processout.json
+++ b/pkg/classification/db/recipes/processout.json
@@ -6,5 +6,6 @@
     "https://api.processout.com"
   ],
   "packages": [],
-  "uuid": "d00782c8-9772-4ee3-8fcf-1a1b9fdb527f"
+  "uuid": "d00782c8-9772-4ee3-8fcf-1a1b9fdb527f",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/profitbricks_ionos.json
+++ b/pkg/classification/db/recipes/profitbricks_ionos.json
@@ -7,5 +7,6 @@
     "https://api.profitbricks.com"
   ],
   "packages": [],
-  "uuid": "f3657c46-ff24-4233-8778-9c59159d4299"
+  "uuid": "f3657c46-ff24-4233-8778-9c59159d4299",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/prometheus.json
+++ b/pkg/classification/db/recipes/prometheus.json
@@ -65,5 +65,6 @@
       "package_manager": "maven"
     }
   ],
-  "uuid": "c43a3f1c-42c9-416a-91ab-a9a410dac9dc"
+  "uuid": "c43a3f1c-42c9-416a-91ab-a9a410dac9dc",
+  "sub_type": "database"
 }

--- a/pkg/classification/db/recipes/pubnub.json
+++ b/pkg/classification/db/recipes/pubnub.json
@@ -12,5 +12,6 @@
       "package_manager": "npm"
     }
   ],
-  "uuid": "a9440c17-f18c-4396-a81e-dc8299fec32f"
+  "uuid": "a9440c17-f18c-4396-a81e-dc8299fec32f",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/pusher.json
+++ b/pkg/classification/db/recipes/pusher.json
@@ -20,5 +20,6 @@
       "package_manager": "npm"
     }
   ],
-  "uuid": "6fcd1852-0c4b-412e-891c-2328867ffeee"
+  "uuid": "6fcd1852-0c4b-412e-891c-2328867ffeee",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/quanta.json
+++ b/pkg/classification/db/recipes/quanta.json
@@ -6,5 +6,6 @@
     "https://app.quanta.io/api"
   ],
   "packages": [],
-  "uuid": "43ff6978-7db9-4155-854a-d9106df82333"
+  "uuid": "43ff6978-7db9-4155-854a-d9106df82333",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/rabbitmq.json
+++ b/pkg/classification/db/recipes/rabbitmq.json
@@ -95,5 +95,6 @@
       "package_manager": "npm"
     }
   ],
-  "uuid": "b4771fe2-a6e5-486a-b0e1-2e50a611f98b"
+  "uuid": "b4771fe2-a6e5-486a-b0e1-2e50a611f98b",
+  "sub_type": "message_bus"
 }

--- a/pkg/classification/db/recipes/rackspace_cloud.json
+++ b/pkg/classification/db/recipes/rackspace_cloud.json
@@ -6,5 +6,6 @@
     "https://api.rackspacecloud.com"
   ],
   "packages": [],
-  "uuid": "1e740268-ca7b-414a-b257-52b9dccd819a"
+  "uuid": "1e740268-ca7b-414a-b257-52b9dccd819a",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/raygun.json
+++ b/pkg/classification/db/recipes/raygun.json
@@ -6,5 +6,6 @@
     "https://api.raygun.com"
   ],
   "packages": [],
-  "uuid": "bd7d5c19-4d92-49a0-a5cb-3a82bd839f31"
+  "uuid": "bd7d5c19-4d92-49a0-a5cb-3a82bd839f31",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/reddit.json
+++ b/pkg/classification/db/recipes/reddit.json
@@ -10,5 +10,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "d5b7521b-af39-4fd6-9fce-35af5576bf3a"
+  "uuid": "d5b7521b-af39-4fd6-9fce-35af5576bf3a",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/redis.json
+++ b/pkg/classification/db/recipes/redis.json
@@ -210,5 +210,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "62c20409-c1bf-4be9-a859-6fe6be7b11e3"
+  "uuid": "62c20409-c1bf-4be9-a859-6fe6be7b11e3",
+  "sub_type": "key_value_cache"
 }

--- a/pkg/classification/db/recipes/reportportal.json
+++ b/pkg/classification/db/recipes/reportportal.json
@@ -12,5 +12,6 @@
       "package_manager": "npm"
     }
   ],
-  "uuid": "b5787c15-474b-43a0-9b95-a1a83fbe736e"
+  "uuid": "b5787c15-474b-43a0-9b95-a1a83fbe736e",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/rethinkdb.json
+++ b/pkg/classification/db/recipes/rethinkdb.json
@@ -10,5 +10,6 @@
       "package_manager": "maven"
     }
   ],
-  "uuid": "1031f084-8063-4605-b0c6-a9993aa073d6"
+  "uuid": "1031f084-8063-4605-b0c6-a9993aa073d6",
+  "sub_type": "database"
 }

--- a/pkg/classification/db/recipes/revolut.json
+++ b/pkg/classification/db/recipes/revolut.json
@@ -6,5 +6,6 @@
     "https://revolut.com/api/"
   ],
   "packages": [],
-  "uuid": "4ab6b4b6-c936-4be1-a8ed-4d77a4381ea3"
+  "uuid": "4ab6b4b6-c936-4be1-a8ed-4d77a4381ea3",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/rocket_chat.json
+++ b/pkg/classification/db/recipes/rocket_chat.json
@@ -10,5 +10,6 @@
       "package_manager": "pypi"
     }
   ],
-  "uuid": "e4639bd9-8042-49ad-82a1-e7e3ec695ba8"
+  "uuid": "e4639bd9-8042-49ad-82a1-e7e3ec695ba8",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/rollbar.json
+++ b/pkg/classification/db/recipes/rollbar.json
@@ -12,5 +12,6 @@
       "package_manager": "npm"
     }
   ],
-  "uuid": "2e0c0423-bc91-46c6-8f29-68a276b3f8f0"
+  "uuid": "2e0c0423-bc91-46c6-8f29-68a276b3f8f0",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/runscope.json
+++ b/pkg/classification/db/recipes/runscope.json
@@ -6,5 +6,6 @@
     "https://api.runscope.com"
   ],
   "packages": [],
-  "uuid": "7127982b-2e46-4376-bd4e-20ad5c5b0d51"
+  "uuid": "7127982b-2e46-4376-bd4e-20ad5c5b0d51",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/rydoo.json
+++ b/pkg/classification/db/recipes/rydoo.json
@@ -6,5 +6,6 @@
     "https://api.rydoo.com"
   ],
   "packages": [],
-  "uuid": "54d194b5-d3ef-4bc1-bbb5-8c340119aa27"
+  "uuid": "54d194b5-d3ef-4bc1-bbb5-8c340119aa27",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/sage.json
+++ b/pkg/classification/db/recipes/sage.json
@@ -11,5 +11,6 @@
     "https://api.intacct.com"
   ],
   "packages": [],
-  "uuid": "6d4cb879-ea28-49ae-99d6-7d3c84ec07bd"
+  "uuid": "6d4cb879-ea28-49ae-99d6-7d3c84ec07bd",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/sakura.json
+++ b/pkg/classification/db/recipes/sakura.json
@@ -6,5 +6,6 @@
     "https://secure.sakura.ad.jp/cloud/zone/*/api/"
   ],
   "packages": [],
-  "uuid": "d399dbe8-d083-4e0f-8853-c575f3aab673"
+  "uuid": "d399dbe8-d083-4e0f-8853-c575f3aab673",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/salesforce.json
+++ b/pkg/classification/db/recipes/salesforce.json
@@ -29,5 +29,6 @@
       "package_manager": "rubygems"
     }
   ],
-  "uuid": "7421be70-674e-4647-a10d-bd8ba963f7cb"
+  "uuid": "7421be70-674e-4647-a10d-bd8ba963f7cb",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/sap.json
+++ b/pkg/classification/db/recipes/sap.json
@@ -6,5 +6,6 @@
     "http://sap.com/xi/*"
   ],
   "packages": [],
-  "uuid": "ccbc8234-4cf3-4ee4-9fd6-abce49ef4fe7"
+  "uuid": "ccbc8234-4cf3-4ee4-9fd6-abce49ef4fe7",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/sap_hana.json
+++ b/pkg/classification/db/recipes/sap_hana.json
@@ -12,5 +12,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "f63c3fa8-783d-4326-8c0c-c9a32dab5b7a"
+  "uuid": "f63c3fa8-783d-4326-8c0c-c9a32dab5b7a",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/satismeter.json
+++ b/pkg/classification/db/recipes/satismeter.json
@@ -6,5 +6,6 @@
     "https://app.satismeter.com/api"
   ],
   "packages": [],
-  "uuid": "a26fecd1-8461-4352-9402-05ac434b579d"
+  "uuid": "a26fecd1-8461-4352-9402-05ac434b579d",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/scaleway_cloud_apis.json
+++ b/pkg/classification/db/recipes/scaleway_cloud_apis.json
@@ -24,5 +24,6 @@
       "package_manager": "npm"
     }
   ],
-  "uuid": "ea84ccdb-fc58-49a9-abdb-3dc98dd8d55b"
+  "uuid": "ea84ccdb-fc58-49a9-abdb-3dc98dd8d55b",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/scalia_ci.json
+++ b/pkg/classification/db/recipes/scalia_ci.json
@@ -4,5 +4,6 @@
   "type": "external_service",
   "urls": [],
   "packages": [],
-  "uuid": "3f4df93f-eca9-4c2b-a26c-14e0a9f76ff9"
+  "uuid": "3f4df93f-eca9-4c2b-a26c-14e0a9f76ff9",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/scout_apm.json
+++ b/pkg/classification/db/recipes/scout_apm.json
@@ -6,5 +6,6 @@
     "https://scoutapm.com/api"
   ],
   "packages": [],
-  "uuid": "42d4d4c4-7a72-4456-bcc5-0902a584e8f2"
+  "uuid": "42d4d4c4-7a72-4456-bcc5-0902a584e8f2",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/seeuletter_mysendingbox.json
+++ b/pkg/classification/db/recipes/seeuletter_mysendingbox.json
@@ -7,5 +7,6 @@
     "https://api.seeuletter.com"
   ],
   "packages": [],
-  "uuid": "54bbc748-7370-4199-a0b0-9e820395c690"
+  "uuid": "54bbc748-7370-4199-a0b0-9e820395c690",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/segment.json
+++ b/pkg/classification/db/recipes/segment.json
@@ -43,5 +43,6 @@
       "package_manager": "maven"
     }
   ],
-  "uuid": "16a3cb75-167c-484b-a5cb-7545b5f65ca1"
+  "uuid": "16a3cb75-167c-484b-a5cb-7545b5f65ca1",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/selligent.json
+++ b/pkg/classification/db/recipes/selligent.json
@@ -6,5 +6,6 @@
     "https://selligent.com/*/organizations"
   ],
   "packages": [],
-  "uuid": "9898b1cd-e47a-4416-a03e-51debb41d624"
+  "uuid": "9898b1cd-e47a-4416-a03e-51debb41d624",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/sendbird.json
+++ b/pkg/classification/db/recipes/sendbird.json
@@ -12,5 +12,6 @@
       "package_manager": "npm"
     }
   ],
-  "uuid": "c3a41875-e9c6-47d4-8690-777bd5e93c50"
+  "uuid": "c3a41875-e9c6-47d4-8690-777bd5e93c50",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/sendgrid.json
+++ b/pkg/classification/db/recipes/sendgrid.json
@@ -62,5 +62,6 @@
       "package_manager": "packagist"
     }
   ],
-  "uuid": "6d201c8d-31cb-4f37-b2e1-aa9941d14ca8"
+  "uuid": "6d201c8d-31cb-4f37-b2e1-aa9941d14ca8",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/sendinblue.json
+++ b/pkg/classification/db/recipes/sendinblue.json
@@ -6,5 +6,6 @@
     "https://api.sendinblue.com"
   ],
   "packages": [],
-  "uuid": "8b97bd5a-bb15-4eea-afc9-bd1687b96fd6"
+  "uuid": "8b97bd5a-bb15-4eea-afc9-bd1687b96fd6",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/sentry.json
+++ b/pkg/classification/db/recipes/sentry.json
@@ -97,5 +97,6 @@
       "package_manager": "maven"
     }
   ],
-  "uuid": "f1ed601f-601a-4fd7-9b82-da8fbbe06c62"
+  "uuid": "f1ed601f-601a-4fd7-9b82-da8fbbe06c62",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/shipbob.json
+++ b/pkg/classification/db/recipes/shipbob.json
@@ -7,5 +7,6 @@
     "https://sandbox-api.shipbob.com"
   ],
   "packages": [],
-  "uuid": "ee20160e-7a15-478f-ab37-cabc3b677b8e"
+  "uuid": "ee20160e-7a15-478f-ab37-cabc3b677b8e",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/shopify.json
+++ b/pkg/classification/db/recipes/shopify.json
@@ -33,5 +33,6 @@
       "package_manager": "packagist"
     }
   ],
-  "uuid": "81c7ae60-256e-46cd-b26d-39557e80f20a"
+  "uuid": "81c7ae60-256e-46cd-b26d-39557e80f20a",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/skyscanner.json
+++ b/pkg/classification/db/recipes/skyscanner.json
@@ -6,5 +6,6 @@
     "https://partners.api.skyscanner.net"
   ],
   "packages": [],
-  "uuid": "df5811cf-3e2f-409c-b5d2-a0b576756c12"
+  "uuid": "df5811cf-3e2f-409c-b5d2-a0b576756c12",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/slack.json
+++ b/pkg/classification/db/recipes/slack.json
@@ -123,5 +123,6 @@
       "package_manager": "maven"
     }
   ],
-  "uuid": "5fc66268-993c-49a3-9031-41dda2e8aff9"
+  "uuid": "5fc66268-993c-49a3-9031-41dda2e8aff9",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/small_improvements.json
+++ b/pkg/classification/db/recipes/small_improvements.json
@@ -6,5 +6,6 @@
     "https://small-improvements.com/api"
   ],
   "packages": [],
-  "uuid": "08192ed4-3bc8-4a19-aff8-34dc9bf988f1"
+  "uuid": "08192ed4-3bc8-4a19-aff8-34dc9bf988f1",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/smb.json
+++ b/pkg/classification/db/recipes/smb.json
@@ -10,5 +10,6 @@
       "package_manager": "pypi"
     }
   ],
-  "uuid": "ce16223c-41ac-4fc7-b12d-e68b4e7755b6"
+  "uuid": "ce16223c-41ac-4fc7-b12d-e68b4e7755b6",
+  "sub_type": "shared_folders"
 }

--- a/pkg/classification/db/recipes/snowflake.json
+++ b/pkg/classification/db/recipes/snowflake.json
@@ -25,5 +25,6 @@
       "package_manager": "npm"
     }
   ],
-  "uuid": "1b018aaf-fa0e-4981-a417-f3bb03bd7a7f"
+  "uuid": "1b018aaf-fa0e-4981-a417-f3bb03bd7a7f",
+  "sub_type": "datalake"
 }

--- a/pkg/classification/db/recipes/societeinfo.json
+++ b/pkg/classification/db/recipes/societeinfo.json
@@ -6,5 +6,6 @@
     "https://societeinfo.com/app/rest/api/"
   ],
   "packages": [],
-  "uuid": "7896a387-f2b8-4f29-885e-b6fdb99a4b7e"
+  "uuid": "7896a387-f2b8-4f29-885e-b6fdb99a4b7e",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/socket_io.json
+++ b/pkg/classification/db/recipes/socket_io.json
@@ -7,5 +7,6 @@
     "https://*.socket.io"
   ],
   "packages": [],
-  "uuid": "f3426905-709b-4b1e-95ba-65e4654c722c"
+  "uuid": "f3426905-709b-4b1e-95ba-65e4654c722c",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/softlayer_ibm_cloud.json
+++ b/pkg/classification/db/recipes/softlayer_ibm_cloud.json
@@ -6,5 +6,6 @@
     "https://api.softlayer.com"
   ],
   "packages": [],
-  "uuid": "96ae0b8c-5b9a-475f-af34-6504ef64b686"
+  "uuid": "96ae0b8c-5b9a-475f-af34-6504ef64b686",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/solocal_bridge.json
+++ b/pkg/classification/db/recipes/solocal_bridge.json
@@ -6,5 +6,6 @@
     "https://api.leadformance.com"
   ],
   "packages": [],
-  "uuid": "b892835e-d651-43a5-a7a6-ab05dbf91655"
+  "uuid": "b892835e-d651-43a5-a7a6-ab05dbf91655",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/splunk.json
+++ b/pkg/classification/db/recipes/splunk.json
@@ -12,5 +12,6 @@
       "package_manager": "pypi"
     }
   ],
-  "uuid": "b3361c33-b5c1-4504-9d37-7eca52286780"
+  "uuid": "b3361c33-b5c1-4504-9d37-7eca52286780",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/sqlite.json
+++ b/pkg/classification/db/recipes/sqlite.json
@@ -55,5 +55,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "aa706b3c-0f6d-4a7b-a7a5-71ee0c5b6c00"
+  "uuid": "aa706b3c-0f6d-4a7b-a7a5-71ee0c5b6c00",
+  "sub_type": "database"
 }

--- a/pkg/classification/db/recipes/sqreen_datadog.json
+++ b/pkg/classification/db/recipes/sqreen_datadog.json
@@ -19,5 +19,6 @@
       "package_manager": "packagist"
     }
   ],
-  "uuid": "79afcebc-9594-4463-ac3c-6030419061e6"
+  "uuid": "79afcebc-9594-4463-ac3c-6030419061e6",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/square.json
+++ b/pkg/classification/db/recipes/square.json
@@ -7,5 +7,6 @@
     "https://connect.squareup.com"
   ],
   "packages": [],
-  "uuid": "3350dca9-629e-43fe-aa85-719186d6d32f"
+  "uuid": "3350dca9-629e-43fe-aa85-719186d6d32f",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/stackify.json
+++ b/pkg/classification/db/recipes/stackify.json
@@ -6,5 +6,6 @@
     "https://api.stackify.net"
   ],
   "packages": [],
-  "uuid": "76bb8a32-b4e3-4d6c-97e3-a54d1a3ab8af"
+  "uuid": "76bb8a32-b4e3-4d6c-97e3-a54d1a3ab8af",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/statuspage.json
+++ b/pkg/classification/db/recipes/statuspage.json
@@ -6,5 +6,6 @@
     "https://api.statuspage.io"
   ],
   "packages": [],
-  "uuid": "e013eb8f-562d-4e04-9b80-f6616e809894"
+  "uuid": "e013eb8f-562d-4e04-9b80-f6616e809894",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/stripe.json
+++ b/pkg/classification/db/recipes/stripe.json
@@ -48,5 +48,6 @@
       "package_manager": "npm"
     }
   ],
-  "uuid": "c24b836a-d035-49dc-808f-1912f16f690d"
+  "uuid": "c24b836a-d035-49dc-808f-1912f16f690d",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/tanker.json
+++ b/pkg/classification/db/recipes/tanker.json
@@ -38,5 +38,6 @@
       "package_manager": "npm"
     }
   ],
-  "uuid": "52c2149a-d92d-4ade-a030-0874faba048f"
+  "uuid": "52c2149a-d92d-4ade-a030-0874faba048f",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/telegram.json
+++ b/pkg/classification/db/recipes/telegram.json
@@ -17,5 +17,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "a4c8692f-db6d-4631-bf15-0cf96509237d"
+  "uuid": "a4c8692f-db6d-4631-bf15-0cf96509237d",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/tencent_cloud_apis.json
+++ b/pkg/classification/db/recipes/tencent_cloud_apis.json
@@ -13,5 +13,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "42f08474-cc6e-4bc4-b9d4-28b611b21fa2"
+  "uuid": "42f08474-cc6e-4bc4-b9d4-28b611b21fa2",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/thunes_limonethik.json
+++ b/pkg/classification/db/recipes/thunes_limonethik.json
@@ -7,5 +7,6 @@
     "https://api.limonetik.com"
   ],
   "packages": [],
-  "uuid": "2c919d7f-b58f-4d8b-9b5f-951fbeab5e0c"
+  "uuid": "2c919d7f-b58f-4d8b-9b5f-951fbeab5e0c",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/tide.json
+++ b/pkg/classification/db/recipes/tide.json
@@ -7,5 +7,6 @@
     "https://api.tide.co"
   ],
   "packages": [],
-  "uuid": "ee47a683-eee9-4b2e-be6f-9583f2125c77"
+  "uuid": "ee47a683-eee9-4b2e-be6f-9583f2125c77",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/tidelift.json
+++ b/pkg/classification/db/recipes/tidelift.json
@@ -6,5 +6,6 @@
     "https://api.tidelift.com"
   ],
   "packages": [],
-  "uuid": "fef02420-1023-4c27-a274-fb1cd8f077a9"
+  "uuid": "fef02420-1023-4c27-a274-fb1cd8f077a9",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/tradier.json
+++ b/pkg/classification/db/recipes/tradier.json
@@ -8,5 +8,6 @@
     "https://api.tradier.com"
   ],
   "packages": [],
-  "uuid": "1bc8c08a-980c-4923-a6a8-3d220cd6ff95"
+  "uuid": "1bc8c08a-980c-4923-a6a8-3d220cd6ff95",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/trafficvance.json
+++ b/pkg/classification/db/recipes/trafficvance.json
@@ -7,5 +7,6 @@
     "https://apitest.trafficvance.com"
   ],
   "packages": [],
-  "uuid": "040baff1-17e7-4071-b206-a470e35591bf"
+  "uuid": "040baff1-17e7-4071-b206-a470e35591bf",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/travefy.json
+++ b/pkg/classification/db/recipes/travefy.json
@@ -6,5 +6,6 @@
     "https://api.travefy.com"
   ],
   "packages": [],
-  "uuid": "b91edd7b-fd90-40f9-b94d-24baa3c56d8d"
+  "uuid": "b91edd7b-fd90-40f9-b94d-24baa3c56d8d",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/travis_ci.json
+++ b/pkg/classification/db/recipes/travis_ci.json
@@ -6,5 +6,6 @@
     "https://api.travis-ci.org"
   ],
   "packages": [],
-  "uuid": "1ecea394-a7da-4f4e-8a3e-76d10e32556a"
+  "uuid": "1ecea394-a7da-4f4e-8a3e-76d10e32556a",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/treezor.json
+++ b/pkg/classification/db/recipes/treezor.json
@@ -6,5 +6,6 @@
     "https://treezor.com/v1/"
   ],
   "packages": [],
-  "uuid": "e561983c-ca8c-4ce5-9214-dde0eb401002"
+  "uuid": "e561983c-ca8c-4ce5-9214-dde0eb401002",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/trello.json
+++ b/pkg/classification/db/recipes/trello.json
@@ -7,5 +7,6 @@
     "https://p.trellocdn.com"
   ],
   "packages": [],
-  "uuid": "73fb1fcf-06a9-4f9e-9640-38b5e2c8f033"
+  "uuid": "73fb1fcf-06a9-4f9e-9640-38b5e2c8f033",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/twilio.json
+++ b/pkg/classification/db/recipes/twilio.json
@@ -33,5 +33,6 @@
       "package_manager": "rubygems"
     }
   ],
-  "uuid": "233c67d0-98a3-48ae-8a3e-451b1da7e192"
+  "uuid": "233c67d0-98a3-48ae-8a3e-451b1da7e192",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/twitter.json
+++ b/pkg/classification/db/recipes/twitter.json
@@ -35,5 +35,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "09155a1d-adec-4839-bebe-2da267fd670c"
+  "uuid": "09155a1d-adec-4839-bebe-2da267fd670c",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/typeform.json
+++ b/pkg/classification/db/recipes/typeform.json
@@ -29,5 +29,6 @@
       "package_manager": "rubygems"
     }
   ],
-  "uuid": "35f2e1d7-af0c-482a-85c5-aeca9b746477"
+  "uuid": "35f2e1d7-af0c-482a-85c5-aeca9b746477",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/unidentified_data_store.json
+++ b/pkg/classification/db/recipes/unidentified_data_store.json
@@ -15,5 +15,6 @@
       "package_manager": "pypi"
     }
   ],
-  "uuid": "a5c2fabf-c99f-44cf-8022-f00dff47b7a7"
+  "uuid": "a5c2fabf-c99f-44cf-8022-f00dff47b7a7",
+  "sub_type": null
 }

--- a/pkg/classification/db/recipes/unsplash.json
+++ b/pkg/classification/db/recipes/unsplash.json
@@ -6,5 +6,6 @@
     "https://api.unsplash.com"
   ],
   "packages": [],
-  "uuid": "41750ede-d0b6-4f81-a90b-9b16511227dc"
+  "uuid": "41750ede-d0b6-4f81-a90b-9b16511227dc",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/uploadecare.json
+++ b/pkg/classification/db/recipes/uploadecare.json
@@ -12,5 +12,6 @@
       "package_manager": "packagist"
     }
   ],
-  "uuid": "60a85fef-01d4-4b7f-a028-90fb2a5987da"
+  "uuid": "60a85fef-01d4-4b7f-a028-90fb2a5987da",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/uptrends.json
+++ b/pkg/classification/db/recipes/uptrends.json
@@ -6,5 +6,6 @@
     "https://api.uptrends.com"
   ],
   "packages": [],
-  "uuid": "e7afe6bb-5d0a-4428-ab6f-1ebfad9f6b07"
+  "uuid": "e7afe6bb-5d0a-4428-ab6f-1ebfad9f6b07",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/userlike_com.json
+++ b/pkg/classification/db/recipes/userlike_com.json
@@ -6,5 +6,6 @@
     "https://api.userlike.com"
   ],
   "packages": [],
-  "uuid": "7c3a5f02-43a0-49d0-8438-a269622c0eb7"
+  "uuid": "7c3a5f02-43a0-49d0-8438-a269622c0eb7",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/usersnap.json
+++ b/pkg/classification/db/recipes/usersnap.json
@@ -7,5 +7,6 @@
     "https://widget.usersnap.com"
   ],
   "packages": [],
-  "uuid": "f4739f9a-e2de-43d1-89ab-2d2d3d57fcf0"
+  "uuid": "f4739f9a-e2de-43d1-89ab-2d2d3d57fcf0",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/vercel.json
+++ b/pkg/classification/db/recipes/vercel.json
@@ -6,5 +6,6 @@
     "https://api.vercel.com"
   ],
   "packages": [],
-  "uuid": "4a6ec484-003a-454e-8e39-a618c24c6d58"
+  "uuid": "4a6ec484-003a-454e-8e39-a618c24c6d58",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/vero.json
+++ b/pkg/classification/db/recipes/vero.json
@@ -17,5 +17,6 @@
       "package_manager": "packagist"
     }
   ],
-  "uuid": "ef05ce19-3e74-4988-b9c8-b511940fdf36"
+  "uuid": "ef05ce19-3e74-4988-b9c8-b511940fdf36",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/victorops_splunk.json
+++ b/pkg/classification/db/recipes/victorops_splunk.json
@@ -6,5 +6,6 @@
     "https://api.victorops.com"
   ],
   "packages": [],
-  "uuid": "b469e77d-3d17-4d7a-a438-e10a62f8b1fb"
+  "uuid": "b469e77d-3d17-4d7a-a438-e10a62f8b1fb",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/vonage.json
+++ b/pkg/classification/db/recipes/vonage.json
@@ -22,5 +22,6 @@
       "package_manager": "npm"
     }
   ],
-  "uuid": "6b2278e4-0386-406b-babc-61cb3c0cbd0a"
+  "uuid": "6b2278e4-0386-406b-babc-61cb3c0cbd0a",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/wistia.json
+++ b/pkg/classification/db/recipes/wistia.json
@@ -8,5 +8,6 @@
     "https://fast.wistia.com"
   ],
   "packages": [],
-  "uuid": "d723116b-1272-4ead-a92a-415df7c8ad1c"
+  "uuid": "d723116b-1272-4ead-a92a-415df7c8ad1c",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/wordnik.json
+++ b/pkg/classification/db/recipes/wordnik.json
@@ -6,5 +6,6 @@
     "https://api.wordnik.com"
   ],
   "packages": [],
-  "uuid": "c275cc5e-6b11-4956-9eb2-80d5947818d8"
+  "uuid": "c275cc5e-6b11-4956-9eb2-80d5947818d8",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/wordpress.json
+++ b/pkg/classification/db/recipes/wordpress.json
@@ -6,5 +6,6 @@
     "https://public-api.wordpress.com"
   ],
   "packages": [],
-  "uuid": "9a9de396-0dd5-4621-ab94-e1407e281311"
+  "uuid": "9a9de396-0dd5-4621-ab94-e1407e281311",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/workos.json
+++ b/pkg/classification/db/recipes/workos.json
@@ -10,5 +10,6 @@
       "package_manager": "rubygems"
     }
   ],
-  "uuid": "2b88cf34-48ac-4fcc-a062-a28d71821122"
+  "uuid": "2b88cf34-48ac-4fcc-a062-a28d71821122",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/wrike.json
+++ b/pkg/classification/db/recipes/wrike.json
@@ -6,5 +6,6 @@
     "https://wrike.com/api"
   ],
   "packages": [],
-  "uuid": "41704ba0-b6c2-447b-b440-44f5d37d9fa3"
+  "uuid": "41704ba0-b6c2-447b-b440-44f5d37d9fa3",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/xero.json
+++ b/pkg/classification/db/recipes/xero.json
@@ -27,5 +27,6 @@
       "package_manager": "rubygems"
     }
   ],
-  "uuid": "18d6a9d6-032e-4a88-8b81-3f7aef3d2507"
+  "uuid": "18d6a9d6-032e-4a88-8b81-3f7aef3d2507",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/xignite.json
+++ b/pkg/classification/db/recipes/xignite.json
@@ -7,5 +7,6 @@
     "https://navs.xignite.com/v2"
   ],
   "packages": [],
-  "uuid": "6b7489e2-e876-4e7f-ae72-8539b19df114"
+  "uuid": "6b7489e2-e876-4e7f-ae72-8539b19df114",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/yandex_cloud_apis.json
+++ b/pkg/classification/db/recipes/yandex_cloud_apis.json
@@ -12,5 +12,6 @@
       "package_manager": "go"
     }
   ],
-  "uuid": "c0dba774-bddd-49fd-90bc-673baefe7d00"
+  "uuid": "c0dba774-bddd-49fd-90bc-673baefe7d00",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/yodlee.json
+++ b/pkg/classification/db/recipes/yodlee.json
@@ -6,5 +6,6 @@
     "https://api.yodlee.com"
   ],
   "packages": [],
-  "uuid": "729a0131-af07-409f-8535-2e09ad02289f"
+  "uuid": "729a0131-af07-409f-8535-2e09ad02289f",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/youtube.json
+++ b/pkg/classification/db/recipes/youtube.json
@@ -17,5 +17,6 @@
       "package_manager": "npm"
     }
   ],
-  "uuid": "954c823b-9629-4bdc-a1a4-db69b1bac85e"
+  "uuid": "954c823b-9629-4bdc-a1a4-db69b1bac85e",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/zapier.json
+++ b/pkg/classification/db/recipes/zapier.json
@@ -7,5 +7,6 @@
     "https://api.zapier.com"
   ],
   "packages": [],
-  "uuid": "f68ddedc-a27f-4947-bf2e-1e6f65f88bc4"
+  "uuid": "f68ddedc-a27f-4947-bf2e-1e6f65f88bc4",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/zendesk.json
+++ b/pkg/classification/db/recipes/zendesk.json
@@ -32,5 +32,6 @@
       "package_manager": "pypi"
     }
   ],
-  "uuid": "31e94b1b-3a27-4d8c-a28f-ffa27c9d5c51"
+  "uuid": "31e94b1b-3a27-4d8c-a28f-ffa27c9d5c51",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/zeplin.json
+++ b/pkg/classification/db/recipes/zeplin.json
@@ -6,5 +6,6 @@
     "https://api.zeplin.dev"
   ],
   "packages": [],
-  "uuid": "573522e8-819b-4818-b9fa-5bdd9ed94183"
+  "uuid": "573522e8-819b-4818-b9fa-5bdd9ed94183",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/db/recipes/zoho.json
+++ b/pkg/classification/db/recipes/zoho.json
@@ -17,5 +17,6 @@
     "https://zoho.com/api"
   ],
   "packages": [],
-  "uuid": "238a9eb3-0783-476d-88c5-5a2366034548"
+  "uuid": "238a9eb3-0783-476d-88c5-5a2366034548",
+  "sub_type": "third_party"
 }

--- a/pkg/classification/dependencies/dependencies.go
+++ b/pkg/classification/dependencies/dependencies.go
@@ -15,10 +15,11 @@ type ClassifiedDependency struct {
 }
 
 type Classification struct {
-	RecipeMatch bool                            `json:"recipe_match" yaml:"recipe_match"`
-	RecipeUUID  string                          `json:"recipe_uuid,omitempty"`
-	RecipeName  string                          `json:"recipe_name,omitempty"`
-	Decision    classify.ClassificationDecision `json:"decision" yaml:"decision"`
+	RecipeMatch   bool                            `json:"recipe_match" yaml:"recipe_match"`
+	RecipeUUID    string                          `json:"recipe_uuid,omitempty"`
+	RecipeName    string                          `json:"recipe_name,omitempty"`
+	RecipeSubType string                          `json:"recipe_sub_type,omitempty"`
+	Decision      classify.ClassificationDecision `json:"decision" yaml:"decision"`
 }
 
 type Classifier struct {
@@ -69,8 +70,9 @@ func (classifier *Classifier) Classify(data detections.Detection) (*ClassifiedDe
 		for _, recipePackage := range recipe.Packages {
 			if isRecipeMatch(recipePackage, value) {
 				classification = &Classification{
-					RecipeUUID:  recipe.UUID,
-					RecipeName:  recipe.Name,
+					RecipeUUID:    recipe.UUID,
+					RecipeName:    recipe.Name,
+					RecipeSubType: recipe.SubType,
 					RecipeMatch: true,
 					Decision: classify.ClassificationDecision{
 						State:  classify.Valid,

--- a/pkg/classification/dependencies/dependencies_test.go
+++ b/pkg/classification/dependencies/dependencies_test.go
@@ -33,6 +33,7 @@ func TestDependencies(t *testing.T) {
 			Want: &dependencies.Classification{
 				RecipeMatch: true,
 				RecipeName:  "Stripe",
+				RecipeSubType: "third_party",
 				RecipeUUID:  "c24b836a-d035-49dc-808f-1912f16f690d",
 				Decision: classify.ClassificationDecision{
 					State:  classify.Valid,
@@ -55,6 +56,7 @@ func TestDependencies(t *testing.T) {
 			Want: &dependencies.Classification{
 				RecipeMatch: true,
 				RecipeName:  "PostgreSQL",
+				RecipeSubType: "database",
 				RecipeUUID:  "428ff7dd-22ea-4e80-8755-84c70cf460db",
 				Decision: classify.ClassificationDecision{
 					State:  classify.Valid,

--- a/pkg/classification/frameworks/frameworks.go
+++ b/pkg/classification/frameworks/frameworks.go
@@ -18,10 +18,11 @@ type ClassifiedFramework struct {
 }
 
 type Classification struct {
-	RecipeMatch bool                            `json:"recipe_match" yaml:"recipe_match"`
-	RecipeName  string                          `json:"recipe_name,omitempty"`
-	RecipeUUID  string                          `json:"recipe_uuid,omitempty"`
-	Decision    classify.ClassificationDecision `json:"decision" yaml:"decision"`
+	RecipeMatch   bool                            `json:"recipe_match" yaml:"recipe_match"`
+	RecipeName    string                          `json:"recipe_name,omitempty"`
+	RecipeUUID    string                          `json:"recipe_uuid,omitempty"`
+	RecipeSubType string                          `json:"recipe_sub_type,omitempty"`
+	Decision      classify.ClassificationDecision `json:"decision" yaml:"decision"`
 }
 
 type Classifier struct {
@@ -77,8 +78,9 @@ func (classifier *Classifier) Classify(data detections.Detection) (*ClassifiedFr
 		for _, recipe := range classifier.config.Recipes {
 			if isRecipeMatch(recipe, technologyKey) {
 				classification = &Classification{
-					RecipeUUID:  recipe.UUID,
-					RecipeName:  recipe.Name,
+					RecipeUUID:    recipe.UUID,
+					RecipeName:    recipe.Name,
+					RecipeSubType: recipe.SubType,
 					RecipeMatch: true,
 					Decision: classify.ClassificationDecision{
 						State:  classify.Valid,

--- a/pkg/classification/frameworks/frameworks_test.go
+++ b/pkg/classification/frameworks/frameworks_test.go
@@ -40,6 +40,7 @@ func TestFrameworks(t *testing.T) {
 			Want: &frameworks.Classification{
 				RecipeMatch: true,
 				RecipeName:  "Redis",
+				RecipeSubType: "key_value_cache",
 				RecipeUUID:  "62c20409-c1bf-4be9-a859-6fe6be7b11e3",
 				Decision: classify.ClassificationDecision{
 					State:  classify.Valid,
@@ -65,6 +66,7 @@ func TestFrameworks(t *testing.T) {
 			Want: &frameworks.Classification{
 				RecipeMatch: true,
 				RecipeName:  "PostgreSQL",
+				RecipeSubType: "database",
 				RecipeUUID:  "428ff7dd-22ea-4e80-8755-84c70cf460db",
 				Decision: classify.ClassificationDecision{
 					State:  classify.Valid,
@@ -91,6 +93,7 @@ func TestFrameworks(t *testing.T) {
 			Want: &frameworks.Classification{
 				RecipeMatch: true,
 				RecipeName:  "AWS S3",
+				RecipeSubType: "object_storage",
 				RecipeUUID:  "4e5a3a3a-47cd-4b0e-b0a6-fa30a0a62499",
 				Decision: classify.ClassificationDecision{
 					State:  classify.Valid,
@@ -205,6 +208,7 @@ func TestFrameworks(t *testing.T) {
 			Want: &frameworks.Classification{
 				RecipeMatch: true,
 				RecipeName: "MySQL",
+				RecipeSubType: "database",
 				RecipeUUID: "ffa70264-2b19-445d-a5c9-be82b64fe750",
 				Decision: classify.ClassificationDecision{
 					State:  classify.Valid,
@@ -232,6 +236,7 @@ func TestFrameworks(t *testing.T) {
 			Want: &frameworks.Classification{
 				RecipeMatch: true,
 				RecipeName: "SQLite",
+				RecipeSubType: "database",
 				RecipeUUID: "aa706b3c-0f6d-4a7b-a7a5-71ee0c5b6c00",
 				Decision: classify.ClassificationDecision{
 					State:  classify.Valid,
@@ -257,6 +262,7 @@ func TestFrameworks(t *testing.T) {
 			Want: &frameworks.Classification{
 				RecipeMatch: true,
 				RecipeName: "MySQL",
+				RecipeSubType: "database",
 				RecipeUUID: "ffa70264-2b19-445d-a5c9-be82b64fe750",
 				Decision: classify.ClassificationDecision{
 					State:  classify.Valid,
@@ -281,6 +287,7 @@ func TestFrameworks(t *testing.T) {
 			Want: &frameworks.Classification{
 				RecipeMatch: true,
 				RecipeName: "Microsoft SQL Server",
+				RecipeSubType: "database",
 				RecipeUUID: "e4db4505-b837-4b76-9184-c3cec3b5e522",
 				Decision: classify.ClassificationDecision{
 					State:  classify.Valid,
@@ -305,6 +312,7 @@ func TestFrameworks(t *testing.T) {
 			Want: &frameworks.Classification{
 				RecipeMatch: true,
 				RecipeName: "MySQL",
+				RecipeSubType: "database",
 				RecipeUUID: "ffa70264-2b19-445d-a5c9-be82b64fe750",
 				Decision: classify.ClassificationDecision{
 					State:  classify.Valid,
@@ -330,6 +338,7 @@ func TestFrameworks(t *testing.T) {
 			Want: &frameworks.Classification{
 				RecipeMatch: true,
 				RecipeName: "Oracle",
+				RecipeSubType: "database",
 				RecipeUUID: "80886e2a-ee2c-423d-98bc-0a3d743787b4",
 				Decision: classify.ClassificationDecision{
 					State:  classify.Valid,

--- a/pkg/classification/interfaces/interfaces.go
+++ b/pkg/classification/interfaces/interfaces.go
@@ -18,11 +18,12 @@ type ClassifiedInterface struct {
 }
 
 type Classification struct {
-	URL         string                          `json:"url" yaml:"url"`
-	RecipeMatch bool                            `json:"recipe_match" yaml:"recipe_match"`
-	RecipeName  string                          `json:"recipe_name,omitempty"`
-	RecipeUUID  string                          `json:"recipe_uuid,omitempty"`
-	Decision    classify.ClassificationDecision `json:"decision" yaml:"decision"`
+	URL           string                          `json:"url" yaml:"url"`
+	RecipeMatch   bool                            `json:"recipe_match" yaml:"recipe_match"`
+	RecipeName    string                          `json:"recipe_name,omitempty"`
+	RecipeUUID    string                          `json:"recipe_uuid,omitempty"`
+	RecipeSubType string                          `json:"recipe_sub_type,omitempty"`
+	Decision      classify.ClassificationDecision `json:"decision" yaml:"decision"`
 }
 
 type Classifier struct {
@@ -38,10 +39,11 @@ type Config struct {
 }
 
 type Recipe struct {
-	UUID string
-	Name string
-	Type string
-	URLS []RecipeURL
+	UUID    string
+	Name    string
+	Type    string
+	SubType string
+	URLS    []RecipeURL
 }
 
 type RecipeURL struct {
@@ -54,6 +56,7 @@ type RecipeURLMatch struct {
 	RecipeURL        string
 	RecipeUUID       string
 	RecipeName       string
+	RecipeSubType    string
 }
 
 var ErrInvalidRecipes = errors.New("invalid interface recipe")
@@ -75,6 +78,7 @@ func New(config Config) (*Classifier, error) {
 			UUID: recipe.UUID,
 			Name: recipe.Name,
 			Type: recipe.Type,
+			SubType: recipe.SubType,
 		}
 		for _, recipeURL := range recipe.URLS {
 			regexpMatcher, err := url.PrepareRegexpMatcher(recipeURL)
@@ -186,8 +190,9 @@ func (classifier *Classifier) Classify(data detections.Detection) (*ClassifiedIn
 			Classification: &Classification{
 				URL:         recipeMatch.DetectionURLPart,
 				RecipeMatch: true,
-				RecipeUUID:  recipeMatch.RecipeUUID,
-				RecipeName:  recipeMatch.RecipeName,
+				RecipeUUID:    recipeMatch.RecipeUUID,
+				RecipeName:    recipeMatch.RecipeName,
+				RecipeSubType: recipeMatch.RecipeSubType,
 			},
 		}
 		if strings.Contains(recipeMatch.DetectionURLPart, "*") {
@@ -251,6 +256,7 @@ func (classifier *Classifier) FindMatchingRecipeUrl(detectionURL string) (*Recip
 				RecipeURL:        recipeURL.URL,
 				RecipeUUID:       recipe.UUID,
 				RecipeName:       recipe.Name,
+				RecipeSubType:    recipe.SubType,
 			}
 		}
 	}

--- a/pkg/classification/interfaces/interfaces_test.go
+++ b/pkg/classification/interfaces/interfaces_test.go
@@ -44,6 +44,7 @@ func TestInterface(t *testing.T) {
 			Want: &interfaces.Classification{
 				URL:         "https://api.stripe.com",
 				RecipeName:  "Stripe",
+				RecipeSubType: "third_party",
 				RecipeUUID:  "c24b836a-d035-49dc-808f-1912f16f690d",
 				RecipeMatch: true,
 				Decision: classify.ClassificationDecision{
@@ -101,6 +102,7 @@ func TestInterface(t *testing.T) {
 			Want: &interfaces.Classification{
 				URL:         "http://*.stripe.com",
 				RecipeName:  "Stripe",
+				RecipeSubType: "third_party",
 				RecipeUUID:  "c24b836a-d035-49dc-808f-1912f16f690d",
 				RecipeMatch: true,
 				Decision: classify.ClassificationDecision{
@@ -131,6 +133,7 @@ func TestInterface(t *testing.T) {
 			Want: &interfaces.Classification{
 				URL:         "https://googleapis.com/auth/spreadsheets",
 				RecipeName:  "Google Spreadsheets",
+				RecipeSubType: "third_party",
 				RecipeUUID:  "ebe2e05e-bc56-4204-9329-d9b8d3cf1837",
 				RecipeMatch: true,
 				Decision: classify.ClassificationDecision{

--- a/pkg/report/output/dataflow/components/components.go
+++ b/pkg/report/output/dataflow/components/components.go
@@ -18,10 +18,11 @@ type Holder struct {
 }
 
 type component struct {
-	name           string
-	component_type string
-	uuid           string
-	detectors      map[string]*detector // group detectors by detectorName
+	name               string
+	component_type     string
+	component_sub_type string
+	uuid               string
+	detectors          map[string]*detector // group detectors by detectorName
 }
 
 type detector struct {
@@ -59,6 +60,7 @@ func (holder *Holder) AddInterface(classifiedDetection interfaceclassification.C
 	}
 
 	componentType := getComponentType(classifiedDetection.Classification.Decision.Reason)
+	componentSubType := classifiedDetection.Classification.RecipeSubType
 
 	componentUUID := classifiedDetection.Classification.RecipeUUID
 	if componentUUID == "" {
@@ -69,6 +71,7 @@ func (holder *Holder) AddInterface(classifiedDetection interfaceclassification.C
 		holder.addComponent(
 			classifiedDetection.Classification.Name(),
 			componentType,
+			componentSubType,
 			componentUUID,
 			string(classifiedDetection.DetectorType),
 			classifiedDetection.Source.Filename,
@@ -85,11 +88,13 @@ func (holder *Holder) AddDependency(classifiedDetection dependenciesclassificati
 	}
 
 	componentType := getComponentType(classifiedDetection.Classification.Decision.Reason)
+	componentSubType := classifiedDetection.Classification.RecipeSubType
 
 	if classifiedDetection.Classification.Decision.State == classify.Valid {
 		holder.addComponent(
 			classifiedDetection.Classification.RecipeName,
 			componentType,
+			componentSubType,
 			classifiedDetection.Classification.RecipeUUID,
 			string(classifiedDetection.DetectorType),
 			classifiedDetection.Source.Filename,
@@ -106,11 +111,13 @@ func (holder *Holder) AddFramework(classifiedDetection frameworkclassification.C
 	}
 
 	componentType := getComponentType(classifiedDetection.Classification.Decision.Reason)
+	componentSubType := classifiedDetection.Classification.RecipeSubType
 
 	if classifiedDetection.Classification.Decision.State == classify.Valid {
 		holder.addComponent(
 			classifiedDetection.Classification.RecipeName,
 			componentType,
+			componentSubType,
 			classifiedDetection.Classification.RecipeUUID,
 			string(classifiedDetection.DetectorType),
 			classifiedDetection.Source.Filename,
@@ -122,7 +129,7 @@ func (holder *Holder) AddFramework(classifiedDetection frameworkclassification.C
 }
 
 // addComponent adds component to hash list and at the same time blocks duplicates
-func (holder *Holder) addComponent(componentName string, componentType string, componentUUID string, detectorName string, fileName string, lineNumber int) {
+func (holder *Holder) addComponent(componentName string, componentType string, componentSubType string, componentUUID string, detectorName string, fileName string, lineNumber int) {
 	// create component entry if it doesn't exist
 	if _, exists := holder.components[componentUUID]; !exists {
 		var uuid string
@@ -130,10 +137,11 @@ func (holder *Holder) addComponent(componentName string, componentType string, c
 			uuid = componentUUID
 		}
 		holder.components[componentUUID] = &component{
-			name:           componentName,
-			component_type: componentType,
-			uuid:           uuid,
-			detectors:      make(map[string]*detector),
+			name:               componentName,
+			component_type:     componentType,
+			component_sub_type: componentSubType,
+			uuid:               uuid,
+			detectors:          make(map[string]*detector),
 		}
 	}
 
@@ -168,6 +176,7 @@ func (holder *Holder) ToDataFlow() []types.Component {
 		constructedComponent := types.Component{
 			Name:      targetComponent.name,
 			Type:      targetComponent.component_type,
+			SubType:   targetComponent.component_sub_type,
 			UUID:      targetComponent.uuid,
 			Locations: make([]types.ComponentLocation, 0),
 		}

--- a/pkg/report/output/dataflow/types/components.go
+++ b/pkg/report/output/dataflow/types/components.go
@@ -3,6 +3,7 @@ package types
 type Component struct {
 	Name      string              `json:"name" yaml:"name"`
 	Type      string              `json:"type" yaml:"type"`
+	SubType   string              `json:"sub_type" yaml:"sub_type"`
 	UUID      string              `json:"uuid,omitempty" yaml:"uuid,omitempty"`
 	Locations []ComponentLocation `json:"locations" yaml:"locations"`
 }

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -21,7 +21,8 @@ do_cleanup() {
 trap do_cleanup 1 2 3 6
 
 do_info "Building Curio binary..."
-go build ./cmd/curio || do_error "Failed to build Curio binary"
+go build -a -o ./curio ./cmd/curio/main.go || do_error "Failed to build Curio binary"
+
 [ -f curio ] || do_error "No Curio binary found"
 
 TEST_ARGS=$DEFAULT_TEST_ARGS

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -2,8 +2,6 @@
 #
 # Run the Curio test suite
 
-set -e
-
 DEFAULT_TEST_ARGS="-count=1 -v ./..."
 
 do_info() {
@@ -14,6 +12,13 @@ do_error() {
   printf "ERROR: $*\n" 1>&2
   exit 1
 }
+
+do_cleanup() {
+  do_info "Cleaning up"
+  rm -f ./curio || do_error "Failed to clean up"
+}
+
+trap do_cleanup 1 2 3 6
 
 do_info "Building Curio binary..."
 go build ./cmd/curio || do_error "Failed to build Curio binary"
@@ -26,7 +31,6 @@ do_info "Running tests..."
 CURIO_BINARY=1 GITHUB_WORKSPACE=`pwd` go test $TEST_ARGS
 TEST_STATUS=$?
 
-do_info "Cleaning up"
-rm -f ./curio || do_error "Failed to clean up"
+do_cleanup
 
 [ $TEST_STATUS -eq 0 ] || do_error "Tests failed"


### PR DESCRIPTION
## Description

Import recipe sub-type data from the Bearer API management application; this allows us to differentiate recipes that are databases &mdash; e.g. PostgreSQL and Redis are both "data stores", but one is a database proper, and the other a key-value store.

Sample output:

```
The policy report is not yet available for your stack. Learn more at https://curio.sh/explanations/reports/

Though this doesn’t mean the curious bear comes empty-handed, it found:

- 6 unique data type(s), representing 25 occurrences, including PII.
- 1 database(s) storing 6 data type(s) including 0 encrypted data type(s).
- 5 external service(s).

Run the data flow report if you want the full output using: curio scan --report dataflow
```

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [X] I've updated or added documentation if required.
- [X] I've included usage information in the description if CLI behavior was updated or added.
- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
