### PR TITLE
feat: insecure url detector

### DIFF
--- a/new/detector/composition/ruby/ruby.go
+++ b/new/detector/composition/ruby/ruby.go
@@ -7,6 +7,7 @@ import (
 	"github.com/bearer/curio/new/detector/evaluator"
 	"github.com/bearer/curio/new/detector/implementation/custom"
 	"github.com/bearer/curio/new/detector/implementation/generic/datatype"
+	"github.com/bearer/curio/new/detector/implementation/generic/insecureurl"
 	"github.com/bearer/curio/new/detector/implementation/ruby/object"
 	"github.com/bearer/curio/new/detector/implementation/ruby/property"
 	stringdetector "github.com/bearer/curio/new/detector/implementation/ruby/string"
@@ -62,6 +63,10 @@ func New(rules map[string]settings.Rule) (types.Composition, error) {
 		{
 			constructor: datatype.New,
 			name:        "datatype detector",
+		},
+		{
+			constructor: insecureurl.New,
+			name:        "insecure url detector",
 		},
 	}
 

--- a/new/detector/implementation/generic/insecureurl/insecureurl.go
+++ b/new/detector/implementation/generic/insecureurl/insecureurl.go
@@ -1,0 +1,44 @@
+package insecureurl
+
+import (
+	"regexp"
+
+	stringdetector "github.com/bearer/curio/new/detector/implementation/ruby/string"
+	"github.com/bearer/curio/new/detector/types"
+	"github.com/bearer/curio/new/language/tree"
+	languagetypes "github.com/bearer/curio/new/language/types"
+)
+
+type insecureURLDetector struct{}
+
+var insecureUrlPattern = regexp.MustCompile(`^http:`)
+
+func New(lang languagetypes.Language) (types.Detector, error) {
+	return &insecureURLDetector{}, nil
+}
+
+func (detector *insecureURLDetector) Name() string {
+	return "insecure_url"
+}
+
+func (detector *insecureURLDetector) DetectAt(
+	node *tree.Node,
+	evaluator types.Evaluator,
+) ([]*types.Detection, error) {
+	detections, err := evaluator.ForNode(node, "string")
+	if err != nil {
+		return nil, err
+	}
+
+	for _, detection := range detections {
+		value := detection.Data.(stringdetector.Data).Value
+
+		if insecureUrlPattern.MatchString(value) {
+			return []*types.Detection{{MatchNode: node}}, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func (detector *insecureURLDetector) Close() {}


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Adds a detector for categorising strings as insecure URLs. This allows custom detectors such as `ruby_http_get_insecure` to work.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [x] I've updated or added documentation if required.
- [x] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
