### PR TITLE
fix: Improve policy placeholder for empty scan results

### DIFF
--- a/pkg/report/output/stats/stats.go
+++ b/pkg/report/output/stats/stats.go
@@ -123,15 +123,28 @@ func GetPlaceholderOutput(inputgocloc *gocloc.Result, inputDataflow *dataflow.Da
 
 	supportURL := "https://curio.sh/explanations/reports/"
 	outputStr.WriteString(fmt.Sprintf(`
-The policy report is not yet available for your stack. Learn more at %s
+The policy report is not yet available for your stack. Learn more at %s`,
+		supportURL))
+
+	anythingFound :=
+		statistics.NumberOfDataTypes != 0 ||
+		statistics.NumberOfDatabases != 0 ||
+		statistics.NumberOfExternalAPIs != 0 ||
+		statistics.NumberOfInternalAPIs != 0
+	if anythingFound {
+		outputStr.WriteString(`
 
 Though this doesn’t mean the curious bear comes empty-handed, it found:
+`)
+	}
 
+	if statistics.NumberOfDataTypes != 0 {
+		outputStr.WriteString(fmt.Sprintf(`
 - %d unique data type(s), representing %d occurrences, including %s.`,
-		supportURL,
-		statistics.NumberOfDataTypes,
-		totalDataTypeOccurrences,
-		strings.Join(statistics.DataGroups, ", ")))
+			statistics.NumberOfDataTypes,
+			totalDataTypeOccurrences,
+			strings.Join(statistics.DataGroups, ", ")))
+	}
 
 	if statistics.NumberOfDatabases != 0 {
 		numberOfEncryptedDataTypes := 0
@@ -141,8 +154,7 @@ Though this doesn’t mean the curious bear comes empty-handed, it found:
 			}
 		}
 
-		outputStr.WriteString(fmt.Sprintf(
-			`
+		outputStr.WriteString(fmt.Sprintf(`
 - %d database(s) storing %d data type(s) including %d encrypted data type(s).`,
 			statistics.NumberOfDatabases,
 			statistics.NumberOfDataTypes,
@@ -150,15 +162,13 @@ Though this doesn’t mean the curious bear comes empty-handed, it found:
 	}
 
 	if statistics.NumberOfExternalAPIs != 0 {
-		outputStr.WriteString(fmt.Sprintf(
-			`
+		outputStr.WriteString(fmt.Sprintf(`
 - %d external service(s).`,
 			statistics.NumberOfExternalAPIs))
 	}
 
 	if statistics.NumberOfInternalAPIs != 0 {
-		outputStr.WriteString(fmt.Sprintf(
-			`
+		outputStr.WriteString(fmt.Sprintf(`
 - %d internal URL(s).`,
 			statistics.NumberOfInternalAPIs))
 	}


### PR DESCRIPTION
## Description

Improve the "placeholder" output for the policies report, to better cope with cases in which data types and other detections are not present.

Closes #303

### Screenshots

#### Nothing found

![Screenshot_2022-12-20_10-36-03](https://user-images.githubusercontent.com/132732/208648377-91edc2ca-5afd-41cf-bfe1-eda49c55a905.png)

#### Lots of detections, including data types

![Screenshot_2022-12-20_10-36-25](https://user-images.githubusercontent.com/132732/208648399-20d9b4e3-c3c9-4ddb-8d42-28014187e078.png)

#### Detections, but no data types found

![Screenshot_2022-12-20_10-36-44](https://user-images.githubusercontent.com/132732/208648412-d46cf9fc-bf25-4b4a-b193-1e964a51ec82.png)


## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [X] I've updated or added documentation if required.
- [X] I've included usage information in the description if CLI behavior was updated or added.
- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
