### PR TITLE
feat: string detector for ruby

### DIFF
--- a/new/detector/composition/ruby/ruby.go
+++ b/new/detector/composition/ruby/ruby.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bearer/curio/new/detector/implementation/generic/datatype"
 	"github.com/bearer/curio/new/detector/implementation/ruby/object"
 	"github.com/bearer/curio/new/detector/implementation/ruby/property"
+	stringdetector "github.com/bearer/curio/new/detector/implementation/ruby/string"
 	detectorset "github.com/bearer/curio/new/detector/set"
 	"github.com/bearer/curio/new/detector/types"
 	detectortypes "github.com/bearer/curio/new/detector/types"
@@ -46,13 +47,18 @@ func New(rules map[string]settings.Rule) (types.Composition, error) {
 		name        string
 	}{
 		{
+			constructor: object.New,
+			name:        "object detector",
+		},
+		{
 			constructor: property.New,
 			name:        "property detector",
 		},
 		{
-			constructor: object.New,
-			name:        "object detector",
+			constructor: stringdetector.New,
+			name:        "string detector",
 		},
+		// Generic
 		{
 			constructor: datatype.New,
 			name:        "datatype detector",
@@ -159,6 +165,7 @@ func (composition *Composition) DetectFromFile(report report.Report, file *file.
 					matchSource,
 					parent,
 				)
+
 				continue
 			}
 
@@ -194,7 +201,6 @@ func (composition *Composition) DetectFromFile(report report.Report, file *file.
 						},
 					})
 				}
-
 			}
 		}
 	}

--- a/new/detector/evaluator/evaluator.go
+++ b/new/detector/evaluator/evaluator.go
@@ -67,7 +67,7 @@ func (evaluator *evaluator) ForNode(
 	}
 
 	for _, unifiedNode := range node.UnifiedNodes() {
-		unifiedNodeDetections, err := evaluator.nonUnifiedNodeDetections(unifiedNode, detectorType)
+		unifiedNodeDetections, err := evaluator.ForNode(unifiedNode, detectorType)
 		if err != nil {
 			return nil, err
 		}

--- a/new/detector/implementation/ruby/string/string.go
+++ b/new/detector/implementation/ruby/string/string.go
@@ -1,0 +1,76 @@
+package string
+
+import (
+	"fmt"
+
+	"github.com/bearer/curio/new/detector/types"
+	"github.com/bearer/curio/new/language/tree"
+	languagetypes "github.com/bearer/curio/new/language/types"
+)
+
+type Data struct {
+	Value string
+}
+
+type stringDetector struct{}
+
+func New(lang languagetypes.Language) (types.Detector, error) {
+	return &stringDetector{}, nil
+}
+
+func (detector *stringDetector) Name() string {
+	return "string"
+}
+
+func (detector *stringDetector) DetectAt(
+	node *tree.Node,
+	evaluator types.Evaluator,
+) ([]*types.Detection, error) {
+	switch node.Type() {
+	case "string_content":
+		return []*types.Detection{{
+			MatchNode: node,
+			Data:      Data{Value: node.Content()},
+		}}, nil
+	case "interpolation", "string":
+		return concatenateChildren(node, evaluator)
+	case "binary":
+		if node.AnonymousChild(0).Content() == "+" {
+			return concatenateChildren(node, evaluator)
+		}
+	}
+
+	return nil, nil
+}
+
+func concatenateChildren(node *tree.Node, evaluator types.Evaluator) ([]*types.Detection, error) {
+	value := ""
+
+	for i := 0; i < node.ChildCount(); i += 1 {
+		child := node.Child(i)
+		if !child.IsNamed() {
+			continue
+		}
+
+		detections, err := evaluator.ForNode(child, "string")
+		if err != nil {
+			return nil, err
+		}
+
+		switch len(detections) {
+		case 0:
+			value += "*"
+		case 1:
+			value += detections[0].Data.(Data).Value
+		default:
+			return nil, fmt.Errorf("expected single string detection but got %d", len(detections))
+		}
+	}
+
+	return []*types.Detection{{
+		MatchNode: node,
+		Data:      Data{Value: value},
+	}}, nil
+}
+
+func (detector *stringDetector) Close() {}

--- a/new/language/implementation/ruby/ruby.go
+++ b/new/language/implementation/ruby/ruby.go
@@ -17,7 +17,7 @@ import (
 )
 
 var (
-	variableLookupParents = []string{"pair", "argument_list"}
+	variableLookupParents = []string{"pair", "argument_list", "interpolation"}
 
 	anonymousPatternNodeParentTypes = []string{"binary"}
 

--- a/new/language/tree/node.go
+++ b/new/language/tree/node.go
@@ -59,6 +59,26 @@ func (node *Node) Child(i int) *Node {
 	return node.tree.wrap(node.sitterNode.Child(i))
 }
 
+func (node *Node) AnonymousChild(i int) *Node {
+	n := int(node.sitterNode.ChildCount())
+	k := 0
+
+	for j := 0; j < n; j++ {
+		child := node.sitterNode.Child(j)
+		if child.IsNamed() {
+			continue
+		}
+
+		if k == i {
+			return node.tree.wrap(child)
+		}
+
+		k += 1
+	}
+
+	return nil
+}
+
 func (node *Node) ChildByFieldName(name string) *Node {
 	return node.tree.wrap(node.sitterNode.ChildByFieldName(name))
 }


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Adds a Ruby detector for extracting string values. See the linked issue for implementation details.

Also fixes a bug with the evaluator where we weren't following all the unified nodes to get detections.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [x] I've updated or added documentation if required.
- [x] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
