### PR TITLE
feat: ruby rule for ftp using user input

### DIFF
--- a/integration/rules/ruby_test.go
+++ b/integration/rules/ruby_test.go
@@ -22,6 +22,10 @@ func TestRubyLangFileGeneration(t *testing.T) {
 	getRunner(t).runTest(t, rubyRulesPath+"lang/file_generation")
 }
 
+func TestRubyLangFtpUsingUserInput(t *testing.T) {
+	getRunner(t).runTest(t, rubyRulesPath+"lang/ftp_using_user_input")
+}
+
 func TestRubyLangHttpGetParams(t *testing.T) {
 	getRunner(t).runTest(t, rubyRulesPath+"lang/http_get_params")
 }

--- a/new/detector/composition/javascript/javascript.go
+++ b/new/detector/composition/javascript/javascript.go
@@ -121,12 +121,12 @@ func New(rules map[string]*settings.Rule, classifier *classification.Classifier)
 
 	for i := 0; i < detectorsLen; i++ {
 		response := <-receiver
-		detectors = append(detectors, response.Detector)
-		composition.closers = append(composition.closers, response.Detector.Close)
 		if response.Error != nil {
 			composition.Close()
-			return nil, fmt.Errorf("failed to create detector %s: %s", response.DetectorName, err)
+			return nil, fmt.Errorf("failed to create detector %s: %s", response.DetectorName, response.Error)
 		}
+		detectors = append(detectors, response.Detector)
+		composition.closers = append(composition.closers, response.Detector.Close)
 	}
 
 	detectorSet, err := detectorset.New(detectors)

--- a/new/detector/composition/ruby/ruby.go
+++ b/new/detector/composition/ruby/ruby.go
@@ -120,12 +120,12 @@ func New(rules map[string]*settings.Rule, classifier *classification.Classifier)
 
 	for i := 0; i < detectorsLen; i++ {
 		response := <-receiver
-		detectors = append(detectors, response.Detector)
-		composition.closers = append(composition.closers, response.Detector.Close)
 		if response.Error != nil {
 			composition.Close()
-			return nil, fmt.Errorf("failed to create detector %s: %s", response.DetectorName, err)
+			return nil, fmt.Errorf("failed to create detector %s: %s", response.DetectorName, response.Error)
 		}
+		detectors = append(detectors, response.Detector)
+		composition.closers = append(composition.closers, response.Detector.Close)
 	}
 
 	detectorSet, err := detectorset.New(detectors)

--- a/pkg/commands/process/settings/rules/ruby/lang/ftp_using_user_input.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/ftp_using_user_input.yml
@@ -1,0 +1,57 @@
+patterns:
+  - pattern: |
+      Net::FTP.new($<...>$<USER_INPUT>$<...>)
+    filters:
+      - variable: USER_INPUT
+        detection: ruby_lang_ftp_using_user_input_user_input
+  - pattern: |
+      Net::FTP.open($<...>$<USER_INPUT>$<...>)$<...>
+    filters:
+      - variable: USER_INPUT
+        detection: ruby_lang_ftp_using_user_input_user_input
+  - pattern: |
+      $<FTP>.$<_>($<...>$<USER_INPUT>$<...>)$<...>
+    filters:
+      - variable: FTP
+        detection: ruby_lang_ftp_using_user_input_ftp
+      - variable: USER_INPUT
+        detection: ruby_lang_ftp_using_user_input_user_input
+auxiliary:
+  - id: ruby_lang_ftp_using_user_input_user_input
+    patterns:
+      - params
+      - request
+      - cookies
+      - | # AWS lambda
+        def $<_>($<!>event:, context:)
+        end
+  - id: ruby_lang_ftp_using_user_input_ftp
+    patterns:
+      - Net::FTP.new()
+      - Net::FTP.open()
+      - Net::FTP.open() { |$<!>$<_:identifier>| }
+languages:
+  - ruby
+trigger: presence
+severity:
+  default: low
+  PII: critical
+  PHI: medium
+  PD: high
+metadata:
+  description: "Do not use user input to form file paths."
+  remediation_message: |
+    ## Description
+
+    TODO
+
+    ## Remediations
+    TODO
+    <!--
+    ## Resources
+    Coming soon.
+    -->
+  dsr_id: DSR-? # FIXME
+  cwe_id:
+    - 22
+  id: ruby_lang_ftp_using_user_input

--- a/pkg/commands/process/settings/rules/ruby/lang/ftp_using_user_input/.snapshots/TestRubyLangFtpUsingUserInput--ok_not_unsafe.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/ftp_using_user_input/.snapshots/TestRubyLangFtpUsingUserInput--ok_not_unsafe.yml
@@ -1,0 +1,30 @@
+low:
+    - rule_dsrid: DSR-2
+      rule_display_id: ruby_lang_insecure_ftp
+      rule_description: Only communicate using SFTP connections.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_insecure_ftp
+      line_number: 1
+      filename: ok_not_unsafe.rb
+      parent_line_number: 1
+      parent_content: Net::FTP.new(x)
+    - rule_dsrid: DSR-2
+      rule_display_id: ruby_lang_insecure_ftp
+      rule_description: Only communicate using SFTP connections.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_insecure_ftp
+      line_number: 3
+      filename: ok_not_unsafe.rb
+      parent_line_number: 3
+      parent_content: |-
+        Net::FTP.open("example.com", username: "user") do
+
+        end
+    - rule_dsrid: DSR-2
+      rule_display_id: ruby_lang_insecure_ftp
+      rule_description: Only communicate using SFTP connections.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_insecure_ftp
+      line_number: 8
+      filename: ok_not_unsafe.rb
+      parent_line_number: 8
+      parent_content: Net::FTP.open("example.com")
+
+

--- a/pkg/commands/process/settings/rules/ruby/lang/ftp_using_user_input/.snapshots/TestRubyLangFtpUsingUserInput--unsafe.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/ftp_using_user_input/.snapshots/TestRubyLangFtpUsingUserInput--unsafe.yml
@@ -1,0 +1,57 @@
+low:
+    - rule_dsrid: DSR-?
+      rule_display_id: ruby_lang_ftp_using_user_input
+      rule_description: Do not use user input to form file paths.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_ftp_using_user_input
+      line_number: 1
+      filename: unsafe.rb
+      parent_line_number: 1
+      parent_content: Net::FTP.new(params[:oops])
+    - rule_dsrid: DSR-?
+      rule_display_id: ruby_lang_ftp_using_user_input
+      rule_description: Do not use user input to form file paths.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_ftp_using_user_input
+      line_number: 3
+      filename: unsafe.rb
+      parent_line_number: 3
+      parent_content: |-
+        Net::FTP.open("example.com", username: params[:user]) do
+
+        end
+    - rule_dsrid: DSR-?
+      rule_display_id: ruby_lang_ftp_using_user_input
+      rule_description: Do not use user input to form file paths.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_ftp_using_user_input
+      line_number: 9
+      filename: unsafe.rb
+      parent_line_number: 9
+      parent_content: ftp.puttextfile("local.txt", event["filename"])
+    - rule_dsrid: DSR-2
+      rule_display_id: ruby_lang_insecure_ftp
+      rule_description: Only communicate using SFTP connections.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_insecure_ftp
+      line_number: 1
+      filename: unsafe.rb
+      parent_line_number: 1
+      parent_content: Net::FTP.new(params[:oops])
+    - rule_dsrid: DSR-2
+      rule_display_id: ruby_lang_insecure_ftp
+      rule_description: Only communicate using SFTP connections.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_insecure_ftp
+      line_number: 3
+      filename: unsafe.rb
+      parent_line_number: 3
+      parent_content: |-
+        Net::FTP.open("example.com", username: params[:user]) do
+
+        end
+    - rule_dsrid: DSR-2
+      rule_display_id: ruby_lang_insecure_ftp
+      rule_description: Only communicate using SFTP connections.
+      rule_documentation_url: https://curio.sh/reference/rules/ruby_lang_insecure_ftp
+      line_number: 8
+      filename: unsafe.rb
+      parent_line_number: 8
+      parent_content: Net::FTP.open("example.com")
+
+

--- a/pkg/commands/process/settings/rules/ruby/lang/ftp_using_user_input/testdata/ok_not_unsafe.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/ftp_using_user_input/testdata/ok_not_unsafe.rb
@@ -1,0 +1,9 @@
+Net::FTP.new(x)
+
+Net::FTP.open("example.com", username: "user") do
+
+end
+
+event = not_from_handler
+ftp = Net::FTP.open("example.com")
+ftp.puttextfile("local.txt", event["filename"])

--- a/pkg/commands/process/settings/rules/ruby/lang/ftp_using_user_input/testdata/unsafe.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/ftp_using_user_input/testdata/unsafe.rb
@@ -1,0 +1,10 @@
+Net::FTP.new(params[:oops])
+
+Net::FTP.open("example.com", username: params[:user]) do
+
+end
+
+def handler(event:, context:)
+  ftp = Net::FTP.open("example.com")
+  ftp.puttextfile("local.txt", event["filename"])
+end


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Adds a Ruby rule for CWE-22, FTP using user input.

Also fixes error handling in parallel rule detector building logic.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [x] I've added test coverage that shows my fix or feature works as expected.
- [x] I've updated or added documentation if required.
- [x] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
