### PR TITLE
fix: resolve homedir when loading external rules

### DIFF
--- a/pkg/commands/process/settings/rules.go
+++ b/pkg/commands/process/settings/rules.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/bearer/curio/pkg/flag"
+	"github.com/rs/zerolog/log"
 	"golang.org/x/exp/maps"
 	"gopkg.in/yaml.v3"
 )
@@ -36,6 +37,11 @@ func loadRules(externalRuleDirs []string, options flag.RuleOptions) (map[string]
 	}
 
 	for _, dir := range externalRuleDirs {
+		if strings.HasPrefix(dir, "~/") {
+			dirname, _ := os.UserHomeDir()
+			dir = filepath.Join(dirname, dir[2:])
+		}
+		log.Debug().Msgf("loading external rules from: %s", dir)
 		if err := loadRuleDefinitions(definitions, os.DirFS(dir)); err != nil {
 			return nil, nil, fmt.Errorf("error loading external rules from %s: %w", dir, err)
 		}


### PR DESCRIPTION
## Description
- When using `--external-rule-dir=~/my-rule-dir` the path is not expanded by the shell and is passed literally to the application. This PR expands out `~` to give the full path again in this situation
- Added debug for loading external rules so users can check they are being loaded at application startup

## Related
- Close #529 

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
