### PR TITLE
ci: ignore ci items in release notes

### DIFF
--- a/.goreleaser/common.yaml
+++ b/.goreleaser/common.yaml
@@ -69,3 +69,4 @@ changelog:
     exclude:
       - "^docs:"
       - "^test:"
+      - "^ci:"


### PR DESCRIPTION
## Description
Ignore CI items from release notes as they dont have much relevance to the binary produced.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
