### PR TITLE
feat: address missing custom rule support

### DIFF
--- a/new/detector/composition/ruby/ruby.go
+++ b/new/detector/composition/ruby/ruby.go
@@ -158,14 +158,9 @@ func (composition *Composition) DetectFromFile(report report.Report, file *file.
 					data.Pattern,
 				)
 
-				var content string
-				// if !rule.OmitParent {
-				content = detection.MatchNode.Content()
-				// }
-
 				parent := &schema.Parent{
 					LineNumber: detection.MatchNode.LineNumber(),
-					Content:    content,
+					Content:    detection.MatchNode.Content(),
 				}
 
 				report.AddDetection(

--- a/new/detector/implementation/custom/custom.go
+++ b/new/detector/implementation/custom/custom.go
@@ -73,7 +73,7 @@ func (detector *customDetector) DetectAt(
 			}
 
 			detections = append(detections, &types.Detection{
-				MatchNode: node,
+				MatchNode: result.MatchNode,
 				Data: Data{
 					Pattern:   pattern.Pattern,
 					Datatypes: datatypeDetections,

--- a/new/detector/implementation/custom/filter.go
+++ b/new/detector/implementation/custom/filter.go
@@ -7,11 +7,12 @@ import (
 
 	"github.com/bearer/curio/new/detector/types"
 	"github.com/bearer/curio/new/language/tree"
+	languagetypes "github.com/bearer/curio/new/language/types"
 	"github.com/bearer/curio/pkg/commands/process/settings"
 )
 
 func matchFilter(
-	result tree.QueryResult,
+	result *languagetypes.PatternQueryResult,
 	evaluator types.Evaluator,
 	filter settings.PatternFilter,
 ) (bool, []*types.Detection, error) {
@@ -19,7 +20,7 @@ func matchFilter(
 		return matchEitherFilters(result, evaluator, filter.Either)
 	}
 
-	node, ok := result[filter.Variable]
+	node, ok := result.Variables[filter.Variable]
 	// shouldn't happen if filters are validated against pattern
 	if !ok {
 		return false, nil, nil
@@ -33,7 +34,7 @@ func matchFilter(
 }
 
 func matchAllFilters(
-	result tree.QueryResult,
+	result *languagetypes.PatternQueryResult,
 	evaluator types.Evaluator,
 	filters []settings.PatternFilter,
 ) (bool, []*types.Detection, error) {
@@ -52,7 +53,7 @@ func matchAllFilters(
 }
 
 func matchEitherFilters(
-	result tree.QueryResult,
+	result *languagetypes.PatternQueryResult,
 	evaluator types.Evaluator,
 	filters []settings.PatternFilter,
 ) (bool, []*types.Detection, error) {
@@ -77,7 +78,7 @@ func matchEitherFilters(
 }
 
 func matchDetectionFilter(
-	result tree.QueryResult,
+	result *languagetypes.PatternQueryResult,
 	evaluator types.Evaluator,
 	node *tree.Node,
 	detectorType string,

--- a/new/language/base/base.go
+++ b/new/language/base/base.go
@@ -37,10 +37,16 @@ func (lang *Language) CompilePatternQuery(input string) (types.PatternQuery, err
 		return nil, fmt.Errorf("error processing variables: %s", err)
 	}
 
+	inputWithoutMatchNode, matchNodeOffset, err := lang.implementation.ExtractPatternMatchNode(inputWithoutVariables)
+	if err != nil {
+		return nil, fmt.Errorf("error processing match node: %s", err)
+	}
+
 	return patternquery.Compile(
 		lang,
 		lang.implementation.AnonymousPatternNodeParentTypes(),
-		inputWithoutVariables,
+		inputWithoutMatchNode,
 		params,
+		matchNodeOffset,
 	)
 }

--- a/new/language/implementation/implementation.go
+++ b/new/language/implementation/implementation.go
@@ -11,5 +11,6 @@ type Implementation interface {
 	SitterLanguage() *sitter.Language
 	AnalyzeFlow(rootNode *tree.Node)
 	ExtractPatternVariables(input string) (string, []patternquerybuilder.Variable, error)
+	ExtractPatternMatchNode(input string) (string, int, error)
 	AnonymousPatternNodeParentTypes() []string
 }

--- a/new/language/tree/node.go
+++ b/new/language/tree/node.go
@@ -39,6 +39,10 @@ func (node *Node) Content() string {
 	return node.sitterNode.Content(node.tree.input)
 }
 
+func (node *Node) StartByte() int {
+	return int(node.sitterNode.StartByte())
+}
+
 func (node *Node) LineNumber() int {
 	return int(node.sitterNode.StartPoint().Row + 1)
 }

--- a/new/language/types/types.go
+++ b/new/language/types/types.go
@@ -2,9 +2,14 @@ package types
 
 import "github.com/bearer/curio/new/language/tree"
 
+type PatternQueryResult struct {
+	MatchNode *tree.Node
+	Variables tree.QueryResult
+}
+
 type PatternQuery interface {
-	MatchAt(node *tree.Node) ([]tree.QueryResult, error)
-	MatchOnceAt(node *tree.Node) (tree.QueryResult, error)
+	MatchAt(node *tree.Node) ([]*PatternQueryResult, error)
+	MatchOnceAt(node *tree.Node) (*PatternQueryResult, error)
 	Close()
 }
 

--- a/pkg/commands/process/settings/custom_detector.yml
+++ b/pkg/commands/process/settings/custom_detector.yml
@@ -4,7 +4,7 @@ ruby_password_length:
     - ruby
   patterns:
     - pattern: |
-        class $<_> < ApplicationRecord
+        class $<_:constant> < ApplicationRecord
           validates :password, length: { minimum: $<LENGTH> }
         end
       filters:
@@ -285,28 +285,26 @@ detect_rails_insecure_smtp:
     - |
       Rails.application.configure do
         config.action_mailer.smtp_settings = {
-          openssl_verify_mode: OpenSSL::SSL::VERIFY_NONE
+          $<!>openssl_verify_mode: OpenSSL::SSL::VERIFY_NONE
         }
       end
     - |
       Rails.application.configure do
         config.action_mailer.smtp_settings = {
-          openssl_verify_mode: "none"
+          $<!>openssl_verify_mode: "none"
         }
       end
   languages:
     - ruby
-  omit_parent: true
 detect_rails_insecure_communication:
   type: "risk"
   patterns:
     - |
       Rails.application.configure do
-        config.force_ssl = false
+        $<!>config.force_ssl = false
       end
   languages:
     - ruby
-  omit_parent: true
 detect_rails_insecure_ftp:
   type: "risk"
   patterns:

--- a/pkg/commands/process/settings/custom_detector.yml
+++ b/pkg/commands/process/settings/custom_detector.yml
@@ -166,7 +166,6 @@ ruby_file_detection:
         - variable: DATA_TYPE
           detection: datatype
   param_parenting: true
-  metavars: {}
   stored: false
 detect_ruby_logger:
   type: "risk"

--- a/pkg/commands/process/settings/custom_detector.yml
+++ b/pkg/commands/process/settings/custom_detector.yml
@@ -256,8 +256,6 @@ detect_encrypted_ruby_class_properties:
       filters:
         - variable: DATA_TYPE
           detection: datatype
-  root_singularize: true
-  root_lowercase: true
   languages:
     - ruby
 detect_sql_create_public_table:

--- a/pkg/commands/process/settings/custom_detector.yml
+++ b/pkg/commands/process/settings/custom_detector.yml
@@ -165,7 +165,6 @@ ruby_file_detection:
             - File
         - variable: DATA_TYPE
           detection: datatype
-  param_parenting: true
   stored: false
 detect_ruby_logger:
   type: "risk"
@@ -251,13 +250,12 @@ detect_encrypted_ruby_class_properties:
   type: "verifier"
   patterns:
     - pattern: |
-        class $<CLASS_NAME:constant> < ApplicationRecord
+        class $<_>
           encrypts $<DATA_TYPE>
         end
-      filters: # FIXME: what to do with class name var?
+      filters:
         - variable: DATA_TYPE
           detection: datatype
-  param_parenting: true
   root_singularize: true
   root_lowercase: true
   languages:

--- a/pkg/commands/process/settings/settings.go
+++ b/pkg/commands/process/settings/settings.go
@@ -87,8 +87,10 @@ type Rule struct {
 	RootSingularize bool `mapstructure:"root_singularize" yaml:"root_singularize" `
 	RootLowercase   bool `mapstructure:"root_lowercase" yaml:"root_lowercase"`
 
+	Stored bool `mapstructure:"stored" json:"stored" yaml:"stored"`
+
+	// FIXME: remove after refactor
 	Metavars       map[string]MetaVar `mapstructure:"metavars" json:"metavars" yaml:"metavars"`
-	Stored         bool               `mapstructure:"stored" json:"stored" yaml:"stored"`
 	DetectPresence bool               `mapstructure:"detect_presence" json:"detect_presence" yaml:"detect_presence"`
 	OmitParent     bool               `mapstructure:"omit_parent" json:"omit_parent" yaml:"omit_parent"`
 }


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Deal with the missing custom rule options for Ruby:
- Remove `metavars` - this is not used
- Replace `omit_parent` - The option was only a workaround for returning too much code for a match. Instead, we= add the ability to specify the position in the code to use as the matched node with `$<!>` in the pattern. 
-  Remove `param_parenting` - One case wasn't necessary at all, the other case will be handled by the way we're implementing object detection now.
- Remove `root_singularize` and `root_lowercase` - We will handle the need for this either at the point we join the detections in Rego, or by using the normalized version of the object/property names. 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [x] I've updated or added documentation if required.
- [x] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
