### PR TITLE
chore: Add a wrapper script for running the tests

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,32 @@
+#!/bin/sh -
+#
+# Run the Curio test suite
+
+set -e
+
+DEFAULT_TEST_ARGS="-count=1 -v ./..."
+
+do_info() {
+  printf "INFO: $*\n"
+}
+
+do_error() {
+  printf "ERROR: $*\n" 1>&2
+  exit 1
+}
+
+do_info "Building Curio binary..."
+go build ./cmd/curio || do_error "Failed to build Curio binary"
+[ -f curio ] || do_error "No Curio binary found"
+
+TEST_ARGS=$DEFAULT_TEST_ARGS
+[ $# -eq 0 ] || TEST_ARGS="$@"
+
+do_info "Running tests..."
+CURIO_BINARY=1 GITHUB_WORKSPACE=`pwd` go test $TEST_ARGS
+TEST_STATUS=$?
+
+do_info "Cleaning up"
+rm -f ./curio || do_error "Failed to clean up"
+
+[ $TEST_STATUS -eq 0 ] || do_error "Tests failed"


### PR DESCRIPTION
## Description

Builds the Curio binary, runs the tests, and cleans up by deleting the built binary afterwards.

When invoked without arguments, runs the entire test suite in verbose, non-cached mode.

If any arguments are specified, these are passed through to the `go test` invocation.

E.g. To run all tests:

```sh
./scripts/run_tests.sh
```

To run just the integration tests:

```sh
./scripts/run_tests.sh ./integration/...
```

To run only the non-integration tests:

```sh
./scripts/run_tests.sh ./pkg/...
```

## Checklist

- [X] I've added test coverage that shows my fix or feature works as expected.
- [X] I've updated or added documentation if required.
- [X] I've included usage information in the description if CLI behavior was updated or added.
- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
