### PR TITLE
feat: add ruby open telemetry rule

### DIFF
--- a/integration/rules/ruby_test.go
+++ b/integration/rules/ruby_test.go
@@ -253,3 +253,13 @@ func TestRubyThirdPartiesAirbrakeDataflow(t *testing.T) {
 	t.Parallel()
 	runRulesTest("ruby/third_parties/airbrake", "dataflow", "ruby_third_parties_airbrake", t)
 }
+
+func TestRubyThirdPartiesOpenTelemetrySummary(t *testing.T) {
+	t.Parallel()
+	runRulesTest("ruby/third_parties/open_telemetry", "summary", "ruby_third_parties_open_telemetry", t)
+}
+
+func TestRubyThirdPartiesOpenTelemetryDataflow(t *testing.T) {
+	t.Parallel()
+	runRulesTest("ruby/third_parties/open_telemetry", "dataflow", "ruby_third_parties_open_telemetry", t)
+}

--- a/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry.yml
@@ -31,6 +31,8 @@ auxiliary:
     patterns:
       - |
         OpenTelemetry::Trace.current_span
+      - |
+        $<_>.in_span() { |$<!>$<_:identifier>| }
 trigger: local
 severity:
   default: low

--- a/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry.yml
@@ -1,0 +1,55 @@
+patterns:
+  - pattern: |
+      $<VAR>.$<METHOD>($<...>$<DATA_TYPE>$<...>)
+    filters:
+      - variable: VAR
+        detection: open_telemetry_current_span
+      - variable: DATA_TYPE
+        detection: datatype
+      - variable: METHOD
+        values:
+          - add_event
+          - add_attributes
+          - set_attribute
+          - record_exception
+  - pattern: |
+      $<_>.in_span($<_>, $<...>$<DATA_TYPE>$<...>)$<...>
+    filters:
+      - variable: DATA_TYPE
+        detection: datatype
+  - pattern: |
+      $<VAR>.status = OpenTelemetry::Trace::Status.error($<...>$<DATA_TYPE>$<...>)
+    filters:
+      - variable: VAR
+        detection: open_telemetry_current_span
+      - variable: DATA_TYPE
+        detection: datatype
+languages:
+  - ruby
+auxiliary:
+  - id: open_telemetry_current_span
+    patterns:
+      - |
+        OpenTelemetry::Trace.current_span
+trigger: local
+severity:
+  default: low
+  PII: critical
+  PHI: medium
+  PD: high
+skip_data_types:
+  - "Unique Identifier"
+metadata:
+  description: "Do not send sensitive data to Open Telemetry."
+  remediation_message: |
+    ## Description
+    Leaking sensitive data to third-party loggers is a common cause of data leaks and can lead to data breaches. This rule looks for instances of sensitive data sent to Open Telemetry.
+
+    ## Remediations
+
+    When logging errors or events, ensure all sensitive data is removed.
+
+    ## Resources
+    - [Open Telemetry Docs](https://opentelemetry.io/docs/)
+  dsr_id: DSR-1
+  id: ruby_third_parties_open_telemetry

--- a/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/.snapshots/TestRubyThirdPartiesOpenTelemetryDataflow-dataflow_ruby_third_parties_open_telemetry_datatype_in_record_exception.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/.snapshots/TestRubyThirdPartiesOpenTelemetryDataflow-dataflow_ruby_third_parties_open_telemetry_datatype_in_record_exception.rb
@@ -1,0 +1,65 @@
+data_types:
+    - name: Email Address
+      detectors:
+        - name: ruby
+          locations:
+            - filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_record_exception.rb
+              line_number: 7
+              field_name: email
+              object_name: current_user
+              subject_name: User
+    - name: IP address
+      detectors:
+        - name: ruby
+          locations:
+            - filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_record_exception.rb
+              line_number: 17
+              field_name: ip_address
+              object_name: user
+              subject_name: User
+risks:
+    - detector_id: ruby_third_parties_open_telemetry
+      data_types:
+        - name: Email Address
+          stored: false
+          locations:
+            - filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_record_exception.rb
+              line_number: 7
+              parent:
+                line_number: 7
+                content: 'current_span.status = OpenTelemetry::Trace::Status.error("error for user #{current_user.email}")'
+              field_name: email
+              object_name: current_user
+              subject_name: User
+        - name: IP address
+          stored: false
+          locations:
+            - filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_record_exception.rb
+              line_number: 17
+              parent:
+                line_number: 17
+                content: 'current_span.record_exception(ex, attributes: { "user.ip" => user.ip_address })'
+              field_name: ip_address
+              object_name: user
+              subject_name: User
+    - detector_id: open_telemetry_current_span
+      locations:
+        - filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_record_exception.rb
+          line_number: 2
+          parent:
+            line_number: 2
+            content: OpenTelemetry::Trace.current_span
+          content: |
+            OpenTelemetry::Trace.current_span
+        - filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_record_exception.rb
+          line_number: 11
+          parent:
+            line_number: 11
+            content: OpenTelemetry::Trace.current_span
+          content: |
+            OpenTelemetry::Trace.current_span
+components: []
+
+
+--
+

--- a/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/.snapshots/TestRubyThirdPartiesOpenTelemetryDataflow-dataflow_ruby_third_parties_open_telemetry_datatype_in_span_attributes.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/.snapshots/TestRubyThirdPartiesOpenTelemetryDataflow-dataflow_ruby_third_parties_open_telemetry_datatype_in_span_attributes.rb
@@ -1,0 +1,85 @@
+data_types:
+    - name: Email Address
+      detectors:
+        - name: ruby
+          locations:
+            - filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_span_attributes.rb
+              line_number: 12
+              field_name: email
+              object_name: user
+              subject_name: User
+            - filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_span_attributes.rb
+              line_number: 18
+              field_name: email
+              object_name: user
+              subject_name: User
+    - name: Firstname
+      detectors:
+        - name: ruby
+          locations:
+            - filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_span_attributes.rb
+              line_number: 7
+              field_name: first_name
+              object_name: user
+              subject_name: User
+risks:
+    - detector_id: ruby_third_parties_open_telemetry
+      data_types:
+        - name: Email Address
+          stored: false
+          locations:
+            - filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_span_attributes.rb
+              line_number: 12
+              parent:
+                line_number: 12
+                content: |-
+                    Tracer.in_span("data leaking", attributes: { "current_user" => user.email, "date" => DateTime.now }) do |span|
+                      puts "in the span block"
+                    end
+              field_name: email
+              object_name: user
+              subject_name: User
+            - filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_span_attributes.rb
+              line_number: 18
+              parent:
+                line_number: 19
+                content: current_span.set_attribute("current_users", users)
+              field_name: email
+              object_name: admin_user
+              subject_name: User
+        - name: Firstname
+          stored: false
+          locations:
+            - filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_span_attributes.rb
+              line_number: 7
+              parent:
+                line_number: 5
+                content: |-
+                    current_span.add_attributes({
+                        "user.id" => user.id,
+                        "user.first_name" => user.first_name
+                      })
+              field_name: first_name
+              object_name: user
+              subject_name: User
+    - detector_id: open_telemetry_current_span
+      locations:
+        - filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_span_attributes.rb
+          line_number: 3
+          parent:
+            line_number: 3
+            content: OpenTelemetry::Trace.current_span
+          content: |
+            OpenTelemetry::Trace.current_span
+        - filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_span_attributes.rb
+          line_number: 17
+          parent:
+            line_number: 17
+            content: OpenTelemetry::Trace.current_span
+          content: |
+            OpenTelemetry::Trace.current_span
+components: []
+
+
+--
+

--- a/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/.snapshots/TestRubyThirdPartiesOpenTelemetryDataflow-dataflow_ruby_third_parties_open_telemetry_datatype_in_span_attributes.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/.snapshots/TestRubyThirdPartiesOpenTelemetryDataflow-dataflow_ruby_third_parties_open_telemetry_datatype_in_span_attributes.rb
@@ -4,12 +4,7 @@ data_types:
         - name: ruby
           locations:
             - filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_span_attributes.rb
-              line_number: 12
-              field_name: email
-              object_name: user
-              subject_name: User
-            - filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_span_attributes.rb
-              line_number: 18
+              line_number: 13
               field_name: email
               object_name: user
               subject_name: User
@@ -29,20 +24,9 @@ risks:
           stored: false
           locations:
             - filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_span_attributes.rb
-              line_number: 12
+              line_number: 13
               parent:
-                line_number: 12
-                content: |-
-                    Tracer.in_span("data leaking", attributes: { "current_user" => user.email, "date" => DateTime.now }) do |span|
-                      puts "in the span block"
-                    end
-              field_name: email
-              object_name: user
-              subject_name: User
-            - filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_span_attributes.rb
-              line_number: 18
-              parent:
-                line_number: 19
+                line_number: 14
                 content: current_span.set_attribute("current_users", users)
               field_name: email
               object_name: admin_user
@@ -72,9 +56,9 @@ risks:
           content: |
             OpenTelemetry::Trace.current_span
         - filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_span_attributes.rb
-          line_number: 17
+          line_number: 12
           parent:
-            line_number: 17
+            line_number: 12
             content: OpenTelemetry::Trace.current_span
           content: |
             OpenTelemetry::Trace.current_span

--- a/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/.snapshots/TestRubyThirdPartiesOpenTelemetryDataflow-dataflow_ruby_third_parties_open_telemetry_datatype_in_span_event.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/.snapshots/TestRubyThirdPartiesOpenTelemetryDataflow-dataflow_ruby_third_parties_open_telemetry_datatype_in_span_event.rb
@@ -1,0 +1,54 @@
+data_types:
+    - name: Email Address
+      detectors:
+        - name: ruby
+          locations:
+            - filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_span_event.rb
+              line_number: 2
+              field_name: email
+              object_name: current_user
+              subject_name: User
+            - filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_span_event.rb
+              line_number: 4
+              field_name: email
+              object_name: current_user
+              subject_name: User
+risks:
+    - detector_id: ruby_third_parties_open_telemetry
+      data_types:
+        - name: Email Address
+          stored: false
+          locations:
+            - filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_span_event.rb
+              line_number: 2
+              parent:
+                line_number: 2
+                content: 'span.add_event("Schedule job for user: #{current_user.email}")'
+              field_name: email
+              object_name: current_user
+              subject_name: User
+            - filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_span_event.rb
+              line_number: 4
+              parent:
+                line_number: 3
+                content: |-
+                    span.add_event("Cancel job for user", attributes: {
+                      "current_user" => current_user.email
+                    })
+              field_name: email
+              object_name: current_user
+              subject_name: User
+    - detector_id: open_telemetry_current_span
+      locations:
+        - filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_span_event.rb
+          line_number: 1
+          parent:
+            line_number: 1
+            content: OpenTelemetry::Trace.current_span
+          content: |
+            OpenTelemetry::Trace.current_span
+components: []
+
+
+--
+

--- a/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/.snapshots/TestRubyThirdPartiesOpenTelemetryDataflow-dataflow_ruby_third_parties_open_telemetry_datatypes_in_span_init_block.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/.snapshots/TestRubyThirdPartiesOpenTelemetryDataflow-dataflow_ruby_third_parties_open_telemetry_datatypes_in_span_init_block.rb
@@ -1,0 +1,97 @@
+data_types:
+    - name: Email Address
+      detectors:
+        - name: ruby
+          locations:
+            - filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatypes_in_span_init_block.rb
+              line_number: 2
+              field_name: email
+              object_name: user
+              subject_name: User
+            - filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatypes_in_span_init_block.rb
+              line_number: 6
+              field_name: email
+              object_name: user
+              subject_name: User
+            - filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatypes_in_span_init_block.rb
+              line_number: 7
+              field_name: email
+              object_name: user
+              subject_name: User
+            - filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatypes_in_span_init_block.rb
+              line_number: 11
+              field_name: email
+              object_name: user
+              subject_name: User
+risks:
+    - detector_id: ruby_third_parties_open_telemetry
+      data_types:
+        - name: Email Address
+          stored: false
+          locations:
+            - filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatypes_in_span_init_block.rb
+              line_number: 2
+              parent:
+                line_number: 2
+                content: |-
+                    Tracer.in_span("data leaking", attributes: { "current_user" => user.email, "date" => DateTime.now }) do |span|
+                      puts "in the span block"
+                    end
+              field_name: email
+              object_name: user
+              subject_name: User
+            - filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatypes_in_span_init_block.rb
+              line_number: 6
+              parent:
+                line_number: 6
+                content: |-
+                    SomeOtherTracer.in_span("data leaking", attributes: { "current_user" => user.email, "date" => DateTime.now }) do |span|
+                      span.add_attributes(user.email)
+                    end
+              field_name: email
+              object_name: user
+              subject_name: User
+            - filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatypes_in_span_init_block.rb
+              line_number: 7
+              parent:
+                line_number: 7
+                content: span.add_attributes(user.email)
+              field_name: email
+              object_name: user
+              subject_name: User
+            - filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatypes_in_span_init_block.rb
+              line_number: 11
+              parent:
+                line_number: 11
+                content: 'span.add_event("leaking data for #{user.email}")'
+              field_name: email
+              object_name: user
+              subject_name: User
+    - detector_id: open_telemetry_current_span
+      locations:
+        - filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatypes_in_span_init_block.rb
+          line_number: 2
+          parent:
+            line_number: 2
+            content: span
+          content: |
+            $<_>.in_span() { |$<!>$<_:identifier>| }
+        - filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatypes_in_span_init_block.rb
+          line_number: 6
+          parent:
+            line_number: 6
+            content: span
+          content: |
+            $<_>.in_span() { |$<!>$<_:identifier>| }
+        - filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatypes_in_span_init_block.rb
+          line_number: 10
+          parent:
+            line_number: 10
+            content: span
+          content: |
+            $<_>.in_span() { |$<!>$<_:identifier>| }
+components: []
+
+
+--
+

--- a/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/.snapshots/TestRubyThirdPartiesOpenTelemetrySummary-summary_ruby_third_parties_open_telemetry_datatype_in_record_exception.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/.snapshots/TestRubyThirdPartiesOpenTelemetrySummary-summary_ruby_third_parties_open_telemetry_datatype_in_record_exception.rb
@@ -1,0 +1,27 @@
+critical:
+    - policy_name: ""
+      policy_dsrid: DSR-1
+      policy_display_id: ruby_third_parties_open_telemetry
+      policy_description: Do not send sensitive data to Open Telemetry.
+      line_number: 7
+      filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_record_exception.rb
+      category_groups:
+        - PII
+        - Personal Data
+      parent_line_number: 7
+      parent_content: 'current_span.status = OpenTelemetry::Trace::Status.error("error for user #{current_user.email}")'
+    - policy_name: ""
+      policy_dsrid: DSR-1
+      policy_display_id: ruby_third_parties_open_telemetry
+      policy_description: Do not send sensitive data to Open Telemetry.
+      line_number: 17
+      filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_record_exception.rb
+      category_groups:
+        - PII
+        - Personal Data
+      parent_line_number: 17
+      parent_content: 'current_span.record_exception(ex, attributes: { "user.ip" => user.ip_address })'
+
+
+--
+

--- a/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/.snapshots/TestRubyThirdPartiesOpenTelemetrySummary-summary_ruby_third_parties_open_telemetry_datatype_in_span_attributes.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/.snapshots/TestRubyThirdPartiesOpenTelemetrySummary-summary_ruby_third_parties_open_telemetry_datatype_in_span_attributes.rb
@@ -17,24 +17,11 @@ critical:
       policy_dsrid: DSR-1
       policy_display_id: ruby_third_parties_open_telemetry
       policy_description: Do not send sensitive data to Open Telemetry.
-      line_number: 12
+      line_number: 13
       filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_span_attributes.rb
       category_groups:
         - PII
-      parent_line_number: 12
-      parent_content: |-
-        Tracer.in_span("data leaking", attributes: { "current_user" => user.email, "date" => DateTime.now }) do |span|
-          puts "in the span block"
-        end
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_open_telemetry
-      policy_description: Do not send sensitive data to Open Telemetry.
-      line_number: 18
-      filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_span_attributes.rb
-      category_groups:
-        - PII
-      parent_line_number: 19
+      parent_line_number: 14
       parent_content: current_span.set_attribute("current_users", users)
 
 

--- a/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/.snapshots/TestRubyThirdPartiesOpenTelemetrySummary-summary_ruby_third_parties_open_telemetry_datatype_in_span_attributes.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/.snapshots/TestRubyThirdPartiesOpenTelemetrySummary-summary_ruby_third_parties_open_telemetry_datatype_in_span_attributes.rb
@@ -1,0 +1,42 @@
+critical:
+    - policy_name: ""
+      policy_dsrid: DSR-1
+      policy_display_id: ruby_third_parties_open_telemetry
+      policy_description: Do not send sensitive data to Open Telemetry.
+      line_number: 7
+      filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_span_attributes.rb
+      category_groups:
+        - PII
+      parent_line_number: 5
+      parent_content: |-
+        current_span.add_attributes({
+            "user.id" => user.id,
+            "user.first_name" => user.first_name
+          })
+    - policy_name: ""
+      policy_dsrid: DSR-1
+      policy_display_id: ruby_third_parties_open_telemetry
+      policy_description: Do not send sensitive data to Open Telemetry.
+      line_number: 12
+      filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_span_attributes.rb
+      category_groups:
+        - PII
+      parent_line_number: 12
+      parent_content: |-
+        Tracer.in_span("data leaking", attributes: { "current_user" => user.email, "date" => DateTime.now }) do |span|
+          puts "in the span block"
+        end
+    - policy_name: ""
+      policy_dsrid: DSR-1
+      policy_display_id: ruby_third_parties_open_telemetry
+      policy_description: Do not send sensitive data to Open Telemetry.
+      line_number: 18
+      filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_span_attributes.rb
+      category_groups:
+        - PII
+      parent_line_number: 19
+      parent_content: current_span.set_attribute("current_users", users)
+
+
+--
+

--- a/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/.snapshots/TestRubyThirdPartiesOpenTelemetrySummary-summary_ruby_third_parties_open_telemetry_datatype_in_span_event.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/.snapshots/TestRubyThirdPartiesOpenTelemetrySummary-summary_ruby_third_parties_open_telemetry_datatype_in_span_event.rb
@@ -1,0 +1,28 @@
+critical:
+    - policy_name: ""
+      policy_dsrid: DSR-1
+      policy_display_id: ruby_third_parties_open_telemetry
+      policy_description: Do not send sensitive data to Open Telemetry.
+      line_number: 2
+      filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_span_event.rb
+      category_groups:
+        - PII
+      parent_line_number: 2
+      parent_content: 'span.add_event("Schedule job for user: #{current_user.email}")'
+    - policy_name: ""
+      policy_dsrid: DSR-1
+      policy_display_id: ruby_third_parties_open_telemetry
+      policy_description: Do not send sensitive data to Open Telemetry.
+      line_number: 4
+      filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_span_event.rb
+      category_groups:
+        - PII
+      parent_line_number: 3
+      parent_content: |-
+        span.add_event("Cancel job for user", attributes: {
+          "current_user" => current_user.email
+        })
+
+
+--
+

--- a/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/.snapshots/TestRubyThirdPartiesOpenTelemetrySummary-summary_ruby_third_parties_open_telemetry_datatypes_in_span_init_block.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/.snapshots/TestRubyThirdPartiesOpenTelemetrySummary-summary_ruby_third_parties_open_telemetry_datatypes_in_span_init_block.rb
@@ -1,0 +1,51 @@
+critical:
+    - policy_name: ""
+      policy_dsrid: DSR-1
+      policy_display_id: ruby_third_parties_open_telemetry
+      policy_description: Do not send sensitive data to Open Telemetry.
+      line_number: 2
+      filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatypes_in_span_init_block.rb
+      category_groups:
+        - PII
+      parent_line_number: 2
+      parent_content: |-
+        Tracer.in_span("data leaking", attributes: { "current_user" => user.email, "date" => DateTime.now }) do |span|
+          puts "in the span block"
+        end
+    - policy_name: ""
+      policy_dsrid: DSR-1
+      policy_display_id: ruby_third_parties_open_telemetry
+      policy_description: Do not send sensitive data to Open Telemetry.
+      line_number: 6
+      filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatypes_in_span_init_block.rb
+      category_groups:
+        - PII
+      parent_line_number: 6
+      parent_content: |-
+        SomeOtherTracer.in_span("data leaking", attributes: { "current_user" => user.email, "date" => DateTime.now }) do |span|
+          span.add_attributes(user.email)
+        end
+    - policy_name: ""
+      policy_dsrid: DSR-1
+      policy_display_id: ruby_third_parties_open_telemetry
+      policy_description: Do not send sensitive data to Open Telemetry.
+      line_number: 7
+      filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatypes_in_span_init_block.rb
+      category_groups:
+        - PII
+      parent_line_number: 7
+      parent_content: span.add_attributes(user.email)
+    - policy_name: ""
+      policy_dsrid: DSR-1
+      policy_display_id: ruby_third_parties_open_telemetry
+      policy_description: Do not send sensitive data to Open Telemetry.
+      line_number: 11
+      filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatypes_in_span_init_block.rb
+      category_groups:
+        - PII
+      parent_line_number: 11
+      parent_content: 'span.add_event("leaking data for #{user.email}")'
+
+
+--
+

--- a/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_record_exception.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_record_exception.rb
@@ -1,0 +1,18 @@
+# set status
+current_span = OpenTelemetry::Trace.current_span
+
+begin
+  1/0 # something that obviously fails
+rescue
+  current_span.status = OpenTelemetry::Trace::Status.error("error for user #{current_user.email}")
+end
+
+# record exception to span (recommended together with set status)
+current_span = OpenTelemetry::Trace.current_span
+begin
+  1/0 # something that obviously fails
+rescue Exception => ex
+  current_span.status = OpenTelemetry::Trace::Status.error("error message here!")
+  current_span.record_exception(ex)
+  current_span.record_exception(ex, attributes: { "user.ip" => user.ip_address })
+end

--- a/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_span_attributes.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_span_attributes.rb
@@ -1,0 +1,21 @@
+# add attributes
+def track_user(user)
+  current_span = OpenTelemetry::Trace.current_span
+
+  current_span.add_attributes({
+    "user.id" => user.id,
+    "user.first_name" => user.first_name
+  })
+end
+
+# add attributes at span creation
+Tracer.in_span("data leaking", attributes: { "current_user" => user.email, "date" => DateTime.now }) do |span|
+  puts "in the span block"
+end
+
+# set attributes
+current_span = OpenTelemetry::Trace.current_span
+users = [user.email, customer.email, admin_user.email]
+current_span.set_attribute("current_users", users)
+
+

--- a/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_span_attributes.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_span_attributes.rb
@@ -8,11 +8,6 @@ def track_user(user)
   })
 end
 
-# add attributes at span creation
-Tracer.in_span("data leaking", attributes: { "current_user" => user.email, "date" => DateTime.now }) do |span|
-  puts "in the span block"
-end
-
 # set attributes
 current_span = OpenTelemetry::Trace.current_span
 users = [user.email, customer.email, admin_user.email]

--- a/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_span_event.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_span_event.rb
@@ -1,0 +1,5 @@
+span = OpenTelemetry::Trace.current_span
+span.add_event("Schedule job for user: #{current_user.email}")
+span.add_event("Cancel job for user", attributes: {
+  "current_user" => current_user.email
+})

--- a/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatypes_in_span_init_block.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatypes_in_span_init_block.rb
@@ -1,0 +1,12 @@
+# add attributes at span creation
+Tracer.in_span("data leaking", attributes: { "current_user" => user.email, "date" => DateTime.now }) do |span|
+  puts "in the span block"
+end
+
+SomeOtherTracer.in_span("data leaking", attributes: { "current_user" => user.email, "date" => DateTime.now }) do |span|
+  span.add_attributes(user.email)
+end
+
+YetAnotherTracer.in_span("data leaking", attributes: { "date" => DateTime.now }) do |span|
+  span.add_event("leaking data for #{user.email}")
+end


### PR DESCRIPTION
## Description
Add Ruby rule for open telemetry tracing

Relates to #366 

<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [x] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
