### PR TITLE
fix: improve pattern/query performance

### DIFF
--- a/new/language/base/base.go
+++ b/new/language/base/base.go
@@ -47,7 +47,7 @@ func (lang *Language) CompilePatternQuery(input string) (types.PatternQuery, err
 
 	return patternquery.Compile(
 		lang,
-		lang.implementation.AnonymousPatternNodeParentTypes(),
+		lang.implementation,
 		inputWithoutMatchNode,
 		params,
 		matchNodeOffset,

--- a/new/language/implementation/implementation.go
+++ b/new/language/implementation/implementation.go
@@ -3,14 +3,15 @@ package implementation
 import (
 	sitter "github.com/smacker/go-tree-sitter"
 
-	patternquerybuilder "github.com/bearer/curio/new/language/patternquery/builder"
+	patternquerytypes "github.com/bearer/curio/new/language/patternquery/types"
 	"github.com/bearer/curio/new/language/tree"
 )
 
 type Implementation interface {
 	SitterLanguage() *sitter.Language
 	AnalyzeFlow(rootNode *tree.Node) error
-	ExtractPatternVariables(input string) (string, []patternquerybuilder.Variable, error)
+	ExtractPatternVariables(input string) (string, []patternquerytypes.Variable, error)
 	ExtractPatternMatchNode(input string) (string, int, error)
 	AnonymousPatternNodeParentTypes() []string
+	PatternIsAnchored(node *tree.Node) bool
 }

--- a/new/language/patternquery/types/types.go
+++ b/new/language/patternquery/types/types.go
@@ -1,0 +1,7 @@
+package types
+
+type Variable struct {
+	NodeTypes  []string
+	DummyValue string
+	Name       string
+}

--- a/new/language/tree/tree.go
+++ b/new/language/tree/tree.go
@@ -11,6 +11,7 @@ type Tree struct {
 	fileName     string
 	sitterTree   *sitter.Tree
 	unifiedNodes map[NodeID][]*Node
+	queryCache   map[int]map[NodeID][]QueryResult
 }
 
 func Parse(sitterLanguage *sitter.Language, input string) (*Tree, error) {
@@ -30,6 +31,7 @@ func Parse(sitterLanguage *sitter.Language, input string) (*Tree, error) {
 		input:        inputBytes,
 		sitterTree:   sitterTree,
 		unifiedNodes: make(map[NodeID][]*Node),
+		queryCache:   make(map[int]map[NodeID][]QueryResult),
 	}, nil
 }
 

--- a/pkg/commands/process/settings/rules/ruby/rails/insecure_communication.yml
+++ b/pkg/commands/process/settings/rules/ruby/rails/insecure_communication.yml
@@ -2,9 +2,8 @@ type: "risk"
 patterns:
   - |
     Rails.application.configure do
-       config.force_ssl = false
-       $<!>config.force_ssl = false
-     end
+      $<!>config.force_ssl = false
+    end
 languages:
   - ruby
 trigger: "global"

--- a/pkg/commands/process/settings/rules/ruby/rails/password_length.yml
+++ b/pkg/commands/process/settings/rules/ruby/rails/password_length.yml
@@ -3,7 +3,7 @@ languages:
   - ruby
 patterns:
   - pattern: |
-      class $<_:constant>
+      class $<_>
         validates :password, length: { minimum: $<LENGTH> }
       end
     filters:


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Ref #402 

Improves the performance of patterns (/tree sitter queries) by:

- Anchoring nodes in the queries generated by patterns, unless they are top-level nodes in a class/method/block body
- Running a query once against the whole tree and caching the result

The anchoring also fixes the behaviour of patterns as previously they could match incorrectly. eg.

```ruby
class $<SOMETHING>
  y
end
```

could actually match:
```ruby
class A
  x
  y
end
```

with `SOMETHING` matching `x`.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [x] I've updated or added documentation if required.
- [x] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
