### PR TITLE
fix: Hide --workers CLI option and configuration file key

### DIFF
--- a/docs/_data/curio_scan.yaml
+++ b/docs/_data/curio_scan.yaml
@@ -26,6 +26,9 @@ options:
     - name: files-to-batch
       default_value: "1"
       usage: Specify the number of files to batch per worker.
+    - name: force
+      default_value: "false"
+      usage: Disable the cache and runs the detections again
     - name: format
       shorthand: f
       usage: Specify report format (json, yaml)
@@ -80,9 +83,6 @@ options:
     - name: timeout-worker-online
       default_value: 1m0s
       usage: Maximum time to wait for a worker process to come online.
-    - name: workers
-      default_value: "1"
-      usage: The number of processing workers to spawn.
 example: |4-
       # Scan a local project, including language-specific files
       $ curio scan /path/to/your_project

--- a/integration/flags/.snapshots/TestInitCommand
+++ b/integration/flags/.snapshots/TestInitCommand
@@ -29,5 +29,4 @@ worker:
     timeout-file-min: 5s
     timeout-file-second-per-bytes: 10000
     timeout-worker-online: 1m0s
-    workers: 1
 

--- a/integration/flags/.snapshots/TestMetadataFlags-help-scan
+++ b/integration/flags/.snapshots/TestMetadataFlags-help-scan
@@ -47,7 +47,6 @@ Worker Flags
       --timeout-file-min duration           Minimum timeout assigned for scanning each file. This config superseeds timeout-second-per-bytes. (default 5s)
       --timeout-file-second-per-bytes int   number of file size bytes producing a second of timeout assigned to scanning a file (default 10000)
       --timeout-worker-online duration      Maximum time to wait for a worker process to come online. (default 1m0s)
-      --workers int                         The number of processing workers to spawn. (default 1)
 
 
 --

--- a/integration/flags/.snapshots/TestMetadataFlags-scan-help
+++ b/integration/flags/.snapshots/TestMetadataFlags-scan-help
@@ -47,7 +47,6 @@ Worker Flags
       --timeout-file-min duration           Minimum timeout assigned for scanning each file. This config superseeds timeout-second-per-bytes. (default 5s)
       --timeout-file-second-per-bytes int   number of file size bytes producing a second of timeout assigned to scanning a file (default 10000)
       --timeout-worker-online duration      Maximum time to wait for a worker process to come online. (default 1m0s)
-      --workers int                         The number of processing workers to spawn. (default 1)
 
 
 --

--- a/integration/flags/.snapshots/TestReportFlagsShouldFail-invalid-context-flag
+++ b/integration/flags/.snapshots/TestReportFlagsShouldFail-invalid-context-flag
@@ -48,7 +48,6 @@ Worker Flags
       --timeout-file-min duration           Minimum timeout assigned for scanning each file. This config superseeds timeout-second-per-bytes. (default 5s)
       --timeout-file-second-per-bytes int   number of file size bytes producing a second of timeout assigned to scanning a file (default 10000)
       --timeout-worker-online duration      Maximum time to wait for a worker process to come online. (default 1m0s)
-      --workers int                         The number of processing workers to spawn. (default 1)
 
 
 flag error: report flags error: invalid format argument; supported values: json, yaml

--- a/integration/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag
+++ b/integration/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag
@@ -48,7 +48,6 @@ Worker Flags
       --timeout-file-min duration           Minimum timeout assigned for scanning each file. This config superseeds timeout-second-per-bytes. (default 5s)
       --timeout-file-second-per-bytes int   number of file size bytes producing a second of timeout assigned to scanning a file (default 10000)
       --timeout-worker-online duration      Maximum time to wait for a worker process to come online. (default 1m0s)
-      --workers int                         The number of processing workers to spawn. (default 1)
 
 
 flag error: report flags error: invalid format argument; supported values: json, yaml

--- a/integration/flags/.snapshots/TestReportFlagsShouldFail-invalid-report-flag
+++ b/integration/flags/.snapshots/TestReportFlagsShouldFail-invalid-report-flag
@@ -48,7 +48,6 @@ Worker Flags
       --timeout-file-min duration           Minimum timeout assigned for scanning each file. This config superseeds timeout-second-per-bytes. (default 5s)
       --timeout-file-second-per-bytes int   number of file size bytes producing a second of timeout assigned to scanning a file (default 10000)
       --timeout-worker-online duration      Maximum time to wait for a worker process to come online. (default 1m0s)
-      --workers int                         The number of processing workers to spawn. (default 1)
 
 
 flag error: report flags error: invalid report argument; supported values: detectors, dataflow, policies, stats

--- a/pkg/flag/worker_flags.go
+++ b/pkg/flag/worker_flags.go
@@ -6,10 +6,10 @@ import (
 
 var (
 	WorkersFlag = Flag{
-		Name:       "workers",
 		ConfigName: "worker.workers",
 		Value:      1,
 		Usage:      "The number of processing workers to spawn.",
+		DisableInConfig: true,
 	}
 	TimeoutFlag = Flag{
 		Name:       "timeout",


### PR DESCRIPTION
## Description

The `--workers` option is currently not being respected. Pending a resolution, we hide the CLI option and associated entry in the configuration file.

## Related

Closes #317

## Checklist

- [X] I've added test coverage that shows my fix or feature works as expected.
- [X] I've updated or added documentation if required.
- [X] I've included usage information in the description if CLI behavior was updated or added.
- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format