### PR TITLE
fix: remove mention of dataflow from launch copy

### DIFF
--- a/integration/flags/.snapshots/TestMetadataFlags-help
+++ b/integration/flags/.snapshots/TestMetadataFlags-help
@@ -18,8 +18,8 @@ Examples:
 	# Scan local directory or file and output security risks
 	$ curio scan <path>
 
-	# Scan current directory and output the data flow to a file
-	$ curio scan --report dataflow --output <output-path> .
+	# Scan current directory and output the privacy report to a file
+	$ curio scan --report privacy --output <output-path> .
 
 Learn More:
 	Curio is a static code analysis tool (SAST) that scans your source code to

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -48,8 +48,8 @@ Examples:
 	# Scan local directory or file and output security risks
 	$ curio scan <path>
 
-	# Scan current directory and output the data flow to a file
-	$ curio scan --report dataflow --output <output-path> .
+	# Scan current directory and output the privacy report to a file
+	$ curio scan --report privacy --output <output-path> .
 
 Learn More:
 	Curio is a static code analysis tool (SAST) that scans your source code to


### PR DESCRIPTION
## Description

Legacy reference to dataflow report in curio launch copy

### Before

<img width="895" alt="Screenshot 2023-02-09 at 10 27 50" src="https://user-images.githubusercontent.com/4560746/217757689-61431e89-a329-4e23-87d9-a996ee378fb4.png">

### After

<img width="895" alt="Screenshot 2023-02-09 at 10 27 42" src="https://user-images.githubusercontent.com/4560746/217757710-8907ed23-ad28-4c42-b86f-2afba9e91292.png">

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
