### PR TITLE
docs: add docs for config file

### DIFF
--- a/docs/_data/nav.js
+++ b/docs/_data/nav.js
@@ -26,6 +26,7 @@ module.exports = [
       { name: "Data Types", url: "/reference/datatypes/" },
       { name: "Policies", url: "/reference/policies/" },
       { name: "Supported Languages", url: "/reference/supported-languages/" },
+      { name: "Configuration", url: "/reference/config/" },
     ],
   },
   {

--- a/docs/_src/styles/prism-theme.css
+++ b/docs/_src/styles/prism-theme.css
@@ -98,7 +98,7 @@ pre[class*="language-"] {
 .token.atrule,
 .token.attr-value,
 .token.keyword {
-  color: #0077aa;
+  color: #4fc0f0;
 }
 .token.function {
   color: #d4bcf8;

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -14,7 +14,6 @@ New to Curio? Check out the [quickstart](/quickstart/) to scan your first projec
 
 Ready to dive in? Curio's [reports](/explanations/reports/) are your path to analyzing data security risks in your application. Check the [supported languages](/reference/supported-languages/), then view the [command reference](/reference/commands/) to configure Curio to your needs.
 
-
 ## Explanations
 
 Explanations dive into the rational behind Curio and explain some of its heavier concepts.
@@ -30,6 +29,7 @@ Reference documents are where you'll find detailed information about each comman
 - [Supported Data Types](/reference/datatypes/)
 - [Built-in Policies](/reference/policies/)
 - [Supported Languages](/reference/supported-languages/)
+- [Configuration](/reference/config/)
 
 ## Contributing
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -1,0 +1,71 @@
+---
+title: Configuration
+layout: layouts/doc.njk
+---
+
+# Configuring Curio
+
+Configuration of Curio can be done with [flags on the `scan` command](/reference/commands/#scan), or by using a `curio.yml` file in the project directory.
+
+To initialize the config file, run the following from your project directory:
+
+```bash
+curio init
+```
+
+This creates a config file in your current directory. Below is an annotated version of that file.
+
+```yml
+# Detector settings
+detector:
+    # Specify the comma-separated ids of the detectors you would like to run. 
+    # Skips all other detectors.
+    only-detector: []
+    # Specify the comma-separated ids of the detectors you would like to skip. 
+    # Runs all other detectors.
+    skip-detector: []
+# Policy settings
+policy:
+    # Specify the comma-separated ids of the policies you would like to run. 
+    # Skips all other policies.
+    only-policy: []
+    # Specify the comma-separated ids of the policies you would like to skip. 
+    # Runs all other policies.
+    skip-policy: []
+# Report settings
+report:
+    # Specify report format (json, yaml)
+    format: ""
+    # Specify the output path for the report.
+    output: ""
+    # Specify the type of report (detectors, dataflow, policies, stats). 
+    report: policies
+# Scan settings
+scan:
+    # Expand context of schema classification 
+    # For example, "health" will include data types particular to health
+    context: ""
+    # Enable debug logs
+    debug: false
+    # Do not attempt to resolve detected domains during classification.
+    disable-domain-resolution: true
+    # Set timeout when attempting to resolve detected domains during classification.
+    domain-resolution-timeout: 3s
+    # Specify directories paths that contain .yaml files with external custom detectors configuration.
+    external-detector-dir: []
+    # Specify directories paths that contain .rego files with external policies configuration.
+    external-policy-dir: []
+    # Disable the cache and runs the detections again every time scan runs.
+    force: false
+    # Define regular expressions for better classification of private or unreachable domains
+    # e.g., ".*.my-company.com,private.sh"
+    internal-domains: []
+    # Suppress non-essential messages
+    quiet: false
+    # Specify the comma separated files and directories to skip. Supports * syntax.
+    skip-path: []
+```
+
+## Utilizing a custom config
+
+By default, Curio will look for a `curio.yml` file in the project directory where the scan is run. Alternately, you can use the `--config-file` flag with the scan command to reference a config file that is outside the project directory.


### PR DESCRIPTION
## Description
Adds config file docs. Should probably auto-generate this in the future.

Worker-flags have been removed in prep for their removal.

## Related
- Close #378 

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
