### PR TITLE
feat: add new filter types for password length

### DIFF
--- a/new/detector/implementation/custom/custom.go
+++ b/new/detector/implementation/custom/custom.go
@@ -60,7 +60,7 @@ func (detector *customDetector) DetectAt(
 		}
 
 		for _, result := range results {
-			filtersMatch, datatypeDetections, err := matchAndFilter(result, evaluator, pattern.Filters)
+			filtersMatch, datatypeDetections, err := matchAllFilters(result, evaluator, pattern.Filters)
 			if err != nil {
 				return nil, err
 			}

--- a/new/detector/implementation/custom/filter.go
+++ b/new/detector/implementation/custom/filter.go
@@ -1,0 +1,145 @@
+package custom
+
+import (
+	"strconv"
+
+	"golang.org/x/exp/slices"
+
+	"github.com/bearer/curio/new/detector/types"
+	"github.com/bearer/curio/new/language/tree"
+	"github.com/bearer/curio/pkg/commands/process/settings"
+)
+
+func matchFilter(
+	result tree.QueryResult,
+	evaluator types.Evaluator,
+	filter settings.PatternFilter,
+) (bool, []*types.Detection, error) {
+	if len(filter.Or) != 0 {
+		return matchOrFilter(result, evaluator, filter.Or)
+	}
+
+	node, ok := result[filter.Variable]
+	// shouldn't happen if filters are validated against pattern
+	if !ok {
+		return false, nil, nil
+	}
+
+	if filter.Detection != "" {
+		return matchDetectionFilter(result, evaluator, node, filter.Detection)
+	}
+
+	return matchContentFilter(filter, node.Content()), nil, nil
+}
+
+func matchAndFilter(
+	result tree.QueryResult,
+	evaluator types.Evaluator,
+	filters []settings.PatternFilter,
+) (bool, []*types.Detection, error) {
+	var datatypeDetections []*types.Detection
+
+	for _, filter := range filters {
+		matched, subDataTypeDetections, err := matchFilter(result, evaluator, filter)
+		if !matched || err != nil {
+			return false, nil, err
+		}
+
+		datatypeDetections = append(datatypeDetections, subDataTypeDetections...)
+	}
+
+	return true, datatypeDetections, nil
+}
+
+func matchOrFilter(
+	result tree.QueryResult,
+	evaluator types.Evaluator,
+	filters []settings.PatternFilter,
+) (bool, []*types.Detection, error) {
+	var datatypeDetections []*types.Detection
+	oneMatched := false
+
+	for _, subFilter := range filters {
+		subMatch, subDatatypeDetections, err := matchFilter(result, evaluator, subFilter)
+		if err != nil {
+			return false, nil, err
+		}
+
+		datatypeDetections = append(datatypeDetections, subDatatypeDetections...)
+		oneMatched = oneMatched || subMatch
+	}
+
+	if !oneMatched {
+		return false, nil, nil
+	}
+
+	return true, datatypeDetections, nil
+}
+
+func matchDetectionFilter(
+	result tree.QueryResult,
+	evaluator types.Evaluator,
+	node *tree.Node,
+	detectorType string,
+) (bool, []*types.Detection, error) {
+	if detectorType == "datatype" {
+		detections, err := evaluator.ForTree(node, "datatype")
+
+		return len(detections) != 0, detections, err
+	}
+
+	hasDetection, err := evaluator.TreeHas(node, detectorType)
+	return hasDetection, nil, err
+}
+
+func matchContentFilter(filter settings.PatternFilter, content string) bool {
+	if len(filter.Values) != 0 && !slices.Contains(filter.Values, content) {
+		return false
+	}
+
+	if filter.LessThan != nil {
+		value, err := strconv.Atoi(content)
+		if err != nil {
+			return false
+		}
+
+		if value >= *filter.LessThan {
+			return false
+		}
+	}
+
+	if filter.LessThanOrEqual != nil {
+		value, err := strconv.Atoi(content)
+		if err != nil {
+			return false
+		}
+
+		if value > *filter.LessThanOrEqual {
+			return false
+		}
+	}
+
+	if filter.GreaterThan != nil {
+		value, err := strconv.Atoi(content)
+		if err != nil {
+			return false
+		}
+
+		if value <= *filter.GreaterThan {
+			return false
+		}
+	}
+
+	if filter.GreaterThanOrEqual != nil {
+		value, err := strconv.Atoi(content)
+		if err != nil {
+			return false
+		}
+
+		if value < *filter.GreaterThanOrEqual {
+			return false
+		}
+	}
+
+	return true
+}

--- a/new/detector/implementation/custom/filter.go
+++ b/new/detector/implementation/custom/filter.go
@@ -15,8 +15,8 @@ func matchFilter(
 	evaluator types.Evaluator,
 	filter settings.PatternFilter,
 ) (bool, []*types.Detection, error) {
-	if len(filter.Or) != 0 {
-		return matchOrFilter(result, evaluator, filter.Or)
+	if len(filter.Either) != 0 {
+		return matchEitherFilters(result, evaluator, filter.Either)
 	}
 
 	node, ok := result[filter.Variable]
@@ -32,7 +32,7 @@ func matchFilter(
 	return matchContentFilter(filter, node.Content()), nil, nil
 }
 
-func matchAndFilter(
+func matchAllFilters(
 	result tree.QueryResult,
 	evaluator types.Evaluator,
 	filters []settings.PatternFilter,
@@ -51,7 +51,7 @@ func matchAndFilter(
 	return true, datatypeDetections, nil
 }
 
-func matchOrFilter(
+func matchEitherFilters(
 	result tree.QueryResult,
 	evaluator types.Evaluator,
 	filters []settings.PatternFilter,

--- a/pkg/commands/process/settings/custom_detector.yml
+++ b/pkg/commands/process/settings/custom_detector.yml
@@ -1,43 +1,39 @@
-# ruby_password_length:
-#   type: "risk"
-#   languages:
-#     - ruby
-#   patterns:
-#     - pattern: |
-#         class $<_> < ApplicationRecord
-#           validates :password, length: { minimum: $<LENGTH> }
-#         end
-#       filters:
-#         - variable: LENGTH
-#           minimum: 8
-#           match_violation: true
-#     - pattern: |
-#         class $<_> < ApplicationRecord
-#           devise password_length: $<MIN_LENGTH>..$<MAX_LENGTH>
-#         end
-#       filters:
-#         - variable: MAX_LENGTH
-#           minimum: 35
-#           match_violation: true
-#         - variable: MIN_LENGTH
-#           minimum: 8
-#           match_violation: true
-#     - pattern: |
-#         Devise.setup do |config|
-#           config.password_length = $<MIN_LENGTH>..$<MAX_LENGTH>
-#         end
-#       filters:
-#         - variable: MIN_LENGTH
-#           minimum: 8
-#           match_violation: true
-#     - pattern: |
-#         Devise.setup do |config|
-#           config.password_length = $<LENGTH>
-#         end
-#       filters:
-#         - variable: LENGTH
-#           minimum: 8
-#           match_violation: true
+ruby_password_length:
+  type: "risk"
+  languages:
+    - ruby
+  patterns:
+    - pattern: |
+        class $<_> < ApplicationRecord
+          validates :password, length: { minimum: $<LENGTH> }
+        end
+      filters:
+        - variable: LENGTH
+          less_than: 8
+    - pattern: |
+        class $<_> < ApplicationRecord
+          devise password_length: $<MIN_LENGTH>..$<MAX_LENGTH>
+        end
+      filters:
+        - or:
+          - variable: MAX_LENGTH
+            less_than: 35
+          - variable: MIN_LENGTH
+            less_than: 8
+    - pattern: |
+        Devise.setup do |config|
+          config.password_length = $<MIN_LENGTH>..$<MAX_LENGTH>
+        end
+      filters:
+        - variable: MIN_LENGTH
+          less_than: 8
+    - pattern: |
+        Devise.setup do |config|
+          config.password_length = $<LENGTH>
+        end
+      filters:
+        - variable: LENGTH
+          less_than: 8
 ruby_http_get_detection:
   type: "risk"
   languages:

--- a/pkg/commands/process/settings/custom_detector.yml
+++ b/pkg/commands/process/settings/custom_detector.yml
@@ -15,7 +15,7 @@ ruby_password_length:
           devise password_length: $<MIN_LENGTH>..$<MAX_LENGTH>
         end
       filters:
-        - or:
+        - either:
           - variable: MAX_LENGTH
             less_than: 35
           - variable: MIN_LENGTH

--- a/pkg/commands/process/settings/settings.go
+++ b/pkg/commands/process/settings/settings.go
@@ -57,12 +57,19 @@ func (modules Modules) ToRegoModules() (output []rego.Module) {
 }
 
 type PatternFilter struct {
-	Variable       string   `mapstructure:"variable" json:"variable" yaml:"variable"`
-	Detection      string   `mapstructure:"detection" json:"detection" yaml:"detection"`
-	Values         []string `mapstructure:"values" json:"values" yaml:"values"`
-	Minimum        *int     `mapstructure:"minimum" json:"minimum" yaml:"minimum"`
-	Maximum        *int     `mapstructure:"maximum" json:"maximum" yaml:"maximum"`
-	MatchViolation bool     `mapstructure:"match_violation" json:"match_violation" yaml:"match_violation"`
+	Or                 []PatternFilter `mapstructure:"or" json:"or" yaml:"or"`
+	Variable           string          `mapstructure:"variable" json:"variable" yaml:"variable"`
+	Detection          string          `mapstructure:"detection" json:"detection" yaml:"detection"`
+	Values             []string        `mapstructure:"values" json:"values" yaml:"values"`
+	LessThan           *int            `mapstructure:"less_than" json:"less_than" yaml:"less_than"`
+	LessThanOrEqual    *int            `mapstructure:"less_than_or_equal" json:"less_than_or_equal" yaml:"less_than_or_equal"`
+	GreaterThan        *int            `mapstructure:"greater_than" json:"greater_than" yaml:"greater_than"`
+	GreaterThanOrEqual *int            `mapstructure:"greater_than_or_equal" json:"greater_than_or_equal" yaml:"greater_than_or_equal"`
+
+	// FIXME: remove when refactor is complete
+	Minimum        *int `mapstructure:"minimum" json:"minimum" yaml:"minimum"`
+	Maximum        *int `mapstructure:"maximum" json:"maximum" yaml:"maximum"`
+	MatchViolation bool `mapstructure:"match_violation" json:"match_violation" yaml:"match_violation"`
 }
 
 type RulePattern struct {

--- a/pkg/commands/process/settings/settings.go
+++ b/pkg/commands/process/settings/settings.go
@@ -57,7 +57,7 @@ func (modules Modules) ToRegoModules() (output []rego.Module) {
 }
 
 type PatternFilter struct {
-	Or                 []PatternFilter `mapstructure:"or" json:"or" yaml:"or"`
+	Either             []PatternFilter `mapstructure:"either" json:"either" yaml:"either"`
 	Variable           string          `mapstructure:"variable" json:"variable" yaml:"variable"`
 	Detection          string          `mapstructure:"detection" json:"detection" yaml:"detection"`
 	Values             []string        `mapstructure:"values" json:"values" yaml:"values"`


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Adds filter support to allow `ruby_password_length` to be re-enabled.

The implementation is different than previously:
- We add an `EITHER` filter which seems more useful than `match_violation` was
- We split the numeric filters into (`<`, `<=`, `>`, `>=`) to make it clearer what the logic is (`minimum`/`maximum` seemed ambiguous).


<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [x] I've updated or added documentation if required.
- [x] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
