### PR TITLE
fix: Do not report policy breaches for encrypted Rails cookies

### DIFF
--- a/integration/custom_detectors/.snapshots/TestCustomDetectors-detect_rails_cookies
+++ b/integration/custom_detectors/.snapshots/TestCustomDetectors-detect_rails_cookies
@@ -23,12 +23,14 @@ data_types:
           locations:
             - filename: integration/custom_detectors/testdata/ruby/detect_rails_cookies.rb
               line_number: 3
+            - filename: integration/custom_detectors/testdata/ruby/detect_rails_cookies.rb
+              line_number: 12
     - name: Username
       detectors:
         - name: ruby
           locations:
             - filename: integration/custom_detectors/testdata/ruby/detect_rails_cookies.rb
-              line_number: 12
+              line_number: 13
 risks:
     - detector_id: detect_rails_cookies
       data_types:

--- a/integration/custom_detectors/testdata/ruby/detect_rails_cookies.rb
+++ b/integration/custom_detectors/testdata/ruby/detect_rails_cookies.rb
@@ -1,6 +1,6 @@
 # Detected
 cookies.signed[:info] = user.email
-cookies.permanent.encrypted[:secret] = user.address
+cookies.permanent.signed[:secret] = user.address
 user_1 = {
   first_name: "John",
 	last_name: "Doe"
@@ -9,6 +9,7 @@ cookies[:login] = { value: user_1.to_json, expires: 1.hour, secure: true }
 
 
 # Not detected
+cookies.permanent.encrypted[:secret] = user.address
 cookies[:user_name] = "david"
 cookies.signed[:user_email] = "mish@bearer.sh"
 cookies.encrypted[:full_name] = "John Doe"

--- a/pkg/commands/process/settings/custom_detectors/detect_rails_cookies.yml
+++ b/pkg/commands/process/settings/custom_detectors/detect_rails_cookies.yml
@@ -8,19 +8,8 @@ patterns:
       - variable: METHOD_CHAIN
         values:
           - permanent
-          - encrypted
           - signed
-          - permanent.encrypted
           - permanent.signed
-          - permanent.encrypted.signed
-          - permanent.signed.encrypted
-          - encrypted.permanent
-          - encrypted.signed
-          - encrypted.permanent.signed
-          - encrypted.signed.permanent
-          - signed.encrypted
           - signed.permanent
-          - signed.permanent.encrypted
-          - signed.encrypted.permanent
 languages:
   - ruby


### PR DESCRIPTION
## Description

Code such as the following should not trigger a policy breach, but currently does.

```ruby
cookies.encrypted[:user_email] = user.email
```

## Related

Closes #328

## Checklist

- [X] I've added test coverage that shows my fix or feature works as expected.
- [X] I've updated or added documentation if required.
- [X] I've included usage information in the description if CLI behavior was updated or added.
- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format