### PR TITLE
chore: reorder category groupings

### DIFF
--- a/pkg/classification/db/category_grouping.json
+++ b/pkg/classification/db/category_grouping.json
@@ -4,6 +4,10 @@
       "name": "Personal Data",
       "parent_uuids": []
     },
+    "f6a0c071-5908-4420-bac2-bba28d41223e": {
+      "name": "Personal Data (Sensitive)",
+      "parent_uuids": []
+    },
     "247fa503-115b-490a-96e5-bcd357bd5686": {
       "name": "PHI",
       "parent_uuids": [
@@ -15,10 +19,6 @@
       "parent_uuids": [
         "e1d3135b-3c0f-4b55-abce-19f27a26cbb3"
       ]
-    },
-    "f6a0c071-5908-4420-bac2-bba28d41223e": {
-      "name": "Personal Data (Sensitive)",
-      "parent_uuids": []
     }
   },
   "category_mapping": {


### PR DESCRIPTION
## Description
Category grouping order separates PD and PD(S), probably just because it was added later. Reordering this to make docs and future output make a bit more sense.


## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
