### PR TITLE
docs(feat): add 404 page

### DIFF
--- a/docs/404.md
+++ b/docs/404.md
@@ -1,0 +1,15 @@
+---
+title: Hmm, we couldn't find that
+permalink: 404.html
+layout: "layouts/doc"
+---
+
+# Page not found (404)
+
+Sorry, but we couldn't find the page you were looking for.
+
+- Curious about Curio? Check out the [overview](/).
+- Want to get started right away? Head over to the [quick start guide](/quickstart/).
+- Curio detects [all sorts of data types](/reference/datatypes/) and has [built-in rules](/reference/rules/) to check for data security risks.
+
+If you're looking for help using Curio, you can [create a new issue on GitHub]({{meta.links.issues}}) or join our [discord community]({{meta.links.discord}}).

--- a/docs/_data/meta.js
+++ b/docs/_data/meta.js
@@ -6,4 +6,8 @@ module.exports = {
   description:
     "Curio is a static code analysis tool (SAST) that scans your source code to discover security risks and vulnerabilities that put your sensitive data at risk (PHI, PD, PII).",
   favicon: "https://curio.sh/assets/img/favicon.svg",
+  links: {
+    discord: "https://discord.gg/eaHZBJUXRF",
+    issues: "https://github.com/Bearer/curio/issues",
+  },
 };


### PR DESCRIPTION
## Description
Adds a 404 page to the docs w/ some light guidance and getting started links.
## Related
- Close #469 
## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
