### PR TITLE
feat: add curio ascii logo using ansi escape codes

### DIFF
--- a/integration/flags/.snapshots/TestMetadataFlags-help
+++ b/integration/flags/.snapshots/TestMetadataFlags-help
@@ -1,4 +1,11 @@
-Curio - discover sensitive data flows and security risks.
+
+  [0;1;35;95m▄▄▄[0m                  [0;37m▀[0m
+[0;35m▄▀[0m   [0;35m▀[0m [0;35m▄[0m   [0;35m▄[0m   [0;37m▄[0m [0;37m▄▄[0m  [0;37m▄▄▄[0m     [0;37m▄▄[0;1;30;90m▄[0m
+[0;35m█[0m      [0;37m█[0m   [0;37m█[0m   [0;37m█▀[0m  [0;37m▀[0m   [0;1;30;90m█[0m    [0;1;30;90m█▀[0m [0;1;30;90m▀█[0m
+[0;37m█[0m      [0;37m█[0m   [0;37m█[0m   [0;1;30;90m█[0m       [0;1;30;90m█[0m    [0;1;30;90m█[0m   [0;1;35;95m█[0m
+ [0;37m▀▄▄▄▀[0m [0;1;30;90m▀▄▄▀█[0m   [0;1;30;90m█[0m     [0;1;30;90m▄▄[0;1;35;95m█▄▄[0m  [0;1;35;95m▀█▄█▀[0m
+
+Discover sensitive data flows and security risks.
 
 Usage: curio <command> [flags]
 
@@ -16,10 +23,10 @@ Examples:
 
 Learn More:
 	Curio is a static code analysis tool (SAST) that scans your source code to
-	discover security risks and vulnerabilities that put your sensitive data 
+	discover security risks and vulnerabilities that put your sensitive data
 	at risk (PHI, PD, PII).
-	
-	For more examples, tutorials, and to learn more about the project 
+
+	For more examples, tutorials, and to learn more about the project
 	visit https://curio.sh
 
 --

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -28,7 +28,14 @@ func NewApp(version string, commitSHA string) *cobra.Command {
 }
 
 func NewRootCommand() *cobra.Command {
-	usageTemplate := `Curio - discover sensitive data flows and security risks.
+	usageTemplate := `
+  [0;1;35;95m▄▄▄[0m                  [0;37m▀[0m
+[0;35m▄▀[0m   [0;35m▀[0m [0;35m▄[0m   [0;35m▄[0m   [0;37m▄[0m [0;37m▄▄[0m  [0;37m▄▄▄[0m     [0;37m▄▄[0;1;30;90m▄[0m
+[0;35m█[0m      [0;37m█[0m   [0;37m█[0m   [0;37m█▀[0m  [0;37m▀[0m   [0;1;30;90m█[0m    [0;1;30;90m█▀[0m [0;1;30;90m▀█[0m
+[0;37m█[0m      [0;37m█[0m   [0;37m█[0m   [0;1;30;90m█[0m       [0;1;30;90m█[0m    [0;1;30;90m█[0m   [0;1;35;95m█[0m
+ [0;37m▀▄▄▄▀[0m [0;1;30;90m▀▄▄▀█[0m   [0;1;30;90m█[0m     [0;1;30;90m▄▄[0;1;35;95m█▄▄[0m  [0;1;35;95m▀█▄█▀[0m
+
+Discover sensitive data flows and security risks.
 
 Usage: curio <command> [flags]
 
@@ -46,10 +53,10 @@ Examples:
 
 Learn More:
 	Curio is a static code analysis tool (SAST) that scans your source code to
-	discover security risks and vulnerabilities that put your sensitive data 
+	discover security risks and vulnerabilities that put your sensitive data
 	at risk (PHI, PD, PII).
-	
-	For more examples, tutorials, and to learn more about the project 
+
+	For more examples, tutorials, and to learn more about the project
 	visit https://curio.sh
 `
 


### PR DESCRIPTION
## Description
We intended to do this little touch for some time but never got to it so here it is:

<img width="677" alt="Screenshot 2023-01-10 at 16 30 11" src="https://user-images.githubusercontent.com/699436/211608009-9c5f42d8-676f-4c4d-a97d-aee66259db57.png">

[Uses standard ANSI escape codes](https://en.wikipedia.org/wiki/ANSI_escape_code#Colors) as this seemed like the most simple way to add it to the root command.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [x] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
