### PR TITLE
feat: add static compilation flag to release

### DIFF
--- a/goreleaser/darwin.yaml
+++ b/goreleaser/darwin.yaml
@@ -18,6 +18,7 @@ builds:
       - arm64
     ldflags:
       - -s -w
+      - -extldflags "-static"
       - -X "github.com/bearer/curio/cmd/curio/build.Version={{.Version}}"
       - -X "github.com/bearer/curio/cmd/curio/build.CommitSHA={{.Commit}}"
     hooks:

--- a/goreleaser/linux.yaml
+++ b/goreleaser/linux.yaml
@@ -15,6 +15,7 @@ builds:
       - amd64
     ldflags:
       - -s -w
+      - -extldflags "-static"
       - -X "github.com/bearer/curio/cmd/curio/build.Version={{.Version}}"
       - -X "github.com/bearer/curio/cmd/curio/build.CommitSHA={{.Commit}}"
 snapshot:


### PR DESCRIPTION
## Description
This pr makes sure that curio runs when c++ toolchain is not installed on system. 

Previously we were depending on c++ being installed on the system, since some distributions like centos, debian, and archlinux in some images don't come with c++ installed, Curio failed to run on those.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
