### PR TITLE
fix: Password reported by application-level encryption policy

### DIFF
--- a/integration/flags/.snapshots/TestInitCommand
+++ b/integration/flags/.snapshots/TestInitCommand
@@ -804,7 +804,7 @@ scan:
                     }
                 - path: policies/application_level_encryption.rego
                   name: bearer.application_level_encryption
-                  content: |-
+                  content: |
                     package bearer.application_level_encryption
 
                     import data.bearer.common
@@ -814,6 +814,7 @@ scan:
                     policy_failure contains item if {
                         datatype = input.dataflow.data_types[_]
                         datatype.name != "Unique Identifier"
+                        datatype.name != "Passwords"
 
                         detector = datatype.detectors[_]
                         location = detector.locations[_]

--- a/integration/policies/.snapshots/TestPolicies-application_level_encryption_missing_schema_rb
+++ b/integration/policies/.snapshots/TestPolicies-application_level_encryption_missing_schema_rb
@@ -33,23 +33,6 @@ low:
             t.datetime "updated_at", null: false
           end
       omit_parent: false
-    - policy_name: Force application-level encryption when processing sensitive data.
-      policy_display_id: CR-021
-      policy_description: Application-level encryption greatly reduces the risk of a data breach or data leak by making data unreadable. This policy checks if sensitive data types found in records are encrypted.
-      line_number: 5
-      filename: integration/policies/testdata/ruby/application_level_encryption_missing/schema_rb/db/schema.rb
-      category_groups:
-        - PII
-      parent_line_number: 2
-      parent_content: |-
-        create_table "users", force: :cascade do |t|
-            t.string "email", null: false
-            t.string "name"
-            t.string "encrypted_password", null: false
-            t.datetime "created_at", null: false
-            t.datetime "updated_at", null: false
-          end
-      omit_parent: false
 
 
 --

--- a/integration/policies/.snapshots/TestPolicies-application_level_encryption_missing_structure_sql
+++ b/integration/policies/.snapshots/TestPolicies-application_level_encryption_missing_structure_sql
@@ -17,24 +17,6 @@ low:
           email character varying DEFAULT ''::character varying NOT NULL
         )
       omit_parent: false
-    - policy_name: Force application-level encryption when processing sensitive data.
-      policy_display_id: CR-021
-      policy_description: Application-level encryption greatly reduces the risk of a data breach or data leak by making data unreadable. This policy checks if sensitive data types found in records are encrypted.
-      line_number: 4
-      filename: integration/policies/testdata/ruby/application_level_encryption_missing/structure_sql/db/structure.sql
-      category_groups:
-        - PII
-      parent_line_number: 1
-      parent_content: |-
-        CREATE TABLE public.users (
-          id bigint NOT NULL,
-          name character varying,
-          password character varying,
-          created_at timestamp(6) without time zone NOT NULL,
-          updated_at timestamp(6) without time zone NOT NULL,
-          email character varying DEFAULT ''::character varying NOT NULL
-        )
-      omit_parent: false
 
 
 --

--- a/pkg/commands/process/settings/policies/application_level_encryption.rego
+++ b/pkg/commands/process/settings/policies/application_level_encryption.rego
@@ -7,6 +7,7 @@ import future.keywords
 policy_failure contains item if {
     datatype = input.dataflow.data_types[_]
     datatype.name != "Unique Identifier"
+    datatype.name != "Passwords"
 
     detector = datatype.detectors[_]
     location = detector.locations[_]


### PR DESCRIPTION
## Description

We should not report policy violations for the "Password" data category, for the application-level encryption missing policy.

Fixes #284

## Checklist

- [X] I've added test coverage that shows my fix or feature works as expected.
- [X] I've updated or added documentation if required.
- [X] I've included usage information in the description if CLI behavior was updated or added.
- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
