### PR TITLE
Fix: empty dir and browserlistrc

### DIFF
--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -23,6 +23,7 @@ import (
 	"github.com/bearer/curio/pkg/commands/process/worker/work"
 	"github.com/bearer/curio/pkg/flag"
 	reportoutput "github.com/bearer/curio/pkg/report/output"
+	"github.com/bearer/curio/pkg/util/output"
 	outputhandler "github.com/bearer/curio/pkg/util/output"
 
 	"github.com/bearer/curio/pkg/types"
@@ -218,6 +219,12 @@ func Run(ctx context.Context, opts flag.Options, targetKind TargetKind) (err err
 	switch targetKind {
 	case TargetFilesystem:
 		if report, err = r.ScanFilesystem(ctx, opts); err != nil {
+			if errors.Is(err, balancer.ErrFileListEmpty) {
+				output.StdOutLogger().Msgf("directory empty: %s", err)
+				os.Exit(0)
+				return
+			}
+
 			return xerrors.Errorf("filesystem scan error: %w", err)
 		}
 	}

--- a/pkg/commands/process/balancer/worker.go
+++ b/pkg/commands/process/balancer/worker.go
@@ -21,7 +21,7 @@ import (
 	"github.com/bearer/curio/pkg/util/tmpfile"
 )
 
-var ErrFileListEmpty = errors.New("we couldn't find any files to scan in specified directory")
+var ErrFileListEmpty = errors.New("We couldn't find any files to scan in the specified directory.")
 
 type Worker struct {
 	FileList []workertype.File

--- a/pkg/commands/process/balancer/worker.go
+++ b/pkg/commands/process/balancer/worker.go
@@ -21,6 +21,8 @@ import (
 	"github.com/bearer/curio/pkg/util/tmpfile"
 )
 
+var ErrFileListEmpty = errors.New("we couldn't find any files to scan in specified directory")
+
 type Worker struct {
 	FileList []workertype.File
 
@@ -75,6 +77,12 @@ func (worker *Worker) Start() {
 	if err != nil {
 		worker.process.kill()
 		worker.complete(err)
+		return
+	}
+
+	if len(worker.FileList) == 0 {
+		worker.process.kill()
+		worker.complete(ErrFileListEmpty)
 		return
 	}
 

--- a/pkg/detectors/gitleaks/gitleaks.go
+++ b/pkg/detectors/gitleaks/gitleaks.go
@@ -38,12 +38,12 @@ var sensitiveFilesRegex = regexp.MustCompile(`.*(
 	|(ba|z|da)?sh-history|(bash|zsh)rc|(bash-|zsh-)?(profile|aliases)
 	|kdbx?|(agile)?keychain|key(store|ring)
 	|mysql-history|psql-history|pgpass|irb-history
-	|log|pcap|sql(dump)?|gnucash|dump
+	|\.log|pcap|sql(dump)?|gnucash|dump
 	|backup|back|bck|~1
 	|kwallet|tblk|pubxml(\.user)?
 	|Favorites\.plist|configuration\.user\.xpl
 	|proftpdpasswd|robomongo\.json
-	|ventrilo-srv.ini|muttrc|trc|ovpn|dayone|tugboat
+	|ventrilo-srv.ini|muttrc|\.trc|ovpn|dayone|tugboat
   )$`)
 
 func New(idGenerator nodeid.Generator) types.Detector {


### PR DESCRIPTION
## Description
This pr fixes empty directory error:
```
$ go run ./cmd/curio/main.go scan ../empty-dir --force
directory empty: we couldn't find any files to scan in specified directory
```
When directory is empty we exit with status 0, I've figured there is no real error but user still needs a warning message.

This pr also fixes .browserlistrc sensitive file detection
We had some complicated regex there detecting sensitive files and `trc` (comes from trace) was being detected there as sensitive, I've changed it to detect only `.trc` file

## Related
- closes https://github.com/Bearer/curio/issues/399
- closes https://github.com/Bearer/curio/issues/413

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
