### PR TITLE
ci: add discord announce to goreleaser config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,8 +149,10 @@ jobs:
         uses: goreleaser/goreleaser-action@v4
         with:
           distribution: goreleaser-pro
-          args: publish --merge
+          args: continue --merge
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.BEARER_GITHUB_TOKEN }}
+          DISCORD_WEBHOOK_ID: ${{ secrets.DISCORD_WEBHOOK_ID }}
+          DISCORD_WEBHOOK_TOKEN: ${{ secrets.DISCORD_WEBHOOK_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -55,3 +55,11 @@ dockers:
       - "--label=org.opencontainers.image.url=https://curio.sh"
       - "--label=org.opencontainers.image.documentation=https://curio.sh"
       - "--platform=linux/amd64"
+
+announce:
+  discord:
+    enabled: true
+    message_template: |
+      Curio {{ .Tag }} is out now! Check it out: https://github.com/Bearer/curio/releases/tag/{{ .Tag }}
+
+      {{ .ReleaseNotes }}


### PR DESCRIPTION
## Description
Updates the goreleaser config to announce releases to the discord #announcements channel.

## Related
- Close #285 

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
