### PR TITLE
docs(fix): change terminology on support page

### DIFF
--- a/docs/reference/supported-languages.md
+++ b/docs/reference/supported-languages.md
@@ -5,17 +5,17 @@ layout: layouts/doc.njk
 
 # Supported languages
 
-Curio currently fully supports Ruby, while JavaScript/TypeScript support is coming soon. Additional languages listed below are supported only for the Data Flow Report features for now.
+Curio currently fully supports Ruby, with JavaScript/TypeScript support coming soon. Additional languages listed below are supported only for the Privacy Report features for now.
 
-| Languages       | Data Flow Report | Policy Report |
-| --------------- | ---------------- | ------------- |
-| Ruby            | ✅                | ✅             |
-| JavaScript / TS | ✅                | Coming soon   |
-| PHP             | ✅                | Coming later  |
-| Java            | ✅                | Coming later  |
-| C#              | ✅                | Coming later  |
-| Go              | ✅                | Coming later  |
-| Python          | ✅                | Coming later  |
+| Languages       | Privacy Report | Summary Report |
+| --------------- | -------------- | -------------- |
+| Ruby            | ✅              | ✅              |
+| JavaScript / TS | ✅              | Coming soon    |
+| PHP             | ✅              | Coming later   |
+| Java            | ✅              | Coming later   |
+| C#              | ✅              | Coming later   |
+| Go              | ✅              | Coming later   |
+| Python          | ✅              | Coming later   |
 
 In addition, Curio also supports these common structured data file formats:
 


### PR DESCRIPTION
## Description
We had some residual references to data flow report and policy report on the supported languages page. This page will probably go through another change soon, but this keeps it up to date with the state of the codebase.

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
