### PR TITLE
docs: add scan video to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,37 +24,8 @@
 ## The data-first security scanner to protect sensitive data from leaks and breaches
 <hr/>
 
-```
-Scanning target ./example-project
- └ 100% [===============] (3305/3305, 115 files/s) [28s]
+https://user-images.githubusercontent.com/1649672/208479520-3476f4d2-2fa2-4f05-abad-5ce4d3f5d3ba.mov
 
-Policy Report
-
-=====================================
-Policy list:
-
-- JWT leaking
-- Insecure communication
-- Insecure HTTP with Data Category
-- Logger leaking
-- Cookie leaking
-- Insecure SMTP
-- HTTP GET parameters
-- Insecure FTP with Data Category
-- Session leaking
-- Insecure FTP
-- Third-party data category exposure
-- SSL certificate verification disabled
-- Application level encryption missing
-- Insecure HTTP GET
-
-=====================================
-
-SUCCESS
-
-14 policies were run and no failures were detected.
-
-```
 
 Curio helps developers and security teams to:
 


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->
Adds scan video to readme in place of output preview, using github's built-in video support.

Preview: https://github.com/Bearer/curio/tree/markmichon-patch-1
<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
