### PR TITLE
ci: add missing login for ghcr

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -63,13 +63,19 @@ jobs:
         with:
           path: dist/linux
           key: linux-${{ env.sha_short }}-canary
+      - name: Login to ghcr.io registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ env.GH_USER }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: goreleaser/goreleaser-action@v4
         if: steps.cache.outputs.cache-hit != 'true' # do not run if cache hit
         name: Run GoReleaser
         with:
           distribution: goreleaser-pro
           version: latest
-          args: release --skip-docker --rm-dist --split -f ./.goreleaser/canary.yaml
+          args: release --rm-dist --split -f ./.goreleaser/canary.yaml
         env:
           GOOS: linux
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,12 @@ jobs:
         with:
           path: dist/linux
           key: linux-${{ env.sha_short }}
+      - name: Login to ghcr.io registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ env.GH_USER }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: goreleaser/goreleaser-action@v4
         if: steps.cache.outputs.cache-hit != 'true' # do not run if cache hit
         name: Run GoReleaser


### PR DESCRIPTION
## Description
We had forgotten to remove `--skip-docker` from canary build so missing the login to ghcr did not surface. When we tried to build for linux we end up not having access to docker to build failed. 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
