### PR TITLE
feat: add "not" and regex filters

### DIFF
--- a/new/detector/implementation/custom/filter.go
+++ b/new/detector/implementation/custom/filter.go
@@ -15,7 +15,15 @@ func matchFilter(
 	result *languagetypes.PatternQueryResult,
 	evaluator types.Evaluator,
 	filter settings.PatternFilter,
-) (bool, []*types.Detection, error) {
+) (*bool, []*types.Detection, error) {
+	if filter.Not != nil {
+		match, _, err := matchFilter(result, evaluator, *filter.Not)
+		if match == nil {
+			return nil, nil, err
+		}
+		return boolPointer(!*match), nil, err
+	}
+
 	if len(filter.Either) != 0 {
 		return matchEitherFilters(result, evaluator, filter.Either)
 	}
@@ -23,7 +31,7 @@ func matchFilter(
 	node, ok := result.Variables[filter.Variable]
 	// shouldn't happen if filters are validated against pattern
 	if !ok {
-		return false, nil, nil
+		return nil, nil, nil
 	}
 
 	if filter.Detection != "" {
@@ -42,7 +50,7 @@ func matchAllFilters(
 
 	for _, filter := range filters {
 		matched, subDataTypeDetections, err := matchFilter(result, evaluator, filter)
-		if !matched || err != nil {
+		if matched == nil || !*matched || err != nil {
 			return false, nil, err
 		}
 
@@ -56,25 +64,31 @@ func matchEitherFilters(
 	result *languagetypes.PatternQueryResult,
 	evaluator types.Evaluator,
 	filters []settings.PatternFilter,
-) (bool, []*types.Detection, error) {
+) (*bool, []*types.Detection, error) {
 	var datatypeDetections []*types.Detection
 	oneMatched := false
+	oneNotMatched := false
 
 	for _, subFilter := range filters {
 		subMatch, subDatatypeDetections, err := matchFilter(result, evaluator, subFilter)
 		if err != nil {
-			return false, nil, err
+			return nil, nil, err
 		}
 
 		datatypeDetections = append(datatypeDetections, subDatatypeDetections...)
-		oneMatched = oneMatched || subMatch
+		oneMatched = oneMatched || (subMatch != nil && *subMatch)
+		oneNotMatched = oneNotMatched || (subMatch != nil && !*subMatch)
 	}
 
-	if !oneMatched {
-		return false, nil, nil
+	if oneMatched {
+		return boolPointer(true), datatypeDetections, nil
 	}
 
-	return true, datatypeDetections, nil
+	if oneNotMatched {
+		return boolPointer(false), nil, nil
+	}
+
+	return nil, nil, nil
 }
 
 func matchDetectionFilter(
@@ -82,65 +96,73 @@ func matchDetectionFilter(
 	evaluator types.Evaluator,
 	node *tree.Node,
 	detectorType string,
-) (bool, []*types.Detection, error) {
+) (*bool, []*types.Detection, error) {
 	if detectorType == "datatype" {
 		detections, err := evaluator.ForTree(node, "datatype", true)
 
-		return len(detections) != 0, detections, err
+		return boolPointer(len(detections) != 0), detections, err
 	}
 
 	hasDetection, err := evaluator.TreeHas(node, detectorType)
-	return hasDetection, nil, err
+	return boolPointer(hasDetection), nil, err
 }
 
-func matchContentFilter(filter settings.PatternFilter, content string) bool {
+func matchContentFilter(filter settings.PatternFilter, content string) *bool {
 	if len(filter.Values) != 0 && !slices.Contains(filter.Values, content) {
-		return false
+		return boolPointer(false)
+	}
+
+	if filter.Regex != nil {
+		return boolPointer(filter.Regex.MatchString(content))
 	}
 
 	if filter.LessThan != nil {
 		value, err := strconv.Atoi(content)
 		if err != nil {
-			return false
+			return nil
 		}
 
 		if value >= *filter.LessThan {
-			return false
+			return boolPointer(false)
 		}
 	}
 
 	if filter.LessThanOrEqual != nil {
 		value, err := strconv.Atoi(content)
 		if err != nil {
-			return false
+			return nil
 		}
 
 		if value > *filter.LessThanOrEqual {
-			return false
+			return boolPointer(false)
 		}
 	}
 
 	if filter.GreaterThan != nil {
 		value, err := strconv.Atoi(content)
 		if err != nil {
-			return false
+			return nil
 		}
 
 		if value <= *filter.GreaterThan {
-			return false
+			return boolPointer(false)
 		}
 	}
 
 	if filter.GreaterThanOrEqual != nil {
 		value, err := strconv.Atoi(content)
 		if err != nil {
-			return false
+			return nil
 		}
 
 		if value < *filter.GreaterThanOrEqual {
-			return false
+			return boolPointer(false)
 		}
 	}
 
-	return true
+	return boolPointer(true)
+}
+
+func boolPointer(value bool) *bool {
+	return &value
 }

--- a/pkg/commands/process/settings/regexp.go
+++ b/pkg/commands/process/settings/regexp.go
@@ -1,0 +1,26 @@
+package settings
+
+import "regexp"
+
+type Regexp struct {
+	*regexp.Regexp
+}
+
+func (r *Regexp) UnmarshalText(b []byte) error {
+	pattern, err := regexp.Compile(string(b))
+	if err != nil {
+		return err
+	}
+
+	r.Regexp = pattern
+
+	return nil
+}
+
+func (r *Regexp) MarshalText() ([]byte, error) {
+	if r.Regexp != nil {
+		return []byte(r.Regexp.String()), nil
+	}
+
+	return nil, nil
+}

--- a/pkg/commands/process/settings/settings.go
+++ b/pkg/commands/process/settings/settings.go
@@ -141,9 +141,11 @@ type Rule struct {
 }
 
 type PatternFilter struct {
+	Not                *PatternFilter  `mapstructure:"not" json:"not" yaml:"not"`
 	Either             []PatternFilter `mapstructure:"either" json:"either" yaml:"either"`
 	Variable           string          `mapstructure:"variable" json:"variable" yaml:"variable"`
 	Detection          string          `mapstructure:"detection" json:"detection" yaml:"detection"`
+	Regex              *Regexp         `mapstructure:"regex" json:"regex" yaml:"regex"`
 	Values             []string        `mapstructure:"values" json:"values" yaml:"values"`
 	LessThan           *int            `mapstructure:"less_than" json:"less_than" yaml:"less_than"`
 	LessThanOrEqual    *int            `mapstructure:"less_than_or_equal" json:"less_than_or_equal" yaml:"less_than_or_equal"`


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Adds support for two new filter types:
- `not` - inverts a filter. This introduces ternary logic to filters so content filters with a non-matching type (eg. `less_than` where the value is not a number) are left as a falsey value when inverted.
- `regex` - matches syntax content against a regular expression (similar to `values`)

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [x] I've updated or added documentation if required.
- [x] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
