### PR TITLE
feat: support ellipsis in ruby patterns

### DIFF
--- a/new/language/base/base.go
+++ b/new/language/base/base.go
@@ -1,8 +1,6 @@
 package base
 
 import (
-	"fmt"
-
 	"github.com/bearer/curio/new/language/implementation"
 	"github.com/bearer/curio/new/language/patternquery"
 	"github.com/bearer/curio/new/language/tree"
@@ -35,21 +33,5 @@ func (lang *Language) CompileQuery(input string) (*tree.Query, error) {
 }
 
 func (lang *Language) CompilePatternQuery(input string) (types.PatternQuery, error) {
-	inputWithoutVariables, params, err := lang.implementation.ExtractPatternVariables(input)
-	if err != nil {
-		return nil, fmt.Errorf("error processing variables: %s", err)
-	}
-
-	inputWithoutMatchNode, matchNodeOffset, err := lang.implementation.ExtractPatternMatchNode(inputWithoutVariables)
-	if err != nil {
-		return nil, fmt.Errorf("error processing match node: %s", err)
-	}
-
-	return patternquery.Compile(
-		lang,
-		lang.implementation,
-		inputWithoutMatchNode,
-		params,
-		matchNodeOffset,
-	)
+	return patternquery.Compile(lang, lang.implementation, input)
 }

--- a/new/language/implementation/implementation.go
+++ b/new/language/implementation/implementation.go
@@ -11,7 +11,8 @@ type Implementation interface {
 	SitterLanguage() *sitter.Language
 	AnalyzeFlow(rootNode *tree.Node) error
 	ExtractPatternVariables(input string) (string, []patternquerytypes.Variable, error)
-	ExtractPatternMatchNode(input string) (string, int, error)
+	FindPatternMatchNode(input []byte) [][]int
+	FindPatternUnanchoredPoints(input []byte) [][]int
 	AnonymousPatternNodeParentTypes() []string
 	PatternIsAnchored(node *tree.Node) bool
 }

--- a/new/language/patternquery/builder/input.go
+++ b/new/language/patternquery/builder/input.go
@@ -1,0 +1,68 @@
+package builder
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/bearer/curio/new/language/implementation"
+)
+
+func processInput(langImplementation implementation.Implementation, input string) (string, *InputParams, error) {
+	inputWithoutVariables, variables, err := langImplementation.ExtractPatternVariables(input)
+	if err != nil {
+		return "", nil, fmt.Errorf("error processing variables: %s", err)
+	}
+
+	inputWithoutVariablesBytes := []byte(inputWithoutVariables)
+	matchNodePositions := langImplementation.FindPatternMatchNode(inputWithoutVariablesBytes)
+	inputWithoutMatchNode := stripPositions(inputWithoutVariablesBytes, matchNodePositions)
+	matchNodeOffset := 0
+
+	if len(matchNodePositions) > 1 {
+		return "", nil, errors.New("pattern must only contain a single match node")
+	}
+
+	if len(matchNodePositions) == 1 {
+		matchNodeOffset = matchNodePositions[0][0]
+	}
+
+	unanchoredPositions := langImplementation.FindPatternUnanchoredPoints(inputWithoutMatchNode)
+	inputWithoutUnanchored := stripPositions(inputWithoutMatchNode, unanchoredPositions)
+
+	unanchoredOffsets := make([]int, len(unanchoredPositions))
+	for i, position := range unanchoredPositions {
+		unanchoredOffsets[i] = adjustForPositions(position[0], unanchoredPositions[:i])
+	}
+
+	return string(inputWithoutUnanchored), &InputParams{
+		Variables:         variables,
+		MatchNodeOffset:   adjustForPositions(matchNodeOffset, unanchoredPositions),
+		UnanchoredOffsets: unanchoredOffsets,
+	}, nil
+}
+
+func stripPositions(input []byte, positions [][]int) []byte {
+	offset := 0
+	var result []byte
+
+	for _, position := range positions {
+		result = append(result, input[offset:position[0]]...)
+		offset = position[1]
+	}
+
+	return append(result, input[offset:]...)
+}
+
+func adjustForPositions(offset int, positions [][]int) int {
+	result := offset
+
+	for _, position := range positions {
+		if position[0] >= offset {
+			break
+		}
+
+		result -= (position[1] - position[0])
+	}
+
+	return result
+}

--- a/new/language/patternquery/patternquery.go
+++ b/new/language/patternquery/patternquery.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/bearer/curio/new/language/implementation"
 	"github.com/bearer/curio/new/language/patternquery/builder"
-	"github.com/bearer/curio/new/language/patternquery/types"
 	"github.com/bearer/curio/new/language/tree"
 	languagetypes "github.com/bearer/curio/new/language/types"
+	"github.com/rs/zerolog/log"
 )
 
 type Query struct {
@@ -21,18 +21,18 @@ func Compile(
 	lang languagetypes.Language,
 	langImplementation implementation.Implementation,
 	input string,
-	variables []types.Variable,
-	matchNodeOffset int,
 ) (*Query, error) {
-	builderResult, err := builder.Build(lang, langImplementation, input, variables, matchNodeOffset)
+	builderResult, err := builder.Build(lang, langImplementation, input)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build: %s", err)
 	}
 
 	treeQuery, err := lang.CompileQuery(builderResult.Query)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compile: %s, %s \n%s", err, builderResult.Query, input)
+		return nil, fmt.Errorf("failed to compile: %s, %s -> %s", err, input, builderResult.Query)
 	}
+
+	log.Debug().Msgf("compiled pattern %s -> %s", input, builderResult.Query)
 
 	return &Query{
 		treeQuery:       treeQuery,

--- a/new/language/tree/node.go
+++ b/new/language/tree/node.go
@@ -43,6 +43,10 @@ func (node *Node) StartByte() int {
 	return int(node.sitterNode.StartByte())
 }
 
+func (node *Node) EndByte() int {
+	return int(node.sitterNode.EndByte())
+}
+
 func (node *Node) LineNumber() int {
 	return int(node.sitterNode.StartPoint().Row + 1)
 }

--- a/new/language/tree/tree.go
+++ b/new/language/tree/tree.go
@@ -22,7 +22,7 @@ func Parse(sitterLanguage *sitter.Language, input string) (*Tree, error) {
 
 	parser.SetLanguage(sitterLanguage)
 
-	sitterTree, err := parser.ParseCtx(context.Background(), nil, inputBytes)
+	sitterTree, err := parser.ParseCtx(context.TODO(), nil, inputBytes)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/commands/process/settings/rules/ruby/lang/ssl_verification.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/ssl_verification.yml
@@ -1,9 +1,13 @@
 type: "risk"
 patterns:
   - |
-    Net::HTTP.start($<_>, $<_>, $<_>, :verify_mode => OpenSSL::SSL::VERIFY_NONE)
+    Net::HTTP.start(:verify_mode => OpenSSL::SSL::VERIFY_NONE)$<...>
   - |
-    Net::HTTP.start($<_>, $<_>, $<_>, verify_mode: OpenSSL::SSL::VERIFY_NONE)
+    Net::HTTP.start(verify_mode: OpenSSL::SSL::VERIFY_NONE)$<...>
+  - |
+    Net::HTTP.start($<...>{ :verify_mode => OpenSSL::SSL::VERIFY_NONE })$<...>
+  - |
+    Net::HTTP.start($<...>{ verify_mode: OpenSSL::SSL::VERIFY_NONE })$<...>
   - |
     $<_>.verify_mode = OpenSSL::SSL::VERIFY_NONE
 languages:


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Adds support for `$<...>` in Ruby patterns. This suppresses anchors being omitted for nodes in the pattern that start/end at this position. 

This is useful for cases such as matching arguments in any position, or when a method can have an optional block.

Also makes a `pair` always un-anchored as this seems more natural.

Closes https://github.com/Bearer/curio/issues/448

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [x] I've updated or added documentation if required.
- [x] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
