### PR TITLE
feat: support multiple node types in patterns

### DIFF
--- a/new/language/patternquery/builder/builder.go
+++ b/new/language/patternquery/builder/builder.go
@@ -2,6 +2,7 @@ package builder
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"golang.org/x/exp/slices"
@@ -12,7 +13,7 @@ import (
 )
 
 type Variable struct {
-	NodeType   string
+	NodeTypes  []string
 	DummyValue string
 	Name       string
 }
@@ -105,9 +106,15 @@ func (builder *builder) compileVariableNode(variable *Variable) {
 	paramName := builder.newParam()
 	builder.variableToParams[variable.Name] = append(builder.variableToParams[variable.Name], paramName)
 
-	builder.write("(")
-	builder.write(variable.NodeType)
-	builder.write(") @")
+	builder.write("[")
+
+	for _, nodeType := range variable.NodeTypes {
+		builder.write("(")
+		builder.write(nodeType)
+		builder.write(")")
+	}
+
+	builder.write("] @")
 	builder.write(paramName)
 }
 
@@ -117,9 +124,7 @@ func (builder *builder) compileAnonymousNode(node *tree.Node) {
 		return
 	}
 
-	builder.write(`"`)
-	builder.write(escapeQueryString(node.Content()))
-	builder.write(`"`)
+	builder.write(strconv.Quote(node.Content()))
 }
 
 // Leaves match their type and content
@@ -182,8 +187,4 @@ func (builder *builder) write(value string) {
 
 func (builder *builder) newParam() string {
 	return "param" + builder.idGenerator.GenerateId()
-}
-
-func escapeQueryString(value string) string {
-	return value // FIXME
 }

--- a/pkg/commands/process/settings/custom_detector.yml
+++ b/pkg/commands/process/settings/custom_detector.yml
@@ -207,38 +207,38 @@ detect_rails_jwt:
           detection: datatype
   languages:
     - ruby
-# detect_rails_cookies:
-#   type: "risk"
-#   patterns:
-#     - pattern: |
-#         cookies[] = $<DATA_TYPE>
-#       filters:
-#         - variable: DATA_TYPE
-#           detection: datatype
-#     - pattern: | # FIXME: either implement alternation, or have our own types that map to mulitple tree-sitter types
-#         cookies.$<METHOD_CHAIN:identifier|call>[] = $<DATA_TYPE>
-#       filters:
-#         - variable: METHOD_CHAIN
-#           values:
-#             - permanent
-#             - encrypted
-#             - signed
-#             - permanent.encrypted
-#             - permanent.signed
-#             - permanent.encrypted.signed
-#             - permanent.signed.encrypted
-#             - encrypted.permanent
-#             - encrypted.signed
-#             - encrypted.permanent.signed
-#             - encrypted.signed.permanent
-#             - signed.encrypted
-#             - signed.permanent
-#             - signed.permanent.encrypted
-#             - signed.encrypted.permanent
-#         - variable: DATA_TYPE
-#           detection: datatype
-#   languages:
-#     - ruby
+detect_rails_cookies:
+  type: "risk"
+  patterns:
+    - pattern: |
+        cookies[] = $<DATA_TYPE>
+      filters:
+        - variable: DATA_TYPE
+          detection: datatype
+    - pattern: |
+        cookies.$<METHOD_CHAIN:identifier|call>[] = $<DATA_TYPE>
+      filters:
+        - variable: METHOD_CHAIN
+          values:
+            - permanent
+            - encrypted
+            - signed
+            - permanent.encrypted
+            - permanent.signed
+            - permanent.encrypted.signed
+            - permanent.signed.encrypted
+            - encrypted.permanent
+            - encrypted.signed
+            - encrypted.permanent.signed
+            - encrypted.signed.permanent
+            - signed.encrypted
+            - signed.permanent
+            - signed.permanent.encrypted
+            - signed.encrypted.permanent
+        - variable: DATA_TYPE
+          detection: datatype
+  languages:
+    - ruby
 ssl_certificate_verification_disabled:
   type: "risk"
   patterns:


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Support an alternation of Tree Sitter node types in rule pattern variables. eg. `$<NAME:type1|type2>`.

Allows re-enabling of the `detect_rails_cookies` rule.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [x] I've updated or added documentation if required.
- [x] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
