### PR TITLE
feat(summary report): Add flag for severity levels

### DIFF
--- a/docs/_data/curio_scan.yaml
+++ b/docs/_data/curio_scan.yaml
@@ -52,8 +52,8 @@ options:
       default_value: summary
       usage: Specify the type of report (summary, privacy).
     - name: severity
-      usage: |
-        Specify which severities are included in the report (critical, high, medium, low).
+      default_value: critical,high,medium,low
+      usage: Specify which severities are included in the report.
     - name: skip-path
       default_value: '[]'
       usage: |

--- a/docs/_data/curio_scan.yaml
+++ b/docs/_data/curio_scan.yaml
@@ -51,6 +51,9 @@ options:
     - name: report
       default_value: summary
       usage: Specify the type of report (summary, privacy).
+    - name: severity
+      usage: |
+        Specify which severities are included in the report (critical, high, medium, low).
     - name: skip-path
       default_value: '[]'
       usage: |

--- a/integration/flags/.snapshots/TestInitCommand
+++ b/integration/flags/.snapshots/TestInitCommand
@@ -2,6 +2,7 @@ report:
     format: ""
     output: ""
     report: summary
+    severity: critical,high,medium,low
 rule:
     only-rule: []
     skip-rule: []

--- a/integration/flags/.snapshots/TestMetadataFlags-help-scan
+++ b/integration/flags/.snapshots/TestMetadataFlags-help-scan
@@ -10,9 +10,10 @@ Examples:
 
 
 Report Flags
-  -f, --format string   Specify report format (json, yaml)
-      --output string   Specify the output path for the report.
-      --report string   Specify the type of report (summary, privacy). (default "summary")
+  -f, --format string     Specify report format (json, yaml)
+      --output string     Specify the output path for the report.
+      --report string     Specify the type of report (summary, privacy). (default "summary")
+      --severity string   Specify which severities are included in the report. (default "critical,high,medium,low")
 
 Rule Flags
       --only-rule strings   Specify the comma-separated ids of the rules you would like to run. Skips all other rules.

--- a/integration/flags/.snapshots/TestMetadataFlags-scan-help
+++ b/integration/flags/.snapshots/TestMetadataFlags-scan-help
@@ -10,9 +10,10 @@ Examples:
 
 
 Report Flags
-  -f, --format string   Specify report format (json, yaml)
-      --output string   Specify the output path for the report.
-      --report string   Specify the type of report (summary, privacy). (default "summary")
+  -f, --format string     Specify report format (json, yaml)
+      --output string     Specify the output path for the report.
+      --report string     Specify the type of report (summary, privacy). (default "summary")
+      --severity string   Specify which severities are included in the report. (default "critical,high,medium,low")
 
 Rule Flags
       --only-rule strings   Specify the comma-separated ids of the rules you would like to run. Skips all other rules.

--- a/integration/flags/.snapshots/TestReportFlagsShouldFail-invalid-context-flag
+++ b/integration/flags/.snapshots/TestReportFlagsShouldFail-invalid-context-flag
@@ -11,9 +11,10 @@ Examples:
 
 
 Report Flags
-  -f, --format string   Specify report format (json, yaml)
-      --output string   Specify the output path for the report.
-      --report string   Specify the type of report (summary, privacy). (default "summary")
+  -f, --format string     Specify report format (json, yaml)
+      --output string     Specify the output path for the report.
+      --report string     Specify the type of report (summary, privacy). (default "summary")
+      --severity string   Specify which severities are included in the report. (default "critical,high,medium,low")
 
 Rule Flags
       --only-rule strings   Specify the comma-separated ids of the rules you would like to run. Skips all other rules.

--- a/integration/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag
+++ b/integration/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag
@@ -11,9 +11,10 @@ Examples:
 
 
 Report Flags
-  -f, --format string   Specify report format (json, yaml)
-      --output string   Specify the output path for the report.
-      --report string   Specify the type of report (summary, privacy). (default "summary")
+  -f, --format string     Specify report format (json, yaml)
+      --output string     Specify the output path for the report.
+      --report string     Specify the type of report (summary, privacy). (default "summary")
+      --severity string   Specify which severities are included in the report. (default "critical,high,medium,low")
 
 Rule Flags
       --only-rule strings   Specify the comma-separated ids of the rules you would like to run. Skips all other rules.

--- a/integration/flags/.snapshots/TestReportFlagsShouldFail-invalid-report-flag
+++ b/integration/flags/.snapshots/TestReportFlagsShouldFail-invalid-report-flag
@@ -11,9 +11,10 @@ Examples:
 
 
 Report Flags
-  -f, --format string   Specify report format (json, yaml)
-      --output string   Specify the output path for the report.
-      --report string   Specify the type of report (summary, privacy). (default "summary")
+  -f, --format string     Specify report format (json, yaml)
+      --output string     Specify the output path for the report.
+      --report string     Specify the type of report (summary, privacy). (default "summary")
+      --severity string   Specify which severities are included in the report. (default "critical,high,medium,low")
 
 Rule Flags
       --only-rule strings   Specify the comma-separated ids of the rules you would like to run. Skips all other rules.

--- a/pkg/commands/process/settings/settings.go
+++ b/pkg/commands/process/settings/settings.go
@@ -48,13 +48,6 @@ type Config struct {
 	BuiltInRules map[string]*Rule   `mapstructure:"built_in_rules" json:"built_in_rules" yaml:"built_in_rules"`
 }
 
-type PolicyLevel string
-
-var LevelCritical = "critical"
-var LevelHigh = "high"
-var LevelMedium = "medium"
-var LevelLow = "low"
-
 type Modules []*PolicyModule
 
 type Policy struct {

--- a/pkg/flag/report_flags.go
+++ b/pkg/flag/report_flags.go
@@ -111,7 +111,14 @@ func (f *ReportFlagGroup) ToOptions() (ReportOptions, error) {
 	}
 
 	severity := getStringSlice(f.Severity)
-	severityMapping := make(map[string]bool)
+	// pre-define mapping to ensure ordering
+	severityMapping := map[string]bool{
+		types.LevelCritical: false,
+		types.LevelHigh:     false,
+		types.LevelMedium:   false,
+		types.LevelLow:      false,
+	}
+
 	for _, severityLevel := range severity {
 		switch severityLevel {
 		case types.LevelCritical:

--- a/pkg/flag/report_flags.go
+++ b/pkg/flag/report_flags.go
@@ -2,9 +2,9 @@ package flag
 
 import (
 	"errors"
-)
 
-type Severity int
+	"github.com/bearer/curio/pkg/types"
+)
 
 var (
 	FormatJSON  = "json"
@@ -16,10 +16,13 @@ var (
 	ReportDetectors = "detectors" // nodoc: internal report type
 	ReportDataFlow  = "dataflow"  // nodoc: internal report type
 	ReportStats     = "stats"     // nodoc: internal report type
+
+	DefaultSeverity = "critical,high,medium,low"
 )
 
 var ErrInvalidFormat = errors.New("invalid format argument; supported values: json, yaml")
 var ErrInvalidReport = errors.New("invalid report argument; supported values: summary, privacy")
+var ErrInvalidSeverity = errors.New("invalid severity argument; supported values: critical, high, medium, low")
 
 var (
 	FormatFlag = Flag{
@@ -41,25 +44,34 @@ var (
 		Value:      "",
 		Usage:      "Specify the output path for the report.",
 	}
+	SeverityFlag = Flag{
+		Name:       "severity",
+		ConfigName: "report.severity",
+		Value:      DefaultSeverity,
+		Usage:      "Specify which severities are included in the report.",
+	}
 )
 
 type ReportFlagGroup struct {
-	Format *Flag
-	Report *Flag
-	Output *Flag
+	Format   *Flag
+	Report   *Flag
+	Output   *Flag
+	Severity *Flag
 }
 
 type ReportOptions struct {
-	Format string `mapstructure:"format" json:"format" yaml:"format"`
-	Report string `mapstructure:"report" json:"report" yaml:"report"`
-	Output string `mapstructure:"output" json:"output" yaml:"output"`
+	Format   string          `mapstructure:"format" json:"format" yaml:"format"`
+	Report   string          `mapstructure:"report" json:"report" yaml:"report"`
+	Output   string          `mapstructure:"output" json:"output" yaml:"output"`
+	Severity map[string]bool `mapstructure:"severity" json:"severity" yaml:"severity"`
 }
 
 func NewReportFlagGroup() *ReportFlagGroup {
 	return &ReportFlagGroup{
-		Format: &FormatFlag,
-		Report: &ReportFlag,
-		Output: &OutputFlag,
+		Format:   &FormatFlag,
+		Report:   &ReportFlag,
+		Output:   &OutputFlag,
+		Severity: &SeverityFlag,
 	}
 }
 
@@ -72,6 +84,7 @@ func (f *ReportFlagGroup) Flags() []*Flag {
 		f.Format,
 		f.Report,
 		f.Output,
+		f.Severity,
 	}
 }
 
@@ -97,9 +110,27 @@ func (f *ReportFlagGroup) ToOptions() (ReportOptions, error) {
 		return ReportOptions{}, ErrInvalidReport
 	}
 
+	severity := getStringSlice(f.Severity)
+	severityMapping := make(map[string]bool)
+	for _, severityLevel := range severity {
+		switch severityLevel {
+		case types.LevelCritical:
+			severityMapping[types.LevelCritical] = true
+		case types.LevelHigh:
+			severityMapping[types.LevelHigh] = true
+		case types.LevelMedium:
+			severityMapping[types.LevelMedium] = true
+		case types.LevelLow:
+			severityMapping[types.LevelLow] = true
+		default:
+			return ReportOptions{}, ErrInvalidSeverity
+		}
+	}
+
 	return ReportOptions{
-		Format: format,
-		Report: report,
-		Output: getString(f.Output),
+		Format:   format,
+		Report:   report,
+		Output:   getString(f.Output),
+		Severity: severityMapping,
 	}, nil
 }

--- a/pkg/report/output/output.go
+++ b/pkg/report/output/output.go
@@ -58,11 +58,11 @@ func ReportSummary(report types.Report, output *zerolog.Event, config settings.C
 	}
 
 	outputToFile := config.Report.Output != ""
-	reportStr := summary.BuildReportString(config.Rules, summaryResults, outputToFile)
+	severityForFailure := config.Report.Severity
+	reportStr, reportPassed := summary.BuildReportString(config.Rules, summaryResults, severityForFailure, outputToFile)
 
 	output.Msg(reportStr.String())
 
-	reportPassed = len(summaryResults) == 0
 	return
 }
 
@@ -148,7 +148,7 @@ func getPrivacyReportOutput(report types.Report, config settings.Config) (*priva
 	return privacy.GetOutput(dataflow, config)
 }
 
-func getSummaryReportOutput(report types.Report, config settings.Config) (map[string][]summary.PolicyResult, error) {
+func getSummaryReportOutput(report types.Report, config settings.Config) (map[string][]summary.Result, error) {
 	dataflow, err := getDataflow(report, config, true)
 	if err != nil {
 		return nil, err

--- a/pkg/report/output/summary/summary.go
+++ b/pkg/report/output/summary/summary.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bearer/curio/pkg/classification/db"
 	"github.com/bearer/curio/pkg/commands/process/settings"
+	"github.com/bearer/curio/pkg/types"
 	"github.com/bearer/curio/pkg/util/file"
 	"github.com/bearer/curio/pkg/util/output"
 	"github.com/bearer/curio/pkg/util/rego"
@@ -20,10 +21,10 @@ import (
 
 var underline = color.New(color.Underline).SprintFunc()
 var severityColorFns = map[string]func(x ...interface{}) string{
-	settings.LevelCritical: color.New(color.FgRed).SprintFunc(),
-	settings.LevelHigh:     color.New(color.FgHiRed).SprintFunc(),
-	settings.LevelMedium:   color.New(color.FgYellow).SprintFunc(),
-	settings.LevelLow:      color.New(color.FgBlue).SprintFunc(),
+	types.LevelCritical: color.New(color.FgRed).SprintFunc(),
+	types.LevelHigh:     color.New(color.FgHiRed).SprintFunc(),
+	types.LevelMedium:   color.New(color.FgYellow).SprintFunc(),
+	types.LevelLow:      color.New(color.FgBlue).SprintFunc(),
 }
 
 type PolicyInput struct {
@@ -144,17 +145,17 @@ func BuildReportString(rules map[string]*settings.Rule, policyResults map[string
 	writeRuleListToString(reportStr, rules)
 
 	policyFailures := map[string]map[string]bool{
-		settings.LevelCritical: make(map[string]bool),
-		settings.LevelHigh:     make(map[string]bool),
-		settings.LevelMedium:   make(map[string]bool),
-		settings.LevelLow:      make(map[string]bool),
+		types.LevelCritical: make(map[string]bool),
+		types.LevelHigh:     make(map[string]bool),
+		types.LevelMedium:   make(map[string]bool),
+		types.LevelLow:      make(map[string]bool),
 	}
 
 	for _, policyLevel := range []string{
-		settings.LevelCritical,
-		settings.LevelHigh,
-		settings.LevelMedium,
-		settings.LevelLow,
+		types.LevelCritical,
+		types.LevelHigh,
+		types.LevelMedium,
+		types.LevelLow,
 	} {
 		for _, policyFailure := range policyResults[policyLevel] {
 			policyFailures[policyLevel][policyFailure.PolicyDSRID] = true
@@ -176,13 +177,13 @@ func FindHighestSeverity(groups []string, severity map[string]string) string {
 	}
 
 	if slices.Contains(severities, "critical") {
-		return settings.LevelCritical
+		return types.LevelCritical
 	} else if slices.Contains(severities, "high") {
-		return settings.LevelHigh
+		return types.LevelHigh
 	} else if slices.Contains(severities, "medium") {
-		return settings.LevelMedium
+		return types.LevelMedium
 	} else if slices.Contains(severities, "low") {
-		return settings.LevelLow
+		return types.LevelLow
 	}
 
 	return severity["default"]
@@ -221,10 +222,10 @@ func writeSummaryToString(
 		return
 	}
 
-	criticalCount := len(policyResults[settings.LevelCritical])
-	highCount := len(policyResults[settings.LevelHigh])
-	mediumCount := len(policyResults[settings.LevelMedium])
-	lowCount := len(policyResults[settings.LevelLow])
+	criticalCount := len(policyResults[types.LevelCritical])
+	highCount := len(policyResults[types.LevelHigh])
+	mediumCount := len(policyResults[types.LevelMedium])
+	lowCount := len(policyResults[types.LevelLow])
 
 	totalCount := criticalCount + highCount + mediumCount + lowCount
 
@@ -232,30 +233,30 @@ func writeSummaryToString(
 	reportStr.WriteString(color.RedString(fmt.Sprint(policyCount) + " checks, " + fmt.Sprint(totalCount) + " failures\n\n"))
 
 	// critical count
-	reportStr.WriteString(formatSeverity(settings.LevelCritical) + fmt.Sprint(criticalCount))
-	if len(policyFailures[settings.LevelCritical]) > 0 {
-		policyIds := maps.Keys(policyFailures[settings.LevelCritical])
+	reportStr.WriteString(formatSeverity(types.LevelCritical) + fmt.Sprint(criticalCount))
+	if len(policyFailures[types.LevelCritical]) > 0 {
+		policyIds := maps.Keys(policyFailures[types.LevelCritical])
 		sort.Strings(policyIds)
 		reportStr.WriteString(" (" + strings.Join(policyIds, ", ") + ")")
 	}
 	// high count
-	reportStr.WriteString("\n" + formatSeverity(settings.LevelHigh) + fmt.Sprint(highCount))
-	if len(policyFailures[settings.LevelHigh]) > 0 {
-		policyIds := maps.Keys(policyFailures[settings.LevelHigh])
+	reportStr.WriteString("\n" + formatSeverity(types.LevelHigh) + fmt.Sprint(highCount))
+	if len(policyFailures[types.LevelHigh]) > 0 {
+		policyIds := maps.Keys(policyFailures[types.LevelHigh])
 		sort.Strings(policyIds)
 		reportStr.WriteString(" (" + strings.Join(policyIds, ", ") + ")")
 	}
 	// medium count
-	reportStr.WriteString("\n" + formatSeverity(settings.LevelMedium) + fmt.Sprint(mediumCount))
-	if len(policyFailures[settings.LevelMedium]) > 0 {
-		policyIds := maps.Keys(policyFailures[settings.LevelMedium])
+	reportStr.WriteString("\n" + formatSeverity(types.LevelMedium) + fmt.Sprint(mediumCount))
+	if len(policyFailures[types.LevelMedium]) > 0 {
+		policyIds := maps.Keys(policyFailures[types.LevelMedium])
 		sort.Strings(policyIds)
 		reportStr.WriteString(" (" + strings.Join(policyIds, ", ") + ")")
 	}
 	// low count
-	reportStr.WriteString("\n" + formatSeverity(settings.LevelLow) + fmt.Sprint(lowCount))
-	if len(policyFailures[settings.LevelLow]) > 0 {
-		policyIds := maps.Keys(policyFailures[settings.LevelLow])
+	reportStr.WriteString("\n" + formatSeverity(types.LevelLow) + fmt.Sprint(lowCount))
+	if len(policyFailures[types.LevelLow]) > 0 {
+		policyIds := maps.Keys(policyFailures[types.LevelLow])
 		sort.Strings(policyIds)
 		reportStr.WriteString(" (" + strings.Join(policyIds, ", ") + ")")
 	}

--- a/pkg/report/output/summary/summary.go
+++ b/pkg/report/output/summary/summary.go
@@ -251,6 +251,10 @@ func writeSummaryToString(
 	reportStr.WriteString(color.RedString(fmt.Sprint(policyCount) + " checks, " + fmt.Sprint(failureCount) + " failures\n\n"))
 
 	for i, severityLevel := range maps.Keys(severityForFailure) {
+		if !severityForFailure[severityLevel] {
+			continue
+		}
+
 		if i > 0 {
 			reportStr.WriteString("\n")
 		}

--- a/pkg/types/severity.go
+++ b/pkg/types/severity.go
@@ -1,0 +1,6 @@
+package types
+
+var LevelCritical = "critical"
+var LevelHigh = "high"
+var LevelMedium = "medium"
+var LevelLow = "low"


### PR DESCRIPTION
## Description

* Add new report flag: `--severity` with default value `"critical,high,medium,low"`
* Report lists only failures with the given severity
* Report fails (exit status 1) only if failures with the given severity are present

References #441 

## Examples

### Failures with given severity

```
curio scan ../Bearer/bear-publishing --severity=low,medium
```

<img width="481" alt="Screenshot 2023-02-06 at 10 08 51" src="https://user-images.githubusercontent.com/4560746/216938027-527050f3-d7e6-4393-9919-1aace141a15a.png">

### No failures with given severity (report passes)

```
curio scan ../Bearer/bear-publishing --severity=medium
```

<img width="554" alt="Screenshot 2023-02-06 at 10 09 08" src="https://user-images.githubusercontent.com/4560746/216938035-b7c17762-4ad2-48ae-a4c9-b4cdf80275d5.png">

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
