### PR TITLE
fix: issues encountered testing on gitlab repo

### DIFF
--- a/new/detector/evaluator/evaluator.go
+++ b/new/detector/evaluator/evaluator.go
@@ -39,7 +39,7 @@ func (evaluator *evaluator) FileName() string {
 func (evaluator *evaluator) ForTree(rootNode *langtree.Node, detectorType string) ([]*types.Detection, error) {
 	var result []*types.Detection
 
-	if err := rootNode.Walk(func(node *langtree.Node) error {
+	if err := rootNode.Walk(func(node *langtree.Node, visitChildren func() error) error {
 		detections, err := evaluator.nonUnifiedNodeDetections(node, detectorType)
 		if err != nil {
 			return err
@@ -56,7 +56,7 @@ func (evaluator *evaluator) ForTree(rootNode *langtree.Node, detectorType string
 			result = append(result, unifiedNodeDetections...)
 		}
 
-		return nil
+		return visitChildren()
 	}); err != nil {
 		return nil, err
 	}
@@ -110,7 +110,7 @@ func (evaluator *evaluator) nonUnifiedNodeDetections(
 func (evaluator *evaluator) TreeHas(rootNode *langtree.Node, detectorType string) (bool, error) {
 	hasDetection := false
 
-	if err := rootNode.Walk(func(node *langtree.Node) error {
+	if err := rootNode.Walk(func(node *langtree.Node, visitChildren func() error) error {
 		var err error
 		hasDetection, err = evaluator.NodeHas(node, detectorType)
 		if err != nil {
@@ -121,7 +121,7 @@ func (evaluator *evaluator) TreeHas(rootNode *langtree.Node, detectorType string
 			return langtree.ErrTerminateWalk
 		}
 
-		return nil
+		return visitChildren()
 	}); err != nil {
 		return false, err
 	}

--- a/new/language/base/base.go
+++ b/new/language/base/base.go
@@ -23,7 +23,10 @@ func (lang *Language) Parse(input string) (*tree.Tree, error) {
 		return nil, err
 	}
 
-	lang.implementation.AnalyzeFlow(tree.RootNode())
+	if err := lang.implementation.AnalyzeFlow(tree.RootNode()); err != nil {
+		return nil, err
+	}
+
 	return tree, nil
 }
 

--- a/new/language/implementation/implementation.go
+++ b/new/language/implementation/implementation.go
@@ -9,7 +9,7 @@ import (
 
 type Implementation interface {
 	SitterLanguage() *sitter.Language
-	AnalyzeFlow(rootNode *tree.Node)
+	AnalyzeFlow(rootNode *tree.Node) error
 	ExtractPatternVariables(input string) (string, []patternquerybuilder.Variable, error)
 	ExtractPatternMatchNode(input string) (string, int, error)
 	AnonymousPatternNodeParentTypes() []string

--- a/new/language/implementation/ruby/ruby.go
+++ b/new/language/implementation/ruby/ruby.go
@@ -39,10 +39,10 @@ func (implementation *rubyImplementation) SitterLanguage() *sitter.Language {
 	return ruby.GetLanguage()
 }
 
-func (implementation *rubyImplementation) AnalyzeFlow(rootNode *tree.Node) {
+func (implementation *rubyImplementation) AnalyzeFlow(rootNode *tree.Node) error {
 	scope := make(map[string]*tree.Node)
 
-	rootNode.Walk(func(node *tree.Node) error {
+	return rootNode.Walk(func(node *tree.Node, visitChildren func() error) error {
 		switch node.Type() {
 		case "method":
 			scope = make(map[string]*tree.Node)
@@ -51,9 +51,12 @@ func (implementation *rubyImplementation) AnalyzeFlow(rootNode *tree.Node) {
 			right := node.ChildByFieldName("right")
 
 			if left.Type() == "identifier" {
-				scope[left.Content()] = node
+				err := visitChildren()
 
+				scope[left.Content()] = node
 				node.UnifyWith(right)
+
+				return err
 			}
 		case "identifier":
 			parent := node.Parent()
@@ -65,7 +68,7 @@ func (implementation *rubyImplementation) AnalyzeFlow(rootNode *tree.Node) {
 			}
 		}
 
-		return nil
+		return visitChildren()
 	})
 }
 

--- a/pkg/report/writer/detectors.go
+++ b/pkg/report/writer/detectors.go
@@ -135,6 +135,10 @@ func (report *Detectors) SchemaGroupAddItem(node *parser.Node, schema schema.Sch
 }
 
 func (report *Detectors) SchemaGroupEnd(idGenerator nodeid.Generator) {
+	if !report.SchemaGroupIsOpen() {
+		return
+	}
+
 	// Build child data types
 	childDataTypes := map[string]datatype.DataTypable{}
 	for node, storedSchema := range report.StoredSchemas.Schemas {


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Fixes the following issues encountered when testing on the gitlab repo:
- We were trying to close schema groups when there wasn't an open one - this is an historic issue (present on `main`)
- In the Ruby flow analysis, we were adding an assignment to the scope before processing it's children. When you have an assignment that overwrites an existing variable, and uses the old value in the right-hand-side, this caused a recursive loop. eg. for `something = something + 1`, the RHS `something` was incorrectly unified with the assignment.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [x] I've updated or added documentation if required.
- [x] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
