### PR TITLE
feat: detect at match node rather than root node

### DIFF
--- a/new/detector/composition/ruby/.snapshots/TestRuby-object.rb
+++ b/new/detector/composition/ruby/.snapshots/TestRuby-object.rb
@@ -1,72 +1,54 @@
 [
 	{
-		"RuleName": "logger",
-		"File": {
-			"AbsolutePath": "/Users/vjeranfistric/go/src/github.com/bearer/curio/new/detector/composition/ruby/testdata/testcases/object.rb",
-			"RelativePath": "object.rb",
-			"FileInfo": {},
-			"IsGenerated": false,
-			"Extension": ".rb",
-			"Base": "object.rb",
-			"IsConfiguration": false,
-			"IsDotFile": false,
-			"IsVendor": false,
-			"Language": "Ruby",
-			"LanguageType": 2
-		},
-		"Detections": [
-			{
-				"MatchNode": {},
-				"ContextNode": null,
-				"Data": {
-					"Pattern": "logger.info($\u003cDATA_TYPE\u003e)\n",
-					"Datatypes": [
-						{
-							"MatchNode": {},
-							"ContextNode": {},
-							"Data": {
-								"Name": "user",
+		"DetectorType": "logger",
+		"MatchNode": {},
+		"Data": {
+			"Pattern": "logger.info($\u003cDATA_TYPE\u003e)\n",
+			"Datatypes": [
+				{
+					"DetectorType": "datatype",
+					"MatchNode": {},
+					"Data": {
+						"Name": "user",
+						"Classification": {
+							"name": "user",
+							"data_type": {
+								"name": "Unique Identifier",
+								"uuid": "12d44ae0-1df7-4faf-9fb1-b46cc4b4dce9",
+								"category_uuid": "14124881-6b92-4fc5-8005-ea7c1c09592e"
+							},
+							"decision": {
+								"state": "valid",
+								"reason": "valid_object_with_valid_properties"
+							}
+						},
+						"Properties": [
+							{
+								"Name": "name",
+								"Detection": {
+									"DetectorType": "object",
+									"MatchNode": {},
+									"Data": {
+										"Name": "name"
+									}
+								},
 								"Classification": {
-									"name": "user",
+									"name": "name",
 									"data_type": {
-										"name": "Unique Identifier",
-										"uuid": "12d44ae0-1df7-4faf-9fb1-b46cc4b4dce9",
+										"name": "Fullname",
+										"uuid": "1617291b-bc22-4267-ad5e-8054b2505958",
 										"category_uuid": "14124881-6b92-4fc5-8005-ea7c1c09592e"
 									},
 									"decision": {
 										"state": "valid",
-										"reason": "valid_object_with_valid_properties"
+										"reason": "known_pattern"
 									}
-								},
-								"Properties": [
-									{
-										"Name": "name",
-										"Detection": {
-											"MatchNode": {},
-											"ContextNode": null,
-											"Data": {
-												"Name": "name"
-											}
-										},
-										"Classification": {
-											"name": "name",
-											"data_type": {
-												"name": "Fullname",
-												"uuid": "1617291b-bc22-4267-ad5e-8054b2505958",
-												"category_uuid": "14124881-6b92-4fc5-8005-ea7c1c09592e"
-											},
-											"decision": {
-												"state": "valid",
-												"reason": "known_pattern"
-											}
-										}
-									}
-								]
+								}
 							}
-						}
-					]
+						]
+					}
 				}
-			}
-		]
+			]
+		}
 	}
 ]

--- a/new/detector/composition/ruby/ruby.go
+++ b/new/detector/composition/ruby/ruby.go
@@ -13,7 +13,6 @@ import (
 	"github.com/bearer/curio/new/detector/implementation/ruby/object"
 	"github.com/bearer/curio/new/detector/implementation/ruby/property"
 	"github.com/bearer/curio/new/language"
-	"github.com/bearer/curio/new/language/tree"
 
 	"github.com/bearer/curio/pkg/classification"
 	"github.com/bearer/curio/pkg/commands/process/settings"
@@ -121,7 +120,7 @@ func (composition *Composition) Close() {
 	}
 }
 
-func (composition *Composition) DetectFromFile(file *file.FileInfo) ([]*detectortypes.CompositionDetection, error) {
+func (composition *Composition) DetectFromFile(file *file.FileInfo) ([]*detectortypes.Detection, error) {
 	if file.Language != "Ruby" {
 		return nil, nil
 	}
@@ -138,25 +137,15 @@ func (composition *Composition) DetectFromFile(file *file.FileInfo) ([]*detector
 
 	evaluator := evaluator.New(composition.lang, composition.detectorSet, tree, file.FileInfo.Name())
 
-	return composition.extractCustomDetectors(evaluator, tree, file)
-
-}
-
-func (composition *Composition) extractCustomDetectors(evaluator detectortypes.Evaluator, tree *tree.Tree, file *file.FileInfo) ([]*detectortypes.CompositionDetection, error) {
-	customDetections := []*detectortypes.CompositionDetection{}
-
+	var result []*detectortypes.Detection
 	for _, detectorType := range composition.customDetectorTypes {
-		detections, err := evaluator.ForTree(tree.RootNode(), detectorType)
+		detections, err := evaluator.ForTree(tree.RootNode(), detectorType, false)
 		if err != nil {
 			return nil, err
 		}
 
-		customDetections = append(customDetections, &detectortypes.CompositionDetection{
-			RuleName:   detectorType,
-			File:       file,
-			Detections: detections,
-		})
+		result = append(result, detections...)
 	}
 
-	return customDetections, nil
+	return result, nil
 }

--- a/new/detector/evaluator/evaluator.go
+++ b/new/detector/evaluator/evaluator.go
@@ -40,7 +40,11 @@ func (evaluator *evaluator) FileName() string {
 	return evaluator.fileName
 }
 
-func (evaluator *evaluator) ForTree(rootNode *langtree.Node, detectorType string) ([]*types.Detection, error) {
+func (evaluator *evaluator) ForTree(
+	rootNode *langtree.Node,
+	detectorType string,
+	followFlow bool,
+) ([]*types.Detection, error) {
 	var result []*types.Detection
 
 	if err := rootNode.Walk(func(node *langtree.Node, visitChildren func() error) error {
@@ -55,13 +59,15 @@ func (evaluator *evaluator) ForTree(rootNode *langtree.Node, detectorType string
 
 		result = append(result, detections...)
 
-		for _, unifiedNode := range node.UnifiedNodes() {
-			unifiedNodeDetections, err := evaluator.ForTree(unifiedNode, detectorType)
-			if err != nil {
-				return err
-			}
+		if followFlow {
+			for _, unifiedNode := range node.UnifiedNodes() {
+				unifiedNodeDetections, err := evaluator.ForTree(unifiedNode, detectorType, true)
+				if err != nil {
+					return err
+				}
 
-			result = append(result, unifiedNodeDetections...)
+				result = append(result, unifiedNodeDetections...)
+			}
 		}
 
 		return visitChildren()
@@ -75,19 +81,22 @@ func (evaluator *evaluator) ForTree(rootNode *langtree.Node, detectorType string
 func (evaluator *evaluator) ForNode(
 	node *langtree.Node,
 	detectorType string,
+	followFlow bool,
 ) ([]*types.Detection, error) {
 	detections, err := evaluator.nonUnifiedNodeDetections(node, detectorType)
 	if err != nil {
 		return nil, err
 	}
 
-	for _, unifiedNode := range node.UnifiedNodes() {
-		unifiedNodeDetections, err := evaluator.ForNode(unifiedNode, detectorType)
-		if err != nil {
-			return nil, err
-		}
+	if followFlow {
+		for _, unifiedNode := range node.UnifiedNodes() {
+			unifiedNodeDetections, err := evaluator.ForNode(unifiedNode, detectorType, true)
+			if err != nil {
+				return nil, err
+			}
 
-		detections = append(detections, unifiedNodeDetections...)
+			detections = append(detections, unifiedNodeDetections...)
+		}
 	}
 
 	return detections, nil
@@ -142,7 +151,7 @@ func (evaluator *evaluator) TreeHas(rootNode *langtree.Node, detectorType string
 }
 
 func (evaluator *evaluator) NodeHas(node *langtree.Node, detectorType string) (bool, error) {
-	detections, err := evaluator.ForNode(node, detectorType)
+	detections, err := evaluator.ForNode(node, detectorType, true)
 	if err != nil {
 		return false, err
 	}

--- a/new/detector/evaluator/evaluator.go
+++ b/new/detector/evaluator/evaluator.go
@@ -44,6 +44,10 @@ func (evaluator *evaluator) ForTree(rootNode *langtree.Node, detectorType string
 	var result []*types.Detection
 
 	if err := rootNode.Walk(func(node *langtree.Node, visitChildren func() error) error {
+		if !node.Equal(rootNode) && !evaluator.lang.DescendIntoDetectionNode(node) {
+			return nil
+		}
+
 		detections, err := evaluator.nonUnifiedNodeDetections(node, detectorType)
 		if err != nil {
 			return err
@@ -58,10 +62,6 @@ func (evaluator *evaluator) ForTree(rootNode *langtree.Node, detectorType string
 			}
 
 			result = append(result, unifiedNodeDetections...)
-		}
-
-		if evaluator.lang.IsTerminalDetectionNode(node) {
-			return nil
 		}
 
 		return visitChildren()

--- a/new/detector/evaluator/evaluator.go
+++ b/new/detector/evaluator/evaluator.go
@@ -111,7 +111,11 @@ func (evaluator *evaluator) nonUnifiedNodeDetections(
 		return detections, nil
 	}
 
-	evaluator.detectAtNode(node, detectorType) //nolint:errcheck
+	err := evaluator.detectAtNode(node, detectorType)
+	if err != nil {
+		return nil, err
+	}
+
 	return nodeDetections[detectorType], nil
 }
 

--- a/new/detector/implementation/custom/custom.go
+++ b/new/detector/implementation/custom/custom.go
@@ -54,8 +54,9 @@ func (detector *customDetector) Name() string {
 func (detector *customDetector) DetectAt(
 	node *tree.Node,
 	evaluator types.Evaluator,
-) ([]*types.Detection, error) {
-	var detections []*types.Detection
+) ([]interface{}, error) {
+	var detectionsData []interface{}
+
 	for _, pattern := range detector.patterns {
 		results, err := pattern.Query.MatchAt(node)
 		if err != nil {
@@ -72,17 +73,14 @@ func (detector *customDetector) DetectAt(
 				continue
 			}
 
-			detections = append(detections, &types.Detection{
-				MatchNode: node,
-				Data: Data{
-					Pattern:   pattern.Pattern,
-					Datatypes: datatypeDetections,
-				},
+			detectionsData = append(detectionsData, Data{
+				Pattern:   pattern.Pattern,
+				Datatypes: datatypeDetections,
 			})
 		}
 	}
 
-	return detections, nil
+	return detectionsData, nil
 }
 
 func (detector *customDetector) Close() {

--- a/new/detector/implementation/custom/custom.go
+++ b/new/detector/implementation/custom/custom.go
@@ -73,7 +73,7 @@ func (detector *customDetector) DetectAt(
 			}
 
 			detections = append(detections, &types.Detection{
-				MatchNode: result.MatchNode,
+				MatchNode: node,
 				Data: Data{
 					Pattern:   pattern.Pattern,
 					Datatypes: datatypeDetections,

--- a/new/detector/implementation/custom/filter.go
+++ b/new/detector/implementation/custom/filter.go
@@ -84,7 +84,7 @@ func matchDetectionFilter(
 	detectorType string,
 ) (bool, []*types.Detection, error) {
 	if detectorType == "datatype" {
-		detections, err := evaluator.ForTree(node, "datatype")
+		detections, err := evaluator.ForTree(node, "datatype", true)
 
 		return len(detections) != 0, detections, err
 	}

--- a/new/detector/implementation/generic/datatype/datatype.go
+++ b/new/detector/implementation/generic/datatype/datatype.go
@@ -55,13 +55,13 @@ func (detector *datatypeDetector) Name() string {
 func (detector *datatypeDetector) DetectAt(
 	node *tree.Node,
 	evaluator types.Evaluator,
-) ([]*types.Detection, error) {
-	objectDetections, err := evaluator.ForNode(node, "object")
+) ([]interface{}, error) {
+	objectDetections, err := evaluator.ForNode(node, "object", false)
 	if err != nil {
 		return nil, err
 	}
 
-	var result []*types.Detection
+	var result []interface{}
 
 	for _, object := range objectDetections {
 		var properties []Property
@@ -91,12 +91,7 @@ func (detector *datatypeDetector) DetectAt(
 
 		mergeClassification(&data, classification)
 
-		result = append(result, &types.Detection{
-			ContextNode: node,
-			MatchNode:   object.MatchNode,
-			Data:        data,
-		})
-
+		result = append(result, data)
 	}
 
 	return result, nil

--- a/new/detector/implementation/generic/insecureurl/insecureurl.go
+++ b/new/detector/implementation/generic/insecureurl/insecureurl.go
@@ -25,8 +25,8 @@ func (detector *insecureURLDetector) Name() string {
 func (detector *insecureURLDetector) DetectAt(
 	node *tree.Node,
 	evaluator types.Evaluator,
-) ([]*types.Detection, error) {
-	detections, err := evaluator.ForNode(node, "string")
+) ([]interface{}, error) {
+	detections, err := evaluator.ForNode(node, "string", false)
 	if err != nil {
 		return nil, err
 	}
@@ -35,7 +35,7 @@ func (detector *insecureURLDetector) DetectAt(
 		value := detection.Data.(generictypes.String).Value
 
 		if insecureUrlPattern.MatchString(value) {
-			return []*types.Detection{{MatchNode: node}}, nil
+			return []interface{}{nil}, nil
 		}
 	}
 

--- a/new/detector/implementation/ruby/object/properties.go
+++ b/new/detector/implementation/ruby/object/properties.go
@@ -10,7 +10,7 @@ import (
 func (detector *objectDetector) getProperties(
 	node *tree.Node,
 	evaluator types.Evaluator,
-) ([]*types.Detection, error) {
+) ([]interface{}, error) {
 	var objectParent *tree.Node
 	var objectProperty *tree.Node
 
@@ -81,17 +81,14 @@ func (detector *objectDetector) getProperties(
 	}
 
 	if objectParent != nil && objectProperty != nil {
-		return []*types.Detection{{
-			MatchNode:   node,
-			ContextNode: node,
-			Data: generictypes.Object{
-				Name: objectParent.Content(),
-				Properties: []*types.Detection{
-					{
-						MatchNode: node,
-						Data: generictypes.Property{
-							Name: objectProperty.Content(),
-						},
+		return []interface{}{generictypes.Object{
+			Name: objectParent.Content(),
+			Properties: []*types.Detection{
+				{
+					DetectorType: detector.Name(),
+					MatchNode:    node,
+					Data: generictypes.Property{
+						Name: objectProperty.Content(),
 					},
 				},
 			},

--- a/new/detector/implementation/ruby/property/property.go
+++ b/new/detector/implementation/ruby/property/property.go
@@ -50,7 +50,7 @@ func (detector *propertyDetector) Name() string {
 func (detector *propertyDetector) DetectAt(
 	node *tree.Node,
 	evaluator types.Evaluator,
-) ([]*types.Detection, error) {
+) ([]interface{}, error) {
 	// run hash pair query
 	result, err := detector.pairQuery.MatchOnceAt(node)
 	if err != nil {
@@ -58,11 +58,9 @@ func (detector *propertyDetector) DetectAt(
 	}
 
 	if len(result) != 0 {
-		return []*types.Detection{{
-			MatchNode:   node,
-			ContextNode: node,
-			Data:        generictypes.Property{Name: result["key"].Content()},
-		}}, nil
+		return []interface{}{
+			generictypes.Property{Name: result["key"].Content()},
+		}, nil
 	}
 
 	// run accessor query
@@ -71,11 +69,9 @@ func (detector *propertyDetector) DetectAt(
 		return nil, err
 	}
 	if len(result) != 0 {
-		return []*types.Detection{{
-			MatchNode:   node,
-			ContextNode: node,
-			Data:        generictypes.Property{Name: result["name"].Content()},
-		}}, nil
+		return []interface{}{
+			generictypes.Property{Name: result["name"].Content()},
+		}, nil
 	}
 
 	// run method name query
@@ -84,11 +80,9 @@ func (detector *propertyDetector) DetectAt(
 		return nil, err
 	}
 	if len(result) != 0 {
-		return []*types.Detection{{
-			MatchNode:   node,
-			ContextNode: node,
-			Data:        generictypes.Property{Name: result["name"].Content()},
-		}}, nil
+		return []interface{}{
+			generictypes.Property{Name: result["name"].Content()},
+		}, nil
 	}
 
 	return nil, nil

--- a/new/detector/implementation/ruby/string/string.go
+++ b/new/detector/implementation/ruby/string/string.go
@@ -23,13 +23,10 @@ func (detector *stringDetector) Name() string {
 func (detector *stringDetector) DetectAt(
 	node *tree.Node,
 	evaluator types.Evaluator,
-) ([]*types.Detection, error) {
+) ([]interface{}, error) {
 	switch node.Type() {
 	case "string_content":
-		return []*types.Detection{{
-			MatchNode: node,
-			Data:      generictypes.String{Value: node.Content()},
-		}}, nil
+		return []interface{}{generictypes.String{Value: node.Content()}}, nil
 	case "interpolation", "string":
 		return concatenateChildren(node, evaluator)
 	case "binary":
@@ -41,7 +38,7 @@ func (detector *stringDetector) DetectAt(
 	return nil, nil
 }
 
-func concatenateChildren(node *tree.Node, evaluator types.Evaluator) ([]*types.Detection, error) {
+func concatenateChildren(node *tree.Node, evaluator types.Evaluator) ([]interface{}, error) {
 	value := ""
 
 	for i := 0; i < node.ChildCount(); i += 1 {
@@ -50,7 +47,7 @@ func concatenateChildren(node *tree.Node, evaluator types.Evaluator) ([]*types.D
 			continue
 		}
 
-		detections, err := evaluator.ForNode(child, "string")
+		detections, err := evaluator.ForNode(child, "string", true)
 		if err != nil {
 			return nil, err
 		}
@@ -65,10 +62,7 @@ func concatenateChildren(node *tree.Node, evaluator types.Evaluator) ([]*types.D
 		}
 	}
 
-	return []*types.Detection{{
-		MatchNode: node,
-		Data:      generictypes.String{Value: value},
-	}}, nil
+	return []interface{}{generictypes.String{Value: value}}, nil
 }
 
 func (detector *stringDetector) Close() {}

--- a/new/detector/set/set.go
+++ b/new/detector/set/set.go
@@ -39,5 +39,19 @@ func (set *set) DetectAt(
 		return nil, fmt.Errorf("detector type '%s' not registered", detectorType)
 	}
 
-	return detector.DetectAt(node, evaluator)
+	detectionsData, err := detector.DetectAt(node, evaluator)
+	if err != nil {
+		return nil, err
+	}
+
+	detections := make([]*types.Detection, len(detectionsData))
+	for i, data := range detectionsData {
+		detections[i] = &types.Detection{
+			DetectorType: detectorType,
+			MatchNode:    node,
+			Data:         data,
+		}
+	}
+
+	return detections, nil
 }

--- a/new/detector/types/types.go
+++ b/new/detector/types/types.go
@@ -6,14 +6,14 @@ import (
 )
 
 type Detection struct {
-	MatchNode   *tree.Node
-	ContextNode *tree.Node
-	Data        interface{}
+	DetectorType string
+	MatchNode    *tree.Node
+	Data         interface{}
 }
 
 type Evaluator interface {
-	ForTree(rootNode *tree.Node, detectorType string) ([]*Detection, error)
-	ForNode(node *tree.Node, detectorType string) ([]*Detection, error)
+	ForTree(rootNode *tree.Node, detectorType string, followFlow bool) ([]*Detection, error)
+	ForNode(node *tree.Node, detectorType string, followFlow bool) ([]*Detection, error)
 	TreeHas(rootNode *tree.Node, detectorType string) (bool, error)
 	NodeHas(node *tree.Node, detectorType string) (bool, error)
 	FileName() string
@@ -29,17 +29,11 @@ type DetectorSet interface {
 
 type Detector interface {
 	Name() string
-	DetectAt(node *tree.Node, evaluator Evaluator) ([]*Detection, error)
+	DetectAt(node *tree.Node, evaluator Evaluator) ([]interface{}, error)
 	Close()
 }
 
-type CompositionDetection struct {
-	RuleName   string
-	File       *file.FileInfo
-	Detections []*Detection
-}
-
 type Composition interface {
-	DetectFromFile(file *file.FileInfo) ([]*CompositionDetection, error)
+	DetectFromFile(file *file.FileInfo) ([]*Detection, error)
 	Close()
 }

--- a/new/language/base/base.go
+++ b/new/language/base/base.go
@@ -36,6 +36,6 @@ func (lang *Language) CompilePatternQuery(input string) (types.PatternQuery, err
 	return patternquery.Compile(lang, lang.implementation, input)
 }
 
-func (lang *Language) IsTerminalDetectionNode(node *tree.Node) bool {
-	return lang.implementation.IsTerminalDetectionNode(node)
+func (lang *Language) DescendIntoDetectionNode(node *tree.Node) bool {
+	return lang.implementation.DescendIntoDetectionNode(node)
 }

--- a/new/language/implementation/implementation.go
+++ b/new/language/implementation/implementation.go
@@ -75,8 +75,8 @@ type Implementation interface {
 	// it is natural for `$<ARG>`` to only match the first argument, but
 	// we wouldn't expect `other_call` to be the first expression in the block
 	PatternIsAnchored(node *tree.Node) bool
-	// IsTerminalDetectionNode returns whether detections should be returned
-	// for sub-nodes of the given node.
+	// DescendIntoDetectionNode returns whether a tree detection search should
+	// proceed down into the given node.
 	//
 	// eg. given Ruby code like this:
 	//   user = Struct.new(email: ..., address: ...)
@@ -84,5 +84,5 @@ type Implementation interface {
 	// `user` in `user.email` is unified with the assignment.
 	// But we don't want to see detections for the assignment when asking for the
 	// detections of `user.email`
-	IsTerminalDetectionNode(node *tree.Node) bool
+	DescendIntoDetectionNode(node *tree.Node) bool
 }

--- a/new/language/implementation/ruby/ruby.go
+++ b/new/language/implementation/ruby/ruby.go
@@ -181,10 +181,12 @@ func (implementation *rubyImplementation) PatternIsAnchored(node *tree.Node) boo
 	return true
 }
 
-func (implementation *rubyImplementation) IsTerminalDetectionNode(node *tree.Node) bool {
-	if node.Type() == "call" {
-		return !slice.Contains(passThroughMethods, node.ChildByFieldName("method").Content())
+func (implementation *rubyImplementation) DescendIntoDetectionNode(node *tree.Node) bool {
+	parent := node.Parent()
+
+	if parent != nil && parent.Type() == "call" && node.Equal(parent.ChildByFieldName("receiver")) {
+		return slice.Contains(passThroughMethods, parent.ChildByFieldName("method").Content())
 	}
 
-	return false
+	return true
 }

--- a/new/language/patternquery/builder/builder.go
+++ b/new/language/patternquery/builder/builder.go
@@ -66,7 +66,10 @@ func Build(
 		paramToContent:     make(map[string]string),
 	}
 
-	result := builder.build(tree.RootNode().Child(0))
+	result, err := builder.build(tree.RootNode().Child(0))
+	if err != nil {
+		return nil, err
+	}
 
 	if !builder.matchNodeFound {
 		return nil, fmt.Errorf("match node not found")
@@ -75,9 +78,14 @@ func Build(
 	return result, nil
 }
 
-func (builder *builder) build(rootNode *tree.Node) *Result {
+func (builder *builder) build(rootNode *tree.Node) (*Result, error) {
 	builder.write("(")
-	builder.compileNode(rootNode, true, false) //nolint:errcheck
+
+	err := builder.compileNode(rootNode, true, false)
+	if err != nil {
+		return nil, err
+	}
+
 	builder.write(" @root")
 	builder.write(")")
 
@@ -88,7 +96,7 @@ func (builder *builder) build(rootNode *tree.Node) *Result {
 		ParamToVariable: paramToVariable,
 		EqualParams:     equalParams,
 		ParamToContent:  builder.paramToContent,
-	}
+	}, nil
 }
 
 func (builder *builder) compileNode(node *tree.Node, isRoot bool, isLastChild bool) error {

--- a/new/language/patternquery/builder/builder.go
+++ b/new/language/patternquery/builder/builder.go
@@ -102,7 +102,9 @@ func (builder *builder) compileNode(node *tree.Node, isRoot bool, isLastChild bo
 	}
 
 	writeMatch := false
-	if !builder.matchNodeFound && node.StartByte() == builder.inputParams.MatchNodeOffset {
+	if !builder.matchNodeFound &&
+		node.StartByte() == builder.inputParams.MatchNodeOffset &&
+		!slices.Contains(builder.langImplementation.PatternMatchNodeContainerTypes(), node.Type()) {
 		builder.matchNodeFound = true
 		writeMatch = true
 	}

--- a/new/language/patternquery/patternquery.go
+++ b/new/language/patternquery/patternquery.go
@@ -8,15 +8,13 @@ import (
 	"github.com/bearer/curio/new/language/tree"
 	languagetypes "github.com/bearer/curio/new/language/types"
 	"github.com/rs/zerolog/log"
-	"golang.org/x/exp/slices"
 )
 
 type Query struct {
-	langImplementation implementation.Implementation
-	treeQuery          *tree.Query
-	paramToVariable    map[string]string
-	equalParams        [][]string
-	paramToContent     map[string]string
+	treeQuery       *tree.Query
+	paramToVariable map[string]string
+	equalParams     [][]string
+	paramToContent  map[string]string
 }
 
 func Compile(
@@ -37,11 +35,10 @@ func Compile(
 	log.Debug().Msgf("compiled pattern %s -> %s", input, builderResult.Query)
 
 	return &Query{
-		langImplementation: langImplementation,
-		treeQuery:          treeQuery,
-		paramToVariable:    builderResult.ParamToVariable,
-		equalParams:        builderResult.EqualParams,
-		paramToContent:     builderResult.ParamToContent,
+		treeQuery:       treeQuery,
+		paramToVariable: builderResult.ParamToVariable,
+		equalParams:     builderResult.EqualParams,
+		paramToContent:  builderResult.ParamToContent,
 	}, nil
 }
 
@@ -104,21 +101,7 @@ func (query *Query) matchAndTranslateTreeResult(treeResult tree.QueryResult, roo
 	}
 
 	return &languagetypes.PatternQueryResult{
-		MatchNode: query.getMatchNode(treeResult["match"], rootNode),
+		MatchNode: treeResult["match"],
 		Variables: variables,
-	}
-}
-
-func (query *Query) getMatchNode(node *tree.Node, rootNode *tree.Node) *tree.Node {
-	for {
-		parent := node.Parent()
-		if parent == nil ||
-			parent.StartByte() != node.StartByte() ||
-			slices.Contains(query.langImplementation.PatternMatchNodeContainerTypes(), parent.Type()) ||
-			node.Equal(rootNode) {
-			return node
-		}
-
-		node = parent
 	}
 }

--- a/new/language/tree/query.go
+++ b/new/language/tree/query.go
@@ -66,7 +66,12 @@ func (query *Query) resultsFor(tree *Tree) (map[NodeID][]QueryResult, error) {
 			return nil, errors.New("missing @root capture in tree sitter query")
 		}
 
-		nodeResults[resultRoot.ID()] = append(nodeResults[resultRoot.ID()], result)
+		matchNode, matchNodeExists := result["match"]
+		if !matchNodeExists {
+			matchNode = resultRoot
+		}
+
+		nodeResults[matchNode.ID()] = append(nodeResults[matchNode.ID()], result)
 	}
 
 	return nodeResults, nil

--- a/new/language/types/types.go
+++ b/new/language/types/types.go
@@ -17,5 +17,5 @@ type Language interface {
 	Parse(input string) (*tree.Tree, error)
 	CompileQuery(input string) (*tree.Query, error)
 	CompilePatternQuery(input string) (PatternQuery, error)
-	IsTerminalDetectionNode(node *tree.Node) bool
+	DescendIntoDetectionNode(node *tree.Node) bool
 }

--- a/new/scanner/scanner.go
+++ b/new/scanner/scanner.go
@@ -60,7 +60,7 @@ func Detect(report report.Report, file *file.FileInfo) (err error) {
 			return fmt.Errorf("%s failed to detect in file %s: %s", language.name, file.AbsolutePath, err)
 		}
 
-		composition.ReportDetections(report, detections)
+		composition.ReportDetections(report, file, detections)
 	}
 
 	return nil

--- a/pkg/commands/process/settings/rules/ruby/lang/http_insecure/.snapshots/TestRubyLangHttpInsecureDataflow-dataflow_ruby_lang_http_insecure_insecure_post_form.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/http_insecure/.snapshots/TestRubyLangHttpInsecureDataflow-dataflow_ruby_lang_http_insecure_insecure_post_form.rb
@@ -8,13 +8,6 @@ risks:
             content: Net::HTTP.post_form("http://my.api.com/users/search")
           content: |
             Net::HTTP.post_form($<INSECURE_URL>)
-        - filename: pkg/commands/process/settings/rules/ruby/lang/http_insecure/testdata/insecure_post_form.rb
-          line_number: 1
-          parent:
-            line_number: 1
-            content: Net::HTTP.post_form("http://my.api.com/users/search")
-          content: |
-            Net::HTTP.post_form($<INSECURE_URL>)
 components: []
 
 

--- a/pkg/commands/process/settings/rules/ruby/lang/http_insecure/.snapshots/TestRubyLangHttpInsecureDataflow-dataflow_ruby_lang_http_insecure_uri_encode_form.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/http_insecure/.snapshots/TestRubyLangHttpInsecureDataflow-dataflow_ruby_lang_http_insecure_uri_encode_form.rb
@@ -8,13 +8,6 @@ risks:
             content: URI('http://my.api.com/users/search')
           content: |
             URI($<INSECURE_URL>)
-        - filename: pkg/commands/process/settings/rules/ruby/lang/http_insecure/testdata/uri_encode_form.rb
-          line_number: 1
-          parent:
-            line_number: 1
-            content: URI('http://my.api.com/users/search')
-          content: |
-            URI($<INSECURE_URL>)
 components: []
 
 

--- a/pkg/commands/process/settings/rules/ruby/lang/http_post_insecure_with_data/.snapshots/TestRubyLangHttpPostInsecureWithDataDataflow-dataflow_ruby_lang_http_post_insecure_with_data_insecure_post_form_with_datatype.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/http_post_insecure_with_data/.snapshots/TestRubyLangHttpPostInsecureWithDataDataflow-dataflow_ruby_lang_http_post_insecure_with_data_insecure_post_form_with_datatype.rb
@@ -38,13 +38,6 @@ risks:
             content: 'Net::HTTP.post_form("http://my.api.com/users/search", email: user.email)'
           content: |
             Net::HTTP.post_form($<INSECURE_URL>)
-        - filename: pkg/commands/process/settings/rules/ruby/lang/http_post_insecure_with_data/testdata/insecure_post_form_with_datatype.rb
-          line_number: 1
-          parent:
-            line_number: 1
-            content: 'Net::HTTP.post_form("http://my.api.com/users/search", email: user.email)'
-          content: |
-            Net::HTTP.post_form($<INSECURE_URL>)
 components: []
 
 

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryptionDataflow-dataflow_ruby_lang_weak_encryption_blowfish.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryptionDataflow-dataflow_ruby_lang_weak_encryption_blowfish.rb
@@ -8,13 +8,6 @@ risks:
             content: Crypt::Blowfish.new("insecure")
           content: |
             Crypt::Blowfish.new()
-        - filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption/testdata/blowfish.rb
-          line_number: 1
-          parent:
-            line_number: 1
-            content: Crypt::Blowfish.new("insecure")
-          content: |
-            Crypt::Blowfish.new()
     - detector_id: ruby_lang_weak_encryption
       locations:
         - filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption/testdata/blowfish.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryptionDataflow-dataflow_ruby_lang_weak_encryption_openssl_dsa.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryptionDataflow-dataflow_ruby_lang_weak_encryption_openssl_dsa.rb
@@ -8,13 +8,6 @@ risks:
             content: OpenSSL::PKey::DSA.new(2048)
           content: |
             OpenSSL::PKey::DSA.new()
-        - filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption/testdata/openssl_dsa.rb
-          line_number: 2
-          parent:
-            line_number: 2
-            content: OpenSSL::PKey::DSA.new(2048)
-          content: |
-            OpenSSL::PKey::DSA.new()
     - detector_id: ruby_lang_weak_encryption
       locations:
         - filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption/testdata/openssl_dsa.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryptionDataflow-dataflow_ruby_lang_weak_encryption_openssl_rsa.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryptionDataflow-dataflow_ruby_lang_weak_encryption_openssl_rsa.rb
@@ -8,13 +8,6 @@ risks:
             content: OpenSSL::PKey::RSA.new(2048)
           content: |
             OpenSSL::PKey::RSA.new()
-        - filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption/testdata/openssl_rsa.rb
-          line_number: 4
-          parent:
-            line_number: 4
-            content: OpenSSL::PKey::RSA.new(2048)
-          content: |
-            OpenSSL::PKey::RSA.new()
     - detector_id: ruby_lang_weak_encryption
       locations:
         - filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption/testdata/openssl_rsa.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryptionDataflow-dataflow_ruby_lang_weak_encryption_rc4_encrypt.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryptionDataflow-dataflow_ruby_lang_weak_encryption_rc4_encrypt.rb
@@ -8,13 +8,6 @@ risks:
             content: RC4.new("insecure")
           content: |
             RC4.new()
-        - filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption/testdata/rc4_encrypt.rb
-          line_number: 3
-          parent:
-            line_number: 3
-            content: RC4.new("insecure")
-          content: |
-            RC4.new()
     - detector_id: ruby_lang_weak_encryption
       locations:
         - filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption/testdata/rc4_encrypt.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithDataDataflow-dataflow_ruby_lang_weak_encryption_with_data_openssl_dsa_data.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithDataDataflow-dataflow_ruby_lang_weak_encryption_with_data_openssl_dsa_data.rb
@@ -62,13 +62,6 @@ risks:
             content: OpenSSL::PKey::DSA.new(2048)
           content: |
             OpenSSL::PKey::DSA.new()
-        - filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/testdata/openssl_dsa_data.rb
-          line_number: 2
-          parent:
-            line_number: 2
-            content: OpenSSL::PKey::DSA.new(2048)
-          content: |
-            OpenSSL::PKey::DSA.new()
     - detector_id: ruby_lang_weak_encryption
       locations:
         - filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/testdata/openssl_dsa_data.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithDataDataflow-dataflow_ruby_lang_weak_encryption_with_data_openssl_rsa_data.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithDataDataflow-dataflow_ruby_lang_weak_encryption_with_data_openssl_rsa_data.rb
@@ -79,13 +79,6 @@ risks:
             content: OpenSSL::PKey::RSA.new(2048)
           content: |
             OpenSSL::PKey::RSA.new()
-        - filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/testdata/openssl_rsa_data.rb
-          line_number: 4
-          parent:
-            line_number: 4
-            content: OpenSSL::PKey::RSA.new(2048)
-          content: |
-            OpenSSL::PKey::RSA.new()
     - detector_id: ruby_lang_weak_encryption
       locations:
         - filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/testdata/openssl_rsa_data.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithDataDataflow-dataflow_ruby_lang_weak_encryption_with_data_rc4_data.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithDataDataflow-dataflow_ruby_lang_weak_encryption_with_data_rc4_data.rb
@@ -55,13 +55,6 @@ risks:
             content: RC4.new("insecure")
           content: |
             RC4.new()
-        - filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/testdata/rc4_data.rb
-          line_number: 3
-          parent:
-            line_number: 3
-            content: RC4.new("insecure")
-          content: |
-            RC4.new()
     - detector_id: ruby_lang_weak_encryption
       locations:
         - filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/testdata/rc4_data.rb

--- a/pkg/commands/process/settings/rules/ruby/rails/insecure_ftp/.snapshots/TestRubyRailsInsecureFtpDataflow-dataflow_ruby_rails_insecure_ftp_ftp_new.rb
+++ b/pkg/commands/process/settings/rules/ruby/rails/insecure_ftp/.snapshots/TestRubyRailsInsecureFtpDataflow-dataflow_ruby_rails_insecure_ftp_ftp_new.rb
@@ -33,13 +33,6 @@ risks:
             content: Net::FTP.new("ftp.ruby-lang.org")
           content: |
             Net::FTP.new()
-        - filename: pkg/commands/process/settings/rules/ruby/rails/insecure_ftp/testdata/ftp_new.rb
-          line_number: 8
-          parent:
-            line_number: 8
-            content: Net::FTP.new("ftp.ruby-lang.org")
-          content: |
-            Net::FTP.new()
 components: []
 
 


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

When a pattern specifies a match node with `$<!>` (or a tree sitter query has a `@match` param), make the pattern/query match at that node, not the root node of the query. This makes associated detections for rules also belong to the match node.

Following this change, all detection nodes are the same as the input node. This allowed refactoring of the detectors to only return the detection data, with the actual detection being built by the detector set. By also adding the detector type to the detection, we removed the need for the composition detection type.

As a side-effect of equating the detection node with the input node, we need to manually specify whether to use the flow/unified nodes when evaluating detections. Without this change, we get duplicate detections in some cases. This has fixed some duplicates we had in our test cases.

Also fixes an issue with the logic of `IsTerminalDetectionNode`. Previously this defined if a node should have it's children evaluated. But in the case of a call in Ruby which has a block passed to it, we want to evaluate the block body but not the receiver. This logic is now replaced with `DescendIntoDetectionNode`.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [x] I've updated or added documentation if required.
- [x] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
