### PR TITLE
spike: group policies by language

### DIFF
--- a/pkg/commands/process/settings/policies/ruby/CR-001/README.md
+++ b/pkg/commands/process/settings/policies/ruby/CR-001/README.md
@@ -1,0 +1,5 @@
+## CR-001 - Ruby - Logger Leaks
+
+Do not send sensitive data to loggers.
+
+Leaking sensitive data to loggers is a common cause of data leaks and can lead to data breaches. This policy looks for instances of sensitive data sent to loggers.

--- a/pkg/commands/process/settings/policies/ruby/CR-001/detectors.yml
+++ b/pkg/commands/process/settings/policies/ruby/CR-001/detectors.yml
@@ -1,0 +1,9 @@
+CR-001:
+  type: "risk"
+  patterns:
+    - |
+      logger.info(<$ARGUMENT>)
+    - |
+      Rails.logger.info(<$ARGUMENT>)
+  languages:
+    - ruby

--- a/pkg/commands/process/settings/policies/ruby/CR-001/policy.rego
+++ b/pkg/commands/process/settings/policies/ruby/CR-001/policy.rego
@@ -1,0 +1,23 @@
+package bearer.cr_001
+
+import data.bearer.common
+
+import future.keywords
+
+policy_failure contains item if {
+    some detector in input.dataflow.risks
+    detector.detector_id == input.policy_id
+
+    data_type = detector.data_types[_]
+    data_type.name != "Unique Identifier"
+
+    location = data_type.locations[_]
+    item := {
+        "category_groups": data.bearer.common.groups_for_datatype(data_type),
+        "severity": data.bearer.common.severity_of_datatype(data_type),
+        "filename": location.filename,
+        "line_number": location.line_number,
+        "parent_line_number": location.parent.line_number,
+        "parent_content": location.parent.content
+    }
+}

--- a/pkg/commands/process/settings/policies/ruby/CR-001/rule.yml
+++ b/pkg/commands/process/settings/policies/ruby/CR-001/rule.yml
@@ -1,0 +1,9 @@
+name: "Do not send sensitive data to loggers."
+id: "CR-001"
+query: |
+  policy_failure = data.bearer.leakage.policy_failure
+modules:
+  - path: policies/common.rego
+    name: bearer.common
+  - path: policies/ruby/CR-001/policy.rego
+    name: bearer.cr_001

--- a/pkg/commands/process/settings/policies/ruby/CR-023/README.md
+++ b/pkg/commands/process/settings/policies/ruby/CR-023/README.md
@@ -1,0 +1,5 @@
+## CR-023 - Ruby - Strong password encryption
+
+Force strong password encryption.
+
+Using a weak encryption or hashing library to encrypt passwords can lead to security breaches and data leaks. This policy checks if weak encryption or hashing libraries are used to encrypt passwords.

--- a/pkg/commands/process/settings/policies/ruby/CR-023/detectors.yml
+++ b/pkg/commands/process/settings/policies/ruby/CR-023/detectors.yml
@@ -1,0 +1,158 @@
+CR-023:
+  type: "risk"
+  patterns:
+    - |
+      Digest::SHA1.hexidigest(<$DATA_TYPE>)
+    - |
+      Digest::MD5.hexdigest(<$DATA_TYPE>)
+    - pattern: |
+        OpenSSL::PKey::$LIBRARY.new($_, <$DATA_TYPE>)
+      filters:
+        - variable: LIBRARY
+        - values:
+            - DSA
+            - RSA
+    - pattern: |
+        RC4.new(...).encrypt(<$DATA_TYPE>)
+      filters: []
+    - pattern: |
+        OpenSSL::PKey::RSA.new($_, <$DATA_TYPE>)
+      filters: []
+    - pattern: |
+        OpenSSL::PKey::RSA.new(...).$METHOD(<$DATA_TYPE>)
+      filters:
+        - variable: METHOD
+          values:
+            - private_decrypt
+            - private_encrypt
+            - public_decrypt
+            - public_encrypt
+    - pattern: |
+        OpenSSL::PKey::DSA.new($_, <$DATA_TYPE>)
+      filters: []
+    - pattern: |
+        OpenSSL::PKey::$LIBRARY.new(...).$METHOD($_, <$DATA_TYPE>)
+      filters:
+        - variable: $LIBRARY
+          values:
+            - DSA
+            - RSA
+        - variable: METHOD
+          values:
+            - export
+            - to_pem
+            - to_s
+    - pattern: |
+        Crypt::Blowfish.new(...).encrypt_pair
+      filters: []
+    - pattern: |
+        Crypt::Blowfish.new(...).$METHOD(<$DATA_TYPE>)
+      filters:
+        - variable: METHOD
+          values:
+            - encrypt_pair
+            - encrypt_string
+            - encrypt_block
+            - decrypt_pair
+            - decrypt_string
+            - decrypt_block
+  languages:
+    - "ruby"
+CR-023-1:
+  name: "encrypt method call"
+  type: "risk"
+  patterns:
+    - pattern: |
+        $_.$METHOD(<$DATA_TYPE>)
+      filters:
+        - variable: METHOD
+          values:
+            - encrypt
+            - encrypt!
+            - decrypt
+  languages:
+    - "ruby"
+CR-023-2:
+  name: "Blowfish init"
+  type: "risk"
+  patterns:
+    - |
+      $_ = Crypt::Blowfish.new(...)
+  languages:
+    - "ruby"
+  detect_presence: true
+CR-023-3:
+  name: "OpenSSL PKey DSA init"
+  type: "risk"
+  patterns:
+    - |
+      $_ = OpenSSL::PKey::DSA.new()
+  languages:
+    - "ruby"
+  detect_presence: true
+CR-023-4:
+  name: "OpenSSL PKey RSA init"
+  type: "risk"
+  patterns:
+    - |
+      $_ = OpenSSL::PKey::RSA.new()
+  languages:
+    - "ruby"
+  detect_presence: true
+CR-023-5:
+  name: "RC4 init"
+  type: "risk"
+  patterns:
+    - |
+      $_ = RC4.new()
+  languages:
+    - "ruby"
+  detect_presence: true
+CR-023-6:
+  name: "Blowfish method call"
+  type: "risk"
+  patterns:
+    - pattern: |
+        $_.$METHOD(<$DATA_TYPE>)
+      filters:
+        - variable: METHOD
+          values:
+            - encrypt_pair
+            - encrypt_string
+            - encrypt_block
+            - decrypt_pair
+            - decrypt_string
+            - decrypt_block
+  languages:
+    - "ruby"
+CR-023-7:
+  name: "OpenSSL PKey method calls"
+  type: "risk"
+  patterns:
+    - pattern: |
+        $_.$METHOD(<$DATA_TYPE>)
+      filters:
+        - variable: METHOD
+          values:
+            - export
+            - to_pem
+            - to_s
+  languages:
+    - "ruby"
+CR-023-8:
+  name: "OpenSSL PKey RSA method calls"
+  type: "risk"
+  patterns:
+    - pattern: |
+        $_.$METHOD(<$DATA_TYPE>)
+      filters:
+        - variable: METHOD
+          values:
+            - private_decrypt
+            - private_encrypt
+            - public_decrypt
+            - public_encrypt
+  languages:
+    - "ruby"
+
+

--- a/pkg/commands/process/settings/policies/ruby/CR-023/policy.rego
+++ b/pkg/commands/process/settings/policies/ruby/CR-023/policy.rego
@@ -1,0 +1,145 @@
+package bearer.cr_023
+
+import data.bearer.common
+
+import future.keywords
+
+password_uuid := "02bb0d3a-2c8c-4842-be1c-c057f0dccd63"
+
+rc4_files contains item if {
+  some detector in input.dataflow.risks
+  detector.detector_id == "CR-023-5"
+
+  location = detector.locations[_]
+
+  item := location.filename
+}
+
+blowfish_files contains item if {
+  some detector in input.dataflow.risks
+  detector.detector_id == "CR-023-2"
+
+  location = detector.locations[_]
+
+  item := location.filename
+}
+
+openssl_pkey_rsa_files contains item if {
+  some detector in input.dataflow.risks
+  detector.detector_id == "CR-023-4"
+
+  location = detector.locations[_]
+
+  item := location.filename
+}
+
+openssl_pkey_dsa_files contains item if {
+  some detector in input.dataflow.risks
+  detector.detector_id == "CR-023-3"
+
+  location = detector.locations[_]
+
+  item := location.filename
+}
+
+# openssl pkey rsa encryption
+policy_failure contains item if {
+    some detector in input.dataflow.risks
+    detector.detector_id in ["CR-023-7", "CR-023-8"]
+
+    data_type = detector.data_types[_]
+    data_type.uuid == password_uuid
+
+    location = data_type.locations[_]
+    location.filename in openssl_pkey_rsa_files
+
+    item := {
+        "category_groups": data.bearer.common.groups_for_datatype(data_type),
+        "severity": data.bearer.common.severity_of_datatype(data_type),
+        "filename": location.filename,
+        "line_number": location.line_number,
+        "parent_line_number": location.parent.line_number,
+        "parent_content": location.parent.content
+    }
+}
+
+# openssl pkey dsa encryption
+policy_failure contains item if {
+    some detector in input.dataflow.risks
+    detector.detector_id in ["CR-023-7"]
+
+    data_type = detector.data_types[_]
+    data_type.uuid == password_uuid
+
+    location = data_type.locations[_]
+    location.filename in openssl_pkey_dsa_files
+
+    item := {
+        "category_groups": data.bearer.common.groups_for_datatype(data_type),
+        "severity": data.bearer.common.severity_of_datatype(data_type),
+        "filename": location.filename,
+        "line_number": location.line_number,
+        "parent_line_number": location.parent.line_number,
+        "parent_content": location.parent.content
+    }
+}
+
+# blowfish encryption
+policy_failure contains item if {
+    some detector in input.dataflow.risks
+    detector.detector_id == "CR-023-6"
+
+    data_type = detector.data_types[_]
+    data_type.uuid == password_uuid
+
+    location = data_type.locations[_]
+    location.filename in blowfish_files
+
+    item := {
+        "category_groups": data.bearer.common.groups_for_datatype(data_type),
+        "severity": data.bearer.common.severity_of_datatype(data_type),
+        "filename": location.filename,
+        "line_number": location.line_number,
+        "parent_line_number": location.parent.line_number,
+        "parent_content": location.parent.content
+    }
+}
+
+# rc4 encryption
+policy_failure contains item if {
+    some detector in input.dataflow.risks
+    detector.detector_id == "CR-023-1"
+
+    data_type = detector.data_types[_]
+    data_type.uuid == password_uuid
+
+    location = data_type.locations[_]
+    location.filename in rc4_files
+
+    item := {
+        "category_groups": data.bearer.common.groups_for_datatype(data_type),
+        "severity": data.bearer.common.severity_of_datatype(data_type),
+        "filename": location.filename,
+        "line_number": location.line_number,
+        "parent_line_number": location.parent.line_number,
+        "parent_content": location.parent.content
+    }
+}
+
+policy_failure contains item if {
+    some detector in input.dataflow.risks
+    detector.detector_id == input.policy_id
+
+    data_type = detector.data_types[_]
+    data_type.uuid == password_uuid
+
+    location = data_type.locations[_]
+    item := {
+        "category_groups": data.bearer.common.groups_for_datatype(data_type),
+        "severity": data.bearer.common.severity_of_datatype(data_type),
+        "filename": location.filename,
+        "line_number": location.line_number,
+        "parent_line_number": location.parent.line_number,
+        "parent_content": location.parent.content
+    }
+}

--- a/pkg/commands/process/settings/policies/ruby/CR-023/rule.yml
+++ b/pkg/commands/process/settings/policies/ruby/CR-023/rule.yml
@@ -1,0 +1,11 @@
+name: "Force strong password encryption."
+id: "CR-023"
+query: |
+  policy_failure = data.bearer.weak_password_encryption.policy_failure
+modules:
+  - path: policies/shared/common.rego
+    name: bearer.common
+  - path: policies/ruby/shared/encryption.rego
+    name: bearer.ruby_encryption
+  - path: policies/ruby/CR-023/policy.rego
+    name: bearer.cr_023

--- a/pkg/commands/process/settings/policies/ruby/CR-024/README.md
+++ b/pkg/commands/process/settings/policies/ruby/CR-024/README.md
@@ -1,0 +1,5 @@
+## CR-024 - Ruby - Weak encryption library
+
+Avoid weak encryption library.
+
+A weak encryption or hashing library can lead to data breaches and greater security risk. This policy checks for the use of weak encryption and hashing libraries or algorithms.

--- a/pkg/commands/process/settings/policies/ruby/CR-024/detectors.yml
+++ b/pkg/commands/process/settings/policies/ruby/CR-024/detectors.yml
@@ -1,0 +1,158 @@
+CR-024:
+  type: "risk"
+  patterns:
+    - |
+      Digest::SHA1.hexidigest(<$DATA_TYPE>)
+    - |
+      Digest::MD5.hexdigest(<$DATA_TYPE>)
+    - pattern: |
+        OpenSSL::PKey::$LIBRARY.new($_, <$DATA_TYPE>)
+      filters:
+        - variable: LIBRARY
+        - values:
+            - DSA
+            - RSA
+    - pattern: |
+        RC4.new(...).encrypt(<$DATA_TYPE>)
+      filters: []
+    - pattern: |
+        OpenSSL::PKey::RSA.new($_, <$DATA_TYPE>)
+      filters: []
+    - pattern: |
+        OpenSSL::PKey::RSA.new(...).$METHOD(<$DATA_TYPE>)
+      filters:
+        - variable: METHOD
+          values:
+            - private_decrypt
+            - private_encrypt
+            - public_decrypt
+            - public_encrypt
+    - pattern: |
+        OpenSSL::PKey::DSA.new($_, <$DATA_TYPE>)
+      filters: []
+    - pattern: |
+        OpenSSL::PKey::$LIBRARY.new(...).$METHOD($_, <$DATA_TYPE>)
+      filters:
+        - variable: $LIBRARY
+          values:
+            - DSA
+            - RSA
+        - variable: METHOD
+          values:
+            - export
+            - to_pem
+            - to_s
+    - pattern: |
+        Crypt::Blowfish.new(...).encrypt_pair
+      filters: []
+    - pattern: |
+        Crypt::Blowfish.new(...).$METHOD(<$DATA_TYPE>)
+      filters:
+        - variable: METHOD
+          values:
+            - encrypt_pair
+            - encrypt_string
+            - encrypt_block
+            - decrypt_pair
+            - decrypt_string
+            - decrypt_block
+  languages:
+    - "ruby"
+CR-024-1:
+  name: "encrypt method call"
+  type: "risk"
+  patterns:
+    - pattern: |
+        $_.$METHOD(<$DATA_TYPE>)
+      filters:
+        - variable: METHOD
+          values:
+            - encrypt
+            - encrypt!
+            - decrypt
+  languages:
+    - "ruby"
+CR-024-2:
+  name: "Blowfish init"
+  type: "risk"
+  patterns:
+    - |
+      $_ = Crypt::Blowfish.new(...)
+  languages:
+    - "ruby"
+  detect_presence: true
+CR-024-3:
+  name: "OpenSSL PKey DSA init"
+  type: "risk"
+  patterns:
+    - |
+      $_ = OpenSSL::PKey::DSA.new()
+  languages:
+    - "ruby"
+  detect_presence: true
+CR-024-4:
+  name: "OpenSSL PKey RSA init"
+  type: "risk"
+  patterns:
+    - |
+      $_ = OpenSSL::PKey::RSA.new()
+  languages:
+    - "ruby"
+  detect_presence: true
+CR-024-5:
+  name: "RC4 init"
+  type: "risk"
+  patterns:
+    - |
+      $_ = RC4.new()
+  languages:
+    - "ruby"
+  detect_presence: true
+CR-024-6:
+  name: "Blowfish method call"
+  type: "risk"
+  patterns:
+    - pattern: |
+        $_.$METHOD(<$DATA_TYPE>)
+      filters:
+        - variable: METHOD
+          values:
+            - encrypt_pair
+            - encrypt_string
+            - encrypt_block
+            - decrypt_pair
+            - decrypt_string
+            - decrypt_block
+  languages:
+    - "ruby"
+CR-024-7:
+  name: "OpenSSL PKey method calls"
+  type: "risk"
+  patterns:
+    - pattern: |
+        $_.$METHOD(<$DATA_TYPE>)
+      filters:
+        - variable: METHOD
+          values:
+            - export
+            - to_pem
+            - to_s
+  languages:
+    - "ruby"
+CR-024-8:
+  name: "OpenSSL PKey RSA method calls"
+  type: "risk"
+  patterns:
+    - pattern: |
+        $_.$METHOD(<$DATA_TYPE>)
+      filters:
+        - variable: METHOD
+          values:
+            - private_decrypt
+            - private_encrypt
+            - public_decrypt
+            - public_encrypt
+  languages:
+    - "ruby"
+
+

--- a/pkg/commands/process/settings/policies/ruby/CR-024/policy.rego
+++ b/pkg/commands/process/settings/policies/ruby/CR-024/policy.rego
@@ -1,0 +1,188 @@
+package bearer.cr_024
+
+import data.bearer.common
+
+import future.keywords
+
+password_uuid := "02bb0d3a-2c8c-4842-be1c-c057f0dccd63"
+
+files_with_password_encryption_calls contains item if {
+  some detector in input.dataflow.risks
+  detector.detector_id in [
+    "CR-024-1",
+    "CR-024-6",
+    "CR-024-7",
+    "CR-024-8"
+  ]
+
+  data_type = detector.data_types[_]
+  data_type.uuid == password_uuid
+
+  location = detector.locations[_]
+
+  item := location.filename
+}
+
+rc4_files contains item if {
+  some detector in input.dataflow.risks
+  detector.detector_id == "CR-024-5"
+
+  location = detector.locations[_]
+
+  item := location.filename
+}
+
+blowfish_files contains item if {
+  some detector in input.dataflow.risks
+  detector.detector_id == "CR-024-2"
+
+  location = detector.locations[_]
+
+  item := location.filename
+}
+
+openssl_pkey_rsa_files contains item if {
+  some detector in input.dataflow.risks
+  detector.detector_id == "CR-024-4"
+
+  location = detector.locations[_]
+
+  item := location.filename
+}
+
+openssl_pkey_dsa_files contains item if {
+  some detector in input.dataflow.risks
+  detector.detector_id == "CR-024-3"
+
+  location = detector.locations[_]
+
+  item := location.filename
+}
+
+# openssl pkey rsa encryption
+policy_failure contains item if {
+    some detector in input.dataflow.risks
+    detector.detector_id in ["CR-024-7", "CR-024-8"]
+
+    data_type = detector.data_types[_]
+    data_type.uuid != password_uuid
+
+    location = data_type.locations[_]
+    location.filename in openssl_pkey_rsa_files
+
+    item := {
+        "category_groups": data.bearer.common.groups_for_datatype(data_type),
+        "severity": "low",
+        "filename": location.filename,
+        "line_number": location.line_number,
+        "parent_line_number": location.parent.line_number,
+        "parent_content": location.parent.content
+    }
+}
+
+# openssl pkey dsa encryption
+policy_failure contains item if {
+    some detector in input.dataflow.risks
+    detector.detector_id in ["CR-024-7"]
+
+    data_type = detector.data_types[_]
+    data_type.uuid != password_uuid
+
+    location = data_type.locations[_]
+    location.filename in openssl_pkey_dsa_files
+
+    item := {
+        "category_groups": data.bearer.common.groups_for_datatype(data_type),
+        "severity": "low",
+        "filename": location.filename,
+        "line_number": location.line_number,
+        "parent_line_number": location.parent.line_number,
+        "parent_content": location.parent.content
+    }
+}
+
+# blowfish encryption
+policy_failure contains item if {
+    some detector in input.dataflow.risks
+    detector.detector_id == "CR-024-6"
+
+    data_type = detector.data_types[_]
+    data_type.uuid != password_uuid
+
+    location = data_type.locations[_]
+    location.filename in blowfish_files
+
+    item := {
+        "category_groups": data.bearer.common.groups_for_datatype(data_type),
+        "severity": "low",
+        "filename": location.filename,
+        "line_number": location.line_number,
+        "parent_line_number": location.parent.line_number,
+        "parent_content": location.parent.content
+    }
+}
+
+# rc4 encryption
+policy_failure contains item if {
+    some detector in input.dataflow.risks
+    detector.detector_id == "CR-024-1"
+
+    data_type = detector.data_types[_]
+    data_type.uuid != password_uuid
+
+    location = data_type.locations[_]
+    location.filename in rc4_files
+
+    item := {
+        "category_groups": data.bearer.common.groups_for_datatype(data_type),
+        "severity": "low",
+        "filename": location.filename,
+        "line_number": location.line_number,
+        "parent_line_number": location.parent.line_number,
+        "parent_content": location.parent.content
+    }
+}
+
+policy_failure contains item if {
+    some detector in input.dataflow.risks
+    detector.detector_id in [
+      "CR-024-2",
+      "CR-024-3",
+      "CR-024-4",
+      "CR-024-5",
+    ]
+
+    data_type = detector.data_types[_]
+    location = data_type.locations[_]
+    # NOT in a file with an encryption method call
+    not location in files_with_password_encryption_calls
+
+    item := {
+        "category_groups": data.bearer.common.groups_for_datatype(data_type),
+        "severity": "low",
+        "filename": location.filename,
+        "line_number": location.line_number,
+        "parent_line_number": location.parent.line_number,
+        "parent_content": location.parent.content
+    }
+}
+
+policy_failure contains item if {
+    some detector in input.dataflow.risks
+    detector.detector_id == "detect_ruby_weak_encryption"
+
+    # NOT password data type
+    data_type = detector.data_types[_]
+    data_type.uuid != password_uuid
+
+    location = data_type.locations[_]
+
+    item := {
+        "category_groups": data.bearer.common.groups_for_datatype(data_type),
+        "severity": "low",
+        "filename": location.filename,
+        "line_number": location.line_number,
+        "parent_line_number": location.parent.line_number,
+        "parent_content": location.parent.content
+    }
+}

--- a/pkg/commands/process/settings/policies/ruby/CR-024/rule.yml
+++ b/pkg/commands/process/settings/policies/ruby/CR-024/rule.yml
@@ -1,0 +1,12 @@
+description: "A weak encryption or hashing library can lead to data breaches and greater security risk. This policy checks for the use of weak encryption and hashing libraries or algorithms."
+name: "Avoid weak encryption library."
+id: "CR-024"
+query: |
+  policy_failure = data.bearer.weak_encryption_library.policy_failure
+modules:
+  - path: policies/shared/common.rego
+    name: bearer.common
+  - path: policies/ruby/shared/encryption.rego
+    name: bearer.ruby_encryption
+  - path: policies/ruby/CR-024.rego
+    name: bearer.cr_024

--- a/pkg/commands/process/settings/policies/shared/common.rego
+++ b/pkg/commands/process/settings/policies/shared/common.rego
@@ -1,0 +1,37 @@
+package bearer.common
+
+import future.keywords
+
+sensitive_data_group_uuid := "f6a0c071-5908-4420-bac2-bba28d41223e"
+personal_data_group_uuid := "e1d3135b-3c0f-4b55-abce-19f27a26cbb3"
+
+severity_of_datatype(data_type) := "critical" if {
+    some category in input.data_categories
+    category.uuid == data_type.category_uuid
+
+    some group in category.groups
+    group.uuid == sensitive_data_group_uuid
+}
+
+severity_of_datatype(data_type) := "high" if {
+    some category in input.data_categories
+    category.uuid == data_type.category_uuid
+
+    some group in category.groups
+    group.uuid == personal_data_group_uuid
+
+    every group_1 in category.groups {
+        group_1.uuid != sensitive_data_group_uuid
+    }
+}
+
+groups_for_datatype(data_type) := x if {
+    some category in input.data_categories
+    category.uuid == data_type.category_uuid
+
+    x := {name | name := category.groups[_].name}
+}
+
+groups_for_datatypes(data_types) := groups if {
+    groups := {name | name := groups_for_datatype(data_types[_])[_]}
+}


### PR DESCRIPTION
## Description
Differs from https://github.com/Bearer/curio/pull/374 - here we are grouping by language and not policy

Unlike #374 this is not a working spike (e.g. the changes to `settings.go` haven't been made)

Main decisions:
* Duplication favoured over shared detectors
* Detectors have IDs that are related to policy ID e.g. CR-001 for single detector, CR-023, CR-023-1 , CR-023-2 for multiple detectors 

Still TODO
- Spike out policy that uses verifier

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
