### PR TITLE
feat(summary): improve output and fix some display issues

### DIFF
--- a/pkg/commands/process/settings/rules.go
+++ b/pkg/commands/process/settings/rules.go
@@ -23,6 +23,12 @@ func loadRules(externalRuleDirs []string, options flag.RuleOptions) (map[string]
 	if err := loadRuleDefinitions(definitions, rulesFs); err != nil {
 		return nil, nil, fmt.Errorf("error loading default rules: %s", err)
 	}
+	// add default documentaiton urls for default rules
+	for id, definition := range definitions {
+		if definition.Metadata.DocumentationUrl == "" {
+			definitions[id].Metadata.DocumentationUrl = "https://curio.sh/reference/rules/" + id
+		}
+	}
 
 	if err := loadRuleDefinitions(builtInDefinitions, builtInRulesFs); err != nil {
 		return nil, nil, fmt.Errorf("error loading default built-in rules: %s", err)
@@ -172,6 +178,7 @@ func buildRules(definitions map[string]RuleDefinition, enabledRules map[string]s
 			Languages:          definition.Languages,
 			ParamParenting:     definition.ParamParenting,
 			Patterns:           definition.Patterns,
+			DocumentationUrl:   definition.Metadata.DocumentationUrl,
 		}
 
 		for _, auxiliaryDefinition := range definition.Auxiliary {

--- a/pkg/commands/process/settings/rules/javascript/express/insecure_cookie/.snapshots/TestExpressSecureCookieSummary-summary_javascript_express_insecure_cookie_http_only.js
+++ b/pkg/commands/process/settings/rules/javascript/express/insecure_cookie/.snapshots/TestExpressSecureCookieSummary-summary_javascript_express_insecure_cookie_http_only.js
@@ -1,8 +1,8 @@
 low:
-    - policy_name: ""
-      policy_dsrid: DSR-5
-      policy_display_id: express_insecure_cookie
-      policy_description: Ensure cookies are sent over https.
+    - rule_dsrid: DSR-5
+      rule_display_id: express_insecure_cookie
+      rule_description: Ensure cookies are sent over https.
+      rule_documentation_url: https://curio.sh/reference/rules/express_insecure_cookie
       line_number: 9
       filename: pkg/commands/process/settings/rules/javascript/express/insecure_cookie/testdata/http_only.js
       parent_line_number: 9

--- a/pkg/commands/process/settings/rules/javascript/express/insecure_cookie/.snapshots/TestExpressSecureCookieSummary-summary_javascript_express_insecure_cookie_insecure_cookie.js
+++ b/pkg/commands/process/settings/rules/javascript/express/insecure_cookie/.snapshots/TestExpressSecureCookieSummary-summary_javascript_express_insecure_cookie_insecure_cookie.js
@@ -1,8 +1,8 @@
 low:
-    - policy_name: ""
-      policy_dsrid: DSR-5
-      policy_display_id: express_insecure_cookie
-      policy_description: Ensure cookies are sent over https.
+    - rule_dsrid: DSR-5
+      rule_display_id: express_insecure_cookie
+      rule_description: Ensure cookies are sent over https.
+      rule_documentation_url: https://curio.sh/reference/rules/express_insecure_cookie
       line_number: 9
       filename: pkg/commands/process/settings/rules/javascript/express/insecure_cookie/testdata/insecure_cookie.js
       parent_line_number: 9

--- a/pkg/commands/process/settings/rules/javascript/lang/logger/.snapshots/TestJavascriptLangLoggerSummary-summary_javascript_lang_logger_child.js
+++ b/pkg/commands/process/settings/rules/javascript/lang/logger/.snapshots/TestJavascriptLangLoggerSummary-summary_javascript_lang_logger_child.js
@@ -1,8 +1,8 @@
 low:
-    - policy_name: ""
-      policy_dsrid: DSR-5
-      policy_display_id: javascript_lang_logger
-      policy_description: Do not send sensitive data to loggers.
+    - rule_dsrid: DSR-5
+      rule_display_id: javascript_lang_logger
+      rule_description: Do not send sensitive data to loggers.
+      rule_documentation_url: https://curio.sh/reference/rules/javascript_lang_logger
       line_number: 3
       filename: pkg/commands/process/settings/rules/javascript/lang/logger/testdata/child.js
       parent_line_number: 7

--- a/pkg/commands/process/settings/rules/javascript/lang/logger/.snapshots/TestJavascriptLangLoggerSummary-summary_javascript_lang_logger_child_level.js
+++ b/pkg/commands/process/settings/rules/javascript/lang/logger/.snapshots/TestJavascriptLangLoggerSummary-summary_javascript_lang_logger_child_level.js
@@ -1,18 +1,18 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-5
-      policy_display_id: javascript_lang_logger
-      policy_description: Do not send sensitive data to loggers.
+    - rule_dsrid: DSR-5
+      rule_display_id: javascript_lang_logger
+      rule_description: Do not send sensitive data to loggers.
+      rule_documentation_url: https://curio.sh/reference/rules/javascript_lang_logger
       line_number: 3
       filename: pkg/commands/process/settings/rules/javascript/lang/logger/testdata/child_level.js
       category_groups:
         - PII
       parent_line_number: 7
       parent_content: logger.child(ctx)
-    - policy_name: ""
-      policy_dsrid: DSR-5
-      policy_display_id: javascript_lang_logger
-      policy_description: Do not send sensitive data to loggers.
+    - rule_dsrid: DSR-5
+      rule_display_id: javascript_lang_logger
+      rule_description: Do not send sensitive data to loggers.
+      rule_documentation_url: https://curio.sh/reference/rules/javascript_lang_logger
       line_number: 7
       filename: pkg/commands/process/settings/rules/javascript/lang/logger/testdata/child_level.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/lang/logger/.snapshots/TestJavascriptLangLoggerSummary-summary_javascript_lang_logger_console.js
+++ b/pkg/commands/process/settings/rules/javascript/lang/logger/.snapshots/TestJavascriptLangLoggerSummary-summary_javascript_lang_logger_console.js
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-5
-      policy_display_id: javascript_lang_logger
-      policy_description: Do not send sensitive data to loggers.
+    - rule_dsrid: DSR-5
+      rule_display_id: javascript_lang_logger
+      rule_description: Do not send sensitive data to loggers.
+      rule_documentation_url: https://curio.sh/reference/rules/javascript_lang_logger
       line_number: 1
       filename: pkg/commands/process/settings/rules/javascript/lang/logger/testdata/console.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/lang/logger/.snapshots/TestJavascriptLangLoggerSummary-summary_javascript_lang_logger_datatype_leak.js
+++ b/pkg/commands/process/settings/rules/javascript/lang/logger/.snapshots/TestJavascriptLangLoggerSummary-summary_javascript_lang_logger_datatype_leak.js
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-5
-      policy_display_id: javascript_lang_logger
-      policy_description: Do not send sensitive data to loggers.
+    - rule_dsrid: DSR-5
+      rule_display_id: javascript_lang_logger
+      rule_description: Do not send sensitive data to loggers.
+      rule_documentation_url: https://curio.sh/reference/rules/javascript_lang_logger
       line_number: 1
       filename: pkg/commands/process/settings/rules/javascript/lang/logger/testdata/datatype_leak.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/lang/logger/.snapshots/TestJavascriptLangLoggerSummary-summary_javascript_lang_logger_log.js
+++ b/pkg/commands/process/settings/rules/javascript/lang/logger/.snapshots/TestJavascriptLangLoggerSummary-summary_javascript_lang_logger_log.js
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-5
-      policy_display_id: javascript_lang_logger
-      policy_description: Do not send sensitive data to loggers.
+    - rule_dsrid: DSR-5
+      rule_display_id: javascript_lang_logger
+      rule_description: Do not send sensitive data to loggers.
+      rule_documentation_url: https://curio.sh/reference/rules/javascript_lang_logger
       line_number: 1
       filename: pkg/commands/process/settings/rules/javascript/lang/logger/testdata/log.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/third_parties/sentry/.snapshots/TestJavascriptThirdPartySentrySummary-summary_javascript_third_parties_sentry_javascript_add_breadcrumb.js
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/sentry/.snapshots/TestJavascriptThirdPartySentrySummary-summary_javascript_third_parties_sentry_javascript_add_breadcrumb.js
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: javascript_third_parties_sentry
-      policy_description: Do not send sensitive data to Sentry.
+    - rule_dsrid: DSR-1
+      rule_display_id: javascript_third_parties_sentry
+      rule_description: Do not send sensitive data to Sentry.
+      rule_documentation_url: https://curio.sh/reference/rules/javascript_third_parties_sentry
       line_number: 2
       filename: pkg/commands/process/settings/rules/javascript/third_parties/sentry/testdata/javascript_add_breadcrumb.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/third_parties/sentry/.snapshots/TestJavascriptThirdPartySentrySummary-summary_javascript_third_parties_sentry_javascript_capture_event.js
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/sentry/.snapshots/TestJavascriptThirdPartySentrySummary-summary_javascript_third_parties_sentry_javascript_capture_event.js
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: javascript_third_parties_sentry
-      policy_description: Do not send sensitive data to Sentry.
+    - rule_dsrid: DSR-1
+      rule_display_id: javascript_third_parties_sentry
+      rule_description: Do not send sensitive data to Sentry.
+      rule_documentation_url: https://curio.sh/reference/rules/javascript_third_parties_sentry
       line_number: 2
       filename: pkg/commands/process/settings/rules/javascript/third_parties/sentry/testdata/javascript_capture_event.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/third_parties/sentry/.snapshots/TestJavascriptThirdPartySentrySummary-summary_javascript_third_parties_sentry_javascript_capture_exception.js
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/sentry/.snapshots/TestJavascriptThirdPartySentrySummary-summary_javascript_third_parties_sentry_javascript_capture_exception.js
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: javascript_third_parties_sentry
-      policy_description: Do not send sensitive data to Sentry.
+    - rule_dsrid: DSR-1
+      rule_display_id: javascript_third_parties_sentry
+      rule_description: Do not send sensitive data to Sentry.
+      rule_documentation_url: https://curio.sh/reference/rules/javascript_third_parties_sentry
       line_number: 2
       filename: pkg/commands/process/settings/rules/javascript/third_parties/sentry/testdata/javascript_capture_exception.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/third_parties/sentry/.snapshots/TestJavascriptThirdPartySentrySummary-summary_javascript_third_parties_sentry_javascript_capture_message.js
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/sentry/.snapshots/TestJavascriptThirdPartySentrySummary-summary_javascript_third_parties_sentry_javascript_capture_message.js
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: javascript_third_parties_sentry
-      policy_description: Do not send sensitive data to Sentry.
+    - rule_dsrid: DSR-1
+      rule_display_id: javascript_third_parties_sentry
+      rule_description: Do not send sensitive data to Sentry.
+      rule_documentation_url: https://curio.sh/reference/rules/javascript_third_parties_sentry
       line_number: 1
       filename: pkg/commands/process/settings/rules/javascript/third_parties/sentry/testdata/javascript_capture_message.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/third_parties/sentry/.snapshots/TestJavascriptThirdPartySentrySummary-summary_javascript_third_parties_sentry_javascript_configure_scope_set_extra.js
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/sentry/.snapshots/TestJavascriptThirdPartySentrySummary-summary_javascript_third_parties_sentry_javascript_configure_scope_set_extra.js
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: javascript_third_parties_sentry
-      policy_description: Do not send sensitive data to Sentry.
+    - rule_dsrid: DSR-1
+      rule_display_id: javascript_third_parties_sentry
+      rule_description: Do not send sensitive data to Sentry.
+      rule_documentation_url: https://curio.sh/reference/rules/javascript_third_parties_sentry
       line_number: 2
       filename: pkg/commands/process/settings/rules/javascript/third_parties/sentry/testdata/javascript_configure_scope_set_extra.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/third_parties/sentry/.snapshots/TestJavascriptThirdPartySentrySummary-summary_javascript_third_parties_sentry_javascript_configure_scope_set_tag.js
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/sentry/.snapshots/TestJavascriptThirdPartySentrySummary-summary_javascript_third_parties_sentry_javascript_configure_scope_set_tag.js
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: javascript_third_parties_sentry
-      policy_description: Do not send sensitive data to Sentry.
+    - rule_dsrid: DSR-1
+      rule_display_id: javascript_third_parties_sentry
+      rule_description: Do not send sensitive data to Sentry.
+      rule_documentation_url: https://curio.sh/reference/rules/javascript_third_parties_sentry
       line_number: 2
       filename: pkg/commands/process/settings/rules/javascript/third_parties/sentry/testdata/javascript_configure_scope_set_tag.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/third_parties/sentry/.snapshots/TestJavascriptThirdPartySentrySummary-summary_javascript_third_parties_sentry_javascript_configure_scope_set_user.js
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/sentry/.snapshots/TestJavascriptThirdPartySentrySummary-summary_javascript_third_parties_sentry_javascript_configure_scope_set_user.js
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: javascript_third_parties_sentry
-      policy_description: Do not send sensitive data to Sentry.
+    - rule_dsrid: DSR-1
+      rule_display_id: javascript_third_parties_sentry
+      rule_description: Do not send sensitive data to Sentry.
+      rule_documentation_url: https://curio.sh/reference/rules/javascript_third_parties_sentry
       line_number: 2
       filename: pkg/commands/process/settings/rules/javascript/third_parties/sentry/testdata/javascript_configure_scope_set_user.js
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/lang/cookies/.snapshots/TestRubyLangCookiesSummary-summary_ruby_lang_cookies_datatype_in_signed_cookies.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/cookies/.snapshots/TestRubyLangCookiesSummary-summary_ruby_lang_cookies_datatype_in_signed_cookies.rb
@@ -1,18 +1,18 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-3
-      policy_display_id: ruby_lang_cookies
-      policy_description: Do not store sensitive data in cookies.
+    - rule_dsrid: DSR-3
+      rule_display_id: ruby_lang_cookies
+      rule_description: Do not store sensitive data in cookies.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_cookies
       line_number: 1
       filename: pkg/commands/process/settings/rules/ruby/lang/cookies/testdata/datatype_in_signed_cookies.rb
       category_groups:
         - PII
       parent_line_number: 1
       parent_content: cookies.signed[:info] = user.email
-    - policy_name: ""
-      policy_dsrid: DSR-3
-      policy_display_id: ruby_lang_cookies
-      policy_description: Do not store sensitive data in cookies.
+    - rule_dsrid: DSR-3
+      rule_display_id: ruby_lang_cookies
+      rule_description: Do not store sensitive data in cookies.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_cookies
       line_number: 2
       filename: pkg/commands/process/settings/rules/ruby/lang/cookies/testdata/datatype_in_signed_cookies.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/lang/cookies/.snapshots/TestRubyLangCookiesSummary-summary_ruby_lang_cookies_datatype_object_in_cookie.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/cookies/.snapshots/TestRubyLangCookiesSummary-summary_ruby_lang_cookies_datatype_object_in_cookie.rb
@@ -1,18 +1,18 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-3
-      policy_display_id: ruby_lang_cookies
-      policy_description: Do not store sensitive data in cookies.
+    - rule_dsrid: DSR-3
+      rule_display_id: ruby_lang_cookies
+      rule_description: Do not store sensitive data in cookies.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_cookies
       line_number: 2
       filename: pkg/commands/process/settings/rules/ruby/lang/cookies/testdata/datatype_object_in_cookie.rb
       category_groups:
         - PII
       parent_line_number: 5
       parent_content: 'cookies[:login] = { value: user.to_json, expires: 1.hour, secure: true }'
-    - policy_name: ""
-      policy_dsrid: DSR-3
-      policy_display_id: ruby_lang_cookies
-      policy_description: Do not store sensitive data in cookies.
+    - rule_dsrid: DSR-3
+      rule_display_id: ruby_lang_cookies
+      rule_description: Do not store sensitive data in cookies.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_cookies
       line_number: 3
       filename: pkg/commands/process/settings/rules/ruby/lang/cookies/testdata/datatype_object_in_cookie.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/lang/exception/.snapshots/TestRubyLangExceptionSummary-summary_ruby_lang_exception_datatype_leak.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/exception/.snapshots/TestRubyLangExceptionSummary-summary_ruby_lang_exception_datatype_leak.rb
@@ -1,18 +1,18 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-5
-      policy_display_id: ruby_lang_exception
-      policy_description: Do not send sensitive data to exceptions.
+    - rule_dsrid: DSR-5
+      rule_display_id: ruby_lang_exception
+      rule_description: Do not send sensitive data to exceptions.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_exception
       line_number: 1
       filename: pkg/commands/process/settings/rules/ruby/lang/exception/testdata/datatype_leak.rb
       category_groups:
         - PII
       parent_line_number: 1
       parent_content: raise CustomException.new(user.email)
-    - policy_name: ""
-      policy_dsrid: DSR-5
-      policy_display_id: ruby_lang_exception
-      policy_description: Do not send sensitive data to exceptions.
+    - rule_dsrid: DSR-5
+      rule_display_id: ruby_lang_exception
+      rule_description: Do not send sensitive data to exceptions.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_exception
       line_number: 2
       filename: pkg/commands/process/settings/rules/ruby/lang/exception/testdata/datatype_leak.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/lang/file_generation/.snapshots/TestRubyLangFileGenerationSummary-summary_ruby_lang_file_generation_datatype_in_file_open.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/file_generation/.snapshots/TestRubyLangFileGenerationSummary-summary_ruby_lang_file_generation_datatype_in_file_open.rb
@@ -1,18 +1,18 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-4
-      policy_display_id: ruby_lang_file_generation
-      policy_description: Do not write sensitive data to static files.
+    - rule_dsrid: DSR-4
+      rule_display_id: ruby_lang_file_generation
+      rule_description: Do not write sensitive data to static files.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_file_generation
       line_number: 1
       filename: pkg/commands/process/settings/rules/ruby/lang/file_generation/testdata/datatype_in_file_open.rb
       category_groups:
         - PII
       parent_line_number: 1
       parent_content: 'f.write "#{Time.now} - User #{user.email} logged in\n"'
-    - policy_name: ""
-      policy_dsrid: DSR-4
-      policy_display_id: ruby_lang_file_generation
-      policy_description: Do not write sensitive data to static files.
+    - rule_dsrid: DSR-4
+      rule_display_id: ruby_lang_file_generation
+      rule_description: Do not write sensitive data to static files.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_file_generation
       line_number: 5
       filename: pkg/commands/process/settings/rules/ruby/lang/file_generation/testdata/datatype_in_file_open.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/lang/file_generation/.snapshots/TestRubyLangFileGenerationSummary-summary_ruby_lang_file_generation_datatype_in_io_sysopen.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/file_generation/.snapshots/TestRubyLangFileGenerationSummary-summary_ruby_lang_file_generation_datatype_in_io_sysopen.rb
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-4
-      policy_display_id: ruby_lang_file_generation
-      policy_description: Do not write sensitive data to static files.
+    - rule_dsrid: DSR-4
+      rule_display_id: ruby_lang_file_generation
+      rule_description: Do not write sensitive data to static files.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_file_generation
       line_number: 3
       filename: pkg/commands/process/settings/rules/ruby/lang/file_generation/testdata/datatype_in_io_sysopen.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/lang/http_get_params/.snapshots/TestRubyLangHttpGetParamsSummary-summary_ruby_lang_http_get_params_datatype_in_param_hash.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/http_get_params/.snapshots/TestRubyLangHttpGetParamsSummary-summary_ruby_lang_http_get_params_datatype_in_param_hash.rb
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-2
-      policy_display_id: ruby_lang_http_get_params
-      policy_description: Do not send sensitive data as HTTP GET parameters.
+    - rule_dsrid: DSR-2
+      rule_display_id: ruby_lang_http_get_params
+      rule_description: Do not send sensitive data as HTTP GET parameters.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_http_get_params
       line_number: 1
       filename: pkg/commands/process/settings/rules/ruby/lang/http_get_params/testdata/datatype_in_param_hash.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/lang/http_get_params/.snapshots/TestRubyLangHttpGetParamsSummary-summary_ruby_lang_http_get_params_datatype_in_params.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/http_get_params/.snapshots/TestRubyLangHttpGetParamsSummary-summary_ruby_lang_http_get_params_datatype_in_params.rb
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-2
-      policy_display_id: ruby_lang_http_get_params
-      policy_description: Do not send sensitive data as HTTP GET parameters.
+    - rule_dsrid: DSR-2
+      rule_display_id: ruby_lang_http_get_params
+      rule_description: Do not send sensitive data as HTTP GET parameters.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_http_get_params
       line_number: 1
       filename: pkg/commands/process/settings/rules/ruby/lang/http_get_params/testdata/datatype_in_params.rb
       category_groups:
@@ -10,10 +10,10 @@ critical:
         - Personal Data (Sensitive)
       parent_line_number: 1
       parent_content: URI("https://my.api.com/users/search?ethnic_origin=#{user.ethnic_origin}")
-    - policy_name: ""
-      policy_dsrid: DSR-2
-      policy_display_id: ruby_lang_http_get_params
-      policy_description: Do not send sensitive data as HTTP GET parameters.
+    - rule_dsrid: DSR-2
+      rule_display_id: ruby_lang_http_get_params
+      rule_description: Do not send sensitive data as HTTP GET parameters.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_http_get_params
       line_number: 3
       filename: pkg/commands/process/settings/rules/ruby/lang/http_get_params/testdata/datatype_in_params.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/lang/http_insecure/.snapshots/TestRubyLangHttpInsecureSummary-summary_ruby_lang_http_insecure_insecure_get.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/http_insecure/.snapshots/TestRubyLangHttpInsecureSummary-summary_ruby_lang_http_insecure_insecure_get.rb
@@ -1,8 +1,8 @@
 low:
-    - policy_name: ""
-      policy_dsrid: DSR-2
-      policy_display_id: ruby_lang_http_insecure
-      policy_description: Only communicate using HTTPS connections.
+    - rule_dsrid: DSR-2
+      rule_display_id: ruby_lang_http_insecure
+      rule_description: Only communicate using HTTPS connections.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_http_insecure
       line_number: 1
       filename: pkg/commands/process/settings/rules/ruby/lang/http_insecure/testdata/insecure_get.rb
       parent_line_number: 1

--- a/pkg/commands/process/settings/rules/ruby/lang/http_insecure/.snapshots/TestRubyLangHttpInsecureSummary-summary_ruby_lang_http_insecure_insecure_post.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/http_insecure/.snapshots/TestRubyLangHttpInsecureSummary-summary_ruby_lang_http_insecure_insecure_post.rb
@@ -1,8 +1,8 @@
 low:
-    - policy_name: ""
-      policy_dsrid: DSR-2
-      policy_display_id: ruby_lang_http_insecure
-      policy_description: Only communicate using HTTPS connections.
+    - rule_dsrid: DSR-2
+      rule_display_id: ruby_lang_http_insecure
+      rule_description: Only communicate using HTTPS connections.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_http_insecure
       line_number: 1
       filename: pkg/commands/process/settings/rules/ruby/lang/http_insecure/testdata/insecure_post.rb
       parent_line_number: 1

--- a/pkg/commands/process/settings/rules/ruby/lang/http_insecure/.snapshots/TestRubyLangHttpInsecureSummary-summary_ruby_lang_http_insecure_insecure_post_form.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/http_insecure/.snapshots/TestRubyLangHttpInsecureSummary-summary_ruby_lang_http_insecure_insecure_post_form.rb
@@ -1,8 +1,8 @@
 low:
-    - policy_name: ""
-      policy_dsrid: DSR-2
-      policy_display_id: ruby_lang_http_insecure
-      policy_description: Only communicate using HTTPS connections.
+    - rule_dsrid: DSR-2
+      rule_display_id: ruby_lang_http_insecure
+      rule_description: Only communicate using HTTPS connections.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_http_insecure
       line_number: 1
       filename: pkg/commands/process/settings/rules/ruby/lang/http_insecure/testdata/insecure_post_form.rb
       parent_line_number: 1

--- a/pkg/commands/process/settings/rules/ruby/lang/http_insecure/.snapshots/TestRubyLangHttpInsecureSummary-summary_ruby_lang_http_insecure_uri_encode_form.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/http_insecure/.snapshots/TestRubyLangHttpInsecureSummary-summary_ruby_lang_http_insecure_uri_encode_form.rb
@@ -1,8 +1,8 @@
 low:
-    - policy_name: ""
-      policy_dsrid: DSR-2
-      policy_display_id: ruby_lang_http_insecure
-      policy_description: Only communicate using HTTPS connections.
+    - rule_dsrid: DSR-2
+      rule_display_id: ruby_lang_http_insecure
+      rule_description: Only communicate using HTTPS connections.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_http_insecure
       line_number: 1
       filename: pkg/commands/process/settings/rules/ruby/lang/http_insecure/testdata/uri_encode_form.rb
       parent_line_number: 1

--- a/pkg/commands/process/settings/rules/ruby/lang/http_post_insecure_with_data/.snapshots/TestRubyLangHttpPostInsecureWithDataSummary-summary_ruby_lang_http_post_insecure_with_data_insecure_post_form_with_datatype.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/http_post_insecure_with_data/.snapshots/TestRubyLangHttpPostInsecureWithDataSummary-summary_ruby_lang_http_post_insecure_with_data_insecure_post_form_with_datatype.rb
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-2
-      policy_display_id: ruby_lang_http_post_insecure_with_data
-      policy_description: Only send sensitive data through HTTPS connections.
+    - rule_dsrid: DSR-2
+      rule_display_id: ruby_lang_http_post_insecure_with_data
+      rule_description: Only send sensitive data through HTTPS connections.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_http_post_insecure_with_data
       line_number: 1
       filename: pkg/commands/process/settings/rules/ruby/lang/http_post_insecure_with_data/testdata/insecure_post_form_with_datatype.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/lang/http_post_insecure_with_data/.snapshots/TestRubyLangHttpPostInsecureWithDataSummary-summary_ruby_lang_http_post_insecure_with_data_insecure_post_with_datatype.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/http_post_insecure_with_data/.snapshots/TestRubyLangHttpPostInsecureWithDataSummary-summary_ruby_lang_http_post_insecure_with_data_insecure_post_with_datatype.rb
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-2
-      policy_display_id: ruby_lang_http_post_insecure_with_data
-      policy_description: Only send sensitive data through HTTPS connections.
+    - rule_dsrid: DSR-2
+      rule_display_id: ruby_lang_http_post_insecure_with_data
+      rule_description: Only send sensitive data through HTTPS connections.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_http_post_insecure_with_data
       line_number: 1
       filename: pkg/commands/process/settings/rules/ruby/lang/http_post_insecure_with_data/testdata/insecure_post_with_datatype.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/lang/insecure_ftp/.snapshots/TestRubyLangInsecureFtpSummary-summary_ruby_lang_insecure_ftp_ftp_new.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/insecure_ftp/.snapshots/TestRubyLangInsecureFtpSummary-summary_ruby_lang_insecure_ftp_ftp_new.rb
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-2
-      policy_display_id: ruby_lang_insecure_ftp
-      policy_description: Only communicate using SFTP connections.
+    - rule_dsrid: DSR-2
+      rule_display_id: ruby_lang_insecure_ftp
+      rule_description: Only communicate using SFTP connections.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_insecure_ftp
       line_number: 8
       filename: pkg/commands/process/settings/rules/ruby/lang/insecure_ftp/testdata/ftp_new.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/lang/insecure_ftp/.snapshots/TestRubyLangInsecureFtpSummary-summary_ruby_lang_insecure_ftp_ftp_open.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/insecure_ftp/.snapshots/TestRubyLangInsecureFtpSummary-summary_ruby_lang_insecure_ftp_ftp_open.rb
@@ -1,8 +1,8 @@
 low:
-    - policy_name: ""
-      policy_dsrid: DSR-2
-      policy_display_id: ruby_lang_insecure_ftp
-      policy_description: Only communicate using SFTP connections.
+    - rule_dsrid: DSR-2
+      rule_display_id: ruby_lang_insecure_ftp
+      rule_description: Only communicate using SFTP connections.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_insecure_ftp
       line_number: 3
       filename: pkg/commands/process/settings/rules/ruby/lang/insecure_ftp/testdata/ftp_open.rb
       parent_line_number: 3

--- a/pkg/commands/process/settings/rules/ruby/lang/insecure_ftp/.snapshots/TestRubyLangInsecureFtpSummary-summary_ruby_lang_insecure_ftp_ftp_open_with_datatype.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/insecure_ftp/.snapshots/TestRubyLangInsecureFtpSummary-summary_ruby_lang_insecure_ftp_ftp_open_with_datatype.rb
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-2
-      policy_display_id: ruby_lang_insecure_ftp
-      policy_description: Only communicate using SFTP connections.
+    - rule_dsrid: DSR-2
+      rule_display_id: ruby_lang_insecure_ftp
+      rule_description: Only communicate using SFTP connections.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_insecure_ftp
       line_number: 3
       filename: pkg/commands/process/settings/rules/ruby/lang/insecure_ftp/testdata/ftp_open_with_datatype.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/lang/jwt/.snapshots/TestRubyLangJwtSummary-summary_ruby_lang_jwt_datatype_in_jwt.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/jwt/.snapshots/TestRubyLangJwtSummary-summary_ruby_lang_jwt_datatype_in_jwt.rb
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-3
-      policy_display_id: ruby_lang_jwt
-      policy_description: Do not store sensitive data in JWTs.
+    - rule_dsrid: DSR-3
+      rule_display_id: ruby_lang_jwt
+      rule_description: Do not store sensitive data in JWTs.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_jwt
       line_number: 1
       filename: pkg/commands/process/settings/rules/ruby/lang/jwt/testdata/datatype_in_jwt.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/lang/jwt/.snapshots/TestRubyLangJwtSummary-summary_ruby_lang_jwt_datatype_object_in_jwt.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/jwt/.snapshots/TestRubyLangJwtSummary-summary_ruby_lang_jwt_datatype_object_in_jwt.rb
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-3
-      policy_display_id: ruby_lang_jwt
-      policy_description: Do not store sensitive data in JWTs.
+    - rule_dsrid: DSR-3
+      rule_display_id: ruby_lang_jwt
+      rule_description: Do not store sensitive data in JWTs.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_jwt
       line_number: 3
       filename: pkg/commands/process/settings/rules/ruby/lang/jwt/testdata/datatype_object_in_jwt.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/lang/jwt/.snapshots/TestRubyLangJwtSummary-summary_ruby_lang_jwt_datatypes_with_encrypted_jwt.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/jwt/.snapshots/TestRubyLangJwtSummary-summary_ruby_lang_jwt_datatypes_with_encrypted_jwt.rb
@@ -1,28 +1,28 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-3
-      policy_display_id: ruby_lang_jwt
-      policy_description: Do not store sensitive data in JWTs.
+    - rule_dsrid: DSR-3
+      rule_display_id: ruby_lang_jwt
+      rule_description: Do not store sensitive data in JWTs.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_jwt
       line_number: 2
       filename: pkg/commands/process/settings/rules/ruby/lang/jwt/testdata/datatypes_with_encrypted_jwt.rb
       category_groups:
         - PII
       parent_line_number: 2
       parent_content: 'JWT.encode({ user: current_user.email }, private_key, ''HS256'', {})'
-    - policy_name: ""
-      policy_dsrid: DSR-3
-      policy_display_id: ruby_lang_jwt
-      policy_description: Do not store sensitive data in JWTs.
+    - rule_dsrid: DSR-3
+      rule_display_id: ruby_lang_jwt
+      rule_description: Do not store sensitive data in JWTs.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_jwt
       line_number: 4
       filename: pkg/commands/process/settings/rules/ruby/lang/jwt/testdata/datatypes_with_encrypted_jwt.rb
       category_groups:
         - PII
       parent_line_number: 4
       parent_content: 'JWT.encode({ user: current_user.email }, ENV["SECRET_KEY"])'
-    - policy_name: ""
-      policy_dsrid: DSR-3
-      policy_display_id: ruby_lang_jwt
-      policy_description: Do not store sensitive data in JWTs.
+    - rule_dsrid: DSR-3
+      rule_display_id: ruby_lang_jwt
+      rule_description: Do not store sensitive data in JWTs.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_jwt
       line_number: 6
       filename: pkg/commands/process/settings/rules/ruby/lang/jwt/testdata/datatypes_with_encrypted_jwt.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/lang/logger/.snapshots/TestRubyLangLoggerSummary-summary_ruby_lang_logger_datatype_leak.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/logger/.snapshots/TestRubyLangLoggerSummary-summary_ruby_lang_logger_datatype_leak.rb
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-5
-      policy_display_id: ruby_lang_logger
-      policy_description: Do not send sensitive data to loggers.
+    - rule_dsrid: DSR-5
+      rule_display_id: ruby_lang_logger
+      rule_description: Do not send sensitive data to loggers.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_logger
       line_number: 1
       filename: pkg/commands/process/settings/rules/ruby/lang/logger/testdata/datatype_leak.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/lang/ssl_verification/.snapshots/TestRubyLangSslVerificationSummary-summary_ruby_lang_ssl_verification_verification_disabled.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/ssl_verification/.snapshots/TestRubyLangSslVerificationSummary-summary_ruby_lang_ssl_verification_verification_disabled.rb
@@ -1,16 +1,16 @@
 low:
-    - policy_name: ""
-      policy_dsrid: DSR-2
-      policy_display_id: ruby_lang_ssl_verification
-      policy_description: Enable SSL Certificate Verification.
+    - rule_dsrid: DSR-2
+      rule_display_id: ruby_lang_ssl_verification
+      rule_description: Enable SSL Certificate Verification.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_ssl_verification
       line_number: 1
       filename: pkg/commands/process/settings/rules/ruby/lang/ssl_verification/testdata/verification_disabled.rb
       parent_line_number: 1
       parent_content: http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-    - policy_name: ""
-      policy_dsrid: DSR-2
-      policy_display_id: ruby_lang_ssl_verification
-      policy_description: Enable SSL Certificate Verification.
+    - rule_dsrid: DSR-2
+      rule_display_id: ruby_lang_ssl_verification
+      rule_description: Enable SSL Certificate Verification.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_ssl_verification
       line_number: 4
       filename: pkg/commands/process/settings/rules/ruby/lang/ssl_verification/testdata/verification_disabled.rb
       parent_line_number: 4

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryptionSummary-summary_ruby_lang_weak_encryption_blowfish.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryptionSummary-summary_ruby_lang_weak_encryption_blowfish.rb
@@ -1,8 +1,8 @@
 low:
-    - policy_name: ""
-      policy_dsrid: DSR-7
-      policy_display_id: ruby_lang_weak_encryption
-      policy_description: Avoid weak encryption libraries.
+    - rule_dsrid: DSR-7
+      rule_display_id: ruby_lang_weak_encryption
+      rule_description: Avoid weak encryption libraries.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_weak_encryption
       line_number: 2
       filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption/testdata/blowfish.rb
       parent_line_number: 2

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryptionSummary-summary_ruby_lang_weak_encryption_digest_md5.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryptionSummary-summary_ruby_lang_weak_encryption_digest_md5.rb
@@ -1,8 +1,8 @@
 low:
-    - policy_name: ""
-      policy_dsrid: DSR-7
-      policy_display_id: ruby_lang_weak_encryption
-      policy_description: Avoid weak encryption libraries.
+    - rule_dsrid: DSR-7
+      rule_display_id: ruby_lang_weak_encryption
+      rule_description: Avoid weak encryption libraries.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_weak_encryption
       line_number: 1
       filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption/testdata/digest_md5.rb
       parent_line_number: 1

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryptionSummary-summary_ruby_lang_weak_encryption_digest_sha1.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryptionSummary-summary_ruby_lang_weak_encryption_digest_sha1.rb
@@ -1,8 +1,8 @@
 low:
-    - policy_name: ""
-      policy_dsrid: DSR-7
-      policy_display_id: ruby_lang_weak_encryption
-      policy_description: Avoid weak encryption libraries.
+    - rule_dsrid: DSR-7
+      rule_display_id: ruby_lang_weak_encryption
+      rule_description: Avoid weak encryption libraries.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_weak_encryption
       line_number: 1
       filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption/testdata/digest_sha1.rb
       parent_line_number: 1

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryptionSummary-summary_ruby_lang_weak_encryption_openssl_dsa.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryptionSummary-summary_ruby_lang_weak_encryption_openssl_dsa.rb
@@ -1,16 +1,16 @@
 low:
-    - policy_name: ""
-      policy_dsrid: DSR-7
-      policy_display_id: ruby_lang_weak_encryption
-      policy_description: Avoid weak encryption libraries.
+    - rule_dsrid: DSR-7
+      rule_display_id: ruby_lang_weak_encryption
+      rule_description: Avoid weak encryption libraries.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_weak_encryption
       line_number: 3
       filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption/testdata/openssl_dsa.rb
       parent_line_number: 3
       parent_content: dsa_encrypt.export(cipher, "hello world")
-    - policy_name: ""
-      policy_dsrid: DSR-7
-      policy_display_id: ruby_lang_weak_encryption
-      policy_description: Avoid weak encryption libraries.
+    - rule_dsrid: DSR-7
+      rule_display_id: ruby_lang_weak_encryption
+      rule_description: Avoid weak encryption libraries.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_weak_encryption
       line_number: 5
       filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption/testdata/openssl_dsa.rb
       parent_line_number: 5

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryptionSummary-summary_ruby_lang_weak_encryption_openssl_rsa.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryptionSummary-summary_ruby_lang_weak_encryption_openssl_rsa.rb
@@ -1,24 +1,24 @@
 low:
-    - policy_name: ""
-      policy_dsrid: DSR-7
-      policy_display_id: ruby_lang_weak_encryption
-      policy_description: Avoid weak encryption libraries.
+    - rule_dsrid: DSR-7
+      rule_display_id: ruby_lang_weak_encryption
+      rule_description: Avoid weak encryption libraries.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_weak_encryption
       line_number: 1
       filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption/testdata/openssl_rsa.rb
       parent_line_number: 1
       parent_content: OpenSSL::PKey::RSA.new(File.read('rsa.pem')).private_encrypt("test")
-    - policy_name: ""
-      policy_dsrid: DSR-7
-      policy_display_id: ruby_lang_weak_encryption
-      policy_description: Avoid weak encryption libraries.
+    - rule_dsrid: DSR-7
+      rule_display_id: ruby_lang_weak_encryption
+      rule_description: Avoid weak encryption libraries.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_weak_encryption
       line_number: 5
       filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption/testdata/openssl_rsa.rb
       parent_line_number: 5
       parent_content: rsa_encrypt.export(cipher, "hello world")
-    - policy_name: ""
-      policy_dsrid: DSR-7
-      policy_display_id: ruby_lang_weak_encryption
-      policy_description: Avoid weak encryption libraries.
+    - rule_dsrid: DSR-7
+      rule_display_id: ruby_lang_weak_encryption
+      rule_description: Avoid weak encryption libraries.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_weak_encryption
       line_number: 7
       filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption/testdata/openssl_rsa.rb
       parent_line_number: 7

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryptionSummary-summary_ruby_lang_weak_encryption_rc4_encrypt.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryptionSummary-summary_ruby_lang_weak_encryption_rc4_encrypt.rb
@@ -1,16 +1,16 @@
 low:
-    - policy_name: ""
-      policy_dsrid: DSR-7
-      policy_display_id: ruby_lang_weak_encryption
-      policy_description: Avoid weak encryption libraries.
+    - rule_dsrid: DSR-7
+      rule_display_id: ruby_lang_weak_encryption
+      rule_description: Avoid weak encryption libraries.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_weak_encryption
       line_number: 1
       filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption/testdata/rc4_encrypt.rb
       parent_line_number: 1
       parent_content: RC4.new("insecure").encrypt("hello world")
-    - policy_name: ""
-      policy_dsrid: DSR-7
-      policy_display_id: ruby_lang_weak_encryption
-      policy_description: Avoid weak encryption libraries.
+    - rule_dsrid: DSR-7
+      rule_display_id: ruby_lang_weak_encryption
+      rule_description: Avoid weak encryption libraries.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_weak_encryption
       line_number: 4
       filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption/testdata/rc4_encrypt.rb
       parent_line_number: 4

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithDataSummary-summary_ruby_lang_weak_encryption_with_data_blowfish_data.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithDataSummary-summary_ruby_lang_weak_encryption_with_data_blowfish_data.rb
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-7
-      policy_display_id: ruby_lang_weak_encryption_with_data
-      policy_description: Do not use weak encryption libraries to encrypt sensitive data.
+    - rule_dsrid: DSR-7
+      rule_display_id: ruby_lang_weak_encryption_with_data
+      rule_description: Do not use weak encryption libraries to encrypt sensitive data.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_weak_encryption_with_data
       line_number: 2
       filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/testdata/blowfish_data.rb
       category_groups:
@@ -12,10 +12,10 @@ critical:
         Crypt::Blowfish.new("insecure").encrypt_block { |user|
           user.password
         }
-    - policy_name: ""
-      policy_dsrid: DSR-7
-      policy_display_id: ruby_lang_weak_encryption_with_data
-      policy_description: Do not use weak encryption libraries to encrypt sensitive data.
+    - rule_dsrid: DSR-7
+      rule_display_id: ruby_lang_weak_encryption_with_data
+      rule_description: Do not use weak encryption libraries to encrypt sensitive data.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_weak_encryption_with_data
       line_number: 6
       filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/testdata/blowfish_data.rb
       category_groups:
@@ -25,10 +25,10 @@ critical:
         Crypt::Blowfish.new("insecure").encrypt_block do |user|
           user.password
         end
-    - policy_name: ""
-      policy_dsrid: DSR-7
-      policy_display_id: ruby_lang_weak_encryption_with_data
-      policy_description: Do not use weak encryption libraries to encrypt sensitive data.
+    - rule_dsrid: DSR-7
+      rule_display_id: ruby_lang_weak_encryption_with_data
+      rule_description: Do not use weak encryption libraries to encrypt sensitive data.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_weak_encryption_with_data
       line_number: 9
       filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/testdata/blowfish_data.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithDataSummary-summary_ruby_lang_weak_encryption_with_data_digest_md5.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithDataSummary-summary_ruby_lang_weak_encryption_with_data_digest_md5.rb
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-7
-      policy_display_id: ruby_lang_weak_encryption_with_data
-      policy_description: Do not use weak encryption libraries to encrypt sensitive data.
+    - rule_dsrid: DSR-7
+      rule_display_id: ruby_lang_weak_encryption_with_data
+      rule_description: Do not use weak encryption libraries to encrypt sensitive data.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_weak_encryption_with_data
       line_number: 1
       filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/testdata/digest_md5.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithDataSummary-summary_ruby_lang_weak_encryption_with_data_digest_sha1.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithDataSummary-summary_ruby_lang_weak_encryption_with_data_digest_sha1.rb
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-7
-      policy_display_id: ruby_lang_weak_encryption_with_data
-      policy_description: Do not use weak encryption libraries to encrypt sensitive data.
+    - rule_dsrid: DSR-7
+      rule_display_id: ruby_lang_weak_encryption_with_data
+      rule_description: Do not use weak encryption libraries to encrypt sensitive data.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_weak_encryption_with_data
       line_number: 1
       filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/testdata/digest_sha1.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithDataSummary-summary_ruby_lang_weak_encryption_with_data_openssl_dsa_data.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithDataSummary-summary_ruby_lang_weak_encryption_with_data_openssl_dsa_data.rb
@@ -1,18 +1,18 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-7
-      policy_display_id: ruby_lang_weak_encryption_with_data
-      policy_description: Do not use weak encryption libraries to encrypt sensitive data.
+    - rule_dsrid: DSR-7
+      rule_display_id: ruby_lang_weak_encryption_with_data
+      rule_description: Do not use weak encryption libraries to encrypt sensitive data.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_weak_encryption_with_data
       line_number: 3
       filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/testdata/openssl_dsa_data.rb
       category_groups:
         - PII
       parent_line_number: 3
       parent_content: dsa_encrypt.export(cipher, user.email)
-    - policy_name: ""
-      policy_dsrid: DSR-7
-      policy_display_id: ruby_lang_weak_encryption_with_data
-      policy_description: Do not use weak encryption libraries to encrypt sensitive data.
+    - rule_dsrid: DSR-7
+      rule_display_id: ruby_lang_weak_encryption_with_data
+      rule_description: Do not use weak encryption libraries to encrypt sensitive data.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_weak_encryption_with_data
       line_number: 5
       filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/testdata/openssl_dsa_data.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithDataSummary-summary_ruby_lang_weak_encryption_with_data_openssl_rsa_data.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithDataSummary-summary_ruby_lang_weak_encryption_with_data_openssl_rsa_data.rb
@@ -1,28 +1,28 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-7
-      policy_display_id: ruby_lang_weak_encryption_with_data
-      policy_description: Do not use weak encryption libraries to encrypt sensitive data.
+    - rule_dsrid: DSR-7
+      rule_display_id: ruby_lang_weak_encryption_with_data
+      rule_description: Do not use weak encryption libraries to encrypt sensitive data.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_weak_encryption_with_data
       line_number: 1
       filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/testdata/openssl_rsa_data.rb
       category_groups:
         - PII
       parent_line_number: 1
       parent_content: OpenSSL::PKey::RSA.new(File.read('rsa.pem')).private_encrypt(user.password)
-    - policy_name: ""
-      policy_dsrid: DSR-7
-      policy_display_id: ruby_lang_weak_encryption_with_data
-      policy_description: Do not use weak encryption libraries to encrypt sensitive data.
+    - rule_dsrid: DSR-7
+      rule_display_id: ruby_lang_weak_encryption_with_data
+      rule_description: Do not use weak encryption libraries to encrypt sensitive data.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_weak_encryption_with_data
       line_number: 5
       filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/testdata/openssl_rsa_data.rb
       category_groups:
         - PII
       parent_line_number: 5
       parent_content: rsa_encrypt.export(cipher, user.password)
-    - policy_name: ""
-      policy_dsrid: DSR-7
-      policy_display_id: ruby_lang_weak_encryption_with_data
-      policy_description: Do not use weak encryption libraries to encrypt sensitive data.
+    - rule_dsrid: DSR-7
+      rule_display_id: ruby_lang_weak_encryption_with_data
+      rule_description: Do not use weak encryption libraries to encrypt sensitive data.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_weak_encryption_with_data
       line_number: 7
       filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/testdata/openssl_rsa_data.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithDataSummary-summary_ruby_lang_weak_encryption_with_data_rc4_data.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithDataSummary-summary_ruby_lang_weak_encryption_with_data_rc4_data.rb
@@ -1,18 +1,18 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-7
-      policy_display_id: ruby_lang_weak_encryption_with_data
-      policy_description: Do not use weak encryption libraries to encrypt sensitive data.
+    - rule_dsrid: DSR-7
+      rule_display_id: ruby_lang_weak_encryption_with_data
+      rule_description: Do not use weak encryption libraries to encrypt sensitive data.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_weak_encryption_with_data
       line_number: 1
       filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/testdata/rc4_data.rb
       category_groups:
         - PII
       parent_line_number: 1
       parent_content: RC4.new("insecure").encrypt(user.password)
-    - policy_name: ""
-      policy_dsrid: DSR-7
-      policy_display_id: ruby_lang_weak_encryption_with_data
-      policy_description: Do not use weak encryption libraries to encrypt sensitive data.
+    - rule_dsrid: DSR-7
+      rule_display_id: ruby_lang_weak_encryption_with_data
+      rule_description: Do not use weak encryption libraries to encrypt sensitive data.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_weak_encryption_with_data
       line_number: 4
       filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/testdata/rc4_data.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/rails/default_encryption/.snapshots/TestRubyRailsDefaultEncryptionSummary-summary_ruby_rails_default_encryption_application_level_encryption_missing
+++ b/pkg/commands/process/settings/rules/ruby/rails/default_encryption/.snapshots/TestRubyRailsDefaultEncryptionSummary-summary_ruby_rails_default_encryption_application_level_encryption_missing
@@ -1,8 +1,8 @@
 warning:
-    - policy_name: ""
-      policy_dsrid: DSR-10
-      policy_display_id: ruby_rails_default_encryption
-      policy_description: Force application-level encryption when processing sensitive data.
+    - rule_dsrid: DSR-10
+      rule_display_id: ruby_rails_default_encryption
+      rule_description: Force application-level encryption when processing sensitive data.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_rails_default_encryption
       line_number: 4
       filename: pkg/commands/process/settings/rules/ruby/rails/default_encryption/testdata/application_level_encryption_missing/schema_rb/db/schema.rb
       category_groups:
@@ -16,10 +16,10 @@ warning:
             t.datetime "created_at", null: false
             t.datetime "updated_at", null: false
           end
-    - policy_name: ""
-      policy_dsrid: DSR-10
-      policy_display_id: ruby_rails_default_encryption
-      policy_description: Force application-level encryption when processing sensitive data.
+    - rule_dsrid: DSR-10
+      rule_display_id: ruby_rails_default_encryption
+      rule_description: Force application-level encryption when processing sensitive data.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_rails_default_encryption
       line_number: 3
       filename: pkg/commands/process/settings/rules/ruby/rails/default_encryption/testdata/application_level_encryption_missing/structure_sql/db/structure.sql
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/rails/insecure_communication/.snapshots/TestRubyRailsInsecureCommunicationSummary-summary_ruby_rails_insecure_communication_no_datatypes.rb
+++ b/pkg/commands/process/settings/rules/ruby/rails/insecure_communication/.snapshots/TestRubyRailsInsecureCommunicationSummary-summary_ruby_rails_insecure_communication_no_datatypes.rb
@@ -1,8 +1,8 @@
 low:
-    - policy_name: ""
-      policy_dsrid: DSR-2
-      policy_display_id: ruby_rails_insecure_communication
-      policy_description: Force all incoming communication through SSL.
+    - rule_dsrid: DSR-2
+      rule_display_id: ruby_rails_insecure_communication
+      rule_description: Force all incoming communication through SSL.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_rails_insecure_communication
       line_number: 2
       filename: pkg/commands/process/settings/rules/ruby/rails/insecure_communication/testdata/no_datatypes.rb
       parent_line_number: 2

--- a/pkg/commands/process/settings/rules/ruby/rails/insecure_communication/.snapshots/TestRubyRailsInsecureCommunicationSummary-summary_ruby_rails_insecure_communication_ssl_disabled.rb
+++ b/pkg/commands/process/settings/rules/ruby/rails/insecure_communication/.snapshots/TestRubyRailsInsecureCommunicationSummary-summary_ruby_rails_insecure_communication_ssl_disabled.rb
@@ -1,8 +1,8 @@
 low:
-    - policy_name: ""
-      policy_dsrid: DSR-2
-      policy_display_id: ruby_rails_insecure_communication
-      policy_description: Force all incoming communication through SSL.
+    - rule_dsrid: DSR-2
+      rule_display_id: ruby_rails_insecure_communication
+      rule_description: Force all incoming communication through SSL.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_rails_insecure_communication
       line_number: 7
       filename: pkg/commands/process/settings/rules/ruby/rails/insecure_communication/testdata/ssl_disabled.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/rails/insecure_smtp/.snapshots/TestRubyRailsInsecureSmtpSummary-summary_ruby_rails_insecure_smtp_verify_none.rb
+++ b/pkg/commands/process/settings/rules/ruby/rails/insecure_smtp/.snapshots/TestRubyRailsInsecureSmtpSummary-summary_ruby_rails_insecure_smtp_verify_none.rb
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-2
-      policy_display_id: ruby_rails_insecure_smtp
-      policy_description: Only communicate with secure SMTP connections.
+    - rule_dsrid: DSR-2
+      rule_display_id: ruby_rails_insecure_smtp
+      rule_description: Only communicate with secure SMTP connections.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_rails_insecure_smtp
       line_number: 8
       filename: pkg/commands/process/settings/rules/ruby/rails/insecure_smtp/testdata/verify_none.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/rails/insecure_smtp/.snapshots/TestRubyRailsInsecureSmtpSummary-summary_ruby_rails_insecure_smtp_verify_none_ssl_var.rb
+++ b/pkg/commands/process/settings/rules/ruby/rails/insecure_smtp/.snapshots/TestRubyRailsInsecureSmtpSummary-summary_ruby_rails_insecure_smtp_verify_none_ssl_var.rb
@@ -1,8 +1,8 @@
 low:
-    - policy_name: ""
-      policy_dsrid: DSR-2
-      policy_display_id: ruby_rails_insecure_smtp
-      policy_description: Only communicate with secure SMTP connections.
+    - rule_dsrid: DSR-2
+      rule_display_id: ruby_rails_insecure_smtp
+      rule_description: Only communicate with secure SMTP connections.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_rails_insecure_smtp
       line_number: 3
       filename: pkg/commands/process/settings/rules/ruby/rails/insecure_smtp/testdata/verify_none_ssl_var.rb
       parent_line_number: 3

--- a/pkg/commands/process/settings/rules/ruby/rails/logger/.snapshots/TestRubyRailsLoggerSummary-summary_ruby_rails_logger_datatype_leak.rb
+++ b/pkg/commands/process/settings/rules/ruby/rails/logger/.snapshots/TestRubyRailsLoggerSummary-summary_ruby_rails_logger_datatype_leak.rb
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-5
-      policy_display_id: ruby_rails_logger
-      policy_description: Do not send sensitive data to Rails loggers.
+    - rule_dsrid: DSR-5
+      rule_display_id: ruby_rails_logger
+      rule_description: Do not send sensitive data to Rails loggers.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_rails_logger
       line_number: 1
       filename: pkg/commands/process/settings/rules/ruby/rails/logger/testdata/datatype_leak.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/rails/password_length/.snapshots/TestRubyRailsPasswordLengthSummary-summary_ruby_rails_password_length_password_too_short.rb
+++ b/pkg/commands/process/settings/rules/ruby/rails/password_length/.snapshots/TestRubyRailsPasswordLengthSummary-summary_ruby_rails_password_length_password_too_short.rb
@@ -1,8 +1,8 @@
 high:
-    - policy_name: ""
-      policy_dsrid: DSR-8
-      policy_display_id: ruby_rails_password_length
-      policy_description: Enforce stronger password requirements.
+    - rule_dsrid: DSR-8
+      rule_display_id: ruby_rails_password_length
+      rule_description: Enforce stronger password requirements.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_rails_password_length
       line_number: 3
       filename: pkg/commands/process/settings/rules/ruby/rails/password_length/testdata/password_too_short.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/rails/session/.snapshots/TestRubyRailsSessionSummary-summary_ruby_rails_session_datatype_in_session.rb
+++ b/pkg/commands/process/settings/rules/ruby/rails/session/.snapshots/TestRubyRailsSessionSummary-summary_ruby_rails_session_datatype_in_session.rb
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-3
-      policy_display_id: ruby_rails_session
-      policy_description: Do not store sensitive data in session cookies.
+    - rule_dsrid: DSR-3
+      rule_display_id: ruby_rails_session
+      rule_description: Do not store sensitive data in session cookies.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_rails_session
       line_number: 1
       filename: pkg/commands/process/settings/rules/ruby/rails/session/testdata/datatype_in_session.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/airbrake/.snapshots/TestRubyThirdPartiesAirbrakeSummary-summary_ruby_third_parties_airbrake_datatype_in_custom_notice.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/airbrake/.snapshots/TestRubyThirdPartiesAirbrakeSummary-summary_ruby_third_parties_airbrake_datatype_in_custom_notice.rb
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_airbrake
-      policy_description: Do not send sensitive data to Airbrake.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_airbrake
+      rule_description: Do not send sensitive data to Airbrake.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_airbrake
       line_number: 5
       filename: pkg/commands/process/settings/rules/ruby/third_parties/airbrake/testdata/datatype_in_custom_notice.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/airbrake/.snapshots/TestRubyThirdPartiesAirbrakeSummary-summary_ruby_third_parties_airbrake_datatype_in_extended_notify_methods.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/airbrake/.snapshots/TestRubyThirdPartiesAirbrakeSummary-summary_ruby_third_parties_airbrake_datatype_in_extended_notify_methods.rb
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_airbrake
-      policy_description: Do not send sensitive data to Airbrake.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_airbrake
+      rule_description: Do not send sensitive data to Airbrake.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_airbrake
       line_number: 3
       filename: pkg/commands/process/settings/rules/ruby/third_parties/airbrake/testdata/datatype_in_extended_notify_methods.rb
       category_groups:
@@ -15,10 +15,10 @@ critical:
           status_code: 200,
           timing: 123.45 # ms
         )
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_airbrake
-      policy_description: Do not send sensitive data to Airbrake.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_airbrake
+      rule_description: Do not send sensitive data to Airbrake.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_airbrake
       line_number: 9
       filename: pkg/commands/process/settings/rules/ruby/third_parties/airbrake/testdata/datatype_in_extended_notify_methods.rb
       category_groups:
@@ -31,10 +31,10 @@ critical:
           status_code: 200,
           timing: 123.45 # ms
         )
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_airbrake
-      policy_description: Do not send sensitive data to Airbrake.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_airbrake
+      rule_description: Do not send sensitive data to Airbrake.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_airbrake
       line_number: 17
       filename: pkg/commands/process/settings/rules/ruby/third_parties/airbrake/testdata/datatype_in_extended_notify_methods.rb
       category_groups:
@@ -47,10 +47,10 @@ critical:
           },
           request_id: 123
         )
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_airbrake
-      policy_description: Do not send sensitive data to Airbrake.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_airbrake
+      rule_description: Do not send sensitive data to Airbrake.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_airbrake
       line_number: 23
       filename: pkg/commands/process/settings/rules/ruby/third_parties/airbrake/testdata/datatype_in_extended_notify_methods.rb
       category_groups:
@@ -63,10 +63,10 @@ critical:
           },
           request_id: 123
         )
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_airbrake
-      policy_description: Do not send sensitive data to Airbrake.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_airbrake
+      rule_description: Do not send sensitive data to Airbrake.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_airbrake
       line_number: 31
       filename: pkg/commands/process/settings/rules/ruby/third_parties/airbrake/testdata/datatype_in_extended_notify_methods.rb
       category_groups:
@@ -78,10 +78,10 @@ critical:
           route: "/users/#{user.first_name}",
           query: 'SELECT * FROM foos'
         )
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_airbrake
-      policy_description: Do not send sensitive data to Airbrake.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_airbrake
+      rule_description: Do not send sensitive data to Airbrake.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_airbrake
       line_number: 36
       filename: pkg/commands/process/settings/rules/ruby/third_parties/airbrake/testdata/datatype_in_extended_notify_methods.rb
       category_groups:
@@ -93,10 +93,10 @@ critical:
           route: "/users/#{user.first_name}",
           query: 'SELECT * FROM foos'
         )
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_airbrake
-      policy_description: Do not send sensitive data to Airbrake.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_airbrake
+      rule_description: Do not send sensitive data to Airbrake.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_airbrake
       line_number: 43
       filename: pkg/commands/process/settings/rules/ruby/third_parties/airbrake/testdata/datatype_in_extended_notify_methods.rb
       category_groups:
@@ -109,10 +109,10 @@ critical:
           },
           request_id: 123
         )
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_airbrake
-      policy_description: Do not send sensitive data to Airbrake.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_airbrake
+      rule_description: Do not send sensitive data to Airbrake.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_airbrake
       line_number: 49
       filename: pkg/commands/process/settings/rules/ruby/third_parties/airbrake/testdata/datatype_in_extended_notify_methods.rb
       category_groups:
@@ -125,10 +125,10 @@ critical:
           },
           request_id: 123
         )
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_airbrake
-      policy_description: Do not send sensitive data to Airbrake.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_airbrake
+      rule_description: Do not send sensitive data to Airbrake.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_airbrake
       line_number: 57
       filename: pkg/commands/process/settings/rules/ruby/third_parties/airbrake/testdata/datatype_in_extended_notify_methods.rb
       category_groups:
@@ -142,10 +142,10 @@ critical:
           groups: { db: 24.0, view: 0.4 }, # ms
           timing: 123.45 # ms
         )
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_airbrake
-      policy_description: Do not send sensitive data to Airbrake.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_airbrake
+      rule_description: Do not send sensitive data to Airbrake.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_airbrake
       line_number: 64
       filename: pkg/commands/process/settings/rules/ruby/third_parties/airbrake/testdata/datatype_in_extended_notify_methods.rb
       category_groups:
@@ -159,10 +159,10 @@ critical:
           groups: { db: 24.0, view: 0.4 }, # ms
           timing: 123.45 # ms
         )
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_airbrake
-      policy_description: Do not send sensitive data to Airbrake.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_airbrake
+      rule_description: Do not send sensitive data to Airbrake.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_airbrake
       line_number: 73
       filename: pkg/commands/process/settings/rules/ruby/third_parties/airbrake/testdata/datatype_in_extended_notify_methods.rb
       category_groups:
@@ -175,10 +175,10 @@ critical:
           },
           request_id: 123
         )
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_airbrake
-      policy_description: Do not send sensitive data to Airbrake.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_airbrake
+      rule_description: Do not send sensitive data to Airbrake.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_airbrake
       line_number: 79
       filename: pkg/commands/process/settings/rules/ruby/third_parties/airbrake/testdata/datatype_in_extended_notify_methods.rb
       category_groups:
@@ -191,10 +191,10 @@ critical:
           },
           request_id: 123
         )
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_airbrake
-      policy_description: Do not send sensitive data to Airbrake.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_airbrake
+      rule_description: Do not send sensitive data to Airbrake.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_airbrake
       line_number: 101
       filename: pkg/commands/process/settings/rules/ruby/third_parties/airbrake/testdata/datatype_in_extended_notify_methods.rb
       category_groups:
@@ -207,10 +207,10 @@ critical:
           },
           job_id: 123
         )
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_airbrake
-      policy_description: Do not send sensitive data to Airbrake.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_airbrake
+      rule_description: Do not send sensitive data to Airbrake.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_airbrake
       line_number: 107
       filename: pkg/commands/process/settings/rules/ruby/third_parties/airbrake/testdata/datatype_in_extended_notify_methods.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/airbrake/.snapshots/TestRubyThirdPartiesAirbrakeSummary-summary_ruby_third_parties_airbrake_datatype_in_merge_context.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/airbrake/.snapshots/TestRubyThirdPartiesAirbrakeSummary-summary_ruby_third_parties_airbrake_datatype_in_merge_context.rb
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_airbrake
-      policy_description: Do not send sensitive data to Airbrake.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_airbrake
+      rule_description: Do not send sensitive data to Airbrake.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_airbrake
       line_number: 1
       filename: pkg/commands/process/settings/rules/ruby/third_parties/airbrake/testdata/datatype_in_merge_context.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/airbrake/.snapshots/TestRubyThirdPartiesAirbrakeSummary-summary_ruby_third_parties_airbrake_datatype_in_notify.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/airbrake/.snapshots/TestRubyThirdPartiesAirbrakeSummary-summary_ruby_third_parties_airbrake_datatype_in_notify.rb
@@ -1,18 +1,18 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_airbrake
-      policy_description: Do not send sensitive data to Airbrake.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_airbrake
+      rule_description: Do not send sensitive data to Airbrake.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_airbrake
       line_number: 1
       filename: pkg/commands/process/settings/rules/ruby/third_parties/airbrake/testdata/datatype_in_notify.rb
       category_groups:
         - PII
       parent_line_number: 1
       parent_content: Airbrake.notify(user.first_name)
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_airbrake
-      policy_description: Do not send sensitive data to Airbrake.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_airbrake
+      rule_description: Do not send sensitive data to Airbrake.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_airbrake
       line_number: 4
       filename: pkg/commands/process/settings/rules/ruby/third_parties/airbrake/testdata/datatype_in_notify.rb
       category_groups:
@@ -22,10 +22,10 @@ critical:
         Airbrake.notify('App crashed!', {
           current_user: user.email
         })
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_airbrake
-      policy_description: Do not send sensitive data to Airbrake.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_airbrake
+      rule_description: Do not send sensitive data to Airbrake.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_airbrake
       line_number: 8
       filename: pkg/commands/process/settings/rules/ruby/third_parties/airbrake/testdata/datatype_in_notify.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/airbrake/.snapshots/TestRubyThirdPartiesAirbrakeSummary-summary_ruby_third_parties_airbrake_datatype_in_rescue_block.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/airbrake/.snapshots/TestRubyThirdPartiesAirbrakeSummary-summary_ruby_third_parties_airbrake_datatype_in_rescue_block.rb
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_airbrake
-      policy_description: Do not send sensitive data to Airbrake.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_airbrake
+      rule_description: Do not send sensitive data to Airbrake.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_airbrake
       line_number: 4
       filename: pkg/commands/process/settings/rules/ruby/third_parties/airbrake/testdata/datatype_in_rescue_block.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/algolia/.snapshots/TestRubyThirdPartiesAlgoliaSummary-summary_ruby_third_parties_algolia_datatype_in_save_object.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/algolia/.snapshots/TestRubyThirdPartiesAlgoliaSummary-summary_ruby_third_parties_algolia_datatype_in_save_object.rb
@@ -1,18 +1,18 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-6
-      policy_display_id: ruby_third_parties_algolia
-      policy_description: Do not store sensitive data in Algolia.
+    - rule_dsrid: DSR-6
+      rule_display_id: ruby_third_parties_algolia
+      rule_description: Do not store sensitive data in Algolia.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_algolia
       line_number: 4
       filename: pkg/commands/process/settings/rules/ruby/third_parties/algolia/testdata/datatype_in_save_object.rb
       category_groups:
         - PII
       parent_line_number: 4
       parent_content: 'index.save_object({ email: user.email }, { auto_generate_object_id_if_not_exist: true })'
-    - policy_name: ""
-      policy_dsrid: DSR-6
-      policy_display_id: ruby_third_parties_algolia
-      policy_description: Do not store sensitive data in Algolia.
+    - rule_dsrid: DSR-6
+      rule_display_id: ruby_third_parties_algolia
+      rule_description: Do not store sensitive data in Algolia.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_algolia
       line_number: 6
       filename: pkg/commands/process/settings/rules/ruby/third_parties/algolia/testdata/datatype_in_save_object.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/bugsnag/.snapshots/TestRubyThirdPartiesBugsnagSummary-summary_ruby_third_parties_bugsnag_breadcrumb.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/bugsnag/.snapshots/TestRubyThirdPartiesBugsnagSummary-summary_ruby_third_parties_bugsnag_breadcrumb.rb
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_bugsnag
-      policy_description: Do not send sensitive data to Bugsnag.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_bugsnag
+      rule_description: Do not send sensitive data to Bugsnag.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_bugsnag
       line_number: 2
       filename: pkg/commands/process/settings/rules/ruby/third_parties/bugsnag/testdata/breadcrumb.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/datadog/.snapshots/TestRubyThirdPartiesDatadogSummary-summary_ruby_third_parties_datadog_datatype_in_tags.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/datadog/.snapshots/TestRubyThirdPartiesDatadogSummary-summary_ruby_third_parties_datadog_datatype_in_tags.rb
@@ -1,48 +1,48 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_datadog
-      policy_description: Do not send sensitive data to Datadog.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_datadog
+      rule_description: Do not send sensitive data to Datadog.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_datadog
       line_number: 2
       filename: pkg/commands/process/settings/rules/ruby/third_parties/datadog/testdata/datatype_in_tags.rb
       category_groups:
         - PII
       parent_line_number: 3
       parent_content: c.tags = user
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_datadog
-      policy_description: Do not send sensitive data to Datadog.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_datadog
+      rule_description: Do not send sensitive data to Datadog.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_datadog
       line_number: 7
       filename: pkg/commands/process/settings/rules/ruby/third_parties/datadog/testdata/datatype_in_tags.rb
       category_groups:
         - PII
       parent_line_number: 7
       parent_content: span.set_tag('user.email', user.email)
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_datadog
-      policy_description: Do not send sensitive data to Datadog.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_datadog
+      rule_description: Do not send sensitive data to Datadog.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_datadog
       line_number: 9
       filename: pkg/commands/process/settings/rules/ruby/third_parties/datadog/testdata/datatype_in_tags.rb
       category_groups:
         - PII
       parent_line_number: 9
       parent_content: Datadog::Tracing.active_span&.set_tag('customer.id', user.email)
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_datadog
-      policy_description: Do not send sensitive data to Datadog.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_datadog
+      rule_description: Do not send sensitive data to Datadog.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_datadog
       line_number: 10
       filename: pkg/commands/process/settings/rules/ruby/third_parties/datadog/testdata/datatype_in_tags.rb
       category_groups:
         - PII
       parent_line_number: 10
       parent_content: Datadog::Tracing.active_span.set_tag('customer.id', user.email)
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_datadog
-      policy_description: Do not send sensitive data to Datadog.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_datadog
+      rule_description: Do not send sensitive data to Datadog.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_datadog
       line_number: 12
       filename: pkg/commands/process/settings/rules/ruby/third_parties/datadog/testdata/datatype_in_tags.rb
       category_groups:
@@ -52,10 +52,10 @@ critical:
         Datadog::Tracing.trace("web.request", tags: { email: user.email }) do |span, trace|
           call
         end
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_datadog
-      policy_description: Do not send sensitive data to Datadog.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_datadog
+      rule_description: Do not send sensitive data to Datadog.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_datadog
       line_number: 17
       filename: pkg/commands/process/settings/rules/ruby/third_parties/datadog/testdata/datatype_in_tags.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/elasticsearch/.snapshots/TestRubyThirdPartiesElasticsearchSummary-summary_ruby_third_parties_elasticsearch_datatype_in_bulk.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/elasticsearch/.snapshots/TestRubyThirdPartiesElasticsearchSummary-summary_ruby_third_parties_elasticsearch_datatype_in_bulk.rb
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-6
-      policy_display_id: ruby_third_parties_elasticsearch
-      policy_description: Do not store sensitive data in Elasticsearch.
+    - rule_dsrid: DSR-6
+      rule_display_id: ruby_third_parties_elasticsearch
+      rule_description: Do not store sensitive data in Elasticsearch.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_elasticsearch
       line_number: 3
       filename: pkg/commands/process/settings/rules/ruby/third_parties/elasticsearch/testdata/datatype_in_bulk.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/elasticsearch/.snapshots/TestRubyThirdPartiesElasticsearchSummary-summary_ruby_third_parties_elasticsearch_datatype_in_index.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/elasticsearch/.snapshots/TestRubyThirdPartiesElasticsearchSummary-summary_ruby_third_parties_elasticsearch_datatype_in_index.rb
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-6
-      policy_display_id: ruby_third_parties_elasticsearch
-      policy_description: Do not store sensitive data in Elasticsearch.
+    - rule_dsrid: DSR-6
+      rule_display_id: ruby_third_parties_elasticsearch
+      rule_description: Do not store sensitive data in Elasticsearch.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_elasticsearch
       line_number: 3
       filename: pkg/commands/process/settings/rules/ruby/third_parties/elasticsearch/testdata/datatype_in_index.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/elasticsearch/.snapshots/TestRubyThirdPartiesElasticsearchSummary-summary_ruby_third_parties_elasticsearch_datatype_in_update.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/elasticsearch/.snapshots/TestRubyThirdPartiesElasticsearchSummary-summary_ruby_third_parties_elasticsearch_datatype_in_update.rb
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-6
-      policy_display_id: ruby_third_parties_elasticsearch
-      policy_description: Do not store sensitive data in Elasticsearch.
+    - rule_dsrid: DSR-6
+      rule_display_id: ruby_third_parties_elasticsearch
+      rule_description: Do not store sensitive data in Elasticsearch.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_elasticsearch
       line_number: 1
       filename: pkg/commands/process/settings/rules/ruby/third_parties/elasticsearch/testdata/datatype_in_update.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/honeybadger/.snapshots/TestRubyThirdPartiesHoneybadgerSummary-summary_ruby_third_parties_honeybadger_honeybadger_breadcrumb.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/honeybadger/.snapshots/TestRubyThirdPartiesHoneybadgerSummary-summary_ruby_third_parties_honeybadger_honeybadger_breadcrumb.rb
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_honeybadger
-      policy_description: Do not send sensitive data to Honeybadger.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_honeybadger
+      rule_description: Do not send sensitive data to Honeybadger.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_honeybadger
       line_number: 1
       filename: pkg/commands/process/settings/rules/ruby/third_parties/honeybadger/testdata/honeybadger_breadcrumb.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/honeybadger/.snapshots/TestRubyThirdPartiesHoneybadgerSummary-summary_ruby_third_parties_honeybadger_honeybadger_context.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/honeybadger/.snapshots/TestRubyThirdPartiesHoneybadgerSummary-summary_ruby_third_parties_honeybadger_honeybadger_context.rb
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_honeybadger
-      policy_description: Do not send sensitive data to Honeybadger.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_honeybadger
+      rule_description: Do not send sensitive data to Honeybadger.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_honeybadger
       line_number: 1
       filename: pkg/commands/process/settings/rules/ruby/third_parties/honeybadger/testdata/honeybadger_context.rb
       category_groups:
@@ -12,10 +12,10 @@ critical:
         Honeybadger.context({
           tags: tags
         })
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_honeybadger
-      policy_description: Do not send sensitive data to Honeybadger.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_honeybadger
+      rule_description: Do not send sensitive data to Honeybadger.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_honeybadger
       line_number: 8
       filename: pkg/commands/process/settings/rules/ruby/third_parties/honeybadger/testdata/honeybadger_context.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/honeybadger/.snapshots/TestRubyThirdPartiesHoneybadgerSummary-summary_ruby_third_parties_honeybadger_honeybadger_methods.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/honeybadger/.snapshots/TestRubyThirdPartiesHoneybadgerSummary-summary_ruby_third_parties_honeybadger_honeybadger_methods.rb
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_honeybadger
-      policy_description: Do not send sensitive data to Honeybadger.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_honeybadger
+      rule_description: Do not send sensitive data to Honeybadger.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_honeybadger
       line_number: 3
       filename: pkg/commands/process/settings/rules/ruby/third_parties/honeybadger/testdata/honeybadger_methods.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/honeybadger/.snapshots/TestRubyThirdPartiesHoneybadgerSummary-summary_ruby_third_parties_honeybadger_honeybadger_notify.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/honeybadger/.snapshots/TestRubyThirdPartiesHoneybadgerSummary-summary_ruby_third_parties_honeybadger_honeybadger_notify.rb
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_honeybadger
-      policy_description: Do not send sensitive data to Honeybadger.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_honeybadger
+      rule_description: Do not send sensitive data to Honeybadger.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_honeybadger
       line_number: 2
       filename: pkg/commands/process/settings/rules/ruby/third_parties/honeybadger/testdata/honeybadger_notify.rb
       category_groups:
@@ -17,10 +17,10 @@ critical:
           context: context,
           parameters: parameters,
         )
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_honeybadger
-      policy_description: Do not send sensitive data to Honeybadger.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_honeybadger
+      rule_description: Do not send sensitive data to Honeybadger.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_honeybadger
       line_number: 9
       filename: pkg/commands/process/settings/rules/ruby/third_parties/honeybadger/testdata/honeybadger_notify.rb
       category_groups:
@@ -35,10 +35,10 @@ critical:
           context: context,
           parameters: parameters,
         )
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_honeybadger
-      policy_description: Do not send sensitive data to Honeybadger.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_honeybadger
+      rule_description: Do not send sensitive data to Honeybadger.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_honeybadger
       line_number: 13
       filename: pkg/commands/process/settings/rules/ruby/third_parties/honeybadger/testdata/honeybadger_notify.rb
       category_groups:
@@ -53,10 +53,10 @@ critical:
           context: context,
           parameters: parameters,
         )
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_honeybadger
-      policy_description: Do not send sensitive data to Honeybadger.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_honeybadger
+      rule_description: Do not send sensitive data to Honeybadger.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_honeybadger
       line_number: 14
       filename: pkg/commands/process/settings/rules/ruby/third_parties/honeybadger/testdata/honeybadger_notify.rb
       category_groups:
@@ -71,10 +71,10 @@ critical:
           context: context,
           parameters: parameters,
         )
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_honeybadger
-      policy_description: Do not send sensitive data to Honeybadger.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_honeybadger
+      rule_description: Do not send sensitive data to Honeybadger.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_honeybadger
       line_number: 22
       filename: pkg/commands/process/settings/rules/ruby/third_parties/honeybadger/testdata/honeybadger_notify.rb
       category_groups:
@@ -89,10 +89,10 @@ critical:
           context: context,
           parameters: parameters,
         )
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_honeybadger
-      policy_description: Do not send sensitive data to Honeybadger.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_honeybadger
+      rule_description: Do not send sensitive data to Honeybadger.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_honeybadger
       line_number: 29
       filename: pkg/commands/process/settings/rules/ruby/third_parties/honeybadger/testdata/honeybadger_notify.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/new_relic/.snapshots/TestRubyThirdPartiesNewRelicSummary-summary_ruby_third_parties_new_relic_datatype_in_add_custom_attributes.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/new_relic/.snapshots/TestRubyThirdPartiesNewRelicSummary-summary_ruby_third_parties_new_relic_datatype_in_add_custom_attributes.rb
@@ -1,18 +1,18 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_new_relic
-      policy_description: Do not send sensitive data to New Relic.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_new_relic
+      rule_description: Do not send sensitive data to New Relic.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_new_relic
       line_number: 1
       filename: pkg/commands/process/settings/rules/ruby/third_parties/new_relic/testdata/datatype_in_add_custom_attributes.rb
       category_groups:
         - PII
       parent_line_number: 2
       parent_content: NewRelic::Agent.add_custom_attributes(user)
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_new_relic
-      policy_description: Do not send sensitive data to New Relic.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_new_relic
+      rule_description: Do not send sensitive data to New Relic.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_new_relic
       line_number: 3
       filename: pkg/commands/process/settings/rules/ruby/third_parties/new_relic/testdata/datatype_in_add_custom_attributes.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/new_relic/.snapshots/TestRubyThirdPartiesNewRelicSummary-summary_ruby_third_parties_new_relic_datatype_in_add_custom_parameters.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/new_relic/.snapshots/TestRubyThirdPartiesNewRelicSummary-summary_ruby_third_parties_new_relic_datatype_in_add_custom_parameters.rb
@@ -1,18 +1,18 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_new_relic
-      policy_description: Do not send sensitive data to New Relic.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_new_relic
+      rule_description: Do not send sensitive data to New Relic.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_new_relic
       line_number: 1
       filename: pkg/commands/process/settings/rules/ruby/third_parties/new_relic/testdata/datatype_in_add_custom_parameters.rb
       category_groups:
         - PII
       parent_line_number: 2
       parent_content: NewRelic::Agent.add_custom_parameters(user)
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_new_relic
-      policy_description: Do not send sensitive data to New Relic.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_new_relic
+      rule_description: Do not send sensitive data to New Relic.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_new_relic
       line_number: 3
       filename: pkg/commands/process/settings/rules/ruby/third_parties/new_relic/testdata/datatype_in_add_custom_parameters.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/new_relic/.snapshots/TestRubyThirdPartiesNewRelicSummary-summary_ruby_third_parties_new_relic_datatype_in_notice_error.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/new_relic/.snapshots/TestRubyThirdPartiesNewRelicSummary-summary_ruby_third_parties_new_relic_datatype_in_notice_error.rb
@@ -1,18 +1,18 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_new_relic
-      policy_description: Do not send sensitive data to New Relic.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_new_relic
+      rule_description: Do not send sensitive data to New Relic.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_new_relic
       line_number: 1
       filename: pkg/commands/process/settings/rules/ruby/third_parties/new_relic/testdata/datatype_in_notice_error.rb
       category_groups:
         - PII
       parent_line_number: 2
       parent_content: 'NewRelic::Agent.notice_error(exception, { custom_params: user })'
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_new_relic
-      policy_description: Do not send sensitive data to New Relic.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_new_relic
+      rule_description: Do not send sensitive data to New Relic.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_new_relic
       line_number: 3
       filename: pkg/commands/process/settings/rules/ruby/third_parties/new_relic/testdata/datatype_in_notice_error.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/.snapshots/TestRubyThirdPartiesOpenTelemetrySummary-summary_ruby_third_parties_open_telemetry_datatype_in_record_exception.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/.snapshots/TestRubyThirdPartiesOpenTelemetrySummary-summary_ruby_third_parties_open_telemetry_datatype_in_record_exception.rb
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_open_telemetry
-      policy_description: Do not send sensitive data to Open Telemetry.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_open_telemetry
+      rule_description: Do not send sensitive data to Open Telemetry.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_open_telemetry
       line_number: 7
       filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_record_exception.rb
       category_groups:
@@ -10,10 +10,10 @@ critical:
         - Personal Data
       parent_line_number: 7
       parent_content: 'current_span.status = OpenTelemetry::Trace::Status.error("error for user #{current_user.email}")'
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_open_telemetry
-      policy_description: Do not send sensitive data to Open Telemetry.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_open_telemetry
+      rule_description: Do not send sensitive data to Open Telemetry.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_open_telemetry
       line_number: 17
       filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_record_exception.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/.snapshots/TestRubyThirdPartiesOpenTelemetrySummary-summary_ruby_third_parties_open_telemetry_datatype_in_span_attributes.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/.snapshots/TestRubyThirdPartiesOpenTelemetrySummary-summary_ruby_third_parties_open_telemetry_datatype_in_span_attributes.rb
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_open_telemetry
-      policy_description: Do not send sensitive data to Open Telemetry.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_open_telemetry
+      rule_description: Do not send sensitive data to Open Telemetry.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_open_telemetry
       line_number: 7
       filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_span_attributes.rb
       category_groups:
@@ -13,10 +13,10 @@ critical:
             "user.id" => user.id,
             "user.first_name" => user.first_name
           })
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_open_telemetry
-      policy_description: Do not send sensitive data to Open Telemetry.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_open_telemetry
+      rule_description: Do not send sensitive data to Open Telemetry.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_open_telemetry
       line_number: 13
       filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_span_attributes.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/.snapshots/TestRubyThirdPartiesOpenTelemetrySummary-summary_ruby_third_parties_open_telemetry_datatype_in_span_event.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/.snapshots/TestRubyThirdPartiesOpenTelemetrySummary-summary_ruby_third_parties_open_telemetry_datatype_in_span_event.rb
@@ -1,18 +1,18 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_open_telemetry
-      policy_description: Do not send sensitive data to Open Telemetry.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_open_telemetry
+      rule_description: Do not send sensitive data to Open Telemetry.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_open_telemetry
       line_number: 2
       filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_span_event.rb
       category_groups:
         - PII
       parent_line_number: 2
       parent_content: 'span.add_event("Schedule job for user: #{current_user.email}")'
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_open_telemetry
-      policy_description: Do not send sensitive data to Open Telemetry.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_open_telemetry
+      rule_description: Do not send sensitive data to Open Telemetry.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_open_telemetry
       line_number: 4
       filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatype_in_span_event.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/.snapshots/TestRubyThirdPartiesOpenTelemetrySummary-summary_ruby_third_parties_open_telemetry_datatypes_in_span_init_block.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/.snapshots/TestRubyThirdPartiesOpenTelemetrySummary-summary_ruby_third_parties_open_telemetry_datatypes_in_span_init_block.rb
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_open_telemetry
-      policy_description: Do not send sensitive data to Open Telemetry.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_open_telemetry
+      rule_description: Do not send sensitive data to Open Telemetry.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_open_telemetry
       line_number: 2
       filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatypes_in_span_init_block.rb
       category_groups:
@@ -12,10 +12,10 @@ critical:
         Tracer.in_span("data leaking", attributes: { "current_user" => user.email, "date" => DateTime.now }) do |span|
           puts "in the span block"
         end
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_open_telemetry
-      policy_description: Do not send sensitive data to Open Telemetry.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_open_telemetry
+      rule_description: Do not send sensitive data to Open Telemetry.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_open_telemetry
       line_number: 6
       filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatypes_in_span_init_block.rb
       category_groups:
@@ -25,20 +25,20 @@ critical:
         SomeOtherTracer.in_span("data leaking", attributes: { "current_user" => user.email, "date" => DateTime.now }) do |span|
           span.add_attributes(user.email)
         end
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_open_telemetry
-      policy_description: Do not send sensitive data to Open Telemetry.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_open_telemetry
+      rule_description: Do not send sensitive data to Open Telemetry.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_open_telemetry
       line_number: 7
       filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatypes_in_span_init_block.rb
       category_groups:
         - PII
       parent_line_number: 7
       parent_content: span.add_attributes(user.email)
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_open_telemetry
-      policy_description: Do not send sensitive data to Open Telemetry.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_open_telemetry
+      rule_description: Do not send sensitive data to Open Telemetry.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_open_telemetry
       line_number: 11
       filename: pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/testdata/datatypes_in_span_init_block.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/rollbar/.snapshots/TestRubyThirdPartiesRollbarSummary-summary_ruby_third_parties_rollbar_datatype_in_context.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/rollbar/.snapshots/TestRubyThirdPartiesRollbarSummary-summary_ruby_third_parties_rollbar_datatype_in_context.rb
@@ -1,8 +1,8 @@
 low:
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_rollbar
-      policy_description: Do not send sensitive data to Rollbar.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_rollbar
+      rule_description: Do not send sensitive data to Rollbar.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_rollbar
       line_number: 1
       filename: pkg/commands/process/settings/rules/ruby/third_parties/rollbar/testdata/datatype_in_context.rb
       parent_line_number: 1

--- a/pkg/commands/process/settings/rules/ruby/third_parties/rollbar/.snapshots/TestRubyThirdPartiesRollbarSummary-summary_ruby_third_parties_rollbar_datatype_in_log.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/rollbar/.snapshots/TestRubyThirdPartiesRollbarSummary-summary_ruby_third_parties_rollbar_datatype_in_log.rb
@@ -1,28 +1,28 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_rollbar
-      policy_description: Do not send sensitive data to Rollbar.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_rollbar
+      rule_description: Do not send sensitive data to Rollbar.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_rollbar
       line_number: 1
       filename: pkg/commands/process/settings/rules/ruby/third_parties/rollbar/testdata/datatype_in_log.rb
       category_groups:
         - PII
       parent_line_number: 1
       parent_content: 'Rollbar.log("error", "oops #{user.email}")'
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_rollbar
-      policy_description: Do not send sensitive data to Rollbar.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_rollbar
+      rule_description: Do not send sensitive data to Rollbar.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_rollbar
       line_number: 2
       filename: pkg/commands/process/settings/rules/ruby/third_parties/rollbar/testdata/datatype_in_log.rb
       category_groups:
         - PII
       parent_line_number: 2
       parent_content: 'Rollbar.log("error", "oops", user: { email: "someone@example.com" })'
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_rollbar
-      policy_description: Do not send sensitive data to Rollbar.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_rollbar
+      rule_description: Do not send sensitive data to Rollbar.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_rollbar
       line_number: 3
       filename: pkg/commands/process/settings/rules/ruby/third_parties/rollbar/testdata/datatype_in_log.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/rollbar/.snapshots/TestRubyThirdPartiesRollbarSummary-summary_ruby_third_parties_rollbar_datatype_in_log_helper.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/rollbar/.snapshots/TestRubyThirdPartiesRollbarSummary-summary_ruby_third_parties_rollbar_datatype_in_log_helper.rb
@@ -1,78 +1,78 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_rollbar
-      policy_description: Do not send sensitive data to Rollbar.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_rollbar
+      rule_description: Do not send sensitive data to Rollbar.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_rollbar
       line_number: 1
       filename: pkg/commands/process/settings/rules/ruby/third_parties/rollbar/testdata/datatype_in_log_helper.rb
       category_groups:
         - PII
       parent_line_number: 1
       parent_content: 'Rollbar.critical("oops #{user.email}")'
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_rollbar
-      policy_description: Do not send sensitive data to Rollbar.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_rollbar
+      rule_description: Do not send sensitive data to Rollbar.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_rollbar
       line_number: 2
       filename: pkg/commands/process/settings/rules/ruby/third_parties/rollbar/testdata/datatype_in_log_helper.rb
       category_groups:
         - PII
       parent_line_number: 2
       parent_content: 'Rollbar.critical(e, "oops #{user.email}")'
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_rollbar
-      policy_description: Do not send sensitive data to Rollbar.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_rollbar
+      rule_description: Do not send sensitive data to Rollbar.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_rollbar
       line_number: 3
       filename: pkg/commands/process/settings/rules/ruby/third_parties/rollbar/testdata/datatype_in_log_helper.rb
       category_groups:
         - PII
       parent_line_number: 3
       parent_content: 'Rollbar.critical(e, user: { email: "someone@example.com" })'
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_rollbar
-      policy_description: Do not send sensitive data to Rollbar.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_rollbar
+      rule_description: Do not send sensitive data to Rollbar.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_rollbar
       line_number: 4
       filename: pkg/commands/process/settings/rules/ruby/third_parties/rollbar/testdata/datatype_in_log_helper.rb
       category_groups:
         - PII
       parent_line_number: 4
       parent_content: 'Rollbar.critical(e, { user: { first_name: "someone" } })'
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_rollbar
-      policy_description: Do not send sensitive data to Rollbar.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_rollbar
+      rule_description: Do not send sensitive data to Rollbar.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_rollbar
       line_number: 6
       filename: pkg/commands/process/settings/rules/ruby/third_parties/rollbar/testdata/datatype_in_log_helper.rb
       category_groups:
         - PII
       parent_line_number: 6
       parent_content: 'Rollbar.error("oops #{user.email}")'
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_rollbar
-      policy_description: Do not send sensitive data to Rollbar.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_rollbar
+      rule_description: Do not send sensitive data to Rollbar.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_rollbar
       line_number: 8
       filename: pkg/commands/process/settings/rules/ruby/third_parties/rollbar/testdata/datatype_in_log_helper.rb
       category_groups:
         - PII
       parent_line_number: 8
       parent_content: 'Rollbar.debug("oops #{user.email}")'
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_rollbar
-      policy_description: Do not send sensitive data to Rollbar.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_rollbar
+      rule_description: Do not send sensitive data to Rollbar.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_rollbar
       line_number: 10
       filename: pkg/commands/process/settings/rules/ruby/third_parties/rollbar/testdata/datatype_in_log_helper.rb
       category_groups:
         - PII
       parent_line_number: 10
       parent_content: 'Rollbar.info("oops #{user.email}")'
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_rollbar
-      policy_description: Do not send sensitive data to Rollbar.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_rollbar
+      rule_description: Do not send sensitive data to Rollbar.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_rollbar
       line_number: 12
       filename: pkg/commands/process/settings/rules/ruby/third_parties/rollbar/testdata/datatype_in_log_helper.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/rollbar/.snapshots/TestRubyThirdPartiesRollbarSummary-summary_ruby_third_parties_rollbar_datatype_in_scope.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/rollbar/.snapshots/TestRubyThirdPartiesRollbarSummary-summary_ruby_third_parties_rollbar_datatype_in_scope.rb
@@ -1,28 +1,28 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_rollbar
-      policy_description: Do not send sensitive data to Rollbar.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_rollbar
+      rule_description: Do not send sensitive data to Rollbar.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_rollbar
       line_number: 1
       filename: pkg/commands/process/settings/rules/ruby/third_parties/rollbar/testdata/datatype_in_scope.rb
       category_groups:
         - PII
       parent_line_number: 1
       parent_content: 'Rollbar.scope!({ user: { email: "someone@example.com" }})'
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_rollbar
-      policy_description: Do not send sensitive data to Rollbar.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_rollbar
+      rule_description: Do not send sensitive data to Rollbar.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_rollbar
       line_number: 3
       filename: pkg/commands/process/settings/rules/ruby/third_parties/rollbar/testdata/datatype_in_scope.rb
       category_groups:
         - PII
       parent_line_number: 5
       parent_content: Rollbar.scope(user)
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_rollbar
-      policy_description: Do not send sensitive data to Rollbar.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_rollbar
+      rule_description: Do not send sensitive data to Rollbar.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_rollbar
       line_number: 7
       filename: pkg/commands/process/settings/rules/ruby/third_parties/rollbar/testdata/datatype_in_scope.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/rollbar/.snapshots/TestRubyThirdPartiesRollbarSummary-summary_ruby_third_parties_rollbar_datatype_in_scoped.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/rollbar/.snapshots/TestRubyThirdPartiesRollbarSummary-summary_ruby_third_parties_rollbar_datatype_in_scoped.rb
@@ -1,8 +1,8 @@
 low:
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_rollbar
-      policy_description: Do not send sensitive data to Rollbar.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_rollbar
+      rule_description: Do not send sensitive data to Rollbar.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_rollbar
       line_number: 1
       filename: pkg/commands/process/settings/rules/ruby/third_parties/rollbar/testdata/datatype_in_scoped.rb
       parent_line_number: 3

--- a/pkg/commands/process/settings/rules/ruby/third_parties/scout_apm/.snapshots/TestRubyThirdPartiesScoutAPMSummary-summary_ruby_third_parties_scout_apm_datatype_in_add.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/scout_apm/.snapshots/TestRubyThirdPartiesScoutAPMSummary-summary_ruby_third_parties_scout_apm_datatype_in_add.rb
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_scout_apm
-      policy_description: Do not send sensitive data to Scout APM.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_scout_apm
+      rule_description: Do not send sensitive data to Scout APM.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_scout_apm
       line_number: 1
       filename: pkg/commands/process/settings/rules/ruby/third_parties/scout_apm/testdata/datatype_in_add.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/scout_apm/.snapshots/TestRubyThirdPartiesScoutAPMSummary-summary_ruby_third_parties_scout_apm_datatype_in_add_user.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/scout_apm/.snapshots/TestRubyThirdPartiesScoutAPMSummary-summary_ruby_third_parties_scout_apm_datatype_in_add_user.rb
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_scout_apm
-      policy_description: Do not send sensitive data to Scout APM.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_scout_apm
+      rule_description: Do not send sensitive data to Scout APM.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_scout_apm
       line_number: 1
       filename: pkg/commands/process/settings/rules/ruby/third_parties/scout_apm/testdata/datatype_in_add_user.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentrySummary-summary_ruby_third_parties_sentry_datatype_in_breadcrumb.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentrySummary-summary_ruby_third_parties_sentry_datatype_in_breadcrumb.rb
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_sentry
-      policy_description: Do not send sensitive data to Sentry.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_sentry
+      rule_description: Do not send sensitive data to Sentry.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_sentry
       line_number: 3
       filename: pkg/commands/process/settings/rules/ruby/third_parties/sentry/testdata/datatype_in_breadcrumb.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentrySummary-summary_ruby_third_parties_sentry_datatype_in_capture_message.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentrySummary-summary_ruby_third_parties_sentry_datatype_in_capture_message.rb
@@ -1,38 +1,38 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_sentry
-      policy_description: Do not send sensitive data to Sentry.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_sentry
+      rule_description: Do not send sensitive data to Sentry.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_sentry
       line_number: 1
       filename: pkg/commands/process/settings/rules/ruby/third_parties/sentry/testdata/datatype_in_capture_message.rb
       category_groups:
         - PII
       parent_line_number: 1
       parent_content: 'Sentry.capture_message("test: #{user.email}")'
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_sentry
-      policy_description: Do not send sensitive data to Sentry.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_sentry
+      rule_description: Do not send sensitive data to Sentry.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_sentry
       line_number: 2
       filename: pkg/commands/process/settings/rules/ruby/third_parties/sentry/testdata/datatype_in_capture_message.rb
       category_groups:
         - PII
       parent_line_number: 2
       parent_content: 'Sentry.capture_message("test", extra: { email: user.email })'
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_sentry
-      policy_description: Do not send sensitive data to Sentry.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_sentry
+      rule_description: Do not send sensitive data to Sentry.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_sentry
       line_number: 3
       filename: pkg/commands/process/settings/rules/ruby/third_parties/sentry/testdata/datatype_in_capture_message.rb
       category_groups:
         - PII
       parent_line_number: 3
       parent_content: 'Sentry.capture_message("test", tags: { email: user.email })'
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_sentry
-      policy_description: Do not send sensitive data to Sentry.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_sentry
+      rule_description: Do not send sensitive data to Sentry.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_sentry
       line_number: 4
       filename: pkg/commands/process/settings/rules/ruby/third_parties/sentry/testdata/datatype_in_capture_message.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentrySummary-summary_ruby_third_parties_sentry_datatype_in_init.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentrySummary-summary_ruby_third_parties_sentry_datatype_in_init.rb
@@ -1,8 +1,8 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_sentry
-      policy_description: Do not send sensitive data to Sentry.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_sentry
+      rule_description: Do not send sensitive data to Sentry.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_sentry
       line_number: 3
       filename: pkg/commands/process/settings/rules/ruby/third_parties/sentry/testdata/datatype_in_init.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentrySummary-summary_ruby_third_parties_sentry_datatype_in_set_context.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentrySummary-summary_ruby_third_parties_sentry_datatype_in_set_context.rb
@@ -1,28 +1,28 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_sentry
-      policy_description: Do not send sensitive data to Sentry.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_sentry
+      rule_description: Do not send sensitive data to Sentry.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_sentry
       line_number: 1
       filename: pkg/commands/process/settings/rules/ruby/third_parties/sentry/testdata/datatype_in_set_context.rb
       category_groups:
         - PII
       parent_line_number: 1
       parent_content: 'Sentry.set_context(''email'', { email: user.email })'
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_sentry
-      policy_description: Do not send sensitive data to Sentry.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_sentry
+      rule_description: Do not send sensitive data to Sentry.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_sentry
       line_number: 4
       filename: pkg/commands/process/settings/rules/ruby/third_parties/sentry/testdata/datatype_in_set_context.rb
       category_groups:
         - PII
       parent_line_number: 4
       parent_content: 'scope.set_context(''email'', { email: user.email })'
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_sentry
-      policy_description: Do not send sensitive data to Sentry.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_sentry
+      rule_description: Do not send sensitive data to Sentry.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_sentry
       line_number: 8
       filename: pkg/commands/process/settings/rules/ruby/third_parties/sentry/testdata/datatype_in_set_context.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentrySummary-summary_ruby_third_parties_sentry_datatype_in_set_extra.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentrySummary-summary_ruby_third_parties_sentry_datatype_in_set_extra.rb
@@ -1,18 +1,18 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_sentry
-      policy_description: Do not send sensitive data to Sentry.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_sentry
+      rule_description: Do not send sensitive data to Sentry.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_sentry
       line_number: 2
       filename: pkg/commands/process/settings/rules/ruby/third_parties/sentry/testdata/datatype_in_set_extra.rb
       category_groups:
         - PII
       parent_line_number: 2
       parent_content: scope.set_extra(:email, user.email)
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_sentry
-      policy_description: Do not send sensitive data to Sentry.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_sentry
+      rule_description: Do not send sensitive data to Sentry.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_sentry
       line_number: 6
       filename: pkg/commands/process/settings/rules/ruby/third_parties/sentry/testdata/datatype_in_set_extra.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentrySummary-summary_ruby_third_parties_sentry_datatype_in_set_extras.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentrySummary-summary_ruby_third_parties_sentry_datatype_in_set_extras.rb
@@ -1,28 +1,28 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_sentry
-      policy_description: Do not send sensitive data to Sentry.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_sentry
+      rule_description: Do not send sensitive data to Sentry.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_sentry
       line_number: 1
       filename: pkg/commands/process/settings/rules/ruby/third_parties/sentry/testdata/datatype_in_set_extras.rb
       category_groups:
         - PII
       parent_line_number: 1
       parent_content: 'Sentry.set_extras(email: user.email)'
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_sentry
-      policy_description: Do not send sensitive data to Sentry.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_sentry
+      rule_description: Do not send sensitive data to Sentry.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_sentry
       line_number: 4
       filename: pkg/commands/process/settings/rules/ruby/third_parties/sentry/testdata/datatype_in_set_extras.rb
       category_groups:
         - PII
       parent_line_number: 4
       parent_content: 'scope.set_extras(email: user.email)'
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_sentry
-      policy_description: Do not send sensitive data to Sentry.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_sentry
+      rule_description: Do not send sensitive data to Sentry.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_sentry
       line_number: 8
       filename: pkg/commands/process/settings/rules/ruby/third_parties/sentry/testdata/datatype_in_set_extras.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentrySummary-summary_ruby_third_parties_sentry_datatype_in_set_tag.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentrySummary-summary_ruby_third_parties_sentry_datatype_in_set_tag.rb
@@ -1,18 +1,18 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_sentry
-      policy_description: Do not send sensitive data to Sentry.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_sentry
+      rule_description: Do not send sensitive data to Sentry.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_sentry
       line_number: 2
       filename: pkg/commands/process/settings/rules/ruby/third_parties/sentry/testdata/datatype_in_set_tag.rb
       category_groups:
         - PII
       parent_line_number: 2
       parent_content: scope.set_tag(:email, user.email)
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_sentry
-      policy_description: Do not send sensitive data to Sentry.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_sentry
+      rule_description: Do not send sensitive data to Sentry.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_sentry
       line_number: 6
       filename: pkg/commands/process/settings/rules/ruby/third_parties/sentry/testdata/datatype_in_set_tag.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentrySummary-summary_ruby_third_parties_sentry_datatype_in_set_tags.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentrySummary-summary_ruby_third_parties_sentry_datatype_in_set_tags.rb
@@ -1,28 +1,28 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_sentry
-      policy_description: Do not send sensitive data to Sentry.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_sentry
+      rule_description: Do not send sensitive data to Sentry.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_sentry
       line_number: 1
       filename: pkg/commands/process/settings/rules/ruby/third_parties/sentry/testdata/datatype_in_set_tags.rb
       category_groups:
         - PII
       parent_line_number: 1
       parent_content: 'Sentry.set_tags(email: user.email)'
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_sentry
-      policy_description: Do not send sensitive data to Sentry.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_sentry
+      rule_description: Do not send sensitive data to Sentry.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_sentry
       line_number: 4
       filename: pkg/commands/process/settings/rules/ruby/third_parties/sentry/testdata/datatype_in_set_tags.rb
       category_groups:
         - PII
       parent_line_number: 4
       parent_content: 'scope.set_tags(email: user.email)'
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_sentry
-      policy_description: Do not send sensitive data to Sentry.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_sentry
+      rule_description: Do not send sensitive data to Sentry.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_sentry
       line_number: 8
       filename: pkg/commands/process/settings/rules/ruby/third_parties/sentry/testdata/datatype_in_set_tags.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentrySummary-summary_ruby_third_parties_sentry_datatype_in_set_user.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentrySummary-summary_ruby_third_parties_sentry_datatype_in_set_user.rb
@@ -1,28 +1,28 @@
 critical:
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_sentry
-      policy_description: Do not send sensitive data to Sentry.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_sentry
+      rule_description: Do not send sensitive data to Sentry.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_sentry
       line_number: 3
       filename: pkg/commands/process/settings/rules/ruby/third_parties/sentry/testdata/datatype_in_set_user.rb
       category_groups:
         - PII
       parent_line_number: 3
       parent_content: 'Sentry.set_user(email: user.email)'
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_sentry
-      policy_description: Do not send sensitive data to Sentry.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_sentry
+      rule_description: Do not send sensitive data to Sentry.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_sentry
       line_number: 6
       filename: pkg/commands/process/settings/rules/ruby/third_parties/sentry/testdata/datatype_in_set_user.rb
       category_groups:
         - PII
       parent_line_number: 6
       parent_content: 'scope.set_user(email: user.email)'
-    - policy_name: ""
-      policy_dsrid: DSR-1
-      policy_display_id: ruby_third_parties_sentry
-      policy_description: Do not send sensitive data to Sentry.
+    - rule_dsrid: DSR-1
+      rule_display_id: ruby_third_parties_sentry
+      rule_description: Do not send sensitive data to Sentry.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_third_parties_sentry
       line_number: 10
       filename: pkg/commands/process/settings/rules/ruby/third_parties/sentry/testdata/datatype_in_set_user.rb
       category_groups:

--- a/pkg/commands/process/settings/settings.go
+++ b/pkg/commands/process/settings/settings.go
@@ -68,6 +68,7 @@ type RuleMetadata struct {
 	DSRID              string `mapstructure:"dsr_id" json:"dsr_id" yaml:"dsr_id"`
 	AssociatedRecipe   string `mapstructure:"associated_recipe" json:"associated_recipe" yaml:"associated_recipe"`
 	ID                 string `mapstructure:"id" json:"id" yaml:"id"`
+	DocumentationUrl   string `mapstructure:"documentation_url" json:"documentation_url" yaml:"documentation_url"`
 }
 
 type RuleDefinition struct {
@@ -87,7 +88,7 @@ type RuleDefinition struct {
 	OnlyDataTypes     []string          `mapstructure:"only_data_types" json:"only_data_types,omitempty" yaml:"only_data_types,omitempty"`
 	OmitParentContent bool              `mapstructure:"omit_parent_content" json:"omit_parent_content,omitempty" yaml:"omit_parent_content,omitempty"`
 	DetailedContext   bool              `mapstructure:"detailed_context" json:"detailed_context,omitempty" yaml:"detailed_context,omitempty"`
-	Metadata          RuleMetadata      `mapstructure:"metadata" json:"metadata" yaml:"metadata"`
+	Metadata          *RuleMetadata     `mapstructure:"metadata" json:"metadata" yaml:"metadata"`
 	Auxiliary         []Auxiliary       `mapstructure:"auxiliary" json:"auxiliary" yaml:"auxiliary"`
 }
 
@@ -130,6 +131,7 @@ type Rule struct {
 	DSRID              string            `mapstructure:"dsr_id" json:"dsr_id" yaml:"dsr_id"`
 	Languages          []string          `mapstructure:"languages" json:"languages" yaml:"languages"`
 	Patterns           []RulePattern     `mapstructure:"patterns" json:"patterns" yaml:"patterns"`
+	DocumentationUrl   string            `mapstructure:"documentation_url" json:"documentation_url" yaml:"documentation_url"`
 
 	// FIXME: remove after refactor of sql
 	Metavars       map[string]MetaVar `mapstructure:"metavars" json:"metavars" yaml:"metavars"`

--- a/pkg/report/output/summary/.snapshots/TestBuildReportString
+++ b/pkg/report/output/summary/.snapshots/TestBuildReportString
@@ -5,8 +5,9 @@ Summary Report
 =====================================
 Checks: 
 
-- Do not send sensitive data to Rails loggers. - ruby_rails_logger [DSR-5/ruby_rails_logger]
-- Enable SSL Certificate Verification. - ruby_lang_ssl_verification [DSR-2/ruby_lang_ssl_verification]
+- Do not send sensitive data to Rails loggers. (ruby_rails_logger) [DSR-5]
+- Enable SSL Certificate Verification. (ruby_lang_ssl_verification) [DSR-2]
+- Its a test! (custom_test_rule)
 
 
 CRITICAL: Do not send sensitive data to Rails loggers. [DSR-5]
@@ -26,7 +27,7 @@ File: config/application.rb:2
 
 =====================================
 
-2 checks, 2 failures, 0 warnings
+3 checks, 2 failures, 0 warnings
 
 CRITICAL: 1 (DSR-5)
 HIGH: 0

--- a/pkg/report/output/summary/.snapshots/TestGetOutput
+++ b/pkg/report/output/summary/.snapshots/TestGetOutput
@@ -1,10 +1,10 @@
 (map[string][]summary.Result) (len=2) {
   (string) (len=8) "critical": ([]summary.Result) (len=1) {
     (summary.Result) {
-      PolicyName: (string) "",
-      PolicyDSRID: (string) (len=5) "DSR-5",
-      PolicyDisplayId: (string) (len=17) "ruby_rails_logger",
-      PolicyDescription: (string) (len=44) "Do not send sensitive data to Rails loggers.",
+      RuleDSRID: (string) (len=5) "DSR-5",
+      RuleDisplayId: (string) (len=17) "ruby_rails_logger",
+      RuleDescription: (string) (len=44) "Do not send sensitive data to Rails loggers.",
+      RuleDocumentationUrl: (string) (len=50) "https://curio.sh/reference/rules/ruby_rails_logger",
       LineNumber: (int) 1,
       Filename: (string) (len=20) "pkg/datatype_leak.rb",
       CategoryGroups: ([]string) (len=1) {
@@ -18,10 +18,10 @@
   },
   (string) (len=3) "low": ([]summary.Result) (len=1) {
     (summary.Result) {
-      PolicyName: (string) "",
-      PolicyDSRID: (string) (len=5) "DSR-2",
-      PolicyDisplayId: (string) (len=26) "ruby_lang_ssl_verification",
-      PolicyDescription: (string) (len=36) "Enable SSL Certificate Verification.",
+      RuleDSRID: (string) (len=5) "DSR-2",
+      RuleDisplayId: (string) (len=26) "ruby_lang_ssl_verification",
+      RuleDescription: (string) (len=36) "Enable SSL Certificate Verification.",
+      RuleDocumentationUrl: (string) (len=59) "https://curio.sh/reference/rules/ruby_lang_ssl_verification",
       LineNumber: (int) 2,
       Filename: (string) (len=21) "config/application.rb",
       CategoryGroups: ([]string) (len=1) {

--- a/pkg/report/output/summary/.snapshots/TestTestGetOutputWithSeverity
+++ b/pkg/report/output/summary/.snapshots/TestTestGetOutputWithSeverity
@@ -1,10 +1,10 @@
 (map[string][]summary.Result) (len=1) {
   (string) (len=8) "critical": ([]summary.Result) (len=1) {
     (summary.Result) {
-      PolicyName: (string) "",
-      PolicyDSRID: (string) (len=5) "DSR-5",
-      PolicyDisplayId: (string) (len=17) "ruby_rails_logger",
-      PolicyDescription: (string) (len=44) "Do not send sensitive data to Rails loggers.",
+      RuleDSRID: (string) (len=5) "DSR-5",
+      RuleDisplayId: (string) (len=17) "ruby_rails_logger",
+      RuleDescription: (string) (len=44) "Do not send sensitive data to Rails loggers.",
+      RuleDocumentationUrl: (string) (len=50) "https://curio.sh/reference/rules/ruby_rails_logger",
       LineNumber: (int) 1,
       Filename: (string) (len=20) "pkg/datatype_leak.rb",
       CategoryGroups: ([]string) (len=1) {

--- a/pkg/report/output/summary/summary.go
+++ b/pkg/report/output/summary/summary.go
@@ -251,7 +251,13 @@ func writeRuleListToString(
 		if !rule.PolicyType() {
 			continue
 		}
-		ruleList = append(ruleList, color.HiBlackString("- "+rule.Description+" - "+key+" ["+rule.DSRID+"/"+rule.Id+"]\n"))
+
+		ruleDSR := ""
+		if rule.DSRID != "" {
+			ruleDSR = " [" + rule.DSRID + "]"
+		}
+
+		ruleList = append(ruleList, color.HiBlackString("- "+rule.Description+" ("+rule.Id+")"+ruleDSR+"\n"))
 	}
 
 	sort.Strings(ruleList)
@@ -314,7 +320,9 @@ func checkAndWriteFailureSummaryToString(
 		if len(failures[severityLevel]) > 0 {
 			ruleIds := maps.Keys(failures[severityLevel])
 			sort.Strings(ruleIds)
-			reportStr.WriteString(" (" + strings.Join(ruleIds, ", ") + ")")
+			if len(ruleIds) > 0 {
+				reportStr.WriteString(" (" + strings.Join(ruleIds, ", ") + ")")
+			}
 		}
 	}
 
@@ -326,8 +334,14 @@ func checkAndWriteFailureSummaryToString(
 func writeFailureToString(reportStr *strings.Builder, result Result, severity string) {
 	reportStr.WriteString("\n\n")
 	reportStr.WriteString(formatSeverity(severity))
-	reportStr.WriteString(result.PolicyDescription + " [" + result.PolicyDSRID + "]" + "\n")
+	reportStr.WriteString(result.PolicyDescription)
+	if result.PolicyDSRID != "" {
+		reportStr.WriteString(" [" + result.PolicyDSRID + "]")
+	}
+	reportStr.WriteString("\n")
+	// dont show link if custom
 	reportStr.WriteString(color.HiBlackString("https://curio.sh/reference/rules/" + result.PolicyDisplayId + "\n"))
+
 	reportStr.WriteString(color.HiBlackString("To skip this rule, use the flag --skip-rule=" + result.PolicyDisplayId + "\n"))
 	reportStr.WriteString("\n")
 	if result.DetailedContext != "" {

--- a/pkg/report/output/summary/summary.go
+++ b/pkg/report/output/summary/summary.go
@@ -38,7 +38,6 @@ var orderedSeverityLevels = [5]string{
 }
 
 type Input struct {
-	PolicyId       string             `json:"policy_id" yaml:"policy_id"`
 	RuleId         string             `json:"rule_id" yaml:"rule_id"`
 	Rule           *settings.Rule     `json:"rule" yaml:"rule"`
 	Dataflow       *dataflow.DataFlow `json:"dataflow" yaml:"dataflow"`
@@ -57,17 +56,17 @@ type Output struct {
 }
 
 type Result struct {
-	PolicyName        string   `json:"policy_name" yaml:"policy_name"`
-	PolicyDSRID       string   `json:"policy_dsrid" yaml:"policy_dsrid"`
-	PolicyDisplayId   string   `json:"policy_display_id" yaml:"policy_display_id"`
-	PolicyDescription string   `json:"policy_description" yaml:"policy_description"`
-	LineNumber        int      `json:"line_number,omitempty" yaml:"line_number,omitempty"`
-	Filename          string   `json:"filename,omitempty" yaml:"filename,omitempty"`
-	CategoryGroups    []string `json:"category_groups,omitempty" yaml:"category_groups,omitempty"`
-	ParentLineNumber  int      `json:"parent_line_number,omitempty" yaml:"parent_line_number,omitempty"`
-	ParentContent     string   `json:"parent_content,omitempty" yaml:"parent_content,omitempty"`
-	OmitParent        bool     `json:"omit_parent,omitempty" yaml:"omit_parent,omitempty"`
-	DetailedContext   string   `json:"detailed_context,omitempty" yaml:"detailed_context,omitempty"`
+	RuleDSRID            string   `json:"rule_dsrid" yaml:"rule_dsrid"`
+	RuleDisplayId        string   `json:"rule_display_id" yaml:"rule_display_id"`
+	RuleDescription      string   `json:"rule_description" yaml:"rule_description"`
+	RuleDocumentationUrl string   `json:"rule_documentation_url" yaml:"rule_documentation_url"`
+	LineNumber           int      `json:"line_number,omitempty" yaml:"line_number,omitempty"`
+	Filename             string   `json:"filename,omitempty" yaml:"filename,omitempty"`
+	CategoryGroups       []string `json:"category_groups,omitempty" yaml:"category_groups,omitempty"`
+	ParentLineNumber     int      `json:"parent_line_number,omitempty" yaml:"parent_line_number,omitempty"`
+	ParentContent        string   `json:"parent_content,omitempty" yaml:"parent_content,omitempty"`
+	OmitParent           bool     `json:"omit_parent,omitempty" yaml:"omit_parent,omitempty"`
+	DetailedContext      string   `json:"detailed_context,omitempty" yaml:"detailed_context,omitempty"`
 }
 
 func GetOutput(dataflow *dataflow.DataFlow, config settings.Config) (map[string][]Result, error) {
@@ -120,16 +119,17 @@ func GetOutput(dataflow *dataflow.DataFlow, config settings.Config) (map[string]
 
 			for _, output := range results["policy_failure"] {
 				result := Result{
-					PolicyDescription: rule.Description,
-					PolicyDisplayId:   rule.Id,
-					PolicyDSRID:       rule.DSRID,
-					Filename:          output.Filename,
-					LineNumber:        output.LineNumber,
-					CategoryGroups:    output.CategoryGroups,
-					OmitParent:        rule.OmitParent,
-					ParentLineNumber:  output.ParentLineNumber,
-					ParentContent:     output.ParentContent,
-					DetailedContext:   output.DetailedContext,
+					RuleDescription:      rule.Description,
+					RuleDisplayId:        rule.Id,
+					RuleDSRID:            rule.DSRID,
+					RuleDocumentationUrl: rule.DocumentationUrl,
+					Filename:             output.Filename,
+					LineNumber:           output.LineNumber,
+					CategoryGroups:       output.CategoryGroups,
+					OmitParent:           rule.OmitParent,
+					ParentLineNumber:     output.ParentLineNumber,
+					ParentContent:        output.ParentContent,
+					DetailedContext:      output.DetailedContext,
 				}
 
 				severity := FindHighestSeverity(result.CategoryGroups, rule.Severity)
@@ -179,7 +179,7 @@ func BuildReportString(config settings.Config, results map[string][]Result, line
 		}
 
 		for _, failure := range results[severityLevel] {
-			failures[severityLevel][failure.PolicyDSRID] = true
+			failures[severityLevel][failure.RuleDSRID] = true
 			writeFailureToString(reportStr, failure, severityLevel)
 		}
 	}
@@ -334,15 +334,17 @@ func checkAndWriteFailureSummaryToString(
 func writeFailureToString(reportStr *strings.Builder, result Result, severity string) {
 	reportStr.WriteString("\n\n")
 	reportStr.WriteString(formatSeverity(severity))
-	reportStr.WriteString(result.PolicyDescription)
-	if result.PolicyDSRID != "" {
-		reportStr.WriteString(" [" + result.PolicyDSRID + "]")
+	reportStr.WriteString(result.RuleDescription)
+	if result.RuleDSRID != "" {
+		reportStr.WriteString(" [" + result.RuleDSRID + "]")
 	}
 	reportStr.WriteString("\n")
-	// dont show link if custom
-	reportStr.WriteString(color.HiBlackString("https://curio.sh/reference/rules/" + result.PolicyDisplayId + "\n"))
 
-	reportStr.WriteString(color.HiBlackString("To skip this rule, use the flag --skip-rule=" + result.PolicyDisplayId + "\n"))
+	if result.RuleDocumentationUrl != "" {
+		reportStr.WriteString(color.HiBlackString(result.RuleDocumentationUrl + "\n"))
+	}
+
+	reportStr.WriteString(color.HiBlackString("To skip this rule, use the flag --skip-rule=" + result.RuleDisplayId + "\n"))
 	reportStr.WriteString("\n")
 	if result.DetailedContext != "" {
 		reportStr.WriteString("Detected: " + result.DetailedContext + "\n")

--- a/pkg/report/output/summary/summary_test.go
+++ b/pkg/report/output/summary/summary_test.go
@@ -25,11 +25,20 @@ func TestBuildReportString(t *testing.T) {
 		},
 	})
 
-	// limit rules so that test doesn't fail just because
 	// new rules are added
+	customRule := &settings.Rule{
+		Id:          "custom_test_rule",
+		Description: "Its a test!",
+		DSRID:       "",
+		Type:        "risk",
+		Severity:    map[string]string{"default": "low"},
+	}
+
+	// limit rules so that test doesn't fail just because
 	config.Rules = map[string]*settings.Rule{
 		"ruby_lang_ssl_verification": config.Rules["ruby_lang_ssl_verification"],
 		"ruby_rails_logger":          config.Rules["ruby_rails_logger"],
+		"custom_test_rule":           customRule,
 	}
 
 	if err != nil {


### PR DESCRIPTION
## Description
- simplify policy listing on summary #519
- fix some key names on json output of summary
- fix output when using custom rules
- allow the specification of a doc url in a rule (`documentation_url` key) as part of the fix for #527

## Related
- Close #519
- Close #528
- Close #527


## Checklist

- [x] I've added test coverage that shows my fix or feature works as expected.
- [x] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
