### PR TITLE
fix(docs): add remediation message for newrelic

### DIFF
--- a/pkg/commands/process/settings/rules/ruby/third_parties/new_relic.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/new_relic.yml
@@ -27,6 +27,16 @@ skip_data_types:
   - "Unique Identifier"
 metadata:
   description: "Do not send sensitive data to New Relic."
-  remediation_message: ""
+  remediation_message: |
+    ## Description
+    Leaking sensitive data to third-party loggers is a common cause of data leaks and can lead to data breaches. This rule looks for instances of sensitive data sent to New Relic.
+
+    ## Remediations
+
+    When logging errors or events, ensure all sensitive data is removed.
+
+    ## Resources
+    - [New Relic Docs](https://docs.newrelic.com/)
+    - [Log obfuscation](https://docs.newrelic.com/docs/logs/ui-data/obfuscation-ui/)
   dsr_id: "DSR-1"
   id: "ruby_third_parties_new_relic"


### PR DESCRIPTION
## Description
Looks like new relic was merged without a remediation message. This brings that rule in line with the sentry rule's remediation format.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
