### PR TITLE
feat: harden integration tests

### DIFF
--- a/integration/flags/init_test.go
+++ b/integration/flags/init_test.go
@@ -12,7 +12,7 @@ func TestInitCommand(t *testing.T) {
 	filePath := testhelper.GetCWD() + "/curio.yml"
 	arguments := []string{"init"}
 
-	cmd := testhelper.CreateCurioCommand(arguments)
+	cmd, _ := testhelper.CreateCurioCommand(arguments)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("failed to run init command err: %s output: %s", err, string(output))

--- a/integration/internal/testhelper/testhelper.go
+++ b/integration/internal/testhelper/testhelper.go
@@ -50,7 +50,7 @@ func executeApp(t *testing.T, arguments []string) (string, error) {
 	var err error
 
 	timer := time.NewTimer(TestTimeout)
-	commandFinished := make(chan struct{})
+	commandFinished := make(chan struct{}, 1)
 
 	go func() {
 		err = cmd.Start()

--- a/integration/internal/testhelper/testhelper.go
+++ b/integration/internal/testhelper/testhelper.go
@@ -2,12 +2,17 @@ package testhelper
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/bradleyjkemp/cupaloy"
 )
+
+var TestTimeout = 1 * time.Minute
 
 type TestCase struct {
 	name          string
@@ -34,21 +39,40 @@ func NewTestCase(name string, arguments []string, options TestCaseOptions) TestC
 	}
 }
 
-func executeApp(arguments []string) (string, error) {
-	cmd := CreateCurioCommand(arguments)
+func executeApp(t *testing.T, arguments []string) (string, error) {
+	cmd, cancel := CreateCurioCommand(arguments)
 
 	buffOut := bytes.NewBuffer(nil)
 	buffErr := bytes.NewBuffer(nil)
 	cmd.Stdout = buffOut
 	cmd.Stderr = buffErr
 
-	err := cmd.Start()
-	if err != nil {
-		return "", err
-	}
+	var err error
 
-	if err := cmd.Wait(); err != nil {
-		return "", err
+	timer := time.NewTimer(TestTimeout)
+	commandFinished := make(chan struct{})
+
+	go func() {
+		err = cmd.Start()
+
+		if err != nil {
+			commandFinished <- struct{}{}
+			return
+		}
+
+		err = cmd.Wait()
+		commandFinished <- struct{}{}
+	}()
+
+	select {
+	case <-timer.C:
+		cancel()
+		t.Fatalf("command failed to complete on time 'curio %s'", strings.Join(arguments, ""))
+	case <-commandFinished:
+		if err != nil {
+			t.Fatalf("command completed with errror %s", err)
+		}
+		cancel()
 	}
 
 	combinedOutput := buffOut.String() + "\n--\n" + buffErr.String()
@@ -56,19 +80,21 @@ func executeApp(arguments []string) (string, error) {
 	return combinedOutput, nil
 }
 
-func CreateCurioCommand(arguments []string) *exec.Cmd {
+func CreateCurioCommand(arguments []string) (*exec.Cmd, context.CancelFunc) {
 	var cmd *exec.Cmd
 
+	ctx, cancel := context.WithCancel(context.Background())
+
 	if os.Getenv("CURIO_BINARY") != "" {
-		cmd = exec.Command("./curio", arguments...)
+		cmd = exec.CommandContext(ctx, "./curio", arguments...)
 	} else {
 		arguments = append([]string{"run", GetCWD() + "/cmd/curio/main.go"}, arguments...)
-		cmd = exec.Command("go", arguments...)
+		cmd = exec.CommandContext(ctx, "go", arguments...)
 	}
 
 	cmd.Dir = os.Getenv("GITHUB_WORKSPACE")
 
-	return cmd
+	return cmd, cancel
 }
 
 func GetCWD() string {
@@ -89,7 +115,7 @@ func RunTests(t *testing.T, tests []TestCase) {
 				arguments = append(arguments, "--force")
 			}
 
-			combinedOutput, err := executeApp(arguments)
+			combinedOutput, err := executeApp(t, arguments)
 
 			cupaloy.SnapshotT(t, combinedOutput)
 


### PR DESCRIPTION
## Description
This pr sets a default timeout of 1min per integration tests.
If the timeout is reached without command finishing its execution the test case should fail.

The goal is to have certain test fail and prevent hanging the whole test suite.

## Related
https://github.com/Bearer/curio/issues/266

## Checklist

- [x] I've added test coverage that shows my fix or feature works as expected.
- [x] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
