### PR TITLE
feat: add CWE ids to newer JS rules

### DIFF
--- a/pkg/commands/process/settings/rules/javascript/third_parties/airbrake.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/airbrake.yml
@@ -34,5 +34,7 @@ metadata:
     ## Resources
     - [Airbrake Docs](https://docs.airbrake.io/)
   dsr_id: DSR-1
+  cwe_id:
+    - 201
   associated_recipe: Airbrake
   id: javascript_third_parties_airbrake

--- a/pkg/commands/process/settings/rules/javascript/third_parties/bugsnag.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/bugsnag.yml
@@ -54,5 +54,7 @@ metadata:
     ## Resources
     - [Bugsnag Docs](https://docs.bugsnag.com/platforms/javascript/)
   dsr_id: DSR-1
+  cwe_id:
+    - 201
   associated_recipe: Bugsnag
   id: javascript_third_parties_bugsnag

--- a/pkg/commands/process/settings/rules/javascript/third_parties/honeybadger.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/honeybadger.yml
@@ -37,4 +37,6 @@ metadata:
     Coming soon.
     -->
   dsr_id: DSR-1
+  cwe_id:
+    - 201
   id: "javascript_honeybadger"

--- a/pkg/commands/process/settings/rules/javascript/third_parties/new_relic.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/new_relic.yml
@@ -66,4 +66,6 @@ metadata:
     - [New Relic Docs](https://docs.newrelic.com/)
     - [Log obfuscation](https://docs.newrelic.com/docs/logs/ui-data/obfuscation-ui/)
   dsr_id: DSR-1
+  cwe_id:
+    - 201
   id: "javascript_third_parties_new_relic"

--- a/pkg/commands/process/settings/rules/javascript/third_parties/open_telemetry.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/open_telemetry.yml
@@ -40,4 +40,6 @@ metadata:
     ## Resources
     - [Open Telemetry Docs](https://opentelemetry.io/docs/)
   dsr_id: DSR-1
+  cwe_id:
+    - 201
   id: javascript_third_parties_open_telemetry

--- a/pkg/commands/process/settings/rules/javascript/third_parties/rollbar.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/rollbar.yml
@@ -39,4 +39,6 @@ metadata:
     Coming soon.
     -->
   dsr_id: DSR-1
+  cwe_id:
+    - 201
   id: "javascript_rollbar"


### PR DESCRIPTION
## Description
Add CWE ids to the newer JS rules e.g. Airbrake, Honeybadger. The CWE ids are taken from the equivalent Ruby rules - all 201 "Insertion of Sensitive Information Into Sent Data"

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
