### PR TITLE
fix: use correct archives for brew

### DIFF
--- a/goreleaser/darwin-brew.yaml
+++ b/goreleaser/darwin-brew.yaml
@@ -20,30 +20,6 @@ builds:
       - -s -w
       - -X "github.com/bearer/curio/cmd/curio/build.Version={{.Version}}"
       - -X "github.com/bearer/curio/cmd/curio/build.CommitSHA={{.Commit}}"
-    hooks:
-      post:
-        - |
-          sh -c '
-          fn=dist/curio-macos-build_{{.Target}}/gon.hcl
-          cat >"$fn" <<EOF
-          source = ["dist/curio-macos-build_{{.Target}}/{{.Name}}"]
-
-          bundle_id = "com.bearer.curio"
-
-          apple_id {
-            password = "@env:AC_PASSWORD"
-          }
-
-          sign {
-            application_identity = "Developer ID Application: Bearer Inc (5T2VP4YAG8)"
-          }
-
-          zip {
-            output_path = "curio_{{.Target}}.zip"
-          }
-          EOF
-          '
-        - "gon -log-level=debug 'dist/curio-macos-build_{{.Target}}/gon.hcl'"
 
 archives:
   - id: macos-archive
@@ -51,8 +27,6 @@ archives:
       - curio-macos-build
 
 release:
-  ids:
-    - none
   skip_upload: true
   mode: keep-existing
   name_template: "Release {{.Tag}}"


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Use correct archives to generate sha256 for brew tap

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
