### PR TITLE
fix: use snakecase in privacy report

### DIFF
--- a/pkg/report/output/privacy/privacy.go
+++ b/pkg/report/output/privacy/privacy.go
@@ -81,8 +81,8 @@ type ThirdParty struct {
 }
 
 type Report struct {
-	Subjects   []Subject
-	ThirdParty []ThirdParty
+	Subjects   []Subject    `json:"subjects,omitempty" yaml:"subjects"`
+	ThirdParty []ThirdParty `json:"third_party,omitempty" yaml:"third_party"`
 }
 
 func BuildCsvString(dataflow *dataflow.DataFlow, config settings.Config) (*strings.Builder, error) {


### PR DESCRIPTION
## Description

Ensure top level attributes are in snakecase in privacy report JSON and YAML formats

<!-- Add this section if required
## Related
-->

- Closes #510

<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
