### PR TITLE
fix: add mapping for rule severity to category

### DIFF
--- a/pkg/commands/process/settings/rules.go
+++ b/pkg/commands/process/settings/rules.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/bearer/curio/pkg/flag"
+	"golang.org/x/exp/maps"
 	"gopkg.in/yaml.v3"
 )
 
@@ -161,7 +162,7 @@ func buildRules(definitions map[string]RuleDefinition, enabledRules map[string]s
 			Trigger:            definition.Trigger,
 			SkipDataTypes:      definition.SkipDataTypes,
 			OnlyDataTypes:      definition.OnlyDataTypes,
-			Severity:           definition.Severity,
+			Severity:           mapSeverityKeysToCategories(definition.Severity),
 			Description:        definition.Metadata.Description,
 			RemediationMessage: definition.Metadata.RemediationMessage,
 			Stored:             definition.Stored,
@@ -186,4 +187,19 @@ func buildRules(definitions map[string]RuleDefinition, enabledRules map[string]s
 	}
 
 	return rules
+}
+
+func mapSeverityKeysToCategories(ruleSeverity map[string]string) map[string]string {
+	// translate data category attributes to data category names
+	for _, key := range maps.Keys(ruleSeverity) {
+		switch key {
+		case "PD":
+			ruleSeverity["Personal Data"] = ruleSeverity[key]
+		case "PD(S)":
+			ruleSeverity["Personal Data (Sensitive)"] = ruleSeverity[key]
+		default:
+		}
+	}
+
+	return ruleSeverity
 }

--- a/pkg/commands/process/settings/settings_test.go
+++ b/pkg/commands/process/settings/settings_test.go
@@ -1,0 +1,37 @@
+package settings_test
+
+import (
+	"testing"
+
+	"github.com/bearer/curio/pkg/commands/process/settings"
+	"github.com/bearer/curio/pkg/flag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRuleSeverityMapping(t *testing.T) {
+	opts := flag.Options{
+		ScanOptions: flag.ScanOptions{},
+		RuleOptions: flag.RuleOptions{},
+		RepoOptions: flag.RepoOptions{},
+		ReportOptions: flag.ReportOptions{
+			Report: "summary",
+			Severity: map[string]bool{
+				"critical": true,
+				"high":     true,
+				"medium":   true,
+				"low":      true,
+				"warning":  true,
+			},
+		},
+		GeneralOptions: flag.GeneralOptions{},
+	}
+	config, err := settings.FromOptions(opts)
+	if err != nil {
+		t.Fatalf("failed to generate config:%s", err)
+	}
+
+	// test random rule's severity has been mapped
+	// as expected
+	loggerRule := config.Rules["ruby_rails_logger"]
+	assert.Equal(t, loggerRule.Severity["Personal Data"] != "", true)
+}


### PR DESCRIPTION
## Description

Where necessary, map rule severity ('PD') to data category name ('Personal Data')

Likely, if data category names turn out to be updated frequently, we will want a more sophisticated solution.
And since we don't delete any keys from the rule severity, custom data categories / custom rules will be respected

<!-- Add this section if required
## Related
-->
- Closes #532
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
