### PR TITLE
docs: hotfix reference links

### DIFF
--- a/docs/reference/rule-pages.njk
+++ b/docs/reference/rule-pages.njk
@@ -3,7 +3,7 @@ pagination:
   data: rules.rules
   size: 1
   alias: rule
-permalink: "references/rules/{{ rule.metadata.id | slug }}/"
+permalink: "reference/rules/{{ rule.metadata.id | slug }}/"
 layout: layouts/doc.njk
 eleventyComputed:
   title: "Rule - {{ rule.metadata.description }}"


### PR DESCRIPTION
## Description

Fixes documentation url issue. Hotfixed on curio.sh already this is the backport to main


## Related
- Close #501 


## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [x] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
