### PR TITLE
fix(privacy report): fix Rules Passed spacing

### DIFF
--- a/pkg/report/output/privacy/privacy.go
+++ b/pkg/report/output/privacy/privacy.go
@@ -87,7 +87,7 @@ type Report struct {
 
 func BuildCsvString(dataflow *dataflow.DataFlow, config settings.Config) (*strings.Builder, error) {
 	csvStr := &strings.Builder{}
-	csvStr.WriteString("\nSubject,Data Types,Detection Count,Critical Risk Failure,High Risk Failure,Medium Risk Failure,Low Risk Failure,RulesPassed\n")
+	csvStr.WriteString("\nSubject,Data Types,Detection Count,Critical Risk Failure,High Risk Failure,Medium Risk Failure,Low Risk Failure,Rules Passed\n")
 	result, err := GetOutput(dataflow, config)
 	if err != nil {
 		return csvStr, err
@@ -108,7 +108,7 @@ func BuildCsvString(dataflow *dataflow.DataFlow, config settings.Config) (*strin
 	}
 
 	csvStr.WriteString("\n")
-	csvStr.WriteString("Third Party,Subject,Data Types,Critical Risk Failure,High Risk Failure,Medium Risk Failure,Low Risk Failure,RulesPassed\n")
+	csvStr.WriteString("Third Party,Subject,Data Types,Critical Risk Failure,High Risk Failure,Medium Risk Failure,Low Risk Failure,Rules Passed\n")
 
 	for _, thirdParty := range result.ThirdParty {
 		thirdPartyArr := []string{


### PR DESCRIPTION
## Description
Missing space between "Rules" and "Passed"

Before

<img width="1418" alt="Screenshot 2023-02-07 at 11 56 50" src="https://user-images.githubusercontent.com/4560746/217212400-95ce75f6-95f6-4988-9dd7-7840db8f157a.png">


After

<img width="1441" alt="Screenshot 2023-02-07 at 11 56 44" src="https://user-images.githubusercontent.com/4560746/217212389-2ea54484-5e66-4b42-9bf9-26766db208b2.png">



<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
