### PR TITLE
fix: fix severity and remove DSW for JS insecure XML ref rule

### DIFF
--- a/pkg/commands/process/settings/rules/javascript/express/insecure_xml_ref.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/insecure_xml_ref.yml
@@ -22,15 +22,11 @@ languages:
 trigger: presence
 severity:
   default: "low"
-  PII: "critical"
-  PHI: "medium"
-  PD: "high"
 metadata:
   description: "Ensure proper restriction of XML external entity references."
   remediation_message: |
     ## Description
     Avoid generating XML documents that include XML entities with URIs that resolve to resources that are outside of the current context.
-  dsr_id: "DSR-3"
   cwe_id:
     - 611
   id: "express_insecure_xml_ref"

--- a/pkg/commands/process/settings/rules/javascript/express/insecure_xml_ref/.snapshots/TestExpressInsecureXmlRef--lib_xml_with_noent_true.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/insecure_xml_ref/.snapshots/TestExpressInsecureXmlRef--lib_xml_with_noent_true.yml
@@ -1,5 +1,5 @@
 low:
-    - rule_dsrid: DSR-3
+    - rule_dsrid: ""
       rule_display_id: express_insecure_xml_ref
       rule_description: Ensure proper restriction of XML external entity references.
       rule_documentation_url: https://curio.sh/reference/rules/express_insecure_xml_ref


### PR DESCRIPTION
## Description
* Remove rogue DSW id (it's copy pasta)
* Remove other severity marks - this is a presence-only rule

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
