### PR TITLE
feat(privacy report): pass flag option for subject mapping override

### DIFF
--- a/docs/_data/curio_scan.yaml
+++ b/docs/_data/curio_scan.yaml
@@ -7,6 +7,9 @@ options:
     - name: context
       usage: |
         Expand context of schema classification e.g., --context=health, to include data types particular to health
+    - name: data-subject-mapping
+      usage: |
+        Override default data subject mapping by providing a path to a custom mapping JSON file
     - name: debug
       default_value: "false"
       usage: Enable debug logs

--- a/integration/flags/.snapshots/TestInitCommand
+++ b/integration/flags/.snapshots/TestInitCommand
@@ -7,6 +7,7 @@ rule:
     skip-rule: []
 scan:
     context: ""
+    data_subject_mapping: ""
     debug: false
     disable-domain-resolution: true
     domain-resolution-timeout: 3s

--- a/integration/flags/.snapshots/TestMetadataFlags-help-scan
+++ b/integration/flags/.snapshots/TestMetadataFlags-help-scan
@@ -20,6 +20,7 @@ Rule Flags
 
 Scan Flags
       --context string                       Expand context of schema classification e.g., --context=health, to include data types particular to health
+      --data-subject-mapping string          Override default data subject mapping by providing a path to a custom mapping JSON file
       --debug                                Enable debug logs
       --disable-domain-resolution            Do not attempt to resolve detected domains during classification (default true)
       --domain-resolution-timeout duration   Set timeout when attempting to resolve detected domains during classification, e.g. --domain-resolution-timeout=3s (default 3s)

--- a/integration/flags/.snapshots/TestMetadataFlags-scan-help
+++ b/integration/flags/.snapshots/TestMetadataFlags-scan-help
@@ -20,6 +20,7 @@ Rule Flags
 
 Scan Flags
       --context string                       Expand context of schema classification e.g., --context=health, to include data types particular to health
+      --data-subject-mapping string          Override default data subject mapping by providing a path to a custom mapping JSON file
       --debug                                Enable debug logs
       --disable-domain-resolution            Do not attempt to resolve detected domains during classification (default true)
       --domain-resolution-timeout duration   Set timeout when attempting to resolve detected domains during classification, e.g. --domain-resolution-timeout=3s (default 3s)

--- a/integration/flags/.snapshots/TestReportFlagsShouldFail-invalid-context-flag
+++ b/integration/flags/.snapshots/TestReportFlagsShouldFail-invalid-context-flag
@@ -21,6 +21,7 @@ Rule Flags
 
 Scan Flags
       --context string                       Expand context of schema classification e.g., --context=health, to include data types particular to health
+      --data-subject-mapping string          Override default data subject mapping by providing a path to a custom mapping JSON file
       --debug                                Enable debug logs
       --disable-domain-resolution            Do not attempt to resolve detected domains during classification (default true)
       --domain-resolution-timeout duration   Set timeout when attempting to resolve detected domains during classification, e.g. --domain-resolution-timeout=3s (default 3s)

--- a/integration/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag
+++ b/integration/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag
@@ -21,6 +21,7 @@ Rule Flags
 
 Scan Flags
       --context string                       Expand context of schema classification e.g., --context=health, to include data types particular to health
+      --data-subject-mapping string          Override default data subject mapping by providing a path to a custom mapping JSON file
       --debug                                Enable debug logs
       --disable-domain-resolution            Do not attempt to resolve detected domains during classification (default true)
       --domain-resolution-timeout duration   Set timeout when attempting to resolve detected domains during classification, e.g. --domain-resolution-timeout=3s (default 3s)

--- a/integration/flags/.snapshots/TestReportFlagsShouldFail-invalid-report-flag
+++ b/integration/flags/.snapshots/TestReportFlagsShouldFail-invalid-report-flag
@@ -21,6 +21,7 @@ Rule Flags
 
 Scan Flags
       --context string                       Expand context of schema classification e.g., --context=health, to include data types particular to health
+      --data-subject-mapping string          Override default data subject mapping by providing a path to a custom mapping JSON file
       --debug                                Enable debug logs
       --disable-domain-resolution            Do not attempt to resolve detected domains during classification (default true)
       --domain-resolution-timeout duration   Set timeout when attempting to resolve detected domains during classification, e.g. --domain-resolution-timeout=3s (default 3s)

--- a/pkg/classification/classification.go
+++ b/pkg/classification/classification.go
@@ -38,11 +38,19 @@ func NewClassifier(config *Config) (*Classifier, error) {
 		return nil, err
 	}
 
+	// apply subject mapping override, if present
+	var knownPersonObjectPatterns []db.KnownPersonObjectPattern
+	if config.Config.Scan.DataSubjectMapping != "" {
+		knownPersonObjectPatterns = db.DefaultWithMapping(config.Config.Scan.DataSubjectMapping).KnownPersonObjectPatterns
+	} else {
+		knownPersonObjectPatterns = db.Default().KnownPersonObjectPatterns
+	}
+
 	schemaClassifier := schema.New(
 		schema.Config{
 			DataTypes:                      db.Default().DataTypes,
 			DataTypeClassificationPatterns: db.Default().DataTypeClassificationPatterns,
-			KnownPersonObjectPatterns:      db.Default().KnownPersonObjectPatterns,
+			KnownPersonObjectPatterns:      knownPersonObjectPatterns,
 			Context:                        config.Config.Scan.Context,
 		},
 	)

--- a/pkg/classification/db/db.go
+++ b/pkg/classification/db/db.go
@@ -4,6 +4,7 @@ import (
 	"embed"
 	"encoding/json"
 	"log"
+	"os"
 	"regexp"
 	"strings"
 
@@ -132,21 +133,25 @@ type KnownPersonObjectPattern struct {
 }
 
 func Default() DefaultDB {
-	return defaultDB("")
+	return defaultDB("", "")
+}
+
+func DefaultWithMapping(subjectMappingPath string) DefaultDB {
+	return defaultDB("", subjectMappingPath)
 }
 
 func DefaultWithContext(context flag.Context) DefaultDB {
-	return defaultDB(context)
+	return defaultDB(context, "")
 }
 
-func defaultDB(context flag.Context) DefaultDB {
+func defaultDB(context flag.Context, subjectMappingPath string) DefaultDB {
 	dataTypes := defaultDataTypes()
 	return DefaultDB{
 		Recipes:                        defaultRecipes(),
 		DataTypes:                      dataTypes,
 		DataCategories:                 defaultDataCategories(context),
 		DataTypeClassificationPatterns: defaultDataTypeClassificationPatterns(dataTypes),
-		KnownPersonObjectPatterns:      defaultKnownPersonObjectPatterns(dataTypes),
+		KnownPersonObjectPatterns:      defaultKnownPersonObjectPatterns(dataTypes, subjectMappingPath),
 	}
 }
 
@@ -332,7 +337,7 @@ func defaultDataTypeClassificationPatterns(dataTypes []DataType) []DataTypeClass
 	return dataTypeClassificationPatterns
 }
 
-func defaultKnownPersonObjectPatterns(dataTypes []DataType) []KnownPersonObjectPattern {
+func defaultKnownPersonObjectPatterns(dataTypes []DataType, subjectMappingPath string) []KnownPersonObjectPattern {
 	knownPersonObjectPatterns := []KnownPersonObjectPattern{}
 
 	// "Identification" > "Unique Identifier" data type
@@ -352,7 +357,12 @@ func defaultKnownPersonObjectPatterns(dataTypes []DataType) []KnownPersonObjectP
 	}
 
 	// read mapping
-	subjectMappingJson, err := subjectMappingFile.ReadFile("subject_mapping.json")
+	var subjectMappingJson []byte
+	if subjectMappingPath != "" {
+		subjectMappingJson, err = os.ReadFile(subjectMappingPath)
+	} else {
+		subjectMappingJson, err = subjectMappingFile.ReadFile("subject_mapping.json")
+	}
 	if err != nil {
 		handleError(err)
 	}

--- a/pkg/flag/scan_flags.go
+++ b/pkg/flag/scan_flags.go
@@ -52,6 +52,12 @@ var (
 		Value:      "",
 		Usage:      "Expand context of schema classification e.g., --context=health, to include data types particular to health",
 	}
+	DataSubjectMappingFlag = Flag{
+		Name:       "data-subject-mapping",
+		ConfigName: "scan.data_subject_mapping",
+		Value:      "",
+		Usage:      "Override default data subject mapping by providing a path to a custom mapping JSON file",
+	}
 	QuietFlag = Flag{
 		Name:       "quiet",
 		ConfigName: "scan.quiet",
@@ -79,6 +85,7 @@ type ScanFlagGroup struct {
 	DomainResolutionTimeoutFlag *Flag
 	InternalDomainsFlag         *Flag
 	ContextFlag                 *Flag
+	DataSubjectMappingFlag      *Flag
 	QuietFlag                   *Flag
 	ForceFlag                   *Flag
 	ExternalRuleDirFlag         *Flag
@@ -92,6 +99,7 @@ type ScanOptions struct {
 	DomainResolutionTimeout time.Duration `mapstructure:"domain-resolution-timeout" json:"domain-resolution-timeout" yaml:"domain-resolution-timeout"`
 	InternalDomains         []string      `mapstructure:"internal-domains" json:"internal-domains" yaml:"internal-domains"`
 	Context                 Context       `mapstructure:"context" json:"context" yaml:"context"`
+	DataSubjectMapping      string        `mapstructure:"data_subject_mapping" json:"data_subject_mapping" yaml:"data_subject_mapping"`
 	Quiet                   bool          `mapstructure:"quiet" json:"quiet" yaml:"quiet"`
 	Force                   bool          `mapstructure:"force" json:"force" yaml:"force"`
 	ExternalRuleDir         []string      `mapstructure:"external-rule-dir" json:"external-rule-dir" yaml:"external-rule-dir"`
@@ -105,6 +113,7 @@ func NewScanFlagGroup() *ScanFlagGroup {
 		DomainResolutionTimeoutFlag: &DomainResolutionTimeoutFlag,
 		InternalDomainsFlag:         &InternalDomainsFlag,
 		ContextFlag:                 &ContextFlag,
+		DataSubjectMappingFlag:      &DataSubjectMappingFlag,
 		QuietFlag:                   &QuietFlag,
 		ForceFlag:                   &ForceFlag,
 		ExternalRuleDirFlag:         &ExternalRuleDirFlag,
@@ -123,6 +132,7 @@ func (f *ScanFlagGroup) Flags() []*Flag {
 		f.DomainResolutionTimeoutFlag,
 		f.InternalDomainsFlag,
 		f.ContextFlag,
+		f.DataSubjectMappingFlag,
 		f.QuietFlag,
 		f.ForceFlag,
 		f.ExternalRuleDirFlag,
@@ -149,6 +159,7 @@ func (f *ScanFlagGroup) ToOptions(args []string) (ScanOptions, error) {
 		DomainResolutionTimeout: getDuration(f.DomainResolutionTimeoutFlag),
 		InternalDomains:         getStringSlice(f.InternalDomainsFlag),
 		Context:                 context,
+		DataSubjectMapping:      getString(f.DataSubjectMappingFlag),
 		Quiet:                   getBool(f.QuietFlag),
 		Force:                   getBool(f.ForceFlag),
 		Target:                  target,


### PR DESCRIPTION
## Description
* Allows users to override data subject mapping by providing a file path to their own mapping. This file is then read during the scan process

References #398

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [x] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behaviour was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
