### PR TITLE
docs(privacy report): add privacy report and clean up reports docs

### DIFF
--- a/docs/_data/curio_scan.yaml
+++ b/docs/_data/curio_scan.yaml
@@ -50,7 +50,7 @@ options:
       usage: Suppress non-essential messages
     - name: report
       default_value: summary
-      usage: Specify the type of report (summary, dataflow, stats).
+      usage: Specify the type of report (summary, privacy).
     - name: skip-path
       default_value: '[]'
       usage: |

--- a/docs/explanations/reports.md
+++ b/docs/explanations/reports.md
@@ -55,6 +55,8 @@ The privacy report provides useful information about how your codebase uses sens
 
 The data subjects portion displays information about each detected subject and any data types associated with it. It also provides statistics on total detections and any counts of rule failures associated with the data type. In the example below, the report detects 14 instances of user telephone numbers with no rule failures.
 
+_Note: These examples use JSON for readability, but the default format for the privacy report is CSV._
+
 ```json
 "Subjects": [
   {
@@ -69,6 +71,7 @@ The data subjects portion displays information about each detected subject and a
   }
 ]
 ```
+
 
 The third parties portion displays data subjects and types that are sent to or processed by known third-party services. In the example below, Curio detects a user email address sent to Sentry via the Sentry SDK and notes that a critical-risk-level rule has failed associated with this data point.
 

--- a/docs/explanations/reports.md
+++ b/docs/explanations/reports.md
@@ -5,7 +5,7 @@ layout: layouts/doc.njk
 
 # Report Types
 
-Curio can generate four types of reports about your codebase, all from the same underlying scan.
+Curio can generate two types of reports about your codebase, all from the same underlying scan.
 
 ## Summary Report
 
@@ -49,121 +49,50 @@ Summary reports are [currently available](/reference/supported-languages/) for R
 
 To run your first summary report, run `curio scan .` on your project directory. By default, the summary report is output in a human-readable format, but you can also output it as YAML or JSON by using the `--format yaml` or `--format json` flags.
 
-## Data Flow Report
+## Privacy Report
 
-The data flow report breaks down the data types and associated components detected in your code. It focuses your app processes personal and sensitive data and where it may be exposed to third parties and databases.
+The privacy report provides useful information about how your codebase uses sensitive data, with an emphasis on data subjects and third parties.
 
-This report type can produce JSON or YAML (using the `--format` flag) and is best used for identifying where data exists in your code. You can then use this to create a record of processing activity (ROPA), AppStore report, or build your data catalog. In the following example, we can see all the places an `Email Address` is processed by our [example application](https://github.com/Bearer/bear-publishing):
+The data subjects portion displays information about each detected subject and any data types associated with it. It also provides statistics on total detections and any counts of rule failures associated with the data type. In the example below, the report detects 14 instances of user telephone numbers with no rule failures.
 
 ```bash
 {
-      "name": "Email Address",
-      "detectors": [
-        {
-          "name": "rails",
-          "locations": [
-            {
-              "filename": "db/schema.rb",
-              "line_number": 91
-            }
-          ]
-        },
-        {
-          "name": "ruby",
-          "locations": [
-            {
-              "filename": "app/controllers/application_controller.rb",
-              "line_number": 35
-            },
-            {
-              "filename": "app/controllers/application_controller.rb",
-              "line_number": 37
-            },
-            {
-              "filename": "app/controllers/application_controller.rb",
-              "line_number": 42
-            },
-            {
-              "filename": "app/controllers/orders_controller.rb",
-              "line_number": 105
-            },
-            {
-              "filename": "app/models/user.rb",
-              "line_number": 8
-            },
-            {
-              "filename": "app/services/marketing_export.rb",
-              "line_number": 23
-            },
-            {
-              "filename": "lib/jwt.rb",
-              "line_number": 6
-            }
-          ]
-        }
-      ]
-    }
-```
-
-If we look at the `db/schema.rb` file mentioned in the report, we can see that email is exposed:
-```ruby
-  create_table "users", force: :cascade do |t|
-    t.string "name"
-    t.string "email"
-    t.string "telephone"
-    t.integer "organization_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["organization_id"], name: "index_users_on_organization_id"
-  end
-```
-
-To run your first data flow report, run `curio scan` with the `--report dataflow` flag. By default, the data flow report is output in JSON format. To format as YAML, use the `--format yaml` flag.
-
-## Stats Report
-
-The stats report provides a minimal overview of the scan including the total lines scanned, the detected data types, and the number of times each was found.
-
-```bash
-Scanning target... 100% [========================================] (278/278, 103 files/s) [2s]
-{
-  "number_of_lines": 1456,
-  "number_of_data_types": 6,
-  "data_types": [
-    {
-      "name": "Email Address",
-      "occurrences": 8
-    },
-    {
-      "name": "Fullname",
-      "occurrences": 3
-    },
-    {
-      "name": "Physical Address",
-      "occurrences": 2
-    },
-    {
-      "name": "Telephone Number",
-      "occurrences": 1
-    },
-    {
-      "name": "Transactions",
-      "occurrences": 7
-    },
-    {
-      "name": "Unique Identifier",
-      "occurrences": 2
-    }
-  ]
+  "subject_name": "User",
+  "name": "Telephone Number",
+  "detection_count": 14,
+  "critical_risk_failure_count": 0,
+  "high_risk_failure_count": 0,
+  "medium_risk_failure_count": 0,
+  "low_risk_failure_count": 0,
+  "rules_passed_count": 11
 }
 ```
 
-This report is useful for putting together ongoing statistics, making a quick check of data processing, or building internal dashboards. For more detailed information, you'll want to run a data flow report.
+The third parties portion displays data subjects and types that are sent to or processed by known third-party services. In the example below, Curio detects a user email address sent to Sentry via the Sentry SDK and notes that a critical-risk-level rule has failed associated with this data point.
 
-To run your first stats report, run `curio scan` with the `--report stats` flag. By default, the stats report is output in JSON format. To format as YAML, use the `--format yaml` flag.
+```bash
+{
+  "third_party": "Sentry",
+  "subject_name": "User",
+  "data_types": [
+    "Email Address"
+  ],
+  "critical_risk_failure_count": 1,
+  "high_risk_failure_count": 0,
+  "medium_risk_failure_count": 0,
+  "low_risk_failure_count": 0,
+  "rules_passed_count": 0
+}
+```
 
-## Detectors Report
+To run the privacy report, run `curio scan` with the `--report privacy` flag. By default, the privacy report is output in CSV format. To format as JSON, use the `--format json` flag.
 
-The detectors report type is the most low-level, data-rich type. You’re unlikely to use this report on its own, but it can be useful for building your own tooling based on the data parsed by Curio.
+## Customizing data subjects
 
-To run your first detectors report, run `curio scan` with the `--report detectors` flag. By default, the detectors report is output in JSON format. To format as YAML, use the `--format yaml` flag.
+By default, Curio maps all subjects to ****“User”, but you can override this by supplying Curio with custom mappings. This is done by passing the path to a JSON file with the `--data-subject-mapping` flag when you run the privacy report. For example:
+
+```bash
+curio scan . --report=privacy --data-subject-mapping=/path/to/mappings.json
+```
+
+The custom map file should follow the format used by [subject_mapping.json](https://github.com/Bearer/curio/blob/main/pkg/classification/db/subject_mapping.json). Replace a key’s value with the higher-level subject you’d like to associate it with. Some examples might include Customer, Employee, Client, Patient, etc.

--- a/docs/explanations/reports.md
+++ b/docs/explanations/reports.md
@@ -49,50 +49,54 @@ Summary reports are [currently available](/reference/supported-languages/) for R
 
 To run your first summary report, run `curio scan .` on your project directory. By default, the summary report is output in a human-readable format, but you can also output it as YAML or JSON by using the `--format yaml` or `--format json` flags.
 
-## Privacy Report
+## Privacy Report
 
 The privacy report provides useful information about how your codebase uses sensitive data, with an emphasis on data subjects and third parties.
 
 The data subjects portion displays information about each detected subject and any data types associated with it. It also provides statistics on total detections and any counts of rule failures associated with the data type. In the example below, the report detects 14 instances of user telephone numbers with no rule failures.
 
-```bash
-{
-  "subject_name": "User",
-  "name": "Telephone Number",
-  "detection_count": 14,
-  "critical_risk_failure_count": 0,
-  "high_risk_failure_count": 0,
-  "medium_risk_failure_count": 0,
-  "low_risk_failure_count": 0,
-  "rules_passed_count": 11
-}
+```json
+"Subjects": [
+  {
+    "subject_name": "User",
+    "name": "Telephone Number",
+    "detection_count": 14,
+    "critical_risk_failure_count": 0,
+    "high_risk_failure_count": 0,
+    "medium_risk_failure_count": 0,
+    "low_risk_failure_count": 0,
+    "rules_passed_count": 11
+  }
+]
 ```
 
 The third parties portion displays data subjects and types that are sent to or processed by known third-party services. In the example below, Curio detects a user email address sent to Sentry via the Sentry SDK and notes that a critical-risk-level rule has failed associated with this data point.
 
-```bash
-{
-  "third_party": "Sentry",
-  "subject_name": "User",
-  "data_types": [
-    "Email Address"
-  ],
-  "critical_risk_failure_count": 1,
-  "high_risk_failure_count": 0,
-  "medium_risk_failure_count": 0,
-  "low_risk_failure_count": 0,
-  "rules_passed_count": 0
-}
+```json
+"ThirdParty": [
+  {
+    "third_party": "Sentry",
+    "subject_name": "User",
+    "data_types": [
+      "Email Address"
+    ],
+    "critical_risk_failure_count": 1,
+    "high_risk_failure_count": 0,
+    "medium_risk_failure_count": 0,
+    "low_risk_failure_count": 0,
+    "rules_passed_count": 0
+  }
+]
 ```
 
 To run the privacy report, run `curio scan` with the `--report privacy` flag. By default, the privacy report is output in CSV format. To format as JSON, use the `--format json` flag.
 
-## Customizing data subjects
+### Customizing data subjects
 
-By default, Curio maps all subjects to ****“User”, but you can override this by supplying Curio with custom mappings. This is done by passing the path to a JSON file with the `--data-subject-mapping` flag when you run the privacy report. For example:
+By default, Curio maps all subjects to “User”, but you can override this by supplying Curio with custom mappings. This is done by passing the path to a JSON file with the `--data-subject-mapping` flag when you run the privacy report. For example:
 
 ```bash
 curio scan . --report=privacy --data-subject-mapping=/path/to/mappings.json
 ```
 
-The custom map file should follow the format used by [subject_mapping.json](https://github.com/Bearer/curio/blob/main/pkg/classification/db/subject_mapping.json). Replace a key’s value with the higher-level subject you’d like to associate it with. Some examples might include Customer, Employee, Client, Patient, etc.
+The custom map file should follow the format used by [subject_mapping.json](https://github.com/Bearer/curio/blob/main/pkg/classification/db/subject_mapping.json). Replace a key’s value with the higher-level subject you’d like to associate it with. Some examples might include Customer, Employee, Client, Patient, etc. Curio will use your replacement file instead of the default, so make sure to include any and all subjects you want reported.

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -16,44 +16,36 @@ curio init
 This creates a config file in your current directory. Below is an annotated version of that file.
 
 ```yml
-# Detector settings
-detector:
-    # Specify the comma-separated ids of the detectors you would like to run. 
-    # Skips all other detectors.
-    only-detector: []
-    # Specify the comma-separated ids of the detectors you would like to skip. 
-    # Runs all other detectors.
-    skip-detector: []
-# Rule settings
-rule:
-    # Specify the comma-separated ids of the rules you would like to run. 
-    # Skips all other rules.
-    only-rule: []
-    # Specify the comma-separated ids of the rules you would like to skip. 
-    # Runs all other rules.
-    skip-rule: []
 # Report settings
 report:
     # Specify report format (json, yaml)
     format: ""
     # Specify the output path for the report.
     output: ""
-    # Specify the type of report (detectors, dataflow, summary, stats). 
+    # Specify the type of report (summary, privacy). 
     report: summary
+# Rule settings
+rule:
+    # Specify the comma-separated ids of the rules you would like to run; 
+    # skips all other rules.
+    only-rule: []
+    # Specify the comma-separated ids of the rules you would like to skip; 
+    # runs all other rules.
+    skip-rule: []
 # Scan settings
 scan:
     # Expand context of schema classification 
     # For example, "health" will include data types particular to health
     context: ""
+    # Override default data subject mapping by providing a path to a custom mapping JSON file
+    data-subject-mapping: ""
     # Enable debug logs
     debug: false
     # Do not attempt to resolve detected domains during classification.
     disable-domain-resolution: true
     # Set timeout when attempting to resolve detected domains during classification.
     domain-resolution-timeout: 3s
-    # Specify directories paths that contain .yaml files with external custom detectors configuration.
-    external-detector-dir: []
-    # Specify directories paths that contain .rego files with external rules configuration.
+    # Specify directories paths that contain yaml files with external rules configuration.
     external-rule-dir: []
     # Disable the cache and runs the detections again every time scan runs.
     force: false
@@ -68,4 +60,4 @@ scan:
 
 ## Utilizing a custom config
 
-By default, Curio will look for a `curio.yml` file in the project directory where the scan is run. Alternately, you can use the `--config-file` flag with the scan command to reference a config file that is outside the project directory.
+By default, Curio will look for a `curio.yml` file in the project directory where the scan is run. Alternatively, you can use the `--config-file` flag with the scan command to reference a config file that is outside the project directory.

--- a/integration/flags/.snapshots/TestMetadataFlags-help-scan
+++ b/integration/flags/.snapshots/TestMetadataFlags-help-scan
@@ -12,7 +12,7 @@ Examples:
 Report Flags
   -f, --format string   Specify report format (json, yaml)
       --output string   Specify the output path for the report.
-      --report string   Specify the type of report (summary, dataflow, stats). (default "summary")
+      --report string   Specify the type of report (summary, privacy). (default "summary")
 
 Rule Flags
       --only-rule strings   Specify the comma-separated ids of the rules you would like to run. Skips all other rules.

--- a/integration/flags/.snapshots/TestMetadataFlags-scan-help
+++ b/integration/flags/.snapshots/TestMetadataFlags-scan-help
@@ -12,7 +12,7 @@ Examples:
 Report Flags
   -f, --format string   Specify report format (json, yaml)
       --output string   Specify the output path for the report.
-      --report string   Specify the type of report (summary, dataflow, stats). (default "summary")
+      --report string   Specify the type of report (summary, privacy). (default "summary")
 
 Rule Flags
       --only-rule strings   Specify the comma-separated ids of the rules you would like to run. Skips all other rules.

--- a/integration/flags/.snapshots/TestReportFlagsShouldFail-invalid-context-flag
+++ b/integration/flags/.snapshots/TestReportFlagsShouldFail-invalid-context-flag
@@ -13,7 +13,7 @@ Examples:
 Report Flags
   -f, --format string   Specify report format (json, yaml)
       --output string   Specify the output path for the report.
-      --report string   Specify the type of report (summary, dataflow, stats). (default "summary")
+      --report string   Specify the type of report (summary, privacy). (default "summary")
 
 Rule Flags
       --only-rule strings   Specify the comma-separated ids of the rules you would like to run. Skips all other rules.

--- a/integration/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag
+++ b/integration/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag
@@ -13,7 +13,7 @@ Examples:
 Report Flags
   -f, --format string   Specify report format (json, yaml)
       --output string   Specify the output path for the report.
-      --report string   Specify the type of report (summary, dataflow, stats). (default "summary")
+      --report string   Specify the type of report (summary, privacy). (default "summary")
 
 Rule Flags
       --only-rule strings   Specify the comma-separated ids of the rules you would like to run. Skips all other rules.

--- a/integration/flags/.snapshots/TestReportFlagsShouldFail-invalid-report-flag
+++ b/integration/flags/.snapshots/TestReportFlagsShouldFail-invalid-report-flag
@@ -1,6 +1,6 @@
 
 --
-Error: flag error: report flags error: invalid report argument; supported values: summary, dataflow, stats
+Error: flag error: report flags error: invalid report argument; supported values: summary, privacy
 Usage:
    scan [flags] <path>
 Aliases:
@@ -13,7 +13,7 @@ Examples:
 Report Flags
   -f, --format string   Specify report format (json, yaml)
       --output string   Specify the output path for the report.
-      --report string   Specify the type of report (summary, dataflow, stats). (default "summary")
+      --report string   Specify the type of report (summary, privacy). (default "summary")
 
 Rule Flags
       --only-rule strings   Specify the comma-separated ids of the rules you would like to run. Skips all other rules.
@@ -35,5 +35,5 @@ General Flags
       --config-file string   Load configuration from the specified path.
 
 
-flag error: report flags error: invalid report argument; supported values: summary, dataflow, stats
+flag error: report flags error: invalid report argument; supported values: summary, privacy
 

--- a/pkg/flag/report_flags.go
+++ b/pkg/flag/report_flags.go
@@ -11,15 +11,15 @@ var (
 	FormatYAML  = "yaml"
 	FormatEmpty = ""
 
-	ReportDetectors = "detectors" // nodoc: internal report type
-	ReportDataFlow  = "dataflow"
 	ReportPrivacy   = "privacy"
 	ReportSummary   = "summary"
-	ReportStats     = "stats"
+	ReportDetectors = "detectors" // nodoc: internal report type
+	ReportDataFlow  = "dataflow"  // nodoc: internal report type
+	ReportStats     = "stats"     // nodoc: internal report type
 )
 
 var ErrInvalidFormat = errors.New("invalid format argument; supported values: json, yaml")
-var ErrInvalidReport = errors.New("invalid report argument; supported values: summary, dataflow, stats")
+var ErrInvalidReport = errors.New("invalid report argument; supported values: summary, privacy")
 
 var (
 	FormatFlag = Flag{
@@ -33,7 +33,7 @@ var (
 		Name:       "report",
 		ConfigName: "report.report",
 		Value:      ReportSummary,
-		Usage:      "Specify the type of report (summary, dataflow, stats).",
+		Usage:      "Specify the type of report (summary, privacy).",
 	}
 	OutputFlag = Flag{
 		Name:       "output",
@@ -87,10 +87,11 @@ func (f *ReportFlagGroup) ToOptions() (ReportOptions, error) {
 
 	report := getString(f.Report)
 	switch report {
-	case ReportDetectors:
-	case ReportDataFlow:
 	case ReportPrivacy:
 	case ReportSummary:
+	// hidden flags for development use
+	case ReportDetectors:
+	case ReportDataFlow:
 	case ReportStats:
 	default:
 		return ReportOptions{}, ErrInvalidReport


### PR DESCRIPTION
## Description

Privacy report is all merged in. This is a draft PR for the related documentation changes. 

* Adds privacy report documentation to docs/reports (from @markmichon 's [Notion doc](https://www.notion.so/bearer/Privacy-Report-description-e98c5d30bfcb408eb1d8caf960aa0739))
* Removes documentation around dataflow, detectors, and stats reports -- these are still available for development use but we do not include them in the docs or as examples for the `--report` flag

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
