### PR TITLE
feat: warn when cached data is used

### DIFF
--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -219,7 +219,7 @@ func Run(ctx context.Context, opts flag.Options, targetKind TargetKind) (err err
 	case TargetFilesystem:
 		if report, err = r.ScanFilesystem(ctx, opts); err != nil {
 			if errors.Is(err, balancer.ErrFileListEmpty) {
-				output.StdOutLogger().Msgf("directory empty: %s", err)
+				outputhandler.StdOutLogger().Msgf("directory empty: %s", err)
 				os.Exit(0)
 				return
 			}


### PR DESCRIPTION
## Description

Adds some warning text to the console output, to tell the user when we're using cached data and to prompt them to use `--force` to force a new scan (if they want)

References #424 

### Screenshots

<img width="656" alt="Screenshot 2023-02-06 at 16 01 03" src="https://user-images.githubusercontent.com/4560746/216996857-d92e3f96-a75e-4918-93be-091ab72d860b.png">

### Summary 

<img width="1034" alt="Screenshot 2023-02-06 at 15 59 18" src="https://user-images.githubusercontent.com/4560746/216996864-0ed9b5c2-91ab-4a5f-9c99-07c2837b85ca.png">

### Stats

<img width="1207" alt="Screenshot 2023-02-06 at 16 56 23" src="https://user-images.githubusercontent.com/4560746/217005399-595bb888-9a7c-4849-b648-6f879fc1247d.png">

### Privacy

<img width="1282" alt="Screenshot 2023-02-06 at 16 56 54" src="https://user-images.githubusercontent.com/4560746/217005341-9c464a38-491e-4fea-895a-516ceab73fcf.png">

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
