### PR TITLE
feat: optimise compilation time

### DIFF
--- a/new/detector/composition/javascript/javascript.go
+++ b/new/detector/composition/javascript/javascript.go
@@ -75,7 +75,7 @@ func New(rules map[string]*settings.Rule, classifier *classification.Classifier)
 	}
 
 	detectorsLen := len(jsRules) + len(staticDetectors)
-	reciever := make(chan types.DetectorInitResult, detectorsLen)
+	receiver := make(chan types.DetectorInitResult, detectorsLen)
 
 	var detectors []detectortypes.Detector
 
@@ -83,7 +83,7 @@ func New(rules map[string]*settings.Rule, classifier *classification.Classifier)
 		creator := detectorCreator
 		go func() {
 			detector, err := creator.constructor(lang)
-			reciever <- types.DetectorInitResult{
+			receiver <- types.DetectorInitResult{
 				Error:        err,
 				Detector:     detector,
 				DetectorName: creator.name,
@@ -111,7 +111,7 @@ func New(rules map[string]*settings.Rule, classifier *classification.Classifier)
 				patterns,
 			)
 
-			reciever <- types.DetectorInitResult{
+			receiver <- types.DetectorInitResult{
 				Error:        err,
 				Detector:     customDetector,
 				DetectorName: "customDetector: " + localRuleName,
@@ -120,7 +120,7 @@ func New(rules map[string]*settings.Rule, classifier *classification.Classifier)
 	}
 
 	for i := 0; i < detectorsLen; i++ {
-		response := <-reciever
+		response := <-receiver
 		detectors = append(detectors, response.Detector)
 		composition.closers = append(composition.closers, response.Detector.Close)
 		if response.Error != nil {

--- a/new/detector/composition/ruby/ruby.go
+++ b/new/detector/composition/ruby/ruby.go
@@ -74,7 +74,7 @@ func New(rules map[string]*settings.Rule, classifier *classification.Classifier)
 	}
 
 	detectorsLen := len(rubyRules) + len(staticDetectors)
-	reciever := make(chan types.DetectorInitResult, detectorsLen)
+	receiver := make(chan types.DetectorInitResult, detectorsLen)
 
 	var detectors []detectortypes.Detector
 
@@ -82,7 +82,7 @@ func New(rules map[string]*settings.Rule, classifier *classification.Classifier)
 		creator := detectorCreator
 		go func() {
 			detector, err := creator.constructor(lang)
-			reciever <- types.DetectorInitResult{
+			receiver <- types.DetectorInitResult{
 				Error:        err,
 				Detector:     detector,
 				DetectorName: creator.name,
@@ -110,7 +110,7 @@ func New(rules map[string]*settings.Rule, classifier *classification.Classifier)
 				patterns,
 			)
 
-			reciever <- types.DetectorInitResult{
+			receiver <- types.DetectorInitResult{
 				Error:        err,
 				Detector:     customDetector,
 				DetectorName: "customDetector:" + localRuleName,
@@ -119,7 +119,7 @@ func New(rules map[string]*settings.Rule, classifier *classification.Classifier)
 	}
 
 	for i := 0; i < detectorsLen; i++ {
-		response := <-reciever
+		response := <-receiver
 		detectors = append(detectors, response.Detector)
 		composition.closers = append(composition.closers, response.Detector.Close)
 		if response.Error != nil {

--- a/new/detector/composition/types/types.go
+++ b/new/detector/composition/types/types.go
@@ -1,0 +1,11 @@
+package types
+
+import (
+	detectortypes "github.com/bearer/curio/new/detector/types"
+)
+
+type DetectorInitResult struct {
+	Error        error
+	Detector     detectortypes.Detector
+	DetectorName string
+}


### PR DESCRIPTION
## Description
This pr offloads each detector creation into a separate gorutine, allowing more efficient cpu utilisation on multi cpu machines.
When benchmarking performance on macbook pro a single js rule test took 7.8s to execute without this fix and 3.4s with this fix. 
3.4s startup time is still a lot but it is also a 2x performance improvement compared to what we previously had

## Checklist

- [x] I've added test coverage that shows my fix or feature works as expected.
- [x] I've updated or added documentation if required.
- [x] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
