### PR TITLE
Feat/implement classification

### DIFF
--- a/new/detector/composition/ruby/ruby.go
+++ b/new/detector/composition/ruby/ruby.go
@@ -128,7 +128,7 @@ func (composition *Composition) DetectFromFile(report report.Report, file *file.
 		return fmt.Errorf("failed to parse file %s", err)
 	}
 
-	evaluator := evaluator.New(composition.detectorSet, tree)
+	evaluator := evaluator.New(composition.detectorSet, tree, file.FileInfo.Name())
 
 	for _, detectorType := range composition.customDetectorTypes {
 		detections, err := evaluator.ForTree(tree.RootNode(), detectorType)

--- a/new/detector/evaluator/evaluator.go
+++ b/new/detector/evaluator/evaluator.go
@@ -14,19 +14,26 @@ type evaluator struct {
 	detectorSet        types.DetectorSet
 	detectionCache     map[langtree.NodeID]map[string][]*types.Detection
 	executingDetectors map[langtree.NodeID][]string
+	fileName           string
 }
 
 func New(
 	detectorSet types.DetectorSet,
 	tree *langtree.Tree,
+	fileName string,
 ) types.Evaluator {
 	detectionCache := make(map[langtree.NodeID]map[string][]*types.Detection)
 
 	return &evaluator{
+		fileName:           fileName,
 		detectorSet:        detectorSet,
 		detectionCache:     detectionCache,
 		executingDetectors: make(map[langtree.NodeID][]string),
 	}
+}
+
+func (evaluator *evaluator) FileName() string {
+	return evaluator.fileName
 }
 
 func (evaluator *evaluator) ForTree(rootNode *langtree.Node, detectorType string) ([]*types.Detection, error) {

--- a/new/detector/implementation/generic/datatype/datatype.go
+++ b/new/detector/implementation/generic/datatype/datatype.go
@@ -8,7 +8,6 @@ import (
 	languagetypes "github.com/bearer/curio/new/language/types"
 	"github.com/bearer/curio/pkg/classification/db"
 	"github.com/bearer/curio/pkg/classification/schema"
-	"github.com/bearer/curio/pkg/parser/nodeid"
 	"github.com/bearer/curio/pkg/util/classify"
 )
 
@@ -23,14 +22,12 @@ type Property struct {
 }
 
 type datatypeDetector struct {
-	classifier  *schema.Classifier
-	idGenerator nodeid.Generator
+	classifier *schema.Classifier
 }
 
-func New(lang languagetypes.Language, classifier *schema.Classifier, idGenerator nodeid.Generator) (types.Detector, error) {
+func New(lang languagetypes.Language, classifier *schema.Classifier) (types.Detector, error) {
 	return &datatypeDetector{
-		classifier:  classifier,
-		idGenerator: idGenerator,
+		classifier: classifier,
 	}, nil
 }
 

--- a/new/detector/implementation/generic/datatype/datatype.go
+++ b/new/detector/implementation/generic/datatype/datatype.go
@@ -8,6 +8,7 @@ import (
 	languagetypes "github.com/bearer/curio/new/language/types"
 	"github.com/bearer/curio/pkg/classification/db"
 	"github.com/bearer/curio/pkg/classification/schema"
+	"github.com/bearer/curio/pkg/parser/nodeid"
 	"github.com/bearer/curio/pkg/util/classify"
 )
 
@@ -22,10 +23,15 @@ type Property struct {
 }
 
 type datatypeDetector struct {
+	classifier  *schema.Classifier
+	idGenerator nodeid.Generator
 }
 
-func New(lang languagetypes.Language) (types.Detector, error) {
-	return &datatypeDetector{}, nil
+func New(lang languagetypes.Language, classifier *schema.Classifier, idGenerator nodeid.Generator) (types.Detector, error) {
+	return &datatypeDetector{
+		classifier:  classifier,
+		idGenerator: idGenerator,
+	}, nil
 }
 
 func (detector *datatypeDetector) Name() string {
@@ -44,6 +50,7 @@ func (detector *datatypeDetector) DetectAt(
 	var result []*types.Detection
 
 	for _, object := range objectDetections {
+
 		var properties []Property
 
 		data := object.Data.(objectdetector.Data)

--- a/new/detector/types/types.go
+++ b/new/detector/types/types.go
@@ -17,6 +17,7 @@ type Evaluator interface {
 	ForNode(node *tree.Node, detectorType string) ([]*Detection, error)
 	TreeHas(rootNode *tree.Node, detectorType string) (bool, error)
 	NodeHas(node *tree.Node, detectorType string) (bool, error)
+	FileName() string
 }
 
 type DetectorSet interface {

--- a/new/language/tree/tree.go
+++ b/new/language/tree/tree.go
@@ -8,6 +8,7 @@ import (
 
 type Tree struct {
 	input        []byte
+	fileName     string
 	sitterTree   *sitter.Tree
 	unifiedNodes map[NodeID][]*Node
 }

--- a/new/scanner/scanner.go
+++ b/new/scanner/scanner.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/bearer/curio/new/detector/composition/ruby"
 	"github.com/bearer/curio/new/detector/types"
+	"github.com/bearer/curio/pkg/classification"
 	"github.com/bearer/curio/pkg/commands/process/settings"
 	"github.com/bearer/curio/pkg/report"
 	"github.com/bearer/curio/pkg/util/file"
@@ -25,9 +26,9 @@ func (scanner scannerType) Close() {
 	}
 }
 
-func Setup(config map[string]settings.Rule) (err error) {
+func Setup(config *settings.Config, classifier *classification.Classifier) (err error) {
 	var toInstantiate = []struct {
-		constructor func(map[string]settings.Rule) (types.Composition, error)
+		constructor func(map[string]settings.Rule, *classification.Classifier) (types.Composition, error)
 		name        string
 	}{{
 		constructor: ruby.New,
@@ -35,7 +36,7 @@ func Setup(config map[string]settings.Rule) (err error) {
 	}}
 
 	for _, instantiatior := range toInstantiate {
-		composition, err := instantiatior.constructor(config)
+		composition, err := instantiatior.constructor(config.CustomDetector, classifier)
 		if err != nil {
 			return fmt.Errorf("failed to instantiate composition %s:%s", instantiatior.name, err)
 		}

--- a/pkg/classification/schema/internal/testhelper/testhelper.go
+++ b/pkg/classification/schema/internal/testhelper/testhelper.go
@@ -92,7 +92,7 @@ func ExtractExpectedOutput(
 		}
 
 		expectedProperties := map[string]ClassificationResult{}
-		detectionProperties := []*schema.Detection{}
+		detectionProperties := []*schema.ClassificationRequestDetection{}
 		for _, inputItemProperty := range inputItem.Properties {
 			result.KPI.DetectionsCount += 1
 
@@ -122,7 +122,7 @@ func ExtractExpectedOutput(
 				}
 			}
 
-			detectionProperties = append(detectionProperties, &schema.Detection{
+			detectionProperties = append(detectionProperties, &schema.ClassificationRequestDetection{
 				Name:       inputItemProperty.Name,
 				SimpleType: inputItemProperty.Type,
 			})
@@ -143,10 +143,10 @@ func ExtractExpectedOutput(
 			}
 		}
 
-		detection := schema.DataTypeDetection{
+		detection := schema.ClassificationRequest{
 			Filename:     inputItem.Filename,
 			DetectorType: detectors.Type(inputItem.DetectorType),
-			Value: &schema.Detection{
+			Value: &schema.ClassificationRequestDetection{
 				Name:       inputItem.Name,
 				Properties: detectionProperties,
 			},

--- a/pkg/classification/schema/internal/testhelper/testhelper.go
+++ b/pkg/classification/schema/internal/testhelper/testhelper.go
@@ -1,12 +1,9 @@
 package testhelper
 
 import (
-	"encoding/json"
-	"io/ioutil"
 	"sort"
 
 	"github.com/bearer/curio/pkg/classification/schema"
-	"github.com/bearer/curio/pkg/report/detectors"
 	"github.com/bearer/curio/pkg/report/schema/datatype"
 	"github.com/bearer/curio/pkg/util/classify"
 
@@ -69,135 +66,135 @@ func ExtractExpectedOutput(
 		ExpectedClassifications: []ClassificationResult{},
 	}
 
-	val, err := ioutil.ReadFile("././fixtures/" + lang + ".json")
-	if err != nil {
-		t.Errorf("error opening file %e", err)
-	}
+	// val, err := ioutil.ReadFile("././fixtures/" + lang + ".json")
+	// if err != nil {
+	// 	t.Errorf("error opening file %e", err)
+	// }
 
-	var input []Input
-	rawBytes := []byte(val)
-	err = json.Unmarshal(rawBytes, &input)
-	if err != nil {
-		t.Errorf("error unmarshalling JSON %e", err)
-	}
+	// var input []Input
+	// rawBytes := []byte(val)
+	// err = json.Unmarshal(rawBytes, &input)
+	// if err != nil {
+	// 	t.Errorf("error unmarshalling JSON %e", err)
+	// }
 
-	for _, inputItem := range input {
-		includeResult := false
-		result.KPI.DetectionsCount += 1
+	// for _, inputItem := range input {
+	// 	includeResult := false
+	// 	result.KPI.DetectionsCount += 1
 
-		expectedClassification := ClassificationResult{
-			Name: inputItem.Name,
-			Decision: classify.ClassificationDecision{
-				State:  classify.ValidationState(inputItem.State),
-				Reason: inputItem.Reason,
-			},
-		}
+	// 	expectedClassification := ClassificationResult{
+	// 		Name: inputItem.Name,
+	// 		Decision: classify.ClassificationDecision{
+	// 			State:  classify.ValidationState(inputItem.State),
+	// 			Reason: inputItem.Reason,
+	// 		},
+	// 	}
 
-		expectedProperties := map[string]ClassificationResult{}
-		detectionProperties := map[string]datatype.DataTypable{}
-		for _, inputItemProperty := range inputItem.Properties {
-			result.KPI.DetectionsCount += 1
+	// 	expectedProperties := map[string]ClassificationResult{}
+	// 	detectionProperties := map[string]datatype.DataTypable{}
+	// 	for _, inputItemProperty := range inputItem.Properties {
+	// 		result.KPI.DetectionsCount += 1
 
-			if inputItemProperty.State == "valid" {
-				result.KPI.ExpectedValidDetectionsCount += 1
-				result.KPI.ExpectedValidFieldDetectionsCount += 1
-				if inputItemProperty.FalsePositive {
-					result.KPI.ExpectedFalsePositivesCount += 1
-				} else {
-					result.KPI.ExpectedTruePositivesCount += 1
-				}
+	// 		if inputItemProperty.State == "valid" {
+	// 			result.KPI.ExpectedValidDetectionsCount += 1
+	// 			result.KPI.ExpectedValidFieldDetectionsCount += 1
+	// 			if inputItemProperty.FalsePositive {
+	// 				result.KPI.ExpectedFalsePositivesCount += 1
+	// 			} else {
+	// 				result.KPI.ExpectedTruePositivesCount += 1
+	// 			}
 
-				expectedProperties[inputItemProperty.Name] = ClassificationResult{
-					Name: inputItemProperty.Name,
-					Decision: classify.ClassificationDecision{
-						State:  classify.Valid,
-						Reason: inputItemProperty.Reason,
-					},
-				}
-			} else {
-				expectedProperties[inputItemProperty.Name] = ClassificationResult{
-					Name: inputItemProperty.Name,
-					Decision: classify.ClassificationDecision{
-						State:  classify.Invalid,
-						Reason: inputItemProperty.Reason,
-					},
-				}
-			}
+	// 			expectedProperties[inputItemProperty.Name] = ClassificationResult{
+	// 				Name: inputItemProperty.Name,
+	// 				Decision: classify.ClassificationDecision{
+	// 					State:  classify.Valid,
+	// 					Reason: inputItemProperty.Reason,
+	// 				},
+	// 			}
+	// 		} else {
+	// 			expectedProperties[inputItemProperty.Name] = ClassificationResult{
+	// 				Name: inputItemProperty.Name,
+	// 				Decision: classify.ClassificationDecision{
+	// 					State:  classify.Invalid,
+	// 					Reason: inputItemProperty.Reason,
+	// 				},
+	// 			}
+	// 		}
 
-			detectionProperties[inputItemProperty.Name] = &datatype.DataType{
-				Name:       inputItemProperty.Name,
-				Type:       inputItemProperty.Type,
-				Properties: map[string]datatype.DataTypable{},
-			}
-		}
+	// 		detectionProperties[inputItemProperty.Name] = &datatype.DataType{
+	// 			Name:       inputItemProperty.Name,
+	// 			Type:       inputItemProperty.Type,
+	// 			Properties: map[string]datatype.DataTypable{},
+	// 		}
+	// 	}
 
-		expectedClassification.Properties = expectedProperties
+	// 	expectedClassification.Properties = expectedProperties
 
-		if inputItem.State == "valid" {
-			result.KPI.ExpectedValidDetectionsCount += 1
-			result.KPI.ExpectedValidObjectDetectionsCount += 1
-			// include as expected classification
-			result.ExpectedClassifications = append(result.ExpectedClassifications, expectedClassification)
+	// 	if inputItem.State == "valid" {
+	// 		result.KPI.ExpectedValidDetectionsCount += 1
+	// 		result.KPI.ExpectedValidObjectDetectionsCount += 1
+	// 		// include as expected classification
+	// 		result.ExpectedClassifications = append(result.ExpectedClassifications, expectedClassification)
 
-			if inputItem.FalsePositive {
-				result.KPI.ExpectedFalsePositivesCount += 1
-			} else {
-				result.KPI.ExpectedTruePositivesCount += 1
-			}
-		}
+	// 		if inputItem.FalsePositive {
+	// 			result.KPI.ExpectedFalsePositivesCount += 1
+	// 		} else {
+	// 			result.KPI.ExpectedTruePositivesCount += 1
+	// 		}
+	// 	}
 
-		detection := schema.DataTypeDetection{
-			Filename:     inputItem.Filename,
-			DetectorType: detectors.Type(inputItem.DetectorType),
-			Value: &datatype.DataType{
-				Name:       inputItem.Name,
-				Properties: detectionProperties,
-			},
-		}
+	// 	detection := schema.DataTypeDetection{
+	// 		Filename:     inputItem.Filename,
+	// 		DetectorType: detectors.Type(inputItem.DetectorType),
+	// 		Value: &datatype.DataType{
+	// 			Name:       inputItem.Name,
+	// 			Properties: detectionProperties,
+	// 		},
+	// 	}
 
-		classification := classifier.Classify(detection)
+	// 	classification := classifier.Classify(detection)
 
-		if classification.Classification.Decision.State == classify.Valid {
-			includeResult = true
-			result.KPI.ValidObjectDetectionsCount += 1
-		}
-		classificationResult := ClassificationResult{
-			Name: classification.GetName(),
-			Decision: classify.ClassificationDecision{
-				State:  classification.Classification.Decision.State,
-				Reason: classification.Classification.Decision.Reason,
-			},
-		}
+	// 	if classification.Classification.Decision.State == classify.Valid {
+	// 		includeResult = true
+	// 		result.KPI.ValidObjectDetectionsCount += 1
+	// 	}
+	// 	classificationResult := ClassificationResult{
+	// 		Name: classification.GetName(),
+	// 		Decision: classify.ClassificationDecision{
+	// 			State:  classification.Classification.Decision.State,
+	// 			Reason: classification.Classification.Decision.Reason,
+	// 		},
+	// 	}
 
-		classifiedProperties := map[string]ClassificationResult{}
-		// sort properties to ensure consistency for snapshot
-		fields := classification.DataTypable.GetProperties()
-		for _, key := range sortKeys(fields) {
-			field := fields[key]
-			fieldClassification, _ := field.GetClassification().(schema.Classification)
-			// TODO: casting does not work if classification is empty
-			if fieldClassification.Decision.State == "valid" {
-				includeResult = true
-				result.KPI.ValidFieldDetectionsCount += 1
-			}
+	// 	classifiedProperties := map[string]ClassificationResult{}
+	// 	// sort properties to ensure consistency for snapshot
+	// 	fields := classification.DataTypable.GetProperties()
+	// 	for _, key := range sortKeys(fields) {
+	// 		field := fields[key]
+	// 		fieldClassification, _ := field.GetClassification().(schema.Classification)
+	// 		// TODO: casting does not work if classification is empty
+	// 		if fieldClassification.Decision.State == "valid" {
+	// 			includeResult = true
+	// 			result.KPI.ValidFieldDetectionsCount += 1
+	// 		}
 
-			classifiedProperties[field.GetName()] = ClassificationResult{
-				Name: field.GetName(),
-				Decision: classify.ClassificationDecision{
-					State:  fieldClassification.Decision.State,
-					Reason: fieldClassification.Decision.Reason,
-				},
-			}
-		}
+	// 		classifiedProperties[field.GetName()] = ClassificationResult{
+	// 			Name: field.GetName(),
+	// 			Decision: classify.ClassificationDecision{
+	// 				State:  fieldClassification.Decision.State,
+	// 				Reason: fieldClassification.Decision.Reason,
+	// 			},
+	// 		}
+	// 	}
 
-		classificationResult.Properties = classifiedProperties
+	// 	classificationResult.Properties = classifiedProperties
 
-		if includeResult {
-			result.ValidClassifications = append(result.ValidClassifications, classificationResult)
-		}
-	}
+	// 	if includeResult {
+	// 		result.ValidClassifications = append(result.ValidClassifications, classificationResult)
+	// 	}
+	// }
 
-	result.KPI.ValidDetectionsCount = result.KPI.ValidObjectDetectionsCount + result.KPI.ValidFieldDetectionsCount
+	// result.KPI.ValidDetectionsCount = result.KPI.ValidObjectDetectionsCount + result.KPI.ValidFieldDetectionsCount
 
 	return result
 }

--- a/pkg/classification/schema/schema.go
+++ b/pkg/classification/schema/schema.go
@@ -45,19 +45,19 @@ func New(config Config) *Classifier {
 	return &Classifier{config: config}
 }
 
-type Detection struct {
+type ClassificationRequestDetection struct {
 	Name       string
 	SimpleType string
-	Properties []*Detection
+	Properties []*ClassificationRequestDetection
 }
 
-type DataTypeDetection struct {
-	Value        *Detection
+type ClassificationRequest struct {
+	Value        *ClassificationRequestDetection
 	Filename     string
 	DetectorType detectors.Type
 }
 
-func (classifier *Classifier) Classify(data DataTypeDetection) *ClassifiedDatatype {
+func (classifier *Classifier) Classify(data ClassificationRequest) *ClassifiedDatatype {
 	var classifiedDatatype *ClassifiedDatatype
 	var normalizedName = normalize_key.Normalize(data.Value.Name)
 
@@ -128,7 +128,7 @@ func (classifier *Classifier) Classify(data DataTypeDetection) *ClassifiedDataty
 	return classifiedDatatype
 }
 
-func (classifier *Classifier) hasIdentifierProperties(objectProperties []*Detection, isJSDetection bool) bool {
+func (classifier *Classifier) hasIdentifierProperties(objectProperties []*ClassificationRequestDetection, isJSDetection bool) bool {
 	for _, property := range objectProperties {
 		if isJSDetection && classify.PropertyStopWordDetected(normalize_key.Normalize(property.Name)) {
 			continue
@@ -143,7 +143,7 @@ func (classifier *Classifier) hasIdentifierProperties(objectProperties []*Detect
 	return false
 }
 
-func (classifier *Classifier) hasUnknownObjectProperties(objectProperties []*Detection, isJSDetection bool) bool {
+func (classifier *Classifier) hasUnknownObjectProperties(objectProperties []*ClassificationRequestDetection, isJSDetection bool) bool {
 	for _, property := range objectProperties {
 		if isJSDetection && classify.PropertyStopWordDetected(normalize_key.Normalize(property.Name)) {
 			continue
@@ -220,7 +220,7 @@ func (classifier *Classifier) matchKnownPersonObjectPatterns(name string, matchA
 	return matchedPattern
 }
 
-func (classifier *Classifier) classifyKnownObject(classifiedDatatype *ClassifiedDatatype, detection *Detection, detectorType detectors.Type) *ClassifiedDatatype {
+func (classifier *Classifier) classifyKnownObject(classifiedDatatype *ClassifiedDatatype, detection *ClassificationRequestDetection, detectorType detectors.Type) *ClassifiedDatatype {
 	isJSDetection := classify.IsJSDetection(detectorType)
 
 	validProperties := false
@@ -268,7 +268,7 @@ func (classifier *Classifier) classifyKnownObject(classifiedDatatype *Classified
 	return classifiedDatatype
 }
 
-func (classifier *Classifier) classifyObjectWithUnknownProperties(classifiedDatatype *ClassifiedDatatype, detection *Detection, isJSDetection bool) *ClassifiedDatatype {
+func (classifier *Classifier) classifyObjectWithUnknownProperties(classifiedDatatype *ClassifiedDatatype, detection *ClassificationRequestDetection, isJSDetection bool) *ClassifiedDatatype {
 	for i, property := range classifiedDatatype.Properties {
 		if isJSDetection && classify.PropertyStopWordDetected(normalize_key.Normalize(property.Name)) {
 			classifiedDatatype.Properties[i] = classifyAsInvalid(detection.Properties[i], "stop_word")
@@ -307,7 +307,7 @@ func (classifier *Classifier) classifyObjectWithUnknownProperties(classifiedData
 	return classifiedDatatype
 }
 
-func (classifier *Classifier) classifyObjectWithIdentifierProperties(classifiedDatatype *ClassifiedDatatype, detection *Detection, isJSDetection bool) *ClassifiedDatatype {
+func (classifier *Classifier) classifyObjectWithIdentifierProperties(classifiedDatatype *ClassifiedDatatype, detection *ClassificationRequestDetection, isJSDetection bool) *ClassifiedDatatype {
 	associatedObjectProperties := false
 	for i, property := range classifiedDatatype.Properties {
 		if isJSDetection && classify.PropertyStopWordDetected(normalize_key.Normalize(property.Name)) {
@@ -394,7 +394,7 @@ func identifiersOnly(classifiedDatatype *ClassifiedDatatype) bool {
 	return identifiersOnly
 }
 
-func classifyObjectAsInvalid(D *Detection, reason string) *ClassifiedDatatype {
+func classifyObjectAsInvalid(D *ClassificationRequestDetection, reason string) *ClassifiedDatatype {
 	classifiedDatatype := &ClassifiedDatatype{
 		Classification: Classification{
 			Name: normalize_key.Normalize(D.Name),
@@ -413,7 +413,7 @@ func classifyObjectAsInvalid(D *Detection, reason string) *ClassifiedDatatype {
 	return classifiedDatatype
 }
 
-func classifyAsValid(D *Detection, datatype db.DataType, reason string) *ClassifiedDatatype {
+func classifyAsValid(D *ClassificationRequestDetection, datatype db.DataType, reason string) *ClassifiedDatatype {
 	return &ClassifiedDatatype{
 		Name: D.Name,
 		Classification: Classification{
@@ -427,7 +427,7 @@ func classifyAsValid(D *Detection, datatype db.DataType, reason string) *Classif
 	}
 }
 
-func classifyAsInvalid(D *Detection, reason string) *ClassifiedDatatype {
+func classifyAsInvalid(D *ClassificationRequestDetection, reason string) *ClassifiedDatatype {
 	return &ClassifiedDatatype{
 		Name: D.Name,
 		Classification: Classification{

--- a/pkg/classification/schema/schema.go
+++ b/pkg/classification/schema/schema.go
@@ -4,18 +4,19 @@ import (
 	"regexp"
 
 	"github.com/bearer/curio/pkg/flag"
-	"github.com/bearer/curio/pkg/report/schema/datatype"
 
 	"github.com/bearer/curio/pkg/classification/db"
 	"github.com/bearer/curio/pkg/report/detectors"
 	"github.com/bearer/curio/pkg/util/classify"
+	"github.com/bearer/curio/pkg/util/normalize_key"
 )
 
 var regexpIdentifierMatcher = regexp.MustCompile(`(uu)?id\z`)
 var regexpTimestampsMatcher = regexp.MustCompile(`\A(created|updated)\sat\z`)
 
 type ClassifiedDatatype struct {
-	datatype.DataTypable
+	Name           string
+	Properties     []*ClassifiedDatatype
 	Classification Classification `json:"classification" yaml:"classification"`
 }
 
@@ -44,14 +45,22 @@ func New(config Config) *Classifier {
 	return &Classifier{config: config}
 }
 
+type Detection struct {
+	Name       string
+	Type       string
+	SimpleType string
+	Properties []*Detection
+}
+
 type DataTypeDetection struct {
-	Value        datatype.DataTypable
+	Value        *Detection
 	Filename     string
 	DetectorType detectors.Type
 }
 
 func (classifier *Classifier) Classify(data DataTypeDetection) *ClassifiedDatatype {
 	var classifiedDatatype *ClassifiedDatatype
+	var normalizedName = normalize_key.Normalize(data.Value.Name)
 
 	// general checks
 	if classify.IsVendored(data.Filename) {
@@ -60,10 +69,10 @@ func (classifier *Classifier) Classify(data DataTypeDetection) *ClassifiedDataty
 	if classify.IsPotentialDetector(data.DetectorType) {
 		classifiedDatatype = classifyObjectAsInvalid(data.Value, classify.PotentialDetectorReason)
 	}
-	if classify.ObjectStopWordDetected(data.Value.GetNormalizedName()) {
+	if classify.ObjectStopWordDetected(normalizedName) {
 		classifiedDatatype = classifyObjectAsInvalid(data.Value, "stop_word")
 	}
-	if data.Value.GetName() == "" {
+	if data.Value.Name == "" {
 		classifiedDatatype = classifyObjectAsInvalid(data.Value, "blank_object_name")
 	}
 
@@ -72,28 +81,38 @@ func (classifier *Classifier) Classify(data DataTypeDetection) *ClassifiedDataty
 	}
 
 	// schema-specific checks
-	classifiedDatatype = &ClassifiedDatatype{
-		DataTypable:    data.Value,
-		Classification: Classification{Name: data.Value.GetNormalizedName()},
+	var properties []ClassifiedDatatype
+	for _, v := range data.Value.Properties {
+		properties = append(properties, ClassifiedDatatype{
+			Name: v.Name,
+			Classification: Classification{
+				Name: normalize_key.Normalize(v.Name),
+			},
+		})
 	}
 
-	matchedKnownPersonObject := classifier.matchKnownPersonObjectPatterns(data.Value.GetNormalizedName(), false)
+	classifiedDatatype = &ClassifiedDatatype{
+		Name:           data.Value.Name,
+		Classification: Classification{Name: normalize_key.Normalize(normalizedName)},
+	}
+
+	matchedKnownPersonObject := classifier.matchKnownPersonObjectPatterns(normalizedName, false)
 	if matchedKnownPersonObject != nil {
 		// add data type to object
 		classifiedDatatype.Classification.DataType = &matchedKnownPersonObject.DataType
-		return classifier.classifyKnownObject(classifiedDatatype, data.DetectorType)
+		return classifier.classifyKnownObject(classifiedDatatype, data.Value, data.DetectorType)
 	}
 
 	// do we have an object with unknown or unknown extended properties?
 	isJSDetection := classify.IsJSDetection(data.DetectorType)
-	if classifier.hasUnknownObjectProperties(classifiedDatatype.DataTypable.GetProperties(), isJSDetection) {
-		return classifier.classifyObjectWithUnknownProperties(classifiedDatatype, isJSDetection)
+	if classifier.hasUnknownObjectProperties(data.Value.Properties, isJSDetection) {
+		return classifier.classifyObjectWithUnknownProperties(classifiedDatatype, data.Value, isJSDetection)
 	}
 
-	hasIdentifierProperties := classifier.hasIdentifierProperties(classifiedDatatype.DataTypable.GetProperties(), isJSDetection)
+	hasIdentifierProperties := classifier.hasIdentifierProperties(data.Value.Properties, isJSDetection)
 	if hasIdentifierProperties {
 		// object is somehow linked with a "person" e.g. an invoice with a user_id property
-		return classifier.classifyObjectWithIdentifierProperties(classifiedDatatype, isJSDetection)
+		return classifier.classifyObjectWithIdentifierProperties(classifiedDatatype, data.Value, isJSDetection)
 	}
 
 	// object and properties are unknown
@@ -109,13 +128,13 @@ func (classifier *Classifier) Classify(data DataTypeDetection) *ClassifiedDataty
 	return classifiedDatatype
 }
 
-func (classifier *Classifier) hasIdentifierProperties(objectProperties map[string]datatype.DataTypable, isJSDetection bool) bool {
+func (classifier *Classifier) hasIdentifierProperties(objectProperties []*Detection, isJSDetection bool) bool {
 	for _, property := range objectProperties {
-		if isJSDetection && classify.PropertyStopWordDetected(property.GetNormalizedName()) {
+		if isJSDetection && classify.PropertyStopWordDetected(normalize_key.Normalize(property.Name)) {
 			continue
 		}
 
-		matchedIdentifier := classifier.matchKnownPersonObjectPatterns(property.GetNormalizedName(), true)
+		matchedIdentifier := classifier.matchKnownPersonObjectPatterns(normalize_key.Normalize(property.Name), true)
 		if matchedIdentifier != nil {
 			return true
 		}
@@ -124,13 +143,13 @@ func (classifier *Classifier) hasIdentifierProperties(objectProperties map[strin
 	return false
 }
 
-func (classifier *Classifier) hasUnknownObjectProperties(objectProperties map[string]datatype.DataTypable, isJSDetection bool) bool {
+func (classifier *Classifier) hasUnknownObjectProperties(objectProperties []*Detection, isJSDetection bool) bool {
 	for _, property := range objectProperties {
-		if isJSDetection && classify.PropertyStopWordDetected(property.GetNormalizedName()) {
+		if isJSDetection && classify.PropertyStopWordDetected(normalize_key.Normalize(property.Name)) {
 			continue
 		}
 
-		matchedUnknownObject := classifier.matchObjectPatterns(property.GetNormalizedName(), property.GetType(), db.UnknownObject)
+		matchedUnknownObject := classifier.matchObjectPatterns(normalize_key.Normalize(property.Name), property.SimpleType, db.UnknownObject)
 		if matchedUnknownObject != nil {
 			return true
 		}
@@ -201,46 +220,36 @@ func (classifier *Classifier) matchKnownPersonObjectPatterns(name string, matchA
 	return matchedPattern
 }
 
-func (classifier *Classifier) classifyKnownObject(classifiedDatatype *ClassifiedDatatype, detectorType detectors.Type) *ClassifiedDatatype {
+func (classifier *Classifier) classifyKnownObject(classifiedDatatype *ClassifiedDatatype, detection *Detection, detectorType detectors.Type) *ClassifiedDatatype {
 	isJSDetection := classify.IsJSDetection(detectorType)
 
 	validProperties := false
-	for _, property := range classifiedDatatype.DataTypable.GetProperties() {
-		if isJSDetection && classify.PropertyStopWordDetected(property.GetNormalizedName()) {
-			classifiedDatatype.DataTypable.SetProperty(
-				property.GetName(),
-				classifyAsInvalid(property, "stop_word"),
-			)
-
+	for i, property := range classifiedDatatype.Properties {
+		if isJSDetection && classify.PropertyStopWordDetected(property.Classification.Name) {
+			classifiedDatatype.Properties[i] = classifyAsInvalid(detection.Properties[i], "stop_word")
 			continue
 		}
 
-		matchedKnownObject := classifier.matchObjectPatterns(property.GetNormalizedName(), property.GetType(), db.KnownObject)
+		matchedKnownObject := classifier.matchObjectPatterns(property.Classification.Name, detection.Properties[i].SimpleType, db.KnownObject)
 		if matchedKnownObject != nil {
 			validProperties = true
-			classifiedDatatype.DataTypable.SetProperty(
-				property.GetName(),
-				classifyAsValid(property, classifier.datatypeFromPattern(matchedKnownObject), "known_pattern"),
-			)
+
+			classifiedDatatype.Properties[i] = classifyAsValid(detection.Properties[i], classifier.datatypeFromPattern(matchedKnownObject), "known_pattern")
 
 			continue
 		}
 
-		matchedKnownIdentifier := classifier.matchKnownPersonObjectPatterns(property.GetNormalizedName(), true)
+		matchedKnownIdentifier := classifier.matchKnownPersonObjectPatterns(normalize_key.Normalize(property.Name), true)
 		if matchedKnownIdentifier != nil {
 			validProperties = true
-			classifiedDatatype.DataTypable.SetProperty(
-				property.GetName(),
-				classifyAsValid(property, matchedKnownIdentifier.DataType, "known_database_identifier"),
-			)
+
+			classifiedDatatype.Properties[i] = classifyAsValid(detection.Properties[i], matchedKnownIdentifier.DataType, "known_database_identifier")
 
 			continue
 		}
 
-		classifiedDatatype.DataTypable.SetProperty(
-			property.GetName(),
-			classifyAsInvalid(property, "invalid_property"),
-		)
+		classifiedDatatype.Properties[i] = classifyAsInvalid(detection.Properties[i], "invalid_property")
+
 	}
 
 	if validProperties {
@@ -263,54 +272,35 @@ func (classifier *Classifier) classifyKnownObject(classifiedDatatype *Classified
 	return classifiedDatatype
 }
 
-func (classifier *Classifier) classifyObjectWithUnknownProperties(classifiedDatatype *ClassifiedDatatype, isJSDetection bool) *ClassifiedDatatype {
-	for _, property := range classifiedDatatype.GetProperties() {
-		if isJSDetection && classify.PropertyStopWordDetected(property.GetNormalizedName()) {
-			classifiedDatatype.DataTypable.SetProperty(
-				property.GetName(),
-				classifyAsInvalid(property, "stop_word"),
-			)
-
+func (classifier *Classifier) classifyObjectWithUnknownProperties(classifiedDatatype *ClassifiedDatatype, detection *Detection, isJSDetection bool) *ClassifiedDatatype {
+	for i, property := range classifiedDatatype.Properties {
+		if isJSDetection && classify.PropertyStopWordDetected(normalize_key.Normalize(property.Name)) {
+			classifiedDatatype.Properties[i] = classifyAsInvalid(detection.Properties[i], "stop_word")
 			continue
 		}
 
 		// check unknown object patterns
-		unknownObject := classifier.matchObjectPatterns(property.GetNormalizedName(), property.GetType(), db.UnknownObject)
+		unknownObject := classifier.matchObjectPatterns(normalize_key.Normalize(property.Name), detection.Properties[i].SimpleType, db.UnknownObject)
 		if unknownObject != nil {
-			classifiedDatatype.DataTypable.SetProperty(
-				property.GetName(),
-				classifyAsValid(property, classifier.datatypeFromPattern(unknownObject), "valid_unknown_pattern"),
-			)
-
+			classifiedDatatype.Properties[i] = classifyAsValid(detection.Properties[i], classifier.datatypeFromPattern(unknownObject), "valid_unknown_pattern")
 			continue
 		}
 
 		// check extended patterns
-		extendedUnknownObject := classifier.matchObjectPatterns(property.GetNormalizedName(), property.GetType(), db.ExtendedUnknownObject)
+		extendedUnknownObject := classifier.matchObjectPatterns(normalize_key.Normalize(property.Name), detection.Properties[i].SimpleType, db.ExtendedUnknownObject)
 		if extendedUnknownObject != nil {
-			classifiedDatatype.DataTypable.SetProperty(
-				property.GetName(),
-				classifyAsValid(property, classifier.datatypeFromPattern(extendedUnknownObject), "valid_extended_pattern"),
-			)
-
+			classifiedDatatype.Properties[i] = classifyAsValid(detection.Properties[i], classifier.datatypeFromPattern(extendedUnknownObject), "valid_extended_pattern")
 			continue
 		}
 
 		// check identifier patterns
-		matchedKnownIdentifier := classifier.matchKnownPersonObjectPatterns(property.GetNormalizedName(), true)
+		matchedKnownIdentifier := classifier.matchKnownPersonObjectPatterns(normalize_key.Normalize(property.Name), true)
 		if matchedKnownIdentifier != nil {
-			classifiedDatatype.DataTypable.SetProperty(
-				property.GetName(),
-				classifyAsValid(property, matchedKnownIdentifier.DataType, "known_database_identifier"),
-			)
-
+			classifiedDatatype.Properties[i] = classifyAsValid(detection.Properties[i], matchedKnownIdentifier.DataType, "known_database_identifier")
 			continue
 		}
 
-		classifiedDatatype.DataTypable.SetProperty(
-			property.GetName(),
-			classifyAsInvalid(property, "invalid_property"),
-		)
+		classifiedDatatype.Properties[i] = classifyAsInvalid(detection.Properties[i], "invalid_property")
 	}
 
 	classifiedDatatype.Classification.Decision = classify.ClassificationDecision{
@@ -321,43 +311,29 @@ func (classifier *Classifier) classifyObjectWithUnknownProperties(classifiedData
 	return classifiedDatatype
 }
 
-func (classifier *Classifier) classifyObjectWithIdentifierProperties(classifiedDatatype *ClassifiedDatatype, isJSDetection bool) *ClassifiedDatatype {
+func (classifier *Classifier) classifyObjectWithIdentifierProperties(classifiedDatatype *ClassifiedDatatype, detection *Detection, isJSDetection bool) *ClassifiedDatatype {
 	associatedObjectProperties := false
-	for _, property := range classifiedDatatype.GetProperties() {
-		if isJSDetection && classify.PropertyStopWordDetected(property.GetNormalizedName()) {
-			classifiedDatatype.DataTypable.SetProperty(
-				property.GetName(),
-				classifyAsInvalid(property, "stop_word"),
-			)
-
+	for i, property := range classifiedDatatype.Properties {
+		if isJSDetection && classify.PropertyStopWordDetected(normalize_key.Normalize(property.Name)) {
+			classifiedDatatype.Properties[i] = classifyAsInvalid(detection.Properties[i], "stop_word")
 			continue
 		}
 
-		matchedDBIdentifier := classifier.matchKnownPersonObjectPatterns(property.GetNormalizedName(), true)
+		matchedDBIdentifier := classifier.matchKnownPersonObjectPatterns(normalize_key.Normalize(property.Name), true)
 		if matchedDBIdentifier != nil {
-			classifiedDatatype.DataTypable.SetProperty(
-				property.GetName(),
-				classifyAsValid(property, matchedDBIdentifier.DataType, "known_database_identifier"),
-			)
-
+			classifiedDatatype.Properties[i] = classifyAsValid(detection.Properties[i], matchedDBIdentifier.DataType, "known_database_identifier")
 			continue
 		}
 
-		matchedAssociatedObjectPattern := classifier.matchObjectPatterns(property.GetNormalizedName(), property.GetType(), db.AssociatedObject)
+		matchedAssociatedObjectPattern := classifier.matchObjectPatterns(normalize_key.Normalize(property.Name), detection.Properties[i].SimpleType, db.AssociatedObject)
 		if matchedAssociatedObjectPattern != nil {
 			associatedObjectProperties = true
-			classifiedDatatype.DataTypable.SetProperty(
-				property.GetName(),
-				classifyAsValid(property, classifier.datatypeFromPattern(matchedAssociatedObjectPattern), "valid_associated_object_pattern"),
-			)
-
+			classifiedDatatype.Properties[i] = classifyAsValid(detection.Properties[i], classifier.datatypeFromPattern(matchedAssociatedObjectPattern), "valid_associated_object_pattern")
 			continue
 		}
 
-		classifiedDatatype.DataTypable.SetProperty(
-			property.GetName(),
-			classifyAsInvalid(property, "invalid_property"),
-		)
+		classifiedDatatype.Properties[i] = classifyAsInvalid(detection.Properties[i], "invalid_property")
+
 	}
 
 	if associatedObjectProperties {
@@ -381,7 +357,7 @@ func (classifier *Classifier) classifySchemaObject(classifiedDatatype *Classifie
 		return classifiedDatatype
 	}
 
-	matchedObjectPattern := classifier.matchObjectPatterns(classifiedDatatype.GetNormalizedName(), "", db.KnownDataObject)
+	matchedObjectPattern := classifier.matchObjectPatterns(classifiedDatatype.Classification.Name, "", db.KnownDataObject)
 	if matchedObjectPattern != nil {
 		classifiedDatatype.Classification.Decision = classify.ClassificationDecision{
 			State:  classify.Valid,
@@ -411,8 +387,8 @@ func (classifier *Classifier) datatypeFromPattern(pattern *db.DataTypeClassifica
 
 func identifiersOnly(classifiedDatatype *ClassifiedDatatype) bool {
 	identifiersOnly := true
-	for _, property := range classifiedDatatype.GetProperties() {
-		normalizedName := property.GetNormalizedName()
+	for _, property := range classifiedDatatype.Properties {
+		normalizedName := property.Classification.Name
 		if !regexpIdentifierMatcher.MatchString(normalizedName) && !regexpTimestampsMatcher.MatchString(normalizedName) {
 			identifiersOnly = false
 			break
@@ -422,11 +398,10 @@ func identifiersOnly(classifiedDatatype *ClassifiedDatatype) bool {
 	return identifiersOnly
 }
 
-func classifyObjectAsInvalid(D datatype.DataTypable, reason string) *ClassifiedDatatype {
+func classifyObjectAsInvalid(D *Detection, reason string) *ClassifiedDatatype {
 	classifiedDatatype := &ClassifiedDatatype{
-		DataTypable: D,
 		Classification: Classification{
-			Name: D.GetNormalizedName(),
+			Name: normalize_key.Normalize(D.Name),
 			Decision: classify.ClassificationDecision{
 				State:  classify.Invalid,
 				Reason: reason,
@@ -435,21 +410,18 @@ func classifyObjectAsInvalid(D datatype.DataTypable, reason string) *ClassifiedD
 	}
 
 	// schema object did not pass initial checks ; mark all fields as invalid
-	for _, property := range D.GetProperties() {
-		classifiedDatatype.DataTypable.SetProperty(
-			property.GetName(),
-			classifyAsInvalid(property, "belongs_to_invalid_object"),
-		)
+	for _, property := range D.Properties {
+		classifiedDatatype.Properties = append(classifiedDatatype.Properties, classifyAsInvalid(property, "belongs_to_invalid_object"))
 	}
 
 	return classifiedDatatype
 }
 
-func classifyAsValid(D datatype.DataTypable, datatype db.DataType, reason string) ClassifiedDatatype {
-	return ClassifiedDatatype{
-		DataTypable: D,
+func classifyAsValid(D *Detection, datatype db.DataType, reason string) *ClassifiedDatatype {
+	return &ClassifiedDatatype{
+		Name: D.Name,
 		Classification: Classification{
-			Name:     D.GetNormalizedName(),
+			Name:     normalize_key.Normalize(D.Name),
 			DataType: &datatype,
 			Decision: classify.ClassificationDecision{
 				State:  classify.Valid,
@@ -459,11 +431,11 @@ func classifyAsValid(D datatype.DataTypable, datatype db.DataType, reason string
 	}
 }
 
-func classifyAsInvalid(D datatype.DataTypable, reason string) ClassifiedDatatype {
-	return ClassifiedDatatype{
-		DataTypable: D,
+func classifyAsInvalid(D *Detection, reason string) *ClassifiedDatatype {
+	return &ClassifiedDatatype{
+		Name: D.Name,
 		Classification: Classification{
-			Name: D.GetNormalizedName(),
+			Name: normalize_key.Normalize(D.Name),
 			Decision: classify.ClassificationDecision{
 				State:  classify.Invalid,
 				Reason: reason,

--- a/pkg/classification/schema/schema.go
+++ b/pkg/classification/schema/schema.go
@@ -47,7 +47,6 @@ func New(config Config) *Classifier {
 
 type Detection struct {
 	Name       string
-	Type       string
 	SimpleType string
 	Properties []*Detection
 }
@@ -81,9 +80,9 @@ func (classifier *Classifier) Classify(data DataTypeDetection) *ClassifiedDataty
 	}
 
 	// schema-specific checks
-	var properties []ClassifiedDatatype
+	var properties []*ClassifiedDatatype
 	for _, v := range data.Value.Properties {
-		properties = append(properties, ClassifiedDatatype{
+		properties = append(properties, &ClassifiedDatatype{
 			Name: v.Name,
 			Classification: Classification{
 				Name: normalize_key.Normalize(v.Name),
@@ -94,6 +93,7 @@ func (classifier *Classifier) Classify(data DataTypeDetection) *ClassifiedDataty
 	classifiedDatatype = &ClassifiedDatatype{
 		Name:           data.Value.Name,
 		Classification: Classification{Name: normalize_key.Normalize(normalizedName)},
+		Properties:     properties,
 	}
 
 	matchedKnownPersonObject := classifier.matchKnownPersonObjectPatterns(normalizedName, false)
@@ -233,18 +233,14 @@ func (classifier *Classifier) classifyKnownObject(classifiedDatatype *Classified
 		matchedKnownObject := classifier.matchObjectPatterns(property.Classification.Name, detection.Properties[i].SimpleType, db.KnownObject)
 		if matchedKnownObject != nil {
 			validProperties = true
-
 			classifiedDatatype.Properties[i] = classifyAsValid(detection.Properties[i], classifier.datatypeFromPattern(matchedKnownObject), "known_pattern")
-
 			continue
 		}
 
 		matchedKnownIdentifier := classifier.matchKnownPersonObjectPatterns(normalize_key.Normalize(property.Name), true)
 		if matchedKnownIdentifier != nil {
 			validProperties = true
-
 			classifiedDatatype.Properties[i] = classifyAsValid(detection.Properties[i], matchedKnownIdentifier.DataType, "known_database_identifier")
-
 			continue
 		}
 

--- a/pkg/classification/schema/schema_test.go
+++ b/pkg/classification/schema/schema_test.go
@@ -28,8 +28,8 @@ func TestSchemaObjectClassification(t *testing.T) {
 				Filename:     "vendor/vendor.rb",
 				DetectorType: detectors.DetectorRuby,
 				Value: &schema.Detection{
-					Name: "User",
-					Type: reportschema.SimpleTypeObject,
+					Name:       "User",
+					SimpleType: reportschema.SimpleTypeObject,
 					Properties: []*schema.Detection{
 						{
 							Name:       "sku_name",
@@ -52,43 +52,44 @@ func TestSchemaObjectClassification(t *testing.T) {
 				Filename:     "db/schema.rb",
 				DetectorType: detectors.DetectorRuby,
 				Value: &schema.Detection{
-					Name: "User",
-					Type: reportschema.SimpleTypeObject,
+					Name:       "User",
+					SimpleType: reportschema.SimpleTypeObject,
 					Properties: []*schema.Detection{
 						{
-							Name: "First Name",
-							Type: reportschema.SimpleTypeBool, // wrong type
+							Name:       "First Name",
+							SimpleType: reportschema.SimpleTypeBool, // wrong type
 						},
 						{
-							Name: "sku_name",
-							Type: reportschema.SimpleTypeString,
+							Name:       "sku_name",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 						{
-							Name: "strokeOpacity",
-							Type: reportschema.SimpleTypeString,
-						},
-						{Name: "velocity",
-							Type: reportschema.SimpleTypeString,
+							Name:       "strokeOpacity",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 						{
-							Name: "primaryDisplay",
-							Type: reportschema.SimpleTypeString,
+							Name:       "velocity",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 						{
-							Name: "primaryDisplay",
-							Type: reportschema.SimpleTypeString,
+							Name:       "primaryDisplay",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 						{
-							Name: "primaryDisplay",
-							Type: reportschema.SimpleTypeString,
+							Name:       "primaryDisplay",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 						{
-							Name: "primaryDisplay",
-							Type: reportschema.SimpleTypeString,
+							Name:       "primaryDisplay",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 						{
-							Name: "primaryDisplay",
-							Type: reportschema.SimpleTypeString,
+							Name:       "primaryDisplay",
+							SimpleType: reportschema.SimpleTypeString,
+						},
+						{
+							Name:       "primaryDisplay",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 					},
 				},
@@ -108,16 +109,16 @@ func TestSchemaObjectClassification(t *testing.T) {
 				Filename:     "db/schema.rb",
 				DetectorType: detectors.DetectorRuby,
 				Value: &schema.Detection{
-					Name: "User",
-					Type: reportschema.SimpleTypeObject,
+					Name:       "User",
+					SimpleType: reportschema.SimpleTypeObject,
 					Properties: []*schema.Detection{
 						{
-							Name: "birthdate",
-							Type: reportschema.SimpleTypeString,
+							Name:       "birthdate",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 						{
-							Name: "First Name",
-							Type: reportschema.SimpleTypeString,
+							Name:       "First Name",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 					},
 				},
@@ -137,20 +138,20 @@ func TestSchemaObjectClassification(t *testing.T) {
 				Filename:     "db/schema.rb",
 				DetectorType: detectors.DetectorRuby,
 				Value: &schema.Detection{
-					Name: "SellerFiscalInformation",
-					Type: reportschema.SimpleTypeObject,
+					Name:       "SellerFiscalInformation",
+					SimpleType: reportschema.SimpleTypeObject,
 					Properties: []*schema.Detection{
 						{
-							Name: "name",
-							Type: reportschema.SimpleTypeString,
+							Name:       "name",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 						{
-							Name: "personName",
-							Type: reportschema.SimpleTypeString,
+							Name:       "personName",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 						{
-							Name: "_customerName",
-							Type: reportschema.SimpleTypeString,
+							Name:       "_customerName",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 					},
 				},
@@ -170,24 +171,24 @@ func TestSchemaObjectClassification(t *testing.T) {
 				Filename:     "db/schema.rb",
 				DetectorType: detectors.DetectorRuby,
 				Value: &schema.Detection{
-					Name: "SellerFiscalInformation",
-					Type: reportschema.SimpleTypeObject,
+					Name:       "SellerFiscalInformation",
+					SimpleType: reportschema.SimpleTypeObject,
 					Properties: []*schema.Detection{
 						{
-							Name: "erp_name",
-							Type: reportschema.SimpleTypeString,
+							Name:       "erp_name",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 						{
-							Name: "brand_name",
-							Type: reportschema.SimpleTypeString,
+							Name:       "brand_name",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 						{
-							Name: "company_front_name",
-							Type: reportschema.SimpleTypeString,
+							Name:       "company_front_name",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 						{
-							Name: "_containerName",
-							Type: reportschema.SimpleTypeString,
+							Name:       "_containerName",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 					},
 				},
@@ -207,12 +208,12 @@ func TestSchemaObjectClassification(t *testing.T) {
 				Filename:     "db/schema.rb",
 				DetectorType: detectors.DetectorRuby,
 				Value: &schema.Detection{
-					Name: "Applicant",
-					Type: reportschema.SimpleTypeObject,
+					Name:       "Applicant",
+					SimpleType: reportschema.SimpleTypeObject,
 					Properties: []*schema.Detection{
 						{
-							Name: "user_id",
-							Type: reportschema.SimpleTypeString,
+							Name:       "user_id",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 					},
 				},
@@ -232,12 +233,12 @@ func TestSchemaObjectClassification(t *testing.T) {
 				Filename:     "db/schema.rb",
 				DetectorType: detectors.DetectorRuby,
 				Value: &schema.Detection{
-					Name: "bank_accounts",
-					Type: reportschema.SimpleTypeObject,
+					Name:       "bank_accounts",
+					SimpleType: reportschema.SimpleTypeObject,
 					Properties: []*schema.Detection{
 						{
-							Name: "credit_card_number",
-							Type: reportschema.SimpleTypeString,
+							Name:       "credit_card_number",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 					},
 				},
@@ -257,12 +258,12 @@ func TestSchemaObjectClassification(t *testing.T) {
 				Filename:     "db/schema.rb",
 				DetectorType: detectors.DetectorRuby,
 				Value: &schema.Detection{
-					Name: "bank_accounts",
-					Type: reportschema.SimpleTypeObject,
+					Name:       "bank_accounts",
+					SimpleType: reportschema.SimpleTypeObject,
 					Properties: []*schema.Detection{
 						{
-							Name: "credit_card_number",
-							Type: reportschema.SimpleTypeBool,
+							Name:       "credit_card_number",
+							SimpleType: reportschema.SimpleTypeBool,
 						},
 					},
 				},
@@ -282,12 +283,12 @@ func TestSchemaObjectClassification(t *testing.T) {
 				Filename:     "db/schema.rb",
 				DetectorType: detectors.DetectorRuby,
 				Value: &schema.Detection{
-					Name: "patients",
-					Type: reportschema.SimpleTypeObject,
+					Name:       "patients",
+					SimpleType: reportschema.SimpleTypeObject,
 					Properties: []*schema.Detection{
 						{
-							Name: "place_of_birth_unknown",
-							Type: reportschema.SimpleTypeBool,
+							Name:       "place_of_birth_unknown",
+							SimpleType: reportschema.SimpleTypeBool,
 						},
 					},
 				},
@@ -307,12 +308,12 @@ func TestSchemaObjectClassification(t *testing.T) {
 				Filename:     "db/schema.rb",
 				DetectorType: detectors.DetectorRuby,
 				Value: &schema.Detection{
-					Name: "accounts",
-					Type: reportschema.SimpleTypeObject,
+					Name:       "accounts",
+					SimpleType: reportschema.SimpleTypeObject,
 					Properties: []*schema.Detection{
 						{
-							Name: "first_name",
-							Type: reportschema.SimpleTypeString,
+							Name:       "first_name",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 					},
 				},
@@ -332,12 +333,12 @@ func TestSchemaObjectClassification(t *testing.T) {
 				Filename:     "db/schema.rb",
 				DetectorType: detectors.DetectorRuby,
 				Value: &schema.Detection{
-					Name: "accounts",
-					Type: reportschema.SimpleTypeObject,
+					Name:       "accounts",
+					SimpleType: reportschema.SimpleTypeObject,
 					Properties: []*schema.Detection{
 						{
-							Name: "first_name",
-							Type: reportschema.SimpleTypeBool,
+							Name:       "first_name",
+							SimpleType: reportschema.SimpleTypeBool,
 						},
 					},
 				},
@@ -357,12 +358,12 @@ func TestSchemaObjectClassification(t *testing.T) {
 				Filename:     "db/schema.rb",
 				DetectorType: detectors.DetectorRuby,
 				Value: &schema.Detection{
-					Name: "accounts",
-					Type: reportschema.SimpleTypeObject,
+					Name:       "accounts",
+					SimpleType: reportschema.SimpleTypeObject,
 					Properties: []*schema.Detection{
 						{
-							Name: "foo",
-							Type: reportschema.SimpleTypeString,
+							Name:       "foo",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 					},
 				},
@@ -382,12 +383,12 @@ func TestSchemaObjectClassification(t *testing.T) {
 				Filename:     "db/schema.rb",
 				DetectorType: detectors.DetectorSQL,
 				Value: &schema.Detection{
-					Name: "accounts",
-					Type: reportschema.SimpleTypeObject,
+					Name:       "accounts",
+					SimpleType: reportschema.SimpleTypeObject,
 					Properties: []*schema.Detection{
 						{
-							Name: "bar",
-							Type: reportschema.SimpleTypeString,
+							Name:       "bar",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 					},
 				},
@@ -407,12 +408,12 @@ func TestSchemaObjectClassification(t *testing.T) {
 				Filename:     "application.js",
 				DetectorType: detectors.DetectorJavascript,
 				Value: &schema.Detection{
-					Name: "prop types",
-					Type: reportschema.SimpleTypeObject,
+					Name:       "prop types",
+					SimpleType: reportschema.SimpleTypeObject,
 					Properties: []*schema.Detection{
 						{
-							Name: "lastname",
-							Type: reportschema.SimpleTypeString,
+							Name:       "lastname",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 					},
 				},
@@ -431,72 +432,72 @@ func TestSchemaObjectClassification(t *testing.T) {
 				Filename:     "db/structure.sql",
 				DetectorType: detectors.DetectorRails,
 				Value: &schema.Detection{
-					Name: "foo",
-					Type: reportschema.SimpleTypeObject,
+					Name:       "foo",
+					SimpleType: reportschema.SimpleTypeObject,
 					Properties: []*schema.Detection{
 						{
-							Name: "way_name",
-							Type: reportschema.SimpleTypeString,
+							Name:       "way_name",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 						{
-							Name: "municipality_name",
-							Type: reportschema.SimpleTypeString,
+							Name:       "municipality_name",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 						{
-							Name: "linnworks_account_name",
-							Type: reportschema.SimpleTypeString,
+							Name:       "linnworks_account_name",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 						{
-							Name: "return_company_name",
-							Type: reportschema.SimpleTypeString,
+							Name:       "return_company_name",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 						{
-							Name: "brandName",
-							Type: reportschema.SimpleTypeString,
+							Name:       "brandName",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 						{
-							Name: "fileName",
-							Type: reportschema.SimpleTypeString,
+							Name:       "fileName",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 						{
-							Name: "InvalidNumberOfParams",
-							Type: reportschema.SimpleTypeString,
+							Name:       "InvalidNumberOfParams",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 						{
-							Name: "prescription_template_id",
-							Type: reportschema.SimpleTypeString,
+							Name:       "prescription_template_id",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 						{
-							Name: "last_name_score",
-							Type: reportschema.SimpleTypeNumber,
+							Name:       "last_name_score",
+							SimpleType: reportschema.SimpleTypeNumber,
 						},
 						{
-							Name: "studentApplicant.id",
-							Type: reportschema.SimpleTypeString,
+							Name:       "studentApplicant.id",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 						{
-							Name: "studentapplicantTest.id",
-							Type: reportschema.SimpleTypeString,
+							Name:       "studentapplicantTest.id",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 						{
-							Name: "return_seller_id",
-							Type: reportschema.SimpleTypeString,
+							Name:       "return_seller_id",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 						{
-							Name: "seller_account_id",
-							Type: reportschema.SimpleTypeString,
+							Name:       "seller_account_id",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 						{
-							Name: "customerReturnId",
-							Type: reportschema.SimpleTypeString,
+							Name:       "customerReturnId",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 						{
-							Name: "lab_test_result_id",
-							Type: reportschema.SimpleTypeString,
+							Name:       "lab_test_result_id",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 						{
-							Name: "master_product_category_updated_by_user_uuid",
-							Type: reportschema.SimpleTypeString,
+							Name:       "master_product_category_updated_by_user_uuid",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 					},
 				},
@@ -515,12 +516,12 @@ func TestSchemaObjectClassification(t *testing.T) {
 				Filename:     "db/structure.sql",
 				DetectorType: detectors.DetectorRails,
 				Value: &schema.Detection{
-					Name: "foo",
-					Type: reportschema.SimpleTypeObject,
+					Name:       "foo",
+					SimpleType: reportschema.SimpleTypeObject,
 					Properties: []*schema.Detection{
 						{
-							Name: "applicants_id",
-							Type: reportschema.SimpleTypeString,
+							Name:       "applicants_id",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 					},
 				},
@@ -539,16 +540,16 @@ func TestSchemaObjectClassification(t *testing.T) {
 				Filename:     "db/structure.sql",
 				DetectorType: detectors.DetectorRails,
 				Value: &schema.Detection{
-					Name: "foo",
-					Type: reportschema.SimpleTypeObject,
+					Name:       "foo",
+					SimpleType: reportschema.SimpleTypeObject,
 					Properties: []*schema.Detection{
 						{
-							Name: "applicants_id",
-							Type: reportschema.SimpleTypeString,
+							Name:       "applicants_id",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 						{
-							Name: "message",
-							Type: reportschema.SimpleTypeString,
+							Name:       "message",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 					},
 				},
@@ -567,20 +568,20 @@ func TestSchemaObjectClassification(t *testing.T) {
 				Filename:     "app.js",
 				DetectorType: detectors.DetectorJavascript,
 				Value: &schema.Detection{
-					Name: "ClientConfig",
-					Type: reportschema.SimpleTypeObject,
+					Name:       "ClientConfig",
+					SimpleType: reportschema.SimpleTypeObject,
 					Properties: []*schema.Detection{
 						{
-							Name: "service_name",
-							Type: reportschema.SimpleTypeString,
+							Name:       "service_name",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 						{
-							Name: "instance_name",
-							Type: reportschema.SimpleTypeString,
+							Name:       "instance_name",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 						{
-							Name: "matchLocationFromPhraseSetName",
-							Type: reportschema.SimpleTypeString,
+							Name:       "matchLocationFromPhraseSetName",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 					},
 				},
@@ -599,12 +600,12 @@ func TestSchemaObjectClassification(t *testing.T) {
 				Filename:     "application.js",
 				DetectorType: detectors.DetectorJavascript,
 				Value: &schema.Detection{
-					Name: "IProps",
-					Type: reportschema.SimpleTypeObject,
+					Name:       "IProps",
+					SimpleType: reportschema.SimpleTypeObject,
 					Properties: []*schema.Detection{
 						{
-							Name: "fontFamily",
-							Type: reportschema.SimpleTypeString,
+							Name:       "fontFamily",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 					},
 				},
@@ -623,12 +624,12 @@ func TestSchemaObjectClassification(t *testing.T) {
 				Filename:     "application.js",
 				DetectorType: detectors.DetectorJavascript,
 				Value: &schema.Detection{
-					Name: "IProps",
-					Type: reportschema.SimpleTypeObject,
+					Name:       "IProps",
+					SimpleType: reportschema.SimpleTypeObject,
 					Properties: []*schema.Detection{
 						{
-							Name: "national_identifier",
-							Type: reportschema.SimpleTypeString,
+							Name:       "national_identifier",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 					},
 				},
@@ -647,16 +648,16 @@ func TestSchemaObjectClassification(t *testing.T) {
 				Filename:     "app.js",
 				DetectorType: detectors.DetectorJavascript,
 				Value: &schema.Detection{
-					Name: "kbv_hm_diagnosis_groups",
-					Type: reportschema.SimpleTypeObject,
+					Name:       "kbv_hm_diagnosis_groups",
+					SimpleType: reportschema.SimpleTypeObject,
 					Properties: []*schema.Detection{
 						{
-							Name: "max_prescription_amount",
-							Type: reportschema.SimpleTypeString,
+							Name:       "max_prescription_amount",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 						{
-							Name: "kbv_hma_prescription_requirement_id",
-							Type: reportschema.SimpleTypeString,
+							Name:       "kbv_hma_prescription_requirement_id",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 					},
 				},
@@ -675,16 +676,16 @@ func TestSchemaObjectClassification(t *testing.T) {
 				Filename:     "app.js",
 				DetectorType: detectors.DetectorJavascript,
 				Value: &schema.Detection{
-					Name: "MiningPoolShares",
-					Type: reportschema.SimpleTypeObject,
+					Name:       "MiningPoolShares",
+					SimpleType: reportschema.SimpleTypeObject,
 					Properties: []*schema.Detection{
 						{
-							Name: "propertyName",
-							Type: reportschema.SimpleTypeString,
+							Name:       "propertyName",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 						{
-							Name: "accountName",
-							Type: reportschema.SimpleTypeString,
+							Name:       "accountName",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 					},
 				},
@@ -703,16 +704,16 @@ func TestSchemaObjectClassification(t *testing.T) {
 				Filename:     "app.js",
 				DetectorType: detectors.DetectorJavascript,
 				Value: &schema.Detection{
-					Name: "MiningPoolShares",
-					Type: reportschema.SimpleTypeObject,
+					Name:       "MiningPoolShares",
+					SimpleType: reportschema.SimpleTypeObject,
 					Properties: []*schema.Detection{
 						{
-							Name: "full_name",
-							Type: reportschema.SimpleTypeString,
+							Name:       "full_name",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 						{
-							Name: "_AuthorName",
-							Type: reportschema.SimpleTypeString,
+							Name:       "_AuthorName",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 					},
 				},
@@ -731,16 +732,16 @@ func TestSchemaObjectClassification(t *testing.T) {
 				Filename:     "app.js",
 				DetectorType: detectors.DetectorJavascript,
 				Value: &schema.Detection{
-					Name: "Foo",
-					Type: reportschema.SimpleTypeObject,
+					Name:       "Foo",
+					SimpleType: reportschema.SimpleTypeObject,
 					Properties: []*schema.Detection{
 						{
-							Name: "person_name",
-							Type: reportschema.SimpleTypeString,
+							Name:       "person_name",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 						{
-							Name: "fullName",
-							Type: reportschema.SimpleTypeString,
+							Name:       "fullName",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 					},
 				},
@@ -759,12 +760,12 @@ func TestSchemaObjectClassification(t *testing.T) {
 				Filename:     "app.js",
 				DetectorType: detectors.DetectorJavascript,
 				Value: &schema.Detection{
-					Name: "Agendas",
-					Type: reportschema.SimpleTypeObject,
+					Name:       "Agendas",
+					SimpleType: reportschema.SimpleTypeObject,
 					Properties: []*schema.Detection{
 						{
-							Name: "last_email_reminder",
-							Type: reportschema.SimpleTypeString,
+							Name:       "last_email_reminder",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 					},
 				},
@@ -783,12 +784,12 @@ func TestSchemaObjectClassification(t *testing.T) {
 				Filename:     "app.js",
 				DetectorType: detectors.DetectorJavascript,
 				Value: &schema.Detection{
-					Name: "AwsRequestSigning",
-					Type: reportschema.SimpleTypeObject,
+					Name:       "AwsRequestSigning",
+					SimpleType: reportschema.SimpleTypeObject,
 					Properties: []*schema.Detection{
 						{
-							Name: "service_name",
-							Type: reportschema.SimpleTypeString,
+							Name:       "service_name",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 					},
 				},
@@ -807,12 +808,12 @@ func TestSchemaObjectClassification(t *testing.T) {
 				Filename:     "app.js",
 				DetectorType: detectors.DetectorJavascript,
 				Value: &schema.Detection{
-					Name: "MetadataCredentialsFromPlugin",
-					Type: reportschema.SimpleTypeObject,
+					Name:       "MetadataCredentialsFromPlugin",
+					SimpleType: reportschema.SimpleTypeObject,
 					Properties: []*schema.Detection{
 						{
-							Name: "service_name",
-							Type: reportschema.SimpleTypeString,
+							Name:       "service_name",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 					},
 				},

--- a/pkg/classification/schema/schema_test.go
+++ b/pkg/classification/schema/schema_test.go
@@ -19,18 +19,18 @@ func TestSchemaObjectClassification(t *testing.T) {
 	}
 	tests := []struct {
 		Name  string
-		Input schema.DataTypeDetection
+		Input schema.ClassificationRequest
 		Want  schema.Classification
 	}{
 		{
 			Name: "from vendors folder",
-			Input: schema.DataTypeDetection{
+			Input: schema.ClassificationRequest{
 				Filename:     "vendor/vendor.rb",
 				DetectorType: detectors.DetectorRuby,
-				Value: &schema.Detection{
+				Value: &schema.ClassificationRequestDetection{
 					Name:       "User",
 					SimpleType: reportschema.SimpleTypeObject,
-					Properties: []*schema.Detection{
+					Properties: []*schema.ClassificationRequestDetection{
 						{
 							Name:       "sku_name",
 							SimpleType: reportschema.SimpleTypeString,
@@ -48,13 +48,13 @@ func TestSchemaObjectClassification(t *testing.T) {
 		},
 		{
 			Name: "known object with no valid properties",
-			Input: schema.DataTypeDetection{
+			Input: schema.ClassificationRequest{
 				Filename:     "db/schema.rb",
 				DetectorType: detectors.DetectorRuby,
-				Value: &schema.Detection{
+				Value: &schema.ClassificationRequestDetection{
 					Name:       "User",
 					SimpleType: reportschema.SimpleTypeObject,
-					Properties: []*schema.Detection{
+					Properties: []*schema.ClassificationRequestDetection{
 						{
 							Name:       "First Name",
 							SimpleType: reportschema.SimpleTypeBool, // wrong type
@@ -105,13 +105,13 @@ func TestSchemaObjectClassification(t *testing.T) {
 		},
 		{
 			Name: "known object with valid properties",
-			Input: schema.DataTypeDetection{
+			Input: schema.ClassificationRequest{
 				Filename:     "db/schema.rb",
 				DetectorType: detectors.DetectorRuby,
-				Value: &schema.Detection{
+				Value: &schema.ClassificationRequestDetection{
 					Name:       "User",
 					SimpleType: reportschema.SimpleTypeObject,
-					Properties: []*schema.Detection{
+					Properties: []*schema.ClassificationRequestDetection{
 						{
 							Name:       "birthdate",
 							SimpleType: reportschema.SimpleTypeString,
@@ -134,13 +134,13 @@ func TestSchemaObjectClassification(t *testing.T) {
 		},
 		{
 			Name: "known object is SellerFiscalInformation with valid properties",
-			Input: schema.DataTypeDetection{
+			Input: schema.ClassificationRequest{
 				Filename:     "db/schema.rb",
 				DetectorType: detectors.DetectorRuby,
-				Value: &schema.Detection{
+				Value: &schema.ClassificationRequestDetection{
 					Name:       "SellerFiscalInformation",
 					SimpleType: reportschema.SimpleTypeObject,
-					Properties: []*schema.Detection{
+					Properties: []*schema.ClassificationRequestDetection{
 						{
 							Name:       "name",
 							SimpleType: reportschema.SimpleTypeString,
@@ -167,13 +167,13 @@ func TestSchemaObjectClassification(t *testing.T) {
 		},
 		{
 			Name: "known object is SellerFiscalInformation with no valid properties",
-			Input: schema.DataTypeDetection{
+			Input: schema.ClassificationRequest{
 				Filename:     "db/schema.rb",
 				DetectorType: detectors.DetectorRuby,
-				Value: &schema.Detection{
+				Value: &schema.ClassificationRequestDetection{
 					Name:       "SellerFiscalInformation",
 					SimpleType: reportschema.SimpleTypeObject,
-					Properties: []*schema.Detection{
+					Properties: []*schema.ClassificationRequestDetection{
 						{
 							Name:       "erp_name",
 							SimpleType: reportschema.SimpleTypeString,
@@ -204,13 +204,13 @@ func TestSchemaObjectClassification(t *testing.T) {
 		},
 		{
 			Name: "known object with properties that match a db identifier",
-			Input: schema.DataTypeDetection{
+			Input: schema.ClassificationRequest{
 				Filename:     "db/schema.rb",
 				DetectorType: detectors.DetectorRuby,
-				Value: &schema.Detection{
+				Value: &schema.ClassificationRequestDetection{
 					Name:       "Applicant",
 					SimpleType: reportschema.SimpleTypeObject,
-					Properties: []*schema.Detection{
+					Properties: []*schema.ClassificationRequestDetection{
 						{
 							Name:       "user_id",
 							SimpleType: reportschema.SimpleTypeString,
@@ -229,13 +229,13 @@ func TestSchemaObjectClassification(t *testing.T) {
 		},
 		{
 			Name: "known object with properties that match exclude patterns",
-			Input: schema.DataTypeDetection{
+			Input: schema.ClassificationRequest{
 				Filename:     "db/schema.rb",
 				DetectorType: detectors.DetectorRuby,
-				Value: &schema.Detection{
+				Value: &schema.ClassificationRequestDetection{
 					Name:       "bank_accounts",
 					SimpleType: reportschema.SimpleTypeObject,
-					Properties: []*schema.Detection{
+					Properties: []*schema.ClassificationRequestDetection{
 						{
 							Name:       "credit_card_number",
 							SimpleType: reportschema.SimpleTypeString,
@@ -254,13 +254,13 @@ func TestSchemaObjectClassification(t *testing.T) {
 		},
 		{
 			Name: "known object with properties that match exclude patterns but are the wrong type (bool) - case #1",
-			Input: schema.DataTypeDetection{
+			Input: schema.ClassificationRequest{
 				Filename:     "db/schema.rb",
 				DetectorType: detectors.DetectorRuby,
-				Value: &schema.Detection{
+				Value: &schema.ClassificationRequestDetection{
 					Name:       "bank_accounts",
 					SimpleType: reportschema.SimpleTypeObject,
-					Properties: []*schema.Detection{
+					Properties: []*schema.ClassificationRequestDetection{
 						{
 							Name:       "credit_card_number",
 							SimpleType: reportschema.SimpleTypeBool,
@@ -279,13 +279,13 @@ func TestSchemaObjectClassification(t *testing.T) {
 		},
 		{
 			Name: "known object with properties that match exclude patterns but are the wrong type (bool) - case #2",
-			Input: schema.DataTypeDetection{
+			Input: schema.ClassificationRequest{
 				Filename:     "db/schema.rb",
 				DetectorType: detectors.DetectorRuby,
-				Value: &schema.Detection{
+				Value: &schema.ClassificationRequestDetection{
 					Name:       "patients",
 					SimpleType: reportschema.SimpleTypeObject,
-					Properties: []*schema.Detection{
+					Properties: []*schema.ClassificationRequestDetection{
 						{
 							Name:       "place_of_birth_unknown",
 							SimpleType: reportschema.SimpleTypeBool,
@@ -304,13 +304,13 @@ func TestSchemaObjectClassification(t *testing.T) {
 		},
 		{
 			Name: "known object with properties that do not match exclude patterns",
-			Input: schema.DataTypeDetection{
+			Input: schema.ClassificationRequest{
 				Filename:     "db/schema.rb",
 				DetectorType: detectors.DetectorRuby,
-				Value: &schema.Detection{
+				Value: &schema.ClassificationRequestDetection{
 					Name:       "accounts",
 					SimpleType: reportschema.SimpleTypeObject,
-					Properties: []*schema.Detection{
+					Properties: []*schema.ClassificationRequestDetection{
 						{
 							Name:       "first_name",
 							SimpleType: reportschema.SimpleTypeString,
@@ -329,13 +329,13 @@ func TestSchemaObjectClassification(t *testing.T) {
 		},
 		{
 			Name: "known object with properties that do not match exclude criteria but are the wrong type (bool)",
-			Input: schema.DataTypeDetection{
+			Input: schema.ClassificationRequest{
 				Filename:     "db/schema.rb",
 				DetectorType: detectors.DetectorRuby,
-				Value: &schema.Detection{
+				Value: &schema.ClassificationRequestDetection{
 					Name:       "accounts",
 					SimpleType: reportschema.SimpleTypeObject,
-					Properties: []*schema.Detection{
+					Properties: []*schema.ClassificationRequestDetection{
 						{
 							Name:       "first_name",
 							SimpleType: reportschema.SimpleTypeBool,
@@ -354,13 +354,13 @@ func TestSchemaObjectClassification(t *testing.T) {
 		},
 		{
 			Name: "known object with properties that do not match any patterns",
-			Input: schema.DataTypeDetection{
+			Input: schema.ClassificationRequest{
 				Filename:     "db/schema.rb",
 				DetectorType: detectors.DetectorRuby,
-				Value: &schema.Detection{
+				Value: &schema.ClassificationRequestDetection{
 					Name:       "accounts",
 					SimpleType: reportschema.SimpleTypeObject,
-					Properties: []*schema.Detection{
+					Properties: []*schema.ClassificationRequestDetection{
 						{
 							Name:       "foo",
 							SimpleType: reportschema.SimpleTypeString,
@@ -379,13 +379,13 @@ func TestSchemaObjectClassification(t *testing.T) {
 		},
 		{
 			Name: "Known object - database detection - with invalid properties",
-			Input: schema.DataTypeDetection{
+			Input: schema.ClassificationRequest{
 				Filename:     "db/schema.rb",
 				DetectorType: detectors.DetectorSQL,
-				Value: &schema.Detection{
+				Value: &schema.ClassificationRequestDetection{
 					Name:       "accounts",
 					SimpleType: reportschema.SimpleTypeObject,
-					Properties: []*schema.Detection{
+					Properties: []*schema.ClassificationRequestDetection{
 						{
 							Name:       "bar",
 							SimpleType: reportschema.SimpleTypeString,
@@ -404,13 +404,13 @@ func TestSchemaObjectClassification(t *testing.T) {
 		},
 		{
 			Name: "Unknown object matching stop word",
-			Input: schema.DataTypeDetection{
+			Input: schema.ClassificationRequest{
 				Filename:     "application.js",
 				DetectorType: detectors.DetectorJavascript,
-				Value: &schema.Detection{
+				Value: &schema.ClassificationRequestDetection{
 					Name:       "prop types",
 					SimpleType: reportschema.SimpleTypeObject,
-					Properties: []*schema.Detection{
+					Properties: []*schema.ClassificationRequestDetection{
 						{
 							Name:       "lastname",
 							SimpleType: reportschema.SimpleTypeString,
@@ -428,13 +428,13 @@ func TestSchemaObjectClassification(t *testing.T) {
 		},
 		{
 			Name: "Unknown object with invalid properties",
-			Input: schema.DataTypeDetection{
+			Input: schema.ClassificationRequest{
 				Filename:     "db/structure.sql",
 				DetectorType: detectors.DetectorRails,
-				Value: &schema.Detection{
+				Value: &schema.ClassificationRequestDetection{
 					Name:       "foo",
 					SimpleType: reportschema.SimpleTypeObject,
-					Properties: []*schema.Detection{
+					Properties: []*schema.ClassificationRequestDetection{
 						{
 							Name:       "way_name",
 							SimpleType: reportschema.SimpleTypeString,
@@ -512,13 +512,13 @@ func TestSchemaObjectClassification(t *testing.T) {
 		},
 		{
 			Name: "Unknown object with db identifier but no associated object properties",
-			Input: schema.DataTypeDetection{
+			Input: schema.ClassificationRequest{
 				Filename:     "db/structure.sql",
 				DetectorType: detectors.DetectorRails,
-				Value: &schema.Detection{
+				Value: &schema.ClassificationRequestDetection{
 					Name:       "foo",
 					SimpleType: reportschema.SimpleTypeObject,
-					Properties: []*schema.Detection{
+					Properties: []*schema.ClassificationRequestDetection{
 						{
 							Name:       "applicants_id",
 							SimpleType: reportschema.SimpleTypeString,
@@ -536,13 +536,13 @@ func TestSchemaObjectClassification(t *testing.T) {
 		},
 		{
 			Name: "Unknown object with db identifier and an associated object property",
-			Input: schema.DataTypeDetection{
+			Input: schema.ClassificationRequest{
 				Filename:     "db/structure.sql",
 				DetectorType: detectors.DetectorRails,
-				Value: &schema.Detection{
+				Value: &schema.ClassificationRequestDetection{
 					Name:       "foo",
 					SimpleType: reportschema.SimpleTypeObject,
-					Properties: []*schema.Detection{
+					Properties: []*schema.ClassificationRequestDetection{
 						{
 							Name:       "applicants_id",
 							SimpleType: reportschema.SimpleTypeString,
@@ -564,13 +564,13 @@ func TestSchemaObjectClassification(t *testing.T) {
 		},
 		{
 			Name: "ClientConfig object",
-			Input: schema.DataTypeDetection{
+			Input: schema.ClassificationRequest{
 				Filename:     "app.js",
 				DetectorType: detectors.DetectorJavascript,
-				Value: &schema.Detection{
+				Value: &schema.ClassificationRequestDetection{
 					Name:       "ClientConfig",
 					SimpleType: reportschema.SimpleTypeObject,
-					Properties: []*schema.Detection{
+					Properties: []*schema.ClassificationRequestDetection{
 						{
 							Name:       "service_name",
 							SimpleType: reportschema.SimpleTypeString,
@@ -596,13 +596,13 @@ func TestSchemaObjectClassification(t *testing.T) {
 		},
 		{
 			Name: "IProps object with invalid properties",
-			Input: schema.DataTypeDetection{
+			Input: schema.ClassificationRequest{
 				Filename:     "application.js",
 				DetectorType: detectors.DetectorJavascript,
-				Value: &schema.Detection{
+				Value: &schema.ClassificationRequestDetection{
 					Name:       "IProps",
 					SimpleType: reportschema.SimpleTypeObject,
-					Properties: []*schema.Detection{
+					Properties: []*schema.ClassificationRequestDetection{
 						{
 							Name:       "fontFamily",
 							SimpleType: reportschema.SimpleTypeString,
@@ -620,13 +620,13 @@ func TestSchemaObjectClassification(t *testing.T) {
 		},
 		{
 			Name: "IProps object with valid properties",
-			Input: schema.DataTypeDetection{
+			Input: schema.ClassificationRequest{
 				Filename:     "application.js",
 				DetectorType: detectors.DetectorJavascript,
-				Value: &schema.Detection{
+				Value: &schema.ClassificationRequestDetection{
 					Name:       "IProps",
 					SimpleType: reportschema.SimpleTypeObject,
-					Properties: []*schema.Detection{
+					Properties: []*schema.ClassificationRequestDetection{
 						{
 							Name:       "national_identifier",
 							SimpleType: reportschema.SimpleTypeString,
@@ -644,13 +644,13 @@ func TestSchemaObjectClassification(t *testing.T) {
 		},
 		{
 			Name: "kbv_hm_diagnosis_groups object",
-			Input: schema.DataTypeDetection{
+			Input: schema.ClassificationRequest{
 				Filename:     "app.js",
 				DetectorType: detectors.DetectorJavascript,
-				Value: &schema.Detection{
+				Value: &schema.ClassificationRequestDetection{
 					Name:       "kbv_hm_diagnosis_groups",
 					SimpleType: reportschema.SimpleTypeObject,
-					Properties: []*schema.Detection{
+					Properties: []*schema.ClassificationRequestDetection{
 						{
 							Name:       "max_prescription_amount",
 							SimpleType: reportschema.SimpleTypeString,
@@ -672,13 +672,13 @@ func TestSchemaObjectClassification(t *testing.T) {
 		},
 		{
 			Name: "MiningPoolShares object",
-			Input: schema.DataTypeDetection{
+			Input: schema.ClassificationRequest{
 				Filename:     "app.js",
 				DetectorType: detectors.DetectorJavascript,
-				Value: &schema.Detection{
+				Value: &schema.ClassificationRequestDetection{
 					Name:       "MiningPoolShares",
 					SimpleType: reportschema.SimpleTypeObject,
-					Properties: []*schema.Detection{
+					Properties: []*schema.ClassificationRequestDetection{
 						{
 							Name:       "propertyName",
 							SimpleType: reportschema.SimpleTypeString,
@@ -700,13 +700,13 @@ func TestSchemaObjectClassification(t *testing.T) {
 		},
 		{
 			Name: "MiningPoolShares object",
-			Input: schema.DataTypeDetection{
+			Input: schema.ClassificationRequest{
 				Filename:     "app.js",
 				DetectorType: detectors.DetectorJavascript,
-				Value: &schema.Detection{
+				Value: &schema.ClassificationRequestDetection{
 					Name:       "MiningPoolShares",
 					SimpleType: reportschema.SimpleTypeObject,
-					Properties: []*schema.Detection{
+					Properties: []*schema.ClassificationRequestDetection{
 						{
 							Name:       "full_name",
 							SimpleType: reportschema.SimpleTypeString,
@@ -728,13 +728,13 @@ func TestSchemaObjectClassification(t *testing.T) {
 		},
 		{
 			Name: "With valid extended data properties",
-			Input: schema.DataTypeDetection{
+			Input: schema.ClassificationRequest{
 				Filename:     "app.js",
 				DetectorType: detectors.DetectorJavascript,
-				Value: &schema.Detection{
+				Value: &schema.ClassificationRequestDetection{
 					Name:       "Foo",
 					SimpleType: reportschema.SimpleTypeObject,
-					Properties: []*schema.Detection{
+					Properties: []*schema.ClassificationRequestDetection{
 						{
 							Name:       "person_name",
 							SimpleType: reportschema.SimpleTypeString,
@@ -756,13 +756,13 @@ func TestSchemaObjectClassification(t *testing.T) {
 		},
 		{
 			Name: "With valid extended data properties",
-			Input: schema.DataTypeDetection{
+			Input: schema.ClassificationRequest{
 				Filename:     "app.js",
 				DetectorType: detectors.DetectorJavascript,
-				Value: &schema.Detection{
+				Value: &schema.ClassificationRequestDetection{
 					Name:       "Agendas",
 					SimpleType: reportschema.SimpleTypeObject,
-					Properties: []*schema.Detection{
+					Properties: []*schema.ClassificationRequestDetection{
 						{
 							Name:       "last_email_reminder",
 							SimpleType: reportschema.SimpleTypeString,
@@ -780,13 +780,13 @@ func TestSchemaObjectClassification(t *testing.T) {
 		},
 		{
 			Name: "With invalid object / field combination - AWS case",
-			Input: schema.DataTypeDetection{
+			Input: schema.ClassificationRequest{
 				Filename:     "app.js",
 				DetectorType: detectors.DetectorJavascript,
-				Value: &schema.Detection{
+				Value: &schema.ClassificationRequestDetection{
 					Name:       "AwsRequestSigning",
 					SimpleType: reportschema.SimpleTypeObject,
-					Properties: []*schema.Detection{
+					Properties: []*schema.ClassificationRequestDetection{
 						{
 							Name:       "service_name",
 							SimpleType: reportschema.SimpleTypeString,
@@ -804,13 +804,13 @@ func TestSchemaObjectClassification(t *testing.T) {
 		},
 		{
 			Name: "With invalid object / field combination - MetadataCredentialsFromPlugin case",
-			Input: schema.DataTypeDetection{
+			Input: schema.ClassificationRequest{
 				Filename:     "app.js",
 				DetectorType: detectors.DetectorJavascript,
-				Value: &schema.Detection{
+				Value: &schema.ClassificationRequestDetection{
 					Name:       "MetadataCredentialsFromPlugin",
 					SimpleType: reportschema.SimpleTypeObject,
-					Properties: []*schema.Detection{
+					Properties: []*schema.ClassificationRequestDetection{
 						{
 							Name:       "service_name",
 							SimpleType: reportschema.SimpleTypeString,

--- a/pkg/classification/schema/schema_test.go
+++ b/pkg/classification/schema/schema_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/bearer/curio/pkg/classification/schema"
 	"github.com/bearer/curio/pkg/report/detectors"
 	reportschema "github.com/bearer/curio/pkg/report/schema"
-	"github.com/bearer/curio/pkg/report/schema/datatype"
 	"github.com/bearer/curio/pkg/util/classify"
 	"github.com/stretchr/testify/assert"
 )
@@ -28,15 +27,13 @@ func TestSchemaObjectClassification(t *testing.T) {
 			Input: schema.DataTypeDetection{
 				Filename:     "vendor/vendor.rb",
 				DetectorType: detectors.DetectorRuby,
-				Value: &datatype.DataType{
+				Value: &schema.Detection{
 					Name: "User",
-					UUID: "1",
 					Type: reportschema.SimpleTypeObject,
-					Properties: map[string]datatype.DataTypable{
-						"sku_name": &datatype.DataType{
-							Name: "sku_name",
-							Type: reportschema.SimpleTypeString,
-							UUID: "3",
+					Properties: []*schema.Detection{
+						{
+							Name:       "sku_name",
+							SimpleType: reportschema.SimpleTypeString,
 						},
 					},
 				},
@@ -54,55 +51,44 @@ func TestSchemaObjectClassification(t *testing.T) {
 			Input: schema.DataTypeDetection{
 				Filename:     "db/schema.rb",
 				DetectorType: detectors.DetectorRuby,
-				Value: &datatype.DataType{
+				Value: &schema.Detection{
 					Name: "User",
-					UUID: "1",
 					Type: reportschema.SimpleTypeObject,
-					Properties: map[string]datatype.DataTypable{
-						"First Name": &datatype.DataType{
+					Properties: []*schema.Detection{
+						{
 							Name: "First Name",
 							Type: reportschema.SimpleTypeBool, // wrong type
-							UUID: "2",
 						},
-						"sku_name": &datatype.DataType{
+						{
 							Name: "sku_name",
 							Type: reportschema.SimpleTypeString,
-							UUID: "3",
 						},
-						"strokeOpacity": &datatype.DataType{
+						{
 							Name: "strokeOpacity",
 							Type: reportschema.SimpleTypeString,
-							UUID: "4",
 						},
-						"velocity": &datatype.DataType{
-							Name: "velocity",
+						{Name: "velocity",
 							Type: reportschema.SimpleTypeString,
-							UUID: "5",
 						},
-						"primaryDisplay": &datatype.DataType{
+						{
 							Name: "primaryDisplay",
 							Type: reportschema.SimpleTypeString,
-							UUID: "6",
 						},
-						"requestPassword": &datatype.DataType{
+						{
 							Name: "primaryDisplay",
 							Type: reportschema.SimpleTypeString,
-							UUID: "7",
 						},
-						"resetPassword": &datatype.DataType{
+						{
 							Name: "primaryDisplay",
 							Type: reportschema.SimpleTypeString,
-							UUID: "8",
 						},
-						"resolveAmbiguousRoles": &datatype.DataType{
+						{
 							Name: "primaryDisplay",
 							Type: reportschema.SimpleTypeString,
-							UUID: "9",
 						},
-						"combinePartialBlindedSignatures": &datatype.DataType{
+						{
 							Name: "primaryDisplay",
 							Type: reportschema.SimpleTypeString,
-							UUID: "10",
 						},
 					},
 				},
@@ -121,20 +107,17 @@ func TestSchemaObjectClassification(t *testing.T) {
 			Input: schema.DataTypeDetection{
 				Filename:     "db/schema.rb",
 				DetectorType: detectors.DetectorRuby,
-				Value: &datatype.DataType{
+				Value: &schema.Detection{
 					Name: "User",
-					UUID: "1",
 					Type: reportschema.SimpleTypeObject,
-					Properties: map[string]datatype.DataTypable{
-						"birthdate": &datatype.DataType{
+					Properties: []*schema.Detection{
+						{
 							Name: "birthdate",
 							Type: reportschema.SimpleTypeString,
-							UUID: "2",
 						},
-						"First Name": &datatype.DataType{
+						{
 							Name: "First Name",
 							Type: reportschema.SimpleTypeString,
-							UUID: "3",
 						},
 					},
 				},
@@ -153,25 +136,21 @@ func TestSchemaObjectClassification(t *testing.T) {
 			Input: schema.DataTypeDetection{
 				Filename:     "db/schema.rb",
 				DetectorType: detectors.DetectorRuby,
-				Value: &datatype.DataType{
+				Value: &schema.Detection{
 					Name: "SellerFiscalInformation",
-					UUID: "1",
 					Type: reportschema.SimpleTypeObject,
-					Properties: map[string]datatype.DataTypable{
-						"name": &datatype.DataType{
+					Properties: []*schema.Detection{
+						{
 							Name: "name",
 							Type: reportschema.SimpleTypeString,
-							UUID: "2",
 						},
-						"personName": &datatype.DataType{
+						{
 							Name: "personName",
 							Type: reportschema.SimpleTypeString,
-							UUID: "3",
 						},
-						"_customerName": &datatype.DataType{
+						{
 							Name: "_customerName",
 							Type: reportschema.SimpleTypeString,
-							UUID: "3",
 						},
 					},
 				},
@@ -190,30 +169,25 @@ func TestSchemaObjectClassification(t *testing.T) {
 			Input: schema.DataTypeDetection{
 				Filename:     "db/schema.rb",
 				DetectorType: detectors.DetectorRuby,
-				Value: &datatype.DataType{
+				Value: &schema.Detection{
 					Name: "SellerFiscalInformation",
-					UUID: "1",
 					Type: reportschema.SimpleTypeObject,
-					Properties: map[string]datatype.DataTypable{
-						"erp_name": &datatype.DataType{
+					Properties: []*schema.Detection{
+						{
 							Name: "erp_name",
 							Type: reportschema.SimpleTypeString,
-							UUID: "2",
 						},
-						"brand_name": &datatype.DataType{
+						{
 							Name: "brand_name",
 							Type: reportschema.SimpleTypeString,
-							UUID: "3",
 						},
-						"company_front_name": &datatype.DataType{
+						{
 							Name: "company_front_name",
 							Type: reportschema.SimpleTypeString,
-							UUID: "3",
 						},
-						"_containerName": &datatype.DataType{
+						{
 							Name: "_containerName",
 							Type: reportschema.SimpleTypeString,
-							UUID: "4",
 						},
 					},
 				},
@@ -232,15 +206,13 @@ func TestSchemaObjectClassification(t *testing.T) {
 			Input: schema.DataTypeDetection{
 				Filename:     "db/schema.rb",
 				DetectorType: detectors.DetectorRuby,
-				Value: &datatype.DataType{
+				Value: &schema.Detection{
 					Name: "Applicant",
-					UUID: "1",
 					Type: reportschema.SimpleTypeObject,
-					Properties: map[string]datatype.DataTypable{
-						"user_id": &datatype.DataType{
+					Properties: []*schema.Detection{
+						{
 							Name: "user_id",
 							Type: reportschema.SimpleTypeString,
-							UUID: "2",
 						},
 					},
 				},
@@ -259,15 +231,13 @@ func TestSchemaObjectClassification(t *testing.T) {
 			Input: schema.DataTypeDetection{
 				Filename:     "db/schema.rb",
 				DetectorType: detectors.DetectorRuby,
-				Value: &datatype.DataType{
+				Value: &schema.Detection{
 					Name: "bank_accounts",
-					UUID: "1",
 					Type: reportschema.SimpleTypeObject,
-					Properties: map[string]datatype.DataTypable{
-						"credit_card_number": &datatype.DataType{
+					Properties: []*schema.Detection{
+						{
 							Name: "credit_card_number",
 							Type: reportschema.SimpleTypeString,
-							UUID: "2",
 						},
 					},
 				},
@@ -286,15 +256,13 @@ func TestSchemaObjectClassification(t *testing.T) {
 			Input: schema.DataTypeDetection{
 				Filename:     "db/schema.rb",
 				DetectorType: detectors.DetectorRuby,
-				Value: &datatype.DataType{
+				Value: &schema.Detection{
 					Name: "bank_accounts",
-					UUID: "1",
 					Type: reportschema.SimpleTypeObject,
-					Properties: map[string]datatype.DataTypable{
-						"credit_card_number": &datatype.DataType{
+					Properties: []*schema.Detection{
+						{
 							Name: "credit_card_number",
 							Type: reportschema.SimpleTypeBool,
-							UUID: "2",
 						},
 					},
 				},
@@ -313,15 +281,13 @@ func TestSchemaObjectClassification(t *testing.T) {
 			Input: schema.DataTypeDetection{
 				Filename:     "db/schema.rb",
 				DetectorType: detectors.DetectorRuby,
-				Value: &datatype.DataType{
+				Value: &schema.Detection{
 					Name: "patients",
-					UUID: "1",
 					Type: reportschema.SimpleTypeObject,
-					Properties: map[string]datatype.DataTypable{
-						"place_of_birth_unknown": &datatype.DataType{
+					Properties: []*schema.Detection{
+						{
 							Name: "place_of_birth_unknown",
 							Type: reportschema.SimpleTypeBool,
-							UUID: "2",
 						},
 					},
 				},
@@ -340,15 +306,13 @@ func TestSchemaObjectClassification(t *testing.T) {
 			Input: schema.DataTypeDetection{
 				Filename:     "db/schema.rb",
 				DetectorType: detectors.DetectorRuby,
-				Value: &datatype.DataType{
+				Value: &schema.Detection{
 					Name: "accounts",
-					UUID: "1",
 					Type: reportschema.SimpleTypeObject,
-					Properties: map[string]datatype.DataTypable{
-						"first_name": &datatype.DataType{
+					Properties: []*schema.Detection{
+						{
 							Name: "first_name",
 							Type: reportschema.SimpleTypeString,
-							UUID: "2",
 						},
 					},
 				},
@@ -367,15 +331,13 @@ func TestSchemaObjectClassification(t *testing.T) {
 			Input: schema.DataTypeDetection{
 				Filename:     "db/schema.rb",
 				DetectorType: detectors.DetectorRuby,
-				Value: &datatype.DataType{
+				Value: &schema.Detection{
 					Name: "accounts",
-					UUID: "1",
 					Type: reportschema.SimpleTypeObject,
-					Properties: map[string]datatype.DataTypable{
-						"first_name": &datatype.DataType{
+					Properties: []*schema.Detection{
+						{
 							Name: "first_name",
 							Type: reportschema.SimpleTypeBool,
-							UUID: "2",
 						},
 					},
 				},
@@ -394,15 +356,13 @@ func TestSchemaObjectClassification(t *testing.T) {
 			Input: schema.DataTypeDetection{
 				Filename:     "db/schema.rb",
 				DetectorType: detectors.DetectorRuby,
-				Value: &datatype.DataType{
+				Value: &schema.Detection{
 					Name: "accounts",
-					UUID: "1",
 					Type: reportschema.SimpleTypeObject,
-					Properties: map[string]datatype.DataTypable{
-						"foo": &datatype.DataType{
+					Properties: []*schema.Detection{
+						{
 							Name: "foo",
 							Type: reportschema.SimpleTypeString,
-							UUID: "2",
 						},
 					},
 				},
@@ -421,15 +381,13 @@ func TestSchemaObjectClassification(t *testing.T) {
 			Input: schema.DataTypeDetection{
 				Filename:     "db/schema.rb",
 				DetectorType: detectors.DetectorSQL,
-				Value: &datatype.DataType{
+				Value: &schema.Detection{
 					Name: "accounts",
-					UUID: "1",
 					Type: reportschema.SimpleTypeObject,
-					Properties: map[string]datatype.DataTypable{
-						"bar": &datatype.DataType{
+					Properties: []*schema.Detection{
+						{
 							Name: "bar",
 							Type: reportschema.SimpleTypeString,
-							UUID: "2",
 						},
 					},
 				},
@@ -448,15 +406,13 @@ func TestSchemaObjectClassification(t *testing.T) {
 			Input: schema.DataTypeDetection{
 				Filename:     "application.js",
 				DetectorType: detectors.DetectorJavascript,
-				Value: &datatype.DataType{
+				Value: &schema.Detection{
 					Name: "prop types",
-					UUID: "1",
 					Type: reportschema.SimpleTypeObject,
-					Properties: map[string]datatype.DataTypable{
-						"lastname": &datatype.DataType{
+					Properties: []*schema.Detection{
+						{
 							Name: "lastname",
 							Type: reportschema.SimpleTypeString,
-							UUID: "2",
 						},
 					},
 				},
@@ -474,72 +430,71 @@ func TestSchemaObjectClassification(t *testing.T) {
 			Input: schema.DataTypeDetection{
 				Filename:     "db/structure.sql",
 				DetectorType: detectors.DetectorRails,
-				Value: &datatype.DataType{
+				Value: &schema.Detection{
 					Name: "foo",
-					UUID: "1",
 					Type: reportschema.SimpleTypeObject,
-					Properties: map[string]datatype.DataTypable{
-						"way_name": &datatype.DataType{
+					Properties: []*schema.Detection{
+						{
 							Name: "way_name",
 							Type: reportschema.SimpleTypeString,
 						},
-						"municipality_name": &datatype.DataType{
+						{
 							Name: "municipality_name",
 							Type: reportschema.SimpleTypeString,
 						},
-						"linnworks_account_name": &datatype.DataType{
+						{
 							Name: "linnworks_account_name",
 							Type: reportschema.SimpleTypeString,
 						},
-						"return_company_name": &datatype.DataType{
+						{
 							Name: "return_company_name",
 							Type: reportschema.SimpleTypeString,
 						},
-						"brandName": &datatype.DataType{
+						{
 							Name: "brandName",
 							Type: reportschema.SimpleTypeString,
 						},
-						"fileName": &datatype.DataType{
+						{
 							Name: "fileName",
 							Type: reportschema.SimpleTypeString,
 						},
-						"InvalidNumberOfParams": &datatype.DataType{
+						{
 							Name: "InvalidNumberOfParams",
 							Type: reportschema.SimpleTypeString,
 						},
-						"prescription_template_id": &datatype.DataType{
+						{
 							Name: "prescription_template_id",
 							Type: reportschema.SimpleTypeString,
 						},
-						"last_name_score": &datatype.DataType{
+						{
 							Name: "last_name_score",
 							Type: reportschema.SimpleTypeNumber,
 						},
-						"studentApplicant.id": &datatype.DataType{
+						{
 							Name: "studentApplicant.id",
 							Type: reportschema.SimpleTypeString,
 						},
-						"studentapplicantTest.id": &datatype.DataType{
+						{
 							Name: "studentapplicantTest.id",
 							Type: reportschema.SimpleTypeString,
 						},
-						"return_seller_id": &datatype.DataType{
+						{
 							Name: "return_seller_id",
 							Type: reportschema.SimpleTypeString,
 						},
-						"seller_account_id": &datatype.DataType{
+						{
 							Name: "seller_account_id",
 							Type: reportschema.SimpleTypeString,
 						},
-						"customerReturnId": &datatype.DataType{
+						{
 							Name: "customerReturnId",
 							Type: reportschema.SimpleTypeString,
 						},
-						"lab_test_result_id": &datatype.DataType{
+						{
 							Name: "lab_test_result_id",
 							Type: reportschema.SimpleTypeString,
 						},
-						"master_product_category_updated_by_user_uuid": &datatype.DataType{
+						{
 							Name: "master_product_category_updated_by_user_uuid",
 							Type: reportschema.SimpleTypeString,
 						},
@@ -559,12 +514,11 @@ func TestSchemaObjectClassification(t *testing.T) {
 			Input: schema.DataTypeDetection{
 				Filename:     "db/structure.sql",
 				DetectorType: detectors.DetectorRails,
-				Value: &datatype.DataType{
+				Value: &schema.Detection{
 					Name: "foo",
-					UUID: "1",
 					Type: reportschema.SimpleTypeObject,
-					Properties: map[string]datatype.DataTypable{
-						"applicants_id": &datatype.DataType{
+					Properties: []*schema.Detection{
+						{
 							Name: "applicants_id",
 							Type: reportschema.SimpleTypeString,
 						},
@@ -584,16 +538,15 @@ func TestSchemaObjectClassification(t *testing.T) {
 			Input: schema.DataTypeDetection{
 				Filename:     "db/structure.sql",
 				DetectorType: detectors.DetectorRails,
-				Value: &datatype.DataType{
+				Value: &schema.Detection{
 					Name: "foo",
-					UUID: "1",
 					Type: reportschema.SimpleTypeObject,
-					Properties: map[string]datatype.DataTypable{
-						"applicants_id": &datatype.DataType{
+					Properties: []*schema.Detection{
+						{
 							Name: "applicants_id",
 							Type: reportschema.SimpleTypeString,
 						},
-						"message": &datatype.DataType{
+						{
 							Name: "message",
 							Type: reportschema.SimpleTypeString,
 						},
@@ -613,20 +566,19 @@ func TestSchemaObjectClassification(t *testing.T) {
 			Input: schema.DataTypeDetection{
 				Filename:     "app.js",
 				DetectorType: detectors.DetectorJavascript,
-				Value: &datatype.DataType{
+				Value: &schema.Detection{
 					Name: "ClientConfig",
-					UUID: "1",
 					Type: reportschema.SimpleTypeObject,
-					Properties: map[string]datatype.DataTypable{
-						"service_name": &datatype.DataType{
+					Properties: []*schema.Detection{
+						{
 							Name: "service_name",
 							Type: reportschema.SimpleTypeString,
 						},
-						"instance_name": &datatype.DataType{
+						{
 							Name: "instance_name",
 							Type: reportschema.SimpleTypeString,
 						},
-						"matchLocationFromPhraseSetName": &datatype.DataType{
+						{
 							Name: "matchLocationFromPhraseSetName",
 							Type: reportschema.SimpleTypeString,
 						},
@@ -646,12 +598,11 @@ func TestSchemaObjectClassification(t *testing.T) {
 			Input: schema.DataTypeDetection{
 				Filename:     "application.js",
 				DetectorType: detectors.DetectorJavascript,
-				Value: &datatype.DataType{
+				Value: &schema.Detection{
 					Name: "IProps",
-					UUID: "1",
 					Type: reportschema.SimpleTypeObject,
-					Properties: map[string]datatype.DataTypable{
-						"fontFamily": &datatype.DataType{
+					Properties: []*schema.Detection{
+						{
 							Name: "fontFamily",
 							Type: reportschema.SimpleTypeString,
 						},
@@ -671,12 +622,11 @@ func TestSchemaObjectClassification(t *testing.T) {
 			Input: schema.DataTypeDetection{
 				Filename:     "application.js",
 				DetectorType: detectors.DetectorJavascript,
-				Value: &datatype.DataType{
+				Value: &schema.Detection{
 					Name: "IProps",
-					UUID: "1",
 					Type: reportschema.SimpleTypeObject,
-					Properties: map[string]datatype.DataTypable{
-						"national_identifier": &datatype.DataType{
+					Properties: []*schema.Detection{
+						{
 							Name: "national_identifier",
 							Type: reportschema.SimpleTypeString,
 						},
@@ -696,16 +646,15 @@ func TestSchemaObjectClassification(t *testing.T) {
 			Input: schema.DataTypeDetection{
 				Filename:     "app.js",
 				DetectorType: detectors.DetectorJavascript,
-				Value: &datatype.DataType{
+				Value: &schema.Detection{
 					Name: "kbv_hm_diagnosis_groups",
-					UUID: "1",
 					Type: reportschema.SimpleTypeObject,
-					Properties: map[string]datatype.DataTypable{
-						"max_prescription_amount": &datatype.DataType{
+					Properties: []*schema.Detection{
+						{
 							Name: "max_prescription_amount",
 							Type: reportschema.SimpleTypeString,
 						},
-						"kbv_hma_prescription_requirement_id": &datatype.DataType{
+						{
 							Name: "kbv_hma_prescription_requirement_id",
 							Type: reportschema.SimpleTypeString,
 						},
@@ -725,16 +674,15 @@ func TestSchemaObjectClassification(t *testing.T) {
 			Input: schema.DataTypeDetection{
 				Filename:     "app.js",
 				DetectorType: detectors.DetectorJavascript,
-				Value: &datatype.DataType{
+				Value: &schema.Detection{
 					Name: "MiningPoolShares",
-					UUID: "1",
 					Type: reportschema.SimpleTypeObject,
-					Properties: map[string]datatype.DataTypable{
-						"propertyName": &datatype.DataType{
+					Properties: []*schema.Detection{
+						{
 							Name: "propertyName",
 							Type: reportschema.SimpleTypeString,
 						},
-						"accountName": &datatype.DataType{
+						{
 							Name: "accountName",
 							Type: reportschema.SimpleTypeString,
 						},
@@ -754,16 +702,15 @@ func TestSchemaObjectClassification(t *testing.T) {
 			Input: schema.DataTypeDetection{
 				Filename:     "app.js",
 				DetectorType: detectors.DetectorJavascript,
-				Value: &datatype.DataType{
+				Value: &schema.Detection{
 					Name: "MiningPoolShares",
-					UUID: "1",
 					Type: reportschema.SimpleTypeObject,
-					Properties: map[string]datatype.DataTypable{
-						"full_name": &datatype.DataType{
+					Properties: []*schema.Detection{
+						{
 							Name: "full_name",
 							Type: reportschema.SimpleTypeString,
 						},
-						"_AuthorName": &datatype.DataType{
+						{
 							Name: "_AuthorName",
 							Type: reportschema.SimpleTypeString,
 						},
@@ -783,16 +730,15 @@ func TestSchemaObjectClassification(t *testing.T) {
 			Input: schema.DataTypeDetection{
 				Filename:     "app.js",
 				DetectorType: detectors.DetectorJavascript,
-				Value: &datatype.DataType{
+				Value: &schema.Detection{
 					Name: "Foo",
-					UUID: "1",
 					Type: reportschema.SimpleTypeObject,
-					Properties: map[string]datatype.DataTypable{
-						"person_name": &datatype.DataType{
+					Properties: []*schema.Detection{
+						{
 							Name: "person_name",
 							Type: reportschema.SimpleTypeString,
 						},
-						"fullName": &datatype.DataType{
+						{
 							Name: "fullName",
 							Type: reportschema.SimpleTypeString,
 						},
@@ -812,12 +758,11 @@ func TestSchemaObjectClassification(t *testing.T) {
 			Input: schema.DataTypeDetection{
 				Filename:     "app.js",
 				DetectorType: detectors.DetectorJavascript,
-				Value: &datatype.DataType{
+				Value: &schema.Detection{
 					Name: "Agendas",
-					UUID: "1",
 					Type: reportschema.SimpleTypeObject,
-					Properties: map[string]datatype.DataTypable{
-						"last_email_reminder": &datatype.DataType{
+					Properties: []*schema.Detection{
+						{
 							Name: "last_email_reminder",
 							Type: reportschema.SimpleTypeString,
 						},
@@ -837,12 +782,11 @@ func TestSchemaObjectClassification(t *testing.T) {
 			Input: schema.DataTypeDetection{
 				Filename:     "app.js",
 				DetectorType: detectors.DetectorJavascript,
-				Value: &datatype.DataType{
+				Value: &schema.Detection{
 					Name: "AwsRequestSigning",
-					UUID: "1",
 					Type: reportschema.SimpleTypeObject,
-					Properties: map[string]datatype.DataTypable{
-						"service_name": &datatype.DataType{
+					Properties: []*schema.Detection{
+						{
 							Name: "service_name",
 							Type: reportschema.SimpleTypeString,
 						},
@@ -862,12 +806,11 @@ func TestSchemaObjectClassification(t *testing.T) {
 			Input: schema.DataTypeDetection{
 				Filename:     "app.js",
 				DetectorType: detectors.DetectorJavascript,
-				Value: &datatype.DataType{
+				Value: &schema.Detection{
 					Name: "MetadataCredentialsFromPlugin",
-					UUID: "1",
 					Type: reportschema.SimpleTypeObject,
-					Properties: map[string]datatype.DataTypable{
-						"service_name": &datatype.DataType{
+					Properties: []*schema.Detection{
+						{
 							Name: "service_name",
 							Type: reportschema.SimpleTypeString,
 						},

--- a/pkg/commands/process/worker/worker.go
+++ b/pkg/commands/process/worker/worker.go
@@ -38,7 +38,7 @@ func Start(port string) error {
 			if err != nil {
 				response.CustomDetectorError = err.Error()
 			}
-			err = customdetector.Setup(config.CustomDetector)
+			err = customdetector.Setup(&config, classifier)
 			if err != nil {
 				response.CustomDetectorError = err.Error()
 			}

--- a/pkg/report/schema/datatype/datatype.go
+++ b/pkg/report/schema/datatype/datatype.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 	"strings"
 
+	classificationschema "github.com/bearer/curio/pkg/classification/schema"
 	"github.com/bearer/curio/pkg/parser"
 	"github.com/bearer/curio/pkg/parser/nodeid"
 	"github.com/bearer/curio/pkg/report/detections"
@@ -25,6 +26,50 @@ type DataType struct {
 	Properties map[string]DataTypable
 	IsHelper   bool // helper dataTypes and their child datatypes don't get exported
 	UUID       string
+}
+
+type ClassifiedDatatype struct {
+	*DataType
+	Classification *classificationschema.ClassifiedDatatype
+	Properties     map[string]DataTypable
+}
+
+func (datatype *ClassifiedDatatype) GetClassification() interface{} {
+	classification := *datatype.Classification
+	classification.Properties = nil
+	return classification
+}
+
+func (datatype *ClassifiedDatatype) GetProperties() map[string]DataTypable {
+	return datatype.Properties
+}
+
+func BuildClassifiedDatatype(datatype *DataType, classification *classificationschema.ClassifiedDatatype) *ClassifiedDatatype {
+	properties := make(map[string]DataTypable)
+
+	for key, propertyDatatypable := range datatype.Properties {
+		propertyDatatype, ok := propertyDatatypable.(*DataType)
+		if !ok {
+			continue
+		}
+
+		for _, classificationProperty := range classification.Properties {
+			if key == classificationProperty.Name {
+				properties[key] = &ClassifiedDatatype{
+					DataType:       propertyDatatype,
+					Classification: classificationProperty,
+					Properties:     make(map[string]DataTypable),
+				}
+			}
+		}
+	}
+	result := &ClassifiedDatatype{
+		DataType:       datatype,
+		Classification: classification,
+		Properties:     properties,
+	}
+
+	return result
 }
 
 func (datatype *DataType) GetClassification() interface{} {
@@ -101,6 +146,19 @@ func (datatype *DataType) Clone() DataTypable {
 	return cloned
 }
 
+func (datatype *DataType) ToClassificationRequestDetection() *classificationschema.ClassificationRequestDetection {
+	detection := &classificationschema.ClassificationRequestDetection{
+		Name:       datatype.Name,
+		SimpleType: datatype.Type,
+	}
+
+	for _, datatypeProperty := range datatype.Properties {
+		detection.Properties = append(detection.Properties, datatypeProperty.ToClassificationRequestDetection())
+	}
+
+	return detection
+}
+
 type DataTypable interface {
 	DeleteProperty(name string)
 	GetClassification() interface{}
@@ -117,6 +175,7 @@ type DataTypable interface {
 	Clone() DataTypable
 	SetProperty(string, DataTypable)
 	CreateProperties()
+	ToClassificationRequestDetection() *classificationschema.ClassificationRequestDetection
 }
 
 func ExportClassified[D DataTypable](report detections.ReportDetection, detectionType detections.DetectionType, detectorType detectors.Type, idGenerator nodeid.Generator, values map[parser.NodeID]D, parent *parser.Node) {


### PR DESCRIPTION
## Description
This Pr refractores classification in a way that reduces dependencies needed for classification.
Schema classification now has its own set of types while new and old detector now to handle converting from their types to classification types and enriching its own types.

### Related
https://github.com/Bearer/curio/issues/393
https://github.com/Bearer/curio/issues/361

### note:
I wasn't able to fully test this pr since integration tests are broken atm at spike/architecture branch.
Will have to fully test it once we reach feature parity of new detectors with old detectors and get integration tests working.

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
