### PR TITLE
docs: remove incorrect SCA acronym from discovery page

### DIFF
--- a/docs/explanations/discovery-and-classification.md
+++ b/docs/explanations/discovery-and-classification.md
@@ -14,7 +14,7 @@ Curio supports 120+ data types from sensitive data categories such as Personal D
 
 ## Data Discovery
 
-Discovery is the first step of the process. Curio uses static code analysis (SCA) in two ways.
+Discovery is the first step of the process. Curio uses static code analysis in two ways.
 
 - Analyzing class **names, methods, functions, variables, properties, and attributes**. It then ties those together to detected data structures. It goes as far as doing variable reconciliation.
 - Analyzing **data structure definitions files** such as OpenAPI, SQL, GraphQL, and Protobuf files.


### PR DESCRIPTION
## Description
Removes the SCA acronym from the Discovery and classification page to avoid confusion with the other SCA.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
