### PR TITLE
fix: flow and nested detections

### DIFF
--- a/new/detector/evaluator/evaluator.go
+++ b/new/detector/evaluator/evaluator.go
@@ -48,10 +48,6 @@ func (evaluator *evaluator) ForTree(
 	var result []*types.Detection
 
 	if err := rootNode.Walk(func(node *langtree.Node, visitChildren func() error) error {
-		if !node.Equal(rootNode) && !evaluator.lang.DescendIntoDetectionNode(node) {
-			return nil
-		}
-
 		detections, err := evaluator.nonUnifiedNodeDetections(node, detectorType)
 		if err != nil {
 			return err
@@ -67,6 +63,17 @@ func (evaluator *evaluator) ForTree(
 				}
 
 				result = append(result, unifiedNodeDetections...)
+			}
+		}
+
+		if len(detections) != 0 {
+			nestedDetections, err := evaluator.detectorSet.NestedDetections(detectorType)
+			if err != nil {
+				return err
+			}
+
+			if !nestedDetections {
+				return nil
 			}
 		}
 
@@ -132,10 +139,6 @@ func (evaluator *evaluator) TreeHas(rootNode *langtree.Node, detectorType string
 	var result bool
 
 	if err := rootNode.Walk(func(node *langtree.Node, visitChildren func() error) error {
-		if !node.Equal(rootNode) && !evaluator.lang.DescendIntoDetectionNode(node) {
-			return nil
-		}
-
 		detections, err := evaluator.nonUnifiedNodeDetections(node, detectorType)
 		if err != nil {
 			return err

--- a/new/detector/implementation/custom/custom.go
+++ b/new/detector/implementation/custom/custom.go
@@ -21,6 +21,7 @@ type Pattern struct {
 }
 
 type customDetector struct {
+	types.DetectorBase
 	detectorType string
 	patterns     []Pattern
 }

--- a/new/detector/implementation/generic/datatype/datatype.go
+++ b/new/detector/implementation/generic/datatype/datatype.go
@@ -39,6 +39,7 @@ type Property struct {
 }
 
 type datatypeDetector struct {
+	types.DetectorBase
 	classifier *classificationschema.Classifier
 }
 

--- a/new/detector/implementation/generic/insecureurl/insecureurl.go
+++ b/new/detector/implementation/generic/insecureurl/insecureurl.go
@@ -10,7 +10,9 @@ import (
 	languagetypes "github.com/bearer/curio/new/language/types"
 )
 
-type insecureURLDetector struct{}
+type insecureURLDetector struct {
+	types.DetectorBase
+}
 
 var insecureUrlPattern = regexp.MustCompile(`^http:`)
 

--- a/new/detector/implementation/javascript/object/object.go
+++ b/new/detector/implementation/javascript/object/object.go
@@ -12,6 +12,7 @@ import (
 )
 
 type objectDetector struct {
+	types.DetectorBase
 	// Gathering properties
 	objectPairQuery *tree.Query
 	// Naming
@@ -84,6 +85,10 @@ func New(lang languagetypes.Language) (types.Detector, error) {
 
 func (detector *objectDetector) Name() string {
 	return "object"
+}
+
+func (detector *objectDetector) NestedDetections() bool {
+	return false
 }
 
 func (detector *objectDetector) DetectAt(

--- a/new/detector/implementation/javascript/property/property.go
+++ b/new/detector/implementation/javascript/property/property.go
@@ -13,6 +13,7 @@ import (
 )
 
 type propertyDetector struct {
+	types.DetectorBase
 	pairQuery         *tree.Query
 	functionNameQuery *tree.Query
 	methodNameQuery   *tree.Query

--- a/new/detector/implementation/javascript/string/string.go
+++ b/new/detector/implementation/javascript/string/string.go
@@ -12,7 +12,9 @@ import (
 	languagetypes "github.com/bearer/curio/new/language/types"
 )
 
-type stringDetector struct{}
+type stringDetector struct {
+	types.DetectorBase
+}
 
 func New(lang languagetypes.Language) (types.Detector, error) {
 	return &stringDetector{}, nil

--- a/new/detector/implementation/ruby/object/object.go
+++ b/new/detector/implementation/ruby/object/object.go
@@ -12,6 +12,7 @@ import (
 )
 
 type objectDetector struct {
+	types.DetectorBase
 	// Gathering properties
 	hashPairQuery *tree.Query
 	// Naming
@@ -73,6 +74,10 @@ func New(lang languagetypes.Language) (types.Detector, error) {
 
 func (detector *objectDetector) Name() string {
 	return "object"
+}
+
+func (detector *objectDetector) NestedDetections() bool {
+	return false
 }
 
 func (detector *objectDetector) DetectAt(

--- a/new/detector/implementation/ruby/property/property.go
+++ b/new/detector/implementation/ruby/property/property.go
@@ -12,6 +12,7 @@ import (
 )
 
 type propertyDetector struct {
+	types.DetectorBase
 	pairQuery       *tree.Query
 	accessorQuery   *tree.Query
 	methodNameQuery *tree.Query

--- a/new/detector/implementation/ruby/string/string.go
+++ b/new/detector/implementation/ruby/string/string.go
@@ -10,7 +10,9 @@ import (
 	languagetypes "github.com/bearer/curio/new/language/types"
 )
 
-type stringDetector struct{}
+type stringDetector struct {
+	types.DetectorBase
+}
 
 func New(lang languagetypes.Language) (types.Detector, error) {
 	return &stringDetector{}, nil

--- a/new/detector/set/set.go
+++ b/new/detector/set/set.go
@@ -29,14 +29,23 @@ func New(detectors []types.Detector) (types.DetectorSet, error) {
 	}, nil
 }
 
+func (set *set) NestedDetections(detectorType string) (bool, error) {
+	detector, err := set.lookupDetector(detectorType)
+	if err != nil {
+		return false, err
+	}
+
+	return detector.NestedDetections(), nil
+}
+
 func (set *set) DetectAt(
 	node *tree.Node,
 	detectorType string,
 	evaluator types.Evaluator,
 ) ([]*types.Detection, error) {
-	detector, ok := set.detectors[detectorType]
-	if !ok {
-		return nil, fmt.Errorf("detector type '%s' not registered", detectorType)
+	detector, err := set.lookupDetector(detectorType)
+	if err != nil {
+		return nil, err
 	}
 
 	detectionsData, err := detector.DetectAt(node, evaluator)
@@ -54,4 +63,13 @@ func (set *set) DetectAt(
 	}
 
 	return detections, nil
+}
+
+func (set *set) lookupDetector(detectorType string) (types.Detector, error) {
+	detector, ok := set.detectors[detectorType]
+	if !ok {
+		return nil, fmt.Errorf("detector type '%s' not registered", detectorType)
+	}
+
+	return detector, nil
 }

--- a/new/detector/types/types.go
+++ b/new/detector/types/types.go
@@ -20,6 +20,7 @@ type Evaluator interface {
 }
 
 type DetectorSet interface {
+	NestedDetections(detectorType string) (bool, error)
 	DetectAt(
 		node *tree.Node,
 		detectorType string,
@@ -30,7 +31,14 @@ type DetectorSet interface {
 type Detector interface {
 	Name() string
 	DetectAt(node *tree.Node, evaluator Evaluator) ([]interface{}, error)
+	NestedDetections() bool
 	Close()
+}
+
+type DetectorBase struct{}
+
+func (*DetectorBase) NestedDetections() bool {
+	return true
 }
 
 type Composition interface {

--- a/new/language/base/base.go
+++ b/new/language/base/base.go
@@ -35,7 +35,3 @@ func (lang *Language) CompileQuery(input string) (*tree.Query, error) {
 func (lang *Language) CompilePatternQuery(input string) (types.PatternQuery, error) {
 	return patternquery.Compile(lang, lang.implementation, input)
 }
-
-func (lang *Language) DescendIntoDetectionNode(node *tree.Node) bool {
-	return lang.implementation.DescendIntoDetectionNode(node)
-}

--- a/new/language/implementation/implementation.go
+++ b/new/language/implementation/implementation.go
@@ -95,16 +95,6 @@ type Implementation interface {
 	//   call(verify_mode: OpenSSL::SSL::VERIFY_NONE)    -> verify_mode
 	//   call(:verify_mode => OpenSSL::SSL::VERIFY_NONE) -> :verify_mode
 	TranslatePatternContent(fromNodeType, toNodeType, content string) string
-	// DescendIntoDetectionNode returns whether a tree detection search should
-	// proceed down into the given node.
-	//
-	// eg. given Ruby code like this:
-	//   user = Struct.new(email: ..., address: ...)
-	// 	 user.email
-	// `user` in `user.email` is unified with the assignment.
-	// But we don't want to see detections for the assignment when asking for the
-	// detections of `user.email`
-	DescendIntoDetectionNode(node *tree.Node) bool
 	// IsRootOfRuleQuery returns whether a node should be ignored or be a root
 	// of a custom rule query
 	//

--- a/new/language/implementation/javascript/javascript.go
+++ b/new/language/implementation/javascript/javascript.go
@@ -232,16 +232,6 @@ func (implementation *javascriptImplementation) PatternIsAnchored(node *tree.Nod
 	return !slices.Contains(unAnchored, node.Type())
 }
 
-func (implementation *javascriptImplementation) DescendIntoDetectionNode(node *tree.Node) bool {
-	// FIXME: this breaks expected behaviour of tests
-	// parent := node.Parent()
-	// if parent != nil && parent.Type() == "member_expression" && node.Equal(parent.ChildByFieldName("object")) {
-	// 	return false
-	// }
-
-	return true
-}
-
 func (implementation *javascriptImplementation) IsRootOfRuleQuery(node *tree.Node) bool {
 	return !(node.Type() == "expression_statement")
 }

--- a/new/language/implementation/ruby/ruby.go
+++ b/new/language/implementation/ruby/ruby.go
@@ -237,16 +237,6 @@ func (*rubyImplementation) TranslatePatternContent(fromNodeType, toNodeType, con
 	return content
 }
 
-func (*rubyImplementation) DescendIntoDetectionNode(node *tree.Node) bool {
-	parent := node.Parent()
-
-	if parent != nil && parent.Type() == "call" && node.Equal(parent.ChildByFieldName("receiver")) {
-		return slice.Contains(passThroughMethods, parent.ChildByFieldName("method").Content())
-	}
-
-	return true
-}
-
 func (implementation *rubyImplementation) IsRootOfRuleQuery(node *tree.Node) bool {
 	return true
 }

--- a/new/language/types/types.go
+++ b/new/language/types/types.go
@@ -17,5 +17,4 @@ type Language interface {
 	Parse(input string) (*tree.Tree, error)
 	CompileQuery(input string) (*tree.Query, error)
 	CompilePatternQuery(input string) (PatternQuery, error)
-	DescendIntoDetectionNode(node *tree.Node) bool
 }

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryptionDataflow-dataflow_ruby_lang_weak_encryption_openssl_dsa.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryptionDataflow-dataflow_ruby_lang_weak_encryption_openssl_dsa.rb
@@ -8,6 +8,13 @@ risks:
             content: OpenSSL::PKey::DSA.new(2048)
           content: |
             OpenSSL::PKey::DSA.new()
+        - filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption/testdata/openssl_dsa.rb
+          line_number: 5
+          parent:
+            line_number: 5
+            content: OpenSSL::PKey::DSA.new(2048)
+          content: |
+            OpenSSL::PKey::DSA.new()
     - detector_id: ruby_lang_weak_encryption
       locations:
         - filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption/testdata/openssl_dsa.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryptionDataflow-dataflow_ruby_lang_weak_encryption_openssl_rsa.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryptionDataflow-dataflow_ruby_lang_weak_encryption_openssl_rsa.rb
@@ -2,9 +2,23 @@ risks:
     - detector_id: openssl_rsa_init
       locations:
         - filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption/testdata/openssl_rsa.rb
+          line_number: 1
+          parent:
+            line_number: 1
+            content: OpenSSL::PKey::RSA.new(File.read('rsa.pem'))
+          content: |
+            OpenSSL::PKey::RSA.new()
+        - filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption/testdata/openssl_rsa.rb
           line_number: 4
           parent:
             line_number: 4
+            content: OpenSSL::PKey::RSA.new(2048)
+          content: |
+            OpenSSL::PKey::RSA.new()
+        - filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption/testdata/openssl_rsa.rb
+          line_number: 7
+          parent:
+            line_number: 7
             content: OpenSSL::PKey::RSA.new(2048)
           content: |
             OpenSSL::PKey::RSA.new()

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryptionDataflow-dataflow_ruby_lang_weak_encryption_rc4_encrypt.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryptionDataflow-dataflow_ruby_lang_weak_encryption_rc4_encrypt.rb
@@ -2,6 +2,13 @@ risks:
     - detector_id: rc4_init
       locations:
         - filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption/testdata/rc4_encrypt.rb
+          line_number: 1
+          parent:
+            line_number: 1
+            content: RC4.new("insecure")
+          content: |
+            RC4.new()
+        - filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption/testdata/rc4_encrypt.rb
           line_number: 3
           parent:
             line_number: 3

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithDataDataflow-dataflow_ruby_lang_weak_encryption_with_data_blowfish_data.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithDataDataflow-dataflow_ruby_lang_weak_encryption_with_data_blowfish_data.rb
@@ -61,6 +61,29 @@ risks:
               field_name: password
               object_name: user
               subject_name: User
+    - detector_id: blowfish_init
+      locations:
+        - filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/testdata/blowfish_data.rb
+          line_number: 1
+          parent:
+            line_number: 1
+            content: Crypt::Blowfish.new("insecure")
+          content: |
+            Crypt::Blowfish.new()
+        - filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/testdata/blowfish_data.rb
+          line_number: 5
+          parent:
+            line_number: 5
+            content: Crypt::Blowfish.new("insecure")
+          content: |
+            Crypt::Blowfish.new()
+        - filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/testdata/blowfish_data.rb
+          line_number: 9
+          parent:
+            line_number: 9
+            content: Crypt::Blowfish.new("your-key")
+          content: |
+            Crypt::Blowfish.new()
 components: []
 
 

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithDataDataflow-dataflow_ruby_lang_weak_encryption_with_data_openssl_dsa_data.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithDataDataflow-dataflow_ruby_lang_weak_encryption_with_data_openssl_dsa_data.rb
@@ -51,6 +51,15 @@ risks:
             content: OpenSSL::PKey::DSA.new(2048)
           content: |
             OpenSSL::PKey::DSA.new()
+    - detector_id: openssl_rsa_init
+      locations:
+        - filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/testdata/openssl_dsa_data.rb
+          line_number: 5
+          parent:
+            line_number: 5
+            content: OpenSSL::PKey::RSA.new(2048)
+          content: |
+            OpenSSL::PKey::RSA.new()
 components: []
 
 

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithDataDataflow-dataflow_ruby_lang_weak_encryption_with_data_openssl_rsa_data.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithDataDataflow-dataflow_ruby_lang_weak_encryption_with_data_openssl_rsa_data.rb
@@ -58,9 +58,23 @@ risks:
     - detector_id: openssl_rsa_init
       locations:
         - filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/testdata/openssl_rsa_data.rb
+          line_number: 1
+          parent:
+            line_number: 1
+            content: OpenSSL::PKey::RSA.new(File.read('rsa.pem'))
+          content: |
+            OpenSSL::PKey::RSA.new()
+        - filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/testdata/openssl_rsa_data.rb
           line_number: 4
           parent:
             line_number: 4
+            content: OpenSSL::PKey::RSA.new(2048)
+          content: |
+            OpenSSL::PKey::RSA.new()
+        - filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/testdata/openssl_rsa_data.rb
+          line_number: 7
+          parent:
+            line_number: 7
             content: OpenSSL::PKey::RSA.new(2048)
           content: |
             OpenSSL::PKey::RSA.new()

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithDataDataflow-dataflow_ruby_lang_weak_encryption_with_data_rc4_data.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithDataDataflow-dataflow_ruby_lang_weak_encryption_with_data_rc4_data.rb
@@ -38,6 +38,13 @@ risks:
     - detector_id: rc4_init
       locations:
         - filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/testdata/rc4_data.rb
+          line_number: 1
+          parent:
+            line_number: 1
+            content: RC4.new("insecure")
+          content: |
+            RC4.new()
+        - filename: pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/testdata/rc4_data.rb
           line_number: 3
           parent:
             line_number: 3

--- a/pkg/commands/process/settings/rules/ruby/third_parties/datadog/.snapshots/TestRubyThirdPartiesDatadogDataflow-dataflow_ruby_third_parties_datadog_datatype_in_tags.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/datadog/.snapshots/TestRubyThirdPartiesDatadogDataflow-dataflow_ruby_third_parties_datadog_datatype_in_tags.rb
@@ -100,6 +100,20 @@ risks:
           content: |
             Datadog.configuration[$<_>][$<_>].active_span
         - filename: pkg/commands/process/settings/rules/ruby/third_parties/datadog/testdata/datatype_in_tags.rb
+          line_number: 9
+          parent:
+            line_number: 9
+            content: Datadog::Tracing.active_span
+          content: |
+            Datadog::Tracing.active_span
+        - filename: pkg/commands/process/settings/rules/ruby/third_parties/datadog/testdata/datatype_in_tags.rb
+          line_number: 10
+          parent:
+            line_number: 10
+            content: Datadog::Tracing.active_span
+          content: |
+            Datadog::Tracing.active_span
+        - filename: pkg/commands/process/settings/rules/ruby/third_parties/datadog/testdata/datatype_in_tags.rb
           line_number: 12
           parent:
             line_number: 12

--- a/pkg/commands/process/settings/rules/ruby/third_parties/elasticsearch/.snapshots/TestRubyThirdPartiesElasticsearchDataflow-dataflow_ruby_third_parties_elasticsearch_datatype_in_update.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/elasticsearch/.snapshots/TestRubyThirdPartiesElasticsearchDataflow-dataflow_ruby_third_parties_elasticsearch_datatype_in_update.rb
@@ -25,6 +25,17 @@ risks:
               field_name: email
               object_name: user
               subject_name: User
+    - detector_id: ruby_third_parties_elasticsearch_client
+      locations:
+        - filename: pkg/commands/process/settings/rules/ruby/third_parties/elasticsearch/testdata/datatype_in_update.rb
+          line_number: 3
+          parent:
+            line_number: 3
+            content: |-
+                Elasticsearch::Client
+                  .new
+          content: |
+            Elasticsearch::Client.new
 components: []
 
 

--- a/pkg/commands/process/settings/rules/ruby/third_parties/segment/.snapshots/TestRubyThirdPartiesSegmentDataflow-dataflow_ruby_third_parties_segment_ok_no_datatypes.rb
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/segment/.snapshots/TestRubyThirdPartiesSegmentDataflow-dataflow_ruby_third_parties_segment_ok_no_datatypes.rb
@@ -1,3 +1,13 @@
+risks:
+    - detector_id: segment_init
+      locations:
+        - filename: pkg/commands/process/settings/rules/ruby/third_parties/segment/testdata/ok_no_datatypes.rb
+          line_number: 1
+          parent:
+            line_number: 1
+            content: 'Segment::Analytics.new(write_key: "ABC123F")'
+          content: |
+            Segment::Analytics.new()
 components: []
 
 


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Fixes the following issues identified during testing:
- Ensure we descend down into unified nodes in `Evaluator.TreeHas` 
- Replace `Implementation.DescendIntoDetectionNode` with `Detector.NestedDetections` - this logic existed to ensure object projections (ie. `user.email`) don't also detect the original object (ie. all properties on `user` in this case). This was previously done by avoiding descending into the receiver of a call when evaluating any detections. Instead we now define the object detectors as not allowing nested detections. ie. when a node returns a detection, we do not look for further detections in it's child nodes.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [x] I've updated or added documentation if required.
- [x] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
