### PR TITLE
chore: Run Ruby-only policies scan as part of battle testing

### DIFF
--- a/.github/workflows/battle_tests.yml
+++ b/.github/workflows/battle_tests.yml
@@ -8,6 +8,7 @@ on:
         default: "5"
         type: choice
         options:
+          - 1
           - 5
           - 25
           - 100
@@ -35,8 +36,15 @@ on:
         default: "1"
         type: string
 
+      curio_release_id:
+        description: "release id"
+        default: ""
+        required: true
+        type: string
+
       curio_version:
-        description: "Version of Curio to use"
+        description: "curio version for report"
+        default: "latest"
         required: true
         type: string
 
@@ -69,19 +77,17 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Install Curio package
-        id: install_curio_package
+      - uses: robinraju/release-downloader@v1.7
+        id: latest_artifact
+        with:
+          releaseId: ${{ inputs.curio_release_id }}
+          fileName: "*_linux_amd64.tar.gz"
+      - name: Extract artifact
         run: |
-          sudo apt-get install apt-transport-https
-          echo "deb [trusted=yes] https://apt.fury.io/bearer/ /" | sudo tee -a /etc/apt/sources.list.d/fury.list
-          sudo apt-get update
-          sudo apt-get install -y curio=${{ inputs.curio_version }}
-
-      - name: Copy Curio binary
-        run: |
+          tar -xzvf curio_*_linux_amd64.tar.gz
+          ls -ltr
           mkdir dist
-          cp /usr/bin/curio dist/
+          cp curio dist/
 
       - name: Build and push latest
         uses: docker/build-push-action@v3

--- a/.github/workflows/battle_tests.yml
+++ b/.github/workflows/battle_tests.yml
@@ -36,8 +36,7 @@ on:
         type: string
 
       curio_version:
-        description: "Version of curio to pick up (`tags/<tag_name>`, `<release_id>` or `latest`)"
-        default: "latest"
+        description: "Version of Curio to use"
         required: true
         type: string
 
@@ -71,23 +70,18 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Retrieve latest Linux Artifact
-        id: latest_artifact
-        uses: dsaltares/fetch-gh-release-asset@1.1.0
-        with:
-          repo: "Bearer/curio"
-          version: ${{ inputs.curio_version }}
-          # version: "tags/v0.5.0"
-          # file: "curio_0.5.0_linux_amd64.tar.gz"
-          regex: true
-          file: "curio_.*_linux_amd64\\.tar\\.gz"
-
-      - name: Extract artifact
+      - name: Install Curio package
+        id: install_curio_package
         run: |
-          tar -xzvf curio_*_linux_amd64.tar.gz
-          ls -ltr
+          sudo apt-get install apt-transport-https
+          echo "deb [trusted=yes] https://apt.fury.io/bearer/ /" | sudo tee -a /etc/apt/sources.list.d/fury.list
+          sudo apt-get update
+          sudo apt-get install -y curio=${{ inputs.curio_version }}
+
+      - name: Copy Curio binary
+        run: |
           mkdir dist
-          cp curio dist/
+          cp /usr/bin/curio dist/
 
       - name: Build and push latest
         uses: docker/build-push-action@v3
@@ -97,10 +91,11 @@ jobs:
           file: battle_tests/Dockerfile
           tags: bearersh/battle-test:latest
           build-args: |
-            CURIO_VERSION=${{ steps.latest_artifact.outputs.version }}
+            CURIO_VERSION=${{ inputs.curio_version }}
             BATTLE_TEST_SHA=${{ github.sha }}
             ATTEMPT=${{ inputs.attempt }}
             LANGUAGE=${{ inputs.language }}
+            S3_BUCKET=bearer-battle-test-reports
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/battle_tests/Dockerfile
+++ b/battle_tests/Dockerfile
@@ -5,6 +5,7 @@ ARG CURIO_VERSION
 ARG BATTLE_TEST_SHA
 ARG ATTEMPT
 ARG LANGUAGE
+ARG S3_BUCKET
 
 RUN mkdir /app
 ADD . /app/
@@ -12,7 +13,7 @@ WORKDIR /app
 
 # RUN apk update && apk upgrade && apk add --no-cache build-base git
 
-RUN go build -ldflags="-X 'github.com/bearer/curio/battle_tests/build.CurioVersion=${CURIO_VERSION}' -X 'github.com/bearer/curio/battle_tests/build.BattleTestSHA=${BATTLE_TEST_SHA}' -X 'github.com/bearer/curio/battle_tests/build.Attempt=${ATTEMPT}' -X 'github.com/bearer/curio/battle_tests/build.Language=${LANGUAGE}'" \
+RUN go build -ldflags="-X 'github.com/bearer/curio/battle_tests/build.CurioVersion=${CURIO_VERSION}' -X 'github.com/bearer/curio/battle_tests/build.BattleTestSHA=${BATTLE_TEST_SHA}' -X 'github.com/bearer/curio/battle_tests/build.Attempt=${ATTEMPT}' -X 'github.com/bearer/curio/battle_tests/build.Language=${LANGUAGE}' -X 'github.com/bearer/curio/battle_tests/build.S3Bucket=${S3_BUCKET}'" \
   -a -o dist/battle_tests ./battle_tests/battle_tests.go
 
 # FROM alpine

--- a/battle_tests/battle_tests.go
+++ b/battle_tests/battle_tests.go
@@ -38,6 +38,8 @@ func main() {
 	signal.Notify(shutdown, syscall.SIGTERM)
 
 	db := db.UnmarshalRaw()
+	log.Debug().Msgf("Selected %d repos for test", len(db))
+
 	sheetClient := sheet.New()
 
 	programCtx := context.TODO()

--- a/battle_tests/battle_tests.go
+++ b/battle_tests/battle_tests.go
@@ -31,6 +31,7 @@ func main() {
 
 	log.Debug().Msgf("curio version %s", build.CurioVersion)
 	log.Debug().Msgf("battle tests SHA %s", build.BattleTestSHA)
+	log.Debug().Msgf("S3 bucket %s", build.S3Bucket)
 
 	shutdown := make(chan os.Signal, 1)
 	signal.Notify(shutdown, os.Interrupt)

--- a/battle_tests/build/build.go
+++ b/battle_tests/build/build.go
@@ -6,4 +6,5 @@ var (
 	BattleTestSHA = "devSHA"
 	Attempt       = "1"
 	Language      = "all"
+	S3Bucket      = "bearer-battle-test-reports"
 )

--- a/battle_tests/db/db.go
+++ b/battle_tests/db/db.go
@@ -5,6 +5,7 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/bearer/curio/battle_tests/build"
 	"github.com/rs/zerolog/log"
@@ -38,7 +39,9 @@ func UnmarshalRaw() []ItemWithLanguage {
 	}
 
 	for _, file := range files {
-		if build.Language != "all" && file.Name() != build.Language {
+		fileLanguage := strings.TrimSuffix(file.Name(), ".json")
+		if build.Language != "all" && fileLanguage != build.Language {
+			log.Debug().Msgf("Skipping %s repos", fileLanguage)
 			continue
 		}
 

--- a/battle_tests/local/local_scan.go
+++ b/battle_tests/local/local_scan.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+
+	"github.com/bearer/curio/battle_tests/config"
+	metricsscan "github.com/bearer/curio/battle_tests/metrics_scan"
+	"github.com/rs/zerolog/log"
+)
+
+func main() {
+	config.Runtime.CurioExecutablePath = os.Getenv("CURIO_EXECUTABLE_PATH")
+	log.Debug().Msgf("binary path: %s", config.Runtime.CurioExecutablePath)
+	ctx := context.TODO()
+	log.Debug().Msg("Starting local test")
+	metricsReport := make(chan *metricsscan.MetricsReport, 1)
+
+	metricsscan.ScanRepository("https://github.com/Bearer/bear-publishing", "ruby", metricsReport)
+
+	select {
+	case <-ctx.Done():
+		log.Error().Msgf("error: %e")
+		return
+	case metrics := <-metricsReport:
+		data, err := json.Marshal(metrics.PolicyBreaches)
+		if err != nil {
+			log.Error().Msgf("Failed to serialize metrics to JSON: %e", err)
+			return
+		}
+		log.Debug().Msgf("result %s", string(data[:]))
+	}
+}

--- a/battle_tests/scan/scan.go
+++ b/battle_tests/scan/scan.go
@@ -27,7 +27,7 @@ func NewScan(repositoryUrl string) *Scanner {
 	}
 }
 
-func (scanner *Scanner) Start() (outputBytes []byte, startTime *time.Time, err error) {
+func (scanner *Scanner) Start(reportType string) (outputBytes []byte, startTime *time.Time, err error) {
 	// create temp directory
 	log.Debug().Msg("creating temporary folder")
 	scanner.TempDir, err = os.MkdirTemp(config.Runtime.EFSLocation, "broker_battle_test*")
@@ -60,7 +60,7 @@ func (scanner *Scanner) Start() (outputBytes []byte, startTime *time.Time, err e
 	output, err := exec.Command(
 		config.Runtime.CurioExecutablePath,
 		"scan",
-		"--report=stats",
+		fmt.Sprintf("--report=%s", reportType),
 		"--debug",
 		"--format=json",
 		cloneDir,

--- a/battle_tests/scan/scan.go
+++ b/battle_tests/scan/scan.go
@@ -55,13 +55,13 @@ func (scanner *Scanner) Start(reportType string) (outputBytes []byte, startTime 
 	log.Debug().Msgf("file for report path %s", scanner.ReportFilePath)
 
 	processStartedAt := time.Now()
-	log.Debug().Msgf("scan process start at %s", processStartedAt)
+	log.Debug().Msgf("scan process (%s) on %s start at %s", reportType, scanner.repositoryUrl, processStartedAt)
 	// process scan
 	output, err := exec.Command(
 		config.Runtime.CurioExecutablePath,
 		"scan",
 		fmt.Sprintf("--report=%s", reportType),
-		"--debug",
+		"--quiet",
 		"--format=json",
 		cloneDir,
 	).Output()

--- a/battle_tests/sheet/sheet.go
+++ b/battle_tests/sheet/sheet.go
@@ -100,7 +100,6 @@ func (client *GoogleSheets) CreateDocument(tagName string, parentFolderId string
 			"Repo Size (KB)",
 			"Scan timing (seconds)",
 			"Language",
-			"Memory consumption",
 			"Number of Data Types",
 			"Number of Line of Code",
 		}
@@ -229,11 +228,6 @@ func (client *GoogleSheets) InsertMetrics(documentID string, metrics *metricssca
 		{
 			UserEnteredValue: &sheets.ExtendedValue{
 				StringValue: &metrics.Language,
-			},
-		},
-		{
-			UserEnteredValue: &sheets.ExtendedValue{
-				NumberValue: &metrics.Memory,
 			},
 		},
 		{

--- a/battle_tests/sync/sync.go
+++ b/battle_tests/sync/sync.go
@@ -1,7 +1,9 @@
 package sync
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"time"
 
 	"github.com/bearer/curio/battle_tests/build"
@@ -11,6 +13,10 @@ import (
 	"github.com/bearer/curio/battle_tests/rediscli"
 	"github.com/bearer/curio/battle_tests/sheet"
 	"github.com/rs/zerolog/log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 )
 
 func GetDocumentID(sheetClient *sheet.GoogleSheets) (documentID string, err error) {
@@ -88,6 +94,11 @@ func DoWork(ctx context.Context, items []repodb.ItemWithLanguage, docID string, 
 				return
 			case metrics := <-metricsReport:
 				sheetClient.InsertMetricsMustPass(docID, metrics)
+
+				err := uploadReportToS3(build.S3Bucket, docID, metrics)
+				if err != nil {
+					log.Error().Msgf("failed to upload report to S3 bucket: %e", err)
+				}
 			}
 		}
 	}()
@@ -104,4 +115,39 @@ func WorkerOffline(docID string, sheetClient *sheet.GoogleSheets) error {
 	log.Debug().Msgf("worker count after offline %d...", workerCount)
 
 	return nil
+}
+
+func uploadReportToS3(bucketName string, documentID string, metrics *metricsscan.MetricsReport) error {
+	sess, err := session.NewSessionWithOptions(session.Options{
+		Profile: "default",
+		Config: aws.Config{
+			Region: aws.String("eu-west-1"),
+		},
+	})
+
+	if err != nil {
+		log.Error().Msgf("Failed to create AWS session: %e", err)
+		return err
+	}
+
+	data, err := json.Marshal(metrics)
+	if err != nil {
+		log.Error().Msgf("Failed to serialize metrics to JSON: %e", err)
+		return err
+	}
+
+	reader := bytes.NewReader(data)
+
+	uploader := s3manager.NewUploader(sess)
+	_, err = uploader.Upload(&s3manager.UploadInput{
+		Bucket: aws.String(bucketName),
+		Key:    aws.String(documentID),
+		Body:   reader,
+	})
+	if err != nil {
+		log.Error().Msgf("Failed to upload file to S3: %e", err)
+		return err
+	}
+
+	return err
 }

--- a/go.mod
+++ b/go.mod
@@ -74,12 +74,14 @@ require (
 	github.com/Microsoft/go-winio v0.5.2 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20221026131551-cf6655e29de4 // indirect
 	github.com/acomagu/bufpipe v1.0.3 // indirect
+	github.com/aws/aws-sdk-go v1.44.181 // indirect
 	github.com/cloudflare/circl v1.1.0 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
 	github.com/onsi/ginkgo v1.16.5 // indirect
 	github.com/onsi/gomega v1.24.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
+github.com/aws/aws-sdk-go v1.44.181 h1:w4OzE8bwIVo62gUTAp/uEFO2HSsUtf1pjXpSs36cluY=
+github.com/aws/aws-sdk-go v1.44.181/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/bradleyjkemp/cupaloy v2.3.0+incompatible h1:UafIjBvWQmS9i/xRg+CamMrnLTKNzo+bdmT/oH34c2Y=
 github.com/bradleyjkemp/cupaloy v2.3.0+incompatible/go.mod h1:Au1Xw1sgaJ5iSFktEhYsS0dbQiS1B0/XMXl+42y9Ilk=
@@ -236,6 +238,9 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.5.0 h1:1jKYvbxEjfUl0fmqTCOfonvskHHXMjBySTLW4y9LFvc=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
+github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213/go.mod h1:vNUNkEQ1e29fT/6vq2aBdFsgNPmy8qMdSay1npru+Sw=
@@ -492,6 +497,7 @@ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.0.0-20220826154423-83b083e8dc8b/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
+golang.org/x/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=
 golang.org/x/net v0.2.0/go.mod h1:KqCZLdyyvdV855qA2rE3GC2aiw5xGR5TEjj8smXukLY=
 golang.org/x/net v0.5.0 h1:GyT4nK/YDHSqa1c4753ouYCDajOYKTja9Xb/OHtgvSw=
 golang.org/x/net v0.5.0/go.mod h1:DivGGAXEgPSlEBzxGzZI+ZLohi+xUj054jfeKui00ws=
@@ -572,6 +578,7 @@ golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220825204002-c680a09ffe64/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.4.0 h1:Zr2JFtRQNX3BCZ8YtxRE9hNJYC8J6I1MVbMg6owUp18=
@@ -579,6 +586,7 @@ golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.0.0-20220722155259-a9ba230a4035/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.2.0/go.mod h1:TVmDHMZPmdnySmBfhjOoOdhjzdE1h4u1VwSiw2l1Nuc=
 golang.org/x/term v0.4.0 h1:O7UWfv5+A2qiuulQk30kVinPoMtoIPeVaKLEgLpVkvg=
 golang.org/x/term v0.4.0/go.mod h1:9P2UbLfCdcvo3p/nzKvsmas4TnlujnuoV9hGgYzW1lQ=


### PR DESCRIPTION
## Description

Run a policies scan as part of the battle testing, for Ruby-language scan targets only.

Also: switch from using a built Linux binary, to use the distributed Linux package, in the battle tests.

Credentials for accessing AWS can be configured using the following environment variables.

* `AWS_ACCESS_KEY_ID`
* `AWS_SECRET_ACCESS_KEY`
* `AWS_REGION` (optional)

## Related

Closes #353

## TODO

- [X] Switch from Linux binary to distributed package
- [X] Run policies scan (Ruby language only)
- [x] Upload battle test results to a new, dedicated S3 bucket
- [x] Configuration for AWS (credentials, region, etc.), as necessary

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [X] I've updated or added documentation if required.
- [X] I've included usage information in the description if CLI behavior was updated or added.
- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
