### PR TITLE
feat: include pattern in risks

### DIFF
--- a/new/detector/composition/ruby/ruby.go
+++ b/new/detector/composition/ruby/ruby.go
@@ -155,7 +155,7 @@ func (composition *Composition) DetectFromFile(report report.Report, file *file.
 					file.Path,
 					detection.MatchNode.LineNumber(),
 					detection.MatchNode.ColumnNumber(),
-					"FIXME: rule.Pattern",
+					data.Pattern,
 				)
 
 				var content string
@@ -186,7 +186,7 @@ func (composition *Composition) DetectFromFile(report report.Report, file *file.
 					file.Path,
 					datatypeDetection.MatchNode.LineNumber(),
 					datatypeDetection.MatchNode.ColumnNumber(),
-					"FIXME: ???",
+					"",
 				), schema.Schema{
 					Classification: data.Classification,
 					Parent: &schema.Parent{
@@ -201,7 +201,7 @@ func (composition *Composition) DetectFromFile(report report.Report, file *file.
 						file.Path,
 						property.Detection.MatchNode.LineNumber(),
 						property.Detection.MatchNode.ColumnNumber(),
-						"FIXME: ???",
+						"",
 					), schema.Schema{
 						Classification: property.Classification,
 						Parent: &schema.Parent{

--- a/new/detector/implementation/custom/custom.go
+++ b/new/detector/implementation/custom/custom.go
@@ -10,10 +10,12 @@ import (
 )
 
 type Data struct {
+	Pattern   string
 	Datatypes []*types.Detection
 }
 
 type Pattern struct {
+	Pattern string
 	Query   languagetypes.PatternQuery
 	Filters []settings.PatternFilter
 }
@@ -31,6 +33,7 @@ func New(lang languagetypes.Language, detectorType string, patterns []settings.R
 			return nil, fmt.Errorf("error compiling pattern: %s", err)
 		}
 		compiledPatterns = append(compiledPatterns, Pattern{
+			Pattern: pattern.Pattern,
 			Query:   patternQuery,
 			Filters: pattern.Filters,
 		})
@@ -72,6 +75,7 @@ func (detector *customDetector) DetectAt(
 			detections = append(detections, &types.Detection{
 				MatchNode: node,
 				Data: Data{
+					Pattern:   pattern.Pattern,
 					Datatypes: datatypeDetections,
 				},
 			})


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Set the content for risks to:
- The rule pattern for non-datatype matching rules
- Nothing for datatype matching rules

This should be consistent with the behaviour on `main`.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [x] I've updated or added documentation if required.
- [x] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
