### PR TITLE
feat: Extend Ruby file custom detector to cover IO.open

### DIFF
--- a/integration/custom_detectors/.snapshots/TestCustomDetectors-ruby_file_detection
+++ b/integration/custom_detectors/.snapshots/TestCustomDetectors-ruby_file_detection
@@ -27,6 +27,12 @@ data_types:
               line_number: 16
             - filename: integration/custom_detectors/testdata/ruby/ruby_file_detection.rb
               line_number: 25
+    - name: Fullname
+      detectors:
+        - name: ruby
+          locations:
+            - filename: integration/custom_detectors/testdata/ruby/ruby_file_detection.rb
+              line_number: 33
     - name: Lastname
       detectors:
         - name: ruby
@@ -125,6 +131,17 @@ risks:
                     			user_5.last_name
                     		]
                     	end
+                    end
+        - name: Fullname
+          stored: false
+          locations:
+            - filename: integration/custom_detectors/testdata/ruby/ruby_file_detection.rb
+              line_number: 33
+              parent:
+                line_number: 32
+                content: |-
+                    IO.open(fd,"w") do |a|
+                      a.puts "Hello, #{user_6.full_name}!"
                     end
         - name: Lastname
           stored: false

--- a/integration/custom_detectors/testdata/ruby/ruby_file_detection.rb
+++ b/integration/custom_detectors/testdata/ruby/ruby_file_detection.rb
@@ -27,3 +27,8 @@ csv_string = CSV.generate do |csv|
 		]
 	end
 end
+
+fd = IO.sysopen("/dev/tty", "w")
+IO.open(fd,"w") do |a|
+  a.puts "Hello, #{user_6.full_name}!"
+end

--- a/integration/flags/.snapshots/TestInitCommand
+++ b/integration/flags/.snapshots/TestInitCommand
@@ -477,6 +477,7 @@ scan:
                       values:
                         - CSV
                         - File
+                        - IO
                       minimum: null
                       maximum: null
                       match_violation: false

--- a/pkg/commands/process/settings/custom_detector.yml
+++ b/pkg/commands/process/settings/custom_detector.yml
@@ -147,6 +147,7 @@ ruby_file_detection:
           values:
             - CSV
             - File
+            - IO
   param_parenting: true
   metavars: {}
   stored: false


### PR DESCRIPTION
## Description

The Ruby file custom detection currently detects `CSV.open` and `File.open`; it should support `IO.open` as well.

## Related

Closes #316 

## Checklist

- [X] I've added test coverage that shows my fix or feature works as expected.
- [X] I've updated or added documentation if required.
- [X] I've included usage information in the description if CLI behavior was updated or added.
- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
