### PR TITLE
docs(rule): rename rules

### DIFF
--- a/pkg/commands/process/settings/rules/internal/internal/secret_detection.yml
+++ b/pkg/commands/process/settings/rules/internal/internal/secret_detection.yml
@@ -5,11 +5,11 @@ severity:
 detailed_context: true
 omit_parent_content: true
 metadata:
-  description: "Do not leak secrets in the codebase."
+  description: "Hard-coded secret detected."
   remediation_message: |
     ## Description
 
-    Hard-coding secrets and keys in a project opens them up to leakage. This rule checks for common secret types such as keys, tokens, and passwords using the popular Gitleaks library and ensures they aren't hard-coded.
+    Hard-coding secrets in a project opens them up to leakage. This rule checks for common secret types such as keys, tokens, and passwords using the popular Gitleaks library and ensures they aren't hard-coded.
 
     ## Remediations
 
@@ -20,4 +20,4 @@ metadata:
   dsr_id: "DSR-4"
   cwe_id:
     - 798
-  id: "gitleaks"
+  id: "secret_detection"

--- a/pkg/commands/process/settings/rules/javascript/express/exposed_dir_listing.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/exposed_dir_listing.yml
@@ -7,7 +7,7 @@ trigger: presence
 severity:
   default: "warning"
 metadata:
-  description: "Ensure directory listing is not inappropriately exposed."
+  description: "Missing access restriction to directory listing detected."
   remediation_message: |
     ## Description
     Inappropriate exposure of a directory listing could give attackers access to sensitive data or source code, either directly or through exploitation of an exposed file structure.

--- a/pkg/commands/process/settings/rules/javascript/express/exposed_dir_listing/.snapshots/TestJavascriptExpressExposedDirListing--serve_index_in_app_use.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/exposed_dir_listing/.snapshots/TestJavascriptExpressExposedDirListing--serve_index_in_app_use.yml
@@ -1,7 +1,7 @@
 warning:
     - rule_dsrid: ""
       rule_display_id: javascript_express_exposed_dir_listing
-      rule_description: Ensure directory listing is not inappropriately exposed.
+      rule_description: Missing access restriction to directory listing detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_express_exposed_dir_listing
       line_number: 5
       filename: serve_index_in_app_use.js

--- a/pkg/commands/process/settings/rules/javascript/express/insecure_cookie.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/insecure_cookie.yml
@@ -22,7 +22,7 @@ severity:
 skip_data_types:
   - "Unique Identifier"
 metadata:
-  description: "Ensure cookies are sent over HTTPS."
+  description: "Missing secure options for cookie detected."
   remediation_message: |
     ## Description
     To make sure cookies don't open your application up to exploits or unauthorized access, don't use default cookie values and make sure to set security options appropriately.

--- a/pkg/commands/process/settings/rules/javascript/express/insecure_cookie/.snapshots/TestExpressSecureCookie--http_only.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/insecure_cookie/.snapshots/TestExpressSecureCookie--http_only.yml
@@ -1,7 +1,7 @@
 low:
     - rule_dsrid: DSR-3
       rule_display_id: express_insecure_cookie
-      rule_description: Ensure cookies are sent over HTTPS.
+      rule_description: Missing secure options for cookie detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/express_insecure_cookie
       line_number: 9
       filename: http_only.js

--- a/pkg/commands/process/settings/rules/javascript/express/insecure_cookie/.snapshots/TestExpressSecureCookie--insecure_cookie.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/insecure_cookie/.snapshots/TestExpressSecureCookie--insecure_cookie.yml
@@ -1,7 +1,7 @@
 low:
     - rule_dsrid: DSR-3
       rule_display_id: express_insecure_cookie
-      rule_description: Ensure cookies are sent over HTTPS.
+      rule_description: Missing secure options for cookie detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/express_insecure_cookie
       line_number: 9
       filename: insecure_cookie.js

--- a/pkg/commands/process/settings/rules/javascript/express/insecure_xml_ref.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/insecure_xml_ref.yml
@@ -23,7 +23,7 @@ trigger: presence
 severity:
   default: "low"
 metadata:
-  description: "Ensure proper restriction of XML external entity references."
+  description: "Missing proper restriction of XML external entity references detected."
   remediation_message: |
     ## Description
     Avoid generating XML documents that include XML entities with URIs that resolve to resources that are outside of the current context.

--- a/pkg/commands/process/settings/rules/javascript/express/insecure_xml_ref/.snapshots/TestExpressInsecureXmlRef--lib_xml_with_noent_true.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/insecure_xml_ref/.snapshots/TestExpressInsecureXmlRef--lib_xml_with_noent_true.yml
@@ -1,7 +1,7 @@
 low:
     - rule_dsrid: ""
       rule_display_id: express_insecure_xml_ref
-      rule_description: Ensure proper restriction of XML external entity references.
+      rule_description: Missing proper restriction of XML external entity references detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/express_insecure_xml_ref
       line_number: 4
       filename: lib_xml_with_noent_true.js

--- a/pkg/commands/process/settings/rules/javascript/lang/exception.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/exception.yml
@@ -34,7 +34,7 @@ severity:
 skip_data_types:
   - Unique Identifier
 metadata:
-  description: "Do not send sensitive data to exceptions."
+  description: "Sensitive data in a exception message detected."
   remediation_message: |
     ## Description
 

--- a/pkg/commands/process/settings/rules/javascript/lang/exception/.snapshots/TestJavascriptLangException--promise_reject.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/exception/.snapshots/TestJavascriptLangException--promise_reject.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-5
       rule_display_id: javascript_lang_exception
-      rule_description: Do not send sensitive data to exceptions.
+      rule_description: Sensitive data in a exception message detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_exception
       line_number: 5
       filename: promise_reject.js

--- a/pkg/commands/process/settings/rules/javascript/lang/exception/.snapshots/TestJavascriptLangException--reject.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/exception/.snapshots/TestJavascriptLangException--reject.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-5
       rule_display_id: javascript_lang_exception
-      rule_description: Do not send sensitive data to exceptions.
+      rule_description: Sensitive data in a exception message detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_exception
       line_number: 5
       filename: reject.js
@@ -11,7 +11,7 @@ critical:
       parent_content: reject("Error with user " + user)
     - rule_dsrid: DSR-5
       rule_display_id: javascript_lang_exception
-      rule_description: Do not send sensitive data to exceptions.
+      rule_description: Sensitive data in a exception message detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_exception
       line_number: 14
       filename: reject.js

--- a/pkg/commands/process/settings/rules/javascript/lang/exception/.snapshots/TestJavascriptLangException--throw_custom_exception.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/exception/.snapshots/TestJavascriptLangException--throw_custom_exception.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-5
       rule_display_id: javascript_lang_exception
-      rule_description: Do not send sensitive data to exceptions.
+      rule_description: Sensitive data in a exception message detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_exception
       line_number: 5
       filename: throw_custom_exception.js

--- a/pkg/commands/process/settings/rules/javascript/lang/exception/.snapshots/TestJavascriptLangException--throw_string.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/exception/.snapshots/TestJavascriptLangException--throw_string.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-5
       rule_display_id: javascript_lang_exception
-      rule_description: Do not send sensitive data to exceptions.
+      rule_description: Sensitive data in a exception message detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_exception
       line_number: 5
       filename: throw_string.js

--- a/pkg/commands/process/settings/rules/javascript/lang/file_generation.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/file_generation.yml
@@ -18,7 +18,7 @@ severity:
   PHI: medium
   PD: high
 metadata:
-  description: "Do not write sensitive data to static files."
+  description: "Sensitive data detected as part of a dynamic file generation."
   remediation_message: |
     ## Description
 

--- a/pkg/commands/process/settings/rules/javascript/lang/file_generation/.snapshots/TestJavascriptLangFileGeneration--file_generation.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/file_generation/.snapshots/TestJavascriptLangFileGeneration--file_generation.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-4
       rule_display_id: javascript_lang_file_generation
-      rule_description: Do not write sensitive data to static files.
+      rule_description: Sensitive data detected as part of a dynamic file generation.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_file_generation
       line_number: 8
       filename: file_generation.js
@@ -15,7 +15,7 @@ critical:
         })
     - rule_dsrid: DSR-4
       rule_display_id: javascript_lang_file_generation
-      rule_description: Do not write sensitive data to static files.
+      rule_description: Sensitive data detected as part of a dynamic file generation.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_file_generation
       line_number: 11
       filename: file_generation.js
@@ -29,7 +29,7 @@ critical:
         })
     - rule_dsrid: DSR-4
       rule_display_id: javascript_lang_file_generation
-      rule_description: Do not write sensitive data to static files.
+      rule_description: Sensitive data detected as part of a dynamic file generation.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_file_generation
       line_number: 12
       filename: file_generation.js

--- a/pkg/commands/process/settings/rules/javascript/lang/http_insecure.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/http_insecure.yml
@@ -35,7 +35,7 @@ trigger: presence
 severity:
   default: low
 metadata:
-  description: "Only communicate using HTTPS connections."
+  description: "Connection with an unsecure HTTP communication detected."
   remediation_message: |
     ## Description
 

--- a/pkg/commands/process/settings/rules/javascript/lang/http_insecure/.snapshots/TestJavascriptHTTPInsecure--axios_insecure.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/http_insecure/.snapshots/TestJavascriptHTTPInsecure--axios_insecure.yml
@@ -1,7 +1,7 @@
 low:
     - rule_dsrid: DSR-5
       rule_display_id: javascript_http_insecure
-      rule_description: Only communicate using HTTPS connections.
+      rule_description: Connection with an unsecure HTTP communication detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_http_insecure
       line_number: 2
       filename: axios_insecure.js

--- a/pkg/commands/process/settings/rules/javascript/lang/http_insecure/.snapshots/TestJavascriptHTTPInsecure--fetch_insecure.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/http_insecure/.snapshots/TestJavascriptHTTPInsecure--fetch_insecure.yml
@@ -1,7 +1,7 @@
 low:
     - rule_dsrid: DSR-5
       rule_display_id: javascript_http_insecure
-      rule_description: Only communicate using HTTPS connections.
+      rule_description: Connection with an unsecure HTTP communication detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_http_insecure
       line_number: 3
       filename: fetch_insecure.js

--- a/pkg/commands/process/settings/rules/javascript/lang/http_insecure/.snapshots/TestJavascriptHTTPInsecure--request_insecure.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/http_insecure/.snapshots/TestJavascriptHTTPInsecure--request_insecure.yml
@@ -1,7 +1,7 @@
 low:
     - rule_dsrid: DSR-5
       rule_display_id: javascript_http_insecure
-      rule_description: Only communicate using HTTPS connections.
+      rule_description: Connection with an unsecure HTTP communication detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_http_insecure
       line_number: 5
       filename: request_insecure.js

--- a/pkg/commands/process/settings/rules/javascript/lang/jwt.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/jwt.yml
@@ -16,7 +16,7 @@ severity:
 skip_data_types:
   - "Unique Identifier"
 metadata:
-  description: "Do not store sensitive data in jwt."
+  description: "Sensitive data in a JWT detected."
   remediation_message: |
     ## Description
 

--- a/pkg/commands/process/settings/rules/javascript/lang/jwt/.snapshots/TestJavascriptJWT--unsecure.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/jwt/.snapshots/TestJavascriptJWT--unsecure.yml
@@ -1,7 +1,7 @@
 low:
     - rule_dsrid: DSR-5
       rule_display_id: javascript_jwt
-      rule_description: Do not store sensitive data in jwt.
+      rule_description: Sensitive data in a JWT detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_jwt
       line_number: 2
       filename: unsecure.js

--- a/pkg/commands/process/settings/rules/javascript/lang/logger.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/logger.yml
@@ -71,7 +71,7 @@ severity:
 skip_data_types:
   - "Unique Identifier"
 metadata:
-  description: "Do not send sensitive data to loggers."
+  description: "Sensitive data in a logger message detected."
   remediation_message: |
     ## Description
 

--- a/pkg/commands/process/settings/rules/javascript/lang/logger/.snapshots/TestJavascriptLangLogger--child.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/logger/.snapshots/TestJavascriptLangLogger--child.yml
@@ -1,7 +1,7 @@
 low:
     - rule_dsrid: DSR-5
       rule_display_id: javascript_lang_logger
-      rule_description: Do not send sensitive data to loggers.
+      rule_description: Sensitive data in a logger message detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_logger
       line_number: 3
       filename: child.js

--- a/pkg/commands/process/settings/rules/javascript/lang/logger/.snapshots/TestJavascriptLangLogger--child_level.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/logger/.snapshots/TestJavascriptLangLogger--child_level.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-5
       rule_display_id: javascript_lang_logger
-      rule_description: Do not send sensitive data to loggers.
+      rule_description: Sensitive data in a logger message detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_logger
       line_number: 3
       filename: child_level.js
@@ -11,7 +11,7 @@ critical:
       parent_content: logger.child(ctx)
     - rule_dsrid: DSR-5
       rule_display_id: javascript_lang_logger
-      rule_description: Do not send sensitive data to loggers.
+      rule_description: Sensitive data in a logger message detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_logger
       line_number: 7
       filename: child_level.js

--- a/pkg/commands/process/settings/rules/javascript/lang/logger/.snapshots/TestJavascriptLangLogger--console.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/logger/.snapshots/TestJavascriptLangLogger--console.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-5
       rule_display_id: javascript_lang_logger
-      rule_description: Do not send sensitive data to loggers.
+      rule_description: Sensitive data in a logger message detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_logger
       line_number: 1
       filename: console.js

--- a/pkg/commands/process/settings/rules/javascript/lang/logger/.snapshots/TestJavascriptLangLogger--datatype_leak.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/logger/.snapshots/TestJavascriptLangLogger--datatype_leak.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-5
       rule_display_id: javascript_lang_logger
-      rule_description: Do not send sensitive data to loggers.
+      rule_description: Sensitive data in a logger message detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_logger
       line_number: 1
       filename: datatype_leak.js

--- a/pkg/commands/process/settings/rules/javascript/lang/logger/.snapshots/TestJavascriptLangLogger--log.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/logger/.snapshots/TestJavascriptLangLogger--log.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-5
       rule_display_id: javascript_lang_logger
-      rule_description: Do not send sensitive data to loggers.
+      rule_description: Sensitive data in a logger message detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_logger
       line_number: 1
       filename: log.js

--- a/pkg/commands/process/settings/rules/javascript/lang/session.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/session.yml
@@ -15,7 +15,7 @@ severity:
 skip_data_types:
   - "Unique Identifier"
 metadata:
-  description: "Do not set sensitive data to session."
+  description: "Sensitive data stored in HTML local storage detected."
   remediation_message: |
     ## Description
 

--- a/pkg/commands/process/settings/rules/javascript/lang/session/.snapshots/TestJavascriptLangSession--session_leak.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/session/.snapshots/TestJavascriptLangSession--session_leak.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-5
       rule_display_id: javascript_session
-      rule_description: Do not set sensitive data to session.
+      rule_description: Sensitive data stored in HTML local storage detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_session
       line_number: 1
       filename: session_leak.js

--- a/pkg/commands/process/settings/rules/javascript/lang/weak_encryption.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/weak_encryption.yml
@@ -31,7 +31,7 @@ severity:
 skip_data_types:
   - "Unique Identifier"
 metadata:
-  description: "Do not weak encrypt sensitive information"
+  description: "Weak encryption library usage detected."
   remediation_message: |
     ## Description
 

--- a/pkg/commands/process/settings/rules/javascript/lang/weak_encryption/.snapshots/TestJavascriptWeakEncryption--md5.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/weak_encryption/.snapshots/TestJavascriptWeakEncryption--md5.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-5
       rule_display_id: javascript_weak_encryption
-      rule_description: Do not weak encrypt sensitive information
+      rule_description: Weak encryption library usage detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_weak_encryption
       line_number: 4
       filename: md5.js
@@ -11,7 +11,7 @@ critical:
       parent_content: crypto.createHmac("md5", key).update(user.password)
     - rule_dsrid: DSR-5
       rule_display_id: javascript_weak_encryption
-      rule_description: Do not weak encrypt sensitive information
+      rule_description: Weak encryption library usage detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_weak_encryption
       line_number: 5
       filename: md5.js

--- a/pkg/commands/process/settings/rules/javascript/lang/weak_encryption/.snapshots/TestJavascriptWeakEncryption--sha1.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/weak_encryption/.snapshots/TestJavascriptWeakEncryption--sha1.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-5
       rule_display_id: javascript_weak_encryption
-      rule_description: Do not weak encrypt sensitive information
+      rule_description: Weak encryption library usage detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_weak_encryption
       line_number: 4
       filename: sha1.js
@@ -11,7 +11,7 @@ critical:
       parent_content: crypto.createHmac("sha1", key).update(user.password)
     - rule_dsrid: DSR-5
       rule_display_id: javascript_weak_encryption
-      rule_description: Do not weak encrypt sensitive information
+      rule_description: Weak encryption library usage detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_weak_encryption
       line_number: 5
       filename: sha1.js

--- a/pkg/commands/process/settings/rules/javascript/react/google_analytics.yml
+++ b/pkg/commands/process/settings/rules/javascript/react/google_analytics.yml
@@ -13,7 +13,7 @@ severity:
   PHI: medium
   PD: high
 metadata:
-  description: "Do not send sensitive data to Google Analytics."
+  description: "Sensitive data sent to Google Analytics detected."
   remediation_message: |
     ## Description
 

--- a/pkg/commands/process/settings/rules/javascript/react/google_analytics/.snapshots/TestJavascriptReactGoogleAnalytics--insecure.yml
+++ b/pkg/commands/process/settings/rules/javascript/react/google_analytics/.snapshots/TestJavascriptReactGoogleAnalytics--insecure.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: javascript_react_google_analytics
-      rule_description: Do not send sensitive data to Google Analytics.
+      rule_description: Sensitive data sent to Google Analytics detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_react_google_analytics
       line_number: 1
       filename: insecure.js
@@ -16,7 +16,7 @@ critical:
         })
     - rule_dsrid: DSR-1
       rule_display_id: javascript_react_google_analytics
-      rule_description: Do not send sensitive data to Google Analytics.
+      rule_description: Sensitive data sent to Google Analytics detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_react_google_analytics
       line_number: 5
       filename: insecure.js

--- a/pkg/commands/process/settings/rules/javascript/third_parties/airbrake.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/airbrake.yml
@@ -22,7 +22,7 @@ severity:
 skip_data_types:
   - "Unique Identifier"
 metadata:
-  description: "Do not send sensitive data to Airbrake."
+  description: "Sensitive data sent to Airbrake detected."
   remediation_message: |
     ## Description
     Leaking sensitive data to third-party loggers is a common cause of data leaks and can lead to data breaches. This rule looks for instances of sensitive data sent to Airbrake.

--- a/pkg/commands/process/settings/rules/javascript/third_parties/airbrake/.snapshots/TestJavascriptAirbrake--datatype_in_notify.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/airbrake/.snapshots/TestJavascriptAirbrake--datatype_in_notify.yml
@@ -1,7 +1,7 @@
 high:
     - rule_dsrid: DSR-1
       rule_display_id: javascript_third_parties_airbrake
-      rule_description: Do not send sensitive data to Airbrake.
+      rule_description: Sensitive data sent to Airbrake detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_airbrake
       line_number: 18
       filename: datatype_in_notify.js

--- a/pkg/commands/process/settings/rules/javascript/third_parties/algolia.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/algolia.yml
@@ -46,7 +46,7 @@ severity:
 skip_data_types:
   - "Unique Identifier"
 metadata:
-  description: "Do not store sensitive data in Algolia."
+  description: "Sensitive data sent to Algolia detected."
   remediation_message: |
     ## Description
     Leaking sensitive data to third-party data tools is a common cause of data leaks and can lead to data breaches. This rule looks for instances of sensitive data sent to Algolia.

--- a/pkg/commands/process/settings/rules/javascript/third_parties/algolia/.snapshots/TestJavascriptAlgolia--datatype_in_index.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/algolia/.snapshots/TestJavascriptAlgolia--datatype_in_index.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-6
       rule_display_id: javascript_third_parties_algolia
-      rule_description: Do not store sensitive data in Algolia.
+      rule_description: Sensitive data sent to Algolia detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_algolia
       line_number: 4
       filename: datatype_in_index.js

--- a/pkg/commands/process/settings/rules/javascript/third_parties/algolia/.snapshots/TestJavascriptAlgolia--datatype_in_save_object.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/algolia/.snapshots/TestJavascriptAlgolia--datatype_in_save_object.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-6
       rule_display_id: javascript_third_parties_algolia
-      rule_description: Do not store sensitive data in Algolia.
+      rule_description: Sensitive data sent to Algolia detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_algolia
       line_number: 7
       filename: datatype_in_save_object.js
@@ -14,7 +14,7 @@ critical:
           .saveObject(userObj, { autoGenerateObjectIDIfNotExist: true })
     - rule_dsrid: DSR-6
       rule_display_id: javascript_third_parties_algolia
-      rule_description: Do not store sensitive data in Algolia.
+      rule_description: Sensitive data sent to Algolia detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_algolia
       line_number: 12
       filename: datatype_in_save_object.js

--- a/pkg/commands/process/settings/rules/javascript/third_parties/bugsnag.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/bugsnag.yml
@@ -42,7 +42,7 @@ severity:
 skip_data_types:
   - "Unique Identifier"
 metadata:
-  description: "Do not send sensitive data to Bugsnag."
+  description: "Sensitive data sent to Bugsnag detected."
   remediation_message: |
     ## Description
     Leaking sensitive data to third-party loggers is a common cause of data leaks and can lead to data breaches. This rule looks for instances of sensitive data sent to Bugsnag.

--- a/pkg/commands/process/settings/rules/javascript/third_parties/bugsnag/.snapshots/TestJavascriptBugsnag--datatype_in_breadcrumb.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/bugsnag/.snapshots/TestJavascriptBugsnag--datatype_in_breadcrumb.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: javascript_third_parties_bugsnag
-      rule_description: Do not send sensitive data to Bugsnag.
+      rule_description: Sensitive data sent to Bugsnag detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_bugsnag
       line_number: 1
       filename: datatype_in_breadcrumb.js

--- a/pkg/commands/process/settings/rules/javascript/third_parties/bugsnag/.snapshots/TestJavascriptBugsnag--datatype_in_notify.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/bugsnag/.snapshots/TestJavascriptBugsnag--datatype_in_notify.yml
@@ -1,7 +1,7 @@
 high:
     - rule_dsrid: DSR-1
       rule_display_id: javascript_third_parties_bugsnag
-      rule_description: Do not send sensitive data to Bugsnag.
+      rule_description: Sensitive data sent to Bugsnag detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_bugsnag
       line_number: 5
       filename: datatype_in_notify.js

--- a/pkg/commands/process/settings/rules/javascript/third_parties/bugsnag/.snapshots/TestJavascriptBugsnag--datatype_in_session.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/bugsnag/.snapshots/TestJavascriptBugsnag--datatype_in_session.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: javascript_third_parties_bugsnag
-      rule_description: Do not send sensitive data to Bugsnag.
+      rule_description: Sensitive data sent to Bugsnag detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_bugsnag
       line_number: 4
       filename: datatype_in_session.js

--- a/pkg/commands/process/settings/rules/javascript/third_parties/bugsnag/.snapshots/TestJavascriptBugsnag--datatype_in_start.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/bugsnag/.snapshots/TestJavascriptBugsnag--datatype_in_start.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: javascript_third_parties_bugsnag
-      rule_description: Do not send sensitive data to Bugsnag.
+      rule_description: Sensitive data sent to Bugsnag detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_bugsnag
       line_number: 3
       filename: datatype_in_start.js
@@ -22,7 +22,7 @@ critical:
         })
     - rule_dsrid: DSR-1
       rule_display_id: javascript_third_parties_bugsnag
-      rule_description: Do not send sensitive data to Bugsnag.
+      rule_description: Sensitive data sent to Bugsnag detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_bugsnag
       line_number: 5
       filename: datatype_in_start.js
@@ -43,7 +43,7 @@ critical:
         })
     - rule_dsrid: DSR-1
       rule_display_id: javascript_third_parties_bugsnag
-      rule_description: Do not send sensitive data to Bugsnag.
+      rule_description: Sensitive data sent to Bugsnag detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_bugsnag
       line_number: 9
       filename: datatype_in_start.js

--- a/pkg/commands/process/settings/rules/javascript/third_parties/datadog.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/datadog.yml
@@ -28,7 +28,7 @@ severity:
 skip_data_types:
   - "Unique Identifier"
 metadata:
-  description: "Do not send sensitive data to Datadog."
+  description: "Sensitive data sent to Datadog detected."
   remediation_message: |
     ## Description
     Leaking sensitive data to third-party loggers is a common cause of data leaks and can lead to data breaches. This rule looks for instances of sensitive data sent to Datadog.

--- a/pkg/commands/process/settings/rules/javascript/third_parties/datadog/.snapshots/TestJavascriptDataDog--unsecure.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/datadog/.snapshots/TestJavascriptDataDog--unsecure.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: javascript_third_parties_datadog
-      rule_description: Do not send sensitive data to Datadog.
+      rule_description: Sensitive data sent to Datadog detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_datadog
       line_number: 3
       filename: unsecure.js

--- a/pkg/commands/process/settings/rules/javascript/third_parties/datadog_browser.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/datadog_browser.yml
@@ -13,7 +13,7 @@ trigger: presence
 severity:
   default: low
 metadata:
-  description: "Do not send sensitive data to Datadog."
+  description: "Sensitive data sent to Datadog detected."
   remediation_message: |
     ## Description
     Sensitive and private data contained in your pages may be sent to datatdog to identify elements that a user interacted with.

--- a/pkg/commands/process/settings/rules/javascript/third_parties/datadog_browser/.snapshots/TestJavascriptDataDogBrowser--unsecure.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/datadog_browser/.snapshots/TestJavascriptDataDogBrowser--unsecure.yml
@@ -1,7 +1,7 @@
 low:
     - rule_dsrid: DSR-1
       rule_display_id: javascript_third_parties_datadog_browser
-      rule_description: Do not send sensitive data to Datadog.
+      rule_description: Sensitive data sent to Datadog detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_datadog_browser
       line_number: 2
       filename: unsecure.js

--- a/pkg/commands/process/settings/rules/javascript/third_parties/elasticsearch.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/elasticsearch.yml
@@ -18,7 +18,7 @@ severity:
   PHI: medium
   PD: high
 metadata:
-  description: "Do not send sensitive data to ElasticSearch."
+  description: "Sensitive data sent to ElasticSearch detected."
   remediation_message: |
     ## Description
 

--- a/pkg/commands/process/settings/rules/javascript/third_parties/elasticsearch/.snapshots/TestJavascriptElasticSearch--unsecure.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/elasticsearch/.snapshots/TestJavascriptElasticSearch--unsecure.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: javascript_elasticsearch
-      rule_description: Do not send sensitive data to ElasticSearch.
+      rule_description: Sensitive data sent to ElasticSearch detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_elasticsearch
       line_number: 1
       filename: unsecure.js

--- a/pkg/commands/process/settings/rules/javascript/third_parties/google_analytics.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/google_analytics.yml
@@ -13,7 +13,7 @@ severity:
   PHI: medium
   PD: high
 metadata:
-  description: "Do not send sensitive data to Google Analytics."
+  description: "Sensitive data sent to Google Analytic detected."
   remediation_message: |
     ## Description
 

--- a/pkg/commands/process/settings/rules/javascript/third_parties/google_analytics/.snapshots/TestJavascriptGoogleAnalytics--unsecure.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/google_analytics/.snapshots/TestJavascriptGoogleAnalytics--unsecure.yml
@@ -1,7 +1,7 @@
 low:
     - rule_dsrid: DSR-1
       rule_display_id: javascript_google_analytics
-      rule_description: Do not send sensitive data to Google Analytics.
+      rule_description: Sensitive data sent to Google Analytic detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_google_analytics
       line_number: 3
       filename: unsecure.js

--- a/pkg/commands/process/settings/rules/javascript/third_parties/google_tag_manager.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/google_tag_manager.yml
@@ -18,7 +18,7 @@ severity:
   PHI: medium
   PD: high
 metadata:
-  description: "Do not send sensitive data to google tag manager."
+  description: "Sensitive data sent to Google Tag Manager detected."
   remediation_message: |
     ## Description
 

--- a/pkg/commands/process/settings/rules/javascript/third_parties/google_tag_manager/.snapshots/TestJavascriptGTM--unsecure.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/google_tag_manager/.snapshots/TestJavascriptGTM--unsecure.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: javascript_google_tag_manager
-      rule_description: Do not send sensitive data to google tag manager.
+      rule_description: Sensitive data sent to Google Tag Manager detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_google_tag_manager
       line_number: 1
       filename: unsecure.js
@@ -14,7 +14,7 @@ critical:
         })
     - rule_dsrid: DSR-1
       rule_display_id: javascript_google_tag_manager
-      rule_description: Do not send sensitive data to google tag manager.
+      rule_description: Sensitive data sent to Google Tag Manager detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_google_tag_manager
       line_number: 4
       filename: unsecure.js

--- a/pkg/commands/process/settings/rules/javascript/third_parties/honeybadger.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/honeybadger.yml
@@ -22,7 +22,7 @@ severity:
   PHI: medium
   PD: high
 metadata:
-  description: "Do not send sensitive data to Honeybadger."
+  description: "Sensitive data sent to Honeybadger detected."
   remediation_message: |
     ## Description
 

--- a/pkg/commands/process/settings/rules/javascript/third_parties/honeybadger/.snapshots/TestJavascriptHoneybadger--unsecure.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/honeybadger/.snapshots/TestJavascriptHoneybadger--unsecure.yml
@@ -1,7 +1,7 @@
 low:
     - rule_dsrid: DSR-1
       rule_display_id: javascript_honeybadger
-      rule_description: Do not send sensitive data to Honeybadger.
+      rule_description: Sensitive data sent to Honeybadger detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_honeybadger
       line_number: 3
       filename: unsecure.js

--- a/pkg/commands/process/settings/rules/javascript/third_parties/new_relic.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/new_relic.yml
@@ -53,7 +53,7 @@ severity:
   PHI: medium
   PD: high
 metadata:
-  description: "Do not send sensitive data to New Relic."
+  description: "Sensitive data sent to New Relic detected."
   remediation_message: |
     ## Description
     Leaking sensitive data to third-party loggers is a common cause of data leaks and can lead to data breaches. This rule looks for instances of sensitive data sent to New Relic.

--- a/pkg/commands/process/settings/rules/javascript/third_parties/new_relic/.snapshots/TestJavascriptNewRelic--datatype_in_interaction_set_attribute.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/new_relic/.snapshots/TestJavascriptNewRelic--datatype_in_interaction_set_attribute.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: javascript_third_parties_new_relic
-      rule_description: Do not send sensitive data to New Relic.
+      rule_description: Sensitive data sent to New Relic detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_new_relic
       line_number: 6
       filename: datatype_in_interaction_set_attribute.js
@@ -13,7 +13,7 @@ critical:
             .setAttribute("username", user.first_name)
     - rule_dsrid: DSR-1
       rule_display_id: javascript_third_parties_new_relic
-      rule_description: Do not send sensitive data to New Relic.
+      rule_description: Sensitive data sent to New Relic detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_new_relic
       line_number: 7
       filename: datatype_in_interaction_set_attribute.js
@@ -26,7 +26,7 @@ critical:
             .setAttribute("postal-code", user.post_code)
     - rule_dsrid: DSR-1
       rule_display_id: javascript_third_parties_new_relic
-      rule_description: Do not send sensitive data to New Relic.
+      rule_description: Sensitive data sent to New Relic detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_new_relic
       line_number: 13
       filename: datatype_in_interaction_set_attribute.js

--- a/pkg/commands/process/settings/rules/javascript/third_parties/new_relic/.snapshots/TestJavascriptNewRelic--datatype_in_notice_error.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/new_relic/.snapshots/TestJavascriptNewRelic--datatype_in_notice_error.yml
@@ -1,7 +1,7 @@
 high:
     - rule_dsrid: DSR-1
       rule_display_id: javascript_third_parties_new_relic
-      rule_description: Do not send sensitive data to New Relic.
+      rule_description: Sensitive data sent to New Relic detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_new_relic
       line_number: 7
       filename: datatype_in_notice_error.js

--- a/pkg/commands/process/settings/rules/javascript/third_parties/new_relic/.snapshots/TestJavascriptNewRelic--datatype_in_set_custom_attribute.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/new_relic/.snapshots/TestJavascriptNewRelic--datatype_in_set_custom_attribute.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: javascript_third_parties_new_relic
-      rule_description: Do not send sensitive data to New Relic.
+      rule_description: Sensitive data sent to New Relic detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_new_relic
       line_number: 3
       filename: datatype_in_set_custom_attribute.js

--- a/pkg/commands/process/settings/rules/javascript/third_parties/new_relic/.snapshots/TestJavascriptNewRelic--datatype_in_set_page_view_name.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/new_relic/.snapshots/TestJavascriptNewRelic--datatype_in_set_page_view_name.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: javascript_third_parties_new_relic
-      rule_description: Do not send sensitive data to New Relic.
+      rule_description: Sensitive data sent to New Relic detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_new_relic
       line_number: 3
       filename: datatype_in_set_page_view_name.js

--- a/pkg/commands/process/settings/rules/javascript/third_parties/open_telemetry.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/open_telemetry.yml
@@ -28,7 +28,7 @@ severity:
 skip_data_types:
   - "Unique Identifier"
 metadata:
-  description: "Do not send sensitive data to Open Telemetry."
+  description: "Sensitive data sent to Open Telemetry detected."
   remediation_message: |
     ## Description
     Leaking sensitive data to third-party loggers is a common cause of data leaks and can lead to data breaches. This rule looks for instances of sensitive data sent to Open Telemetry.

--- a/pkg/commands/process/settings/rules/javascript/third_parties/open_telemetry/.snapshots/TestJavascriptOpenTelemetry--datatype_in_add_event.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/open_telemetry/.snapshots/TestJavascriptOpenTelemetry--datatype_in_add_event.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: javascript_third_parties_open_telemetry
-      rule_description: Do not send sensitive data to Open Telemetry.
+      rule_description: Sensitive data sent to Open Telemetry detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_open_telemetry
       line_number: 5
       filename: datatype_in_add_event.js

--- a/pkg/commands/process/settings/rules/javascript/third_parties/open_telemetry/.snapshots/TestJavascriptOpenTelemetry--datatype_in_record_exception.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/open_telemetry/.snapshots/TestJavascriptOpenTelemetry--datatype_in_record_exception.yml
@@ -1,7 +1,7 @@
 high:
     - rule_dsrid: DSR-1
       rule_display_id: javascript_third_parties_open_telemetry
-      rule_description: Do not send sensitive data to Open Telemetry.
+      rule_description: Sensitive data sent to Open Telemetry detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_open_telemetry
       line_number: 9
       filename: datatype_in_record_exception.js

--- a/pkg/commands/process/settings/rules/javascript/third_parties/open_telemetry/.snapshots/TestJavascriptOpenTelemetry--datatype_in_set_attribute.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/open_telemetry/.snapshots/TestJavascriptOpenTelemetry--datatype_in_set_attribute.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: javascript_third_parties_open_telemetry
-      rule_description: Do not send sensitive data to Open Telemetry.
+      rule_description: Sensitive data sent to Open Telemetry detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_open_telemetry
       line_number: 6
       filename: datatype_in_set_attribute.js
@@ -11,7 +11,7 @@ critical:
       parent_content: span.setAttribute("current-user", currentUser.emailAddress)
     - rule_dsrid: DSR-1
       rule_display_id: javascript_third_parties_open_telemetry
-      rule_description: Do not send sensitive data to Open Telemetry.
+      rule_description: Sensitive data sent to Open Telemetry detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_open_telemetry
       line_number: 11
       filename: datatype_in_set_attribute.js

--- a/pkg/commands/process/settings/rules/javascript/third_parties/open_telemetry/.snapshots/TestJavascriptOpenTelemetry--datatype_in_set_status.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/open_telemetry/.snapshots/TestJavascriptOpenTelemetry--datatype_in_set_status.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: javascript_third_parties_open_telemetry
-      rule_description: Do not send sensitive data to Open Telemetry.
+      rule_description: Sensitive data sent to Open Telemetry detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_open_telemetry
       line_number: 9
       filename: datatype_in_set_status.js

--- a/pkg/commands/process/settings/rules/javascript/third_parties/rollbar.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/rollbar.yml
@@ -24,7 +24,7 @@ severity:
   PHI: medium
   PD: high
 metadata:
-  description: "Do not send sensitive data to Rollbar."
+  description: "Sensitive data sent to Rollbar detected."
   remediation_message: |
     ## Description
 

--- a/pkg/commands/process/settings/rules/javascript/third_parties/rollbar/.snapshots/TestJavascriptRollbar--browser_unsecure.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/rollbar/.snapshots/TestJavascriptRollbar--browser_unsecure.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: javascript_rollbar
-      rule_description: Do not send sensitive data to Rollbar.
+      rule_description: Sensitive data sent to Rollbar detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_rollbar
       line_number: 1
       filename: browser_unsecure.js

--- a/pkg/commands/process/settings/rules/javascript/third_parties/segment.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/segment.yml
@@ -31,7 +31,7 @@ severity:
 skip_data_types:
   - "Unique Identifier"
 metadata:
-  description: "Do not send sensitive data to Segment."
+  description: "Sensitive data sent to Segment detected."
   remediation_message: |
     ## Description
     Leaking sensitive data to third-party analytics tools is a common cause of data leaks and can lead to data breaches. This rule looks for instances of sensitive data sent to Segment.

--- a/pkg/commands/process/settings/rules/javascript/third_parties/segment/.snapshots/TestJavascriptSegmentDataflow--datatype_in_alias.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/segment/.snapshots/TestJavascriptSegmentDataflow--datatype_in_alias.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: javascript_third_parties_segment
-      rule_description: Do not send sensitive data to Segment.
+      rule_description: Sensitive data sent to Segment detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_segment
       line_number: 8
       filename: datatype_in_alias.js

--- a/pkg/commands/process/settings/rules/javascript/third_parties/segment/.snapshots/TestJavascriptSegmentDataflow--datatype_in_group.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/segment/.snapshots/TestJavascriptSegmentDataflow--datatype_in_group.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: javascript_third_parties_segment
-      rule_description: Do not send sensitive data to Segment.
+      rule_description: Sensitive data sent to Segment detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_segment
       line_number: 8
       filename: datatype_in_group.js

--- a/pkg/commands/process/settings/rules/javascript/third_parties/segment/.snapshots/TestJavascriptSegmentDataflow--datatype_in_identify.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/segment/.snapshots/TestJavascriptSegmentDataflow--datatype_in_identify.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: javascript_third_parties_segment
-      rule_description: Do not send sensitive data to Segment.
+      rule_description: Sensitive data sent to Segment detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_segment
       line_number: 8
       filename: datatype_in_identify.js
@@ -20,7 +20,7 @@ critical:
         })
     - rule_dsrid: DSR-1
       rule_display_id: javascript_third_parties_segment
-      rule_description: Do not send sensitive data to Segment.
+      rule_description: Sensitive data sent to Segment detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_segment
       line_number: 9
       filename: datatype_in_identify.js
@@ -39,7 +39,7 @@ critical:
         })
     - rule_dsrid: DSR-1
       rule_display_id: javascript_third_parties_segment
-      rule_description: Do not send sensitive data to Segment.
+      rule_description: Sensitive data sent to Segment detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_segment
       line_number: 11
       filename: datatype_in_identify.js
@@ -58,7 +58,7 @@ critical:
         })
     - rule_dsrid: DSR-1
       rule_display_id: javascript_third_parties_segment
-      rule_description: Do not send sensitive data to Segment.
+      rule_description: Sensitive data sent to Segment detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_segment
       line_number: 18
       filename: datatype_in_identify.js

--- a/pkg/commands/process/settings/rules/javascript/third_parties/segment/.snapshots/TestJavascriptSegmentDataflow--datatype_in_page.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/segment/.snapshots/TestJavascriptSegmentDataflow--datatype_in_page.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: javascript_third_parties_segment
-      rule_description: Do not send sensitive data to Segment.
+      rule_description: Sensitive data sent to Segment detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_segment
       line_number: 10
       filename: datatype_in_page.js

--- a/pkg/commands/process/settings/rules/javascript/third_parties/segment/.snapshots/TestJavascriptSegmentDataflow--datatype_in_track.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/segment/.snapshots/TestJavascriptSegmentDataflow--datatype_in_track.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: javascript_third_parties_segment
-      rule_description: Do not send sensitive data to Segment.
+      rule_description: Sensitive data sent to Segment detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_segment
       line_number: 8
       filename: datatype_in_track.js
@@ -17,7 +17,7 @@ critical:
         })
     - rule_dsrid: DSR-1
       rule_display_id: javascript_third_parties_segment
-      rule_description: Do not send sensitive data to Segment.
+      rule_description: Sensitive data sent to Segment detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_segment
       line_number: 17
       filename: datatype_in_track.js

--- a/pkg/commands/process/settings/rules/javascript/third_parties/sentry.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/sentry.yml
@@ -38,7 +38,7 @@ severity:
 skip_data_types:
   - "Unique Identifier"
 metadata:
-  description: "Do not send sensitive data to Sentry."
+  description: "Sensitive data sent to Sentry detected."
   remediation_message: |
     ## Description
     Leaking sensitive data to third-party loggers is a common cause of data leaks and can lead to data breaches. This rule looks for instances of sensitive data sent to Sentry.

--- a/pkg/commands/process/settings/rules/javascript/third_parties/sentry/.snapshots/TestJavascriptThirdPartySentry--javascript_add_breadcrumb.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/sentry/.snapshots/TestJavascriptThirdPartySentry--javascript_add_breadcrumb.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: javascript_third_parties_sentry
-      rule_description: Do not send sensitive data to Sentry.
+      rule_description: Sensitive data sent to Sentry detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_sentry
       line_number: 2
       filename: javascript_add_breadcrumb.js

--- a/pkg/commands/process/settings/rules/javascript/third_parties/sentry/.snapshots/TestJavascriptThirdPartySentry--javascript_capture_event.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/sentry/.snapshots/TestJavascriptThirdPartySentry--javascript_capture_event.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: javascript_third_parties_sentry
-      rule_description: Do not send sensitive data to Sentry.
+      rule_description: Sensitive data sent to Sentry detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_sentry
       line_number: 2
       filename: javascript_capture_event.js

--- a/pkg/commands/process/settings/rules/javascript/third_parties/sentry/.snapshots/TestJavascriptThirdPartySentry--javascript_capture_exception.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/sentry/.snapshots/TestJavascriptThirdPartySentry--javascript_capture_exception.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: javascript_third_parties_sentry
-      rule_description: Do not send sensitive data to Sentry.
+      rule_description: Sensitive data sent to Sentry detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_sentry
       line_number: 2
       filename: javascript_capture_exception.js

--- a/pkg/commands/process/settings/rules/javascript/third_parties/sentry/.snapshots/TestJavascriptThirdPartySentry--javascript_capture_message.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/sentry/.snapshots/TestJavascriptThirdPartySentry--javascript_capture_message.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: javascript_third_parties_sentry
-      rule_description: Do not send sensitive data to Sentry.
+      rule_description: Sensitive data sent to Sentry detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_sentry
       line_number: 1
       filename: javascript_capture_message.js

--- a/pkg/commands/process/settings/rules/javascript/third_parties/sentry/.snapshots/TestJavascriptThirdPartySentry--javascript_configure_scope_set_extra.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/sentry/.snapshots/TestJavascriptThirdPartySentry--javascript_configure_scope_set_extra.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: javascript_third_parties_sentry
-      rule_description: Do not send sensitive data to Sentry.
+      rule_description: Sensitive data sent to Sentry detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_sentry
       line_number: 2
       filename: javascript_configure_scope_set_extra.js

--- a/pkg/commands/process/settings/rules/javascript/third_parties/sentry/.snapshots/TestJavascriptThirdPartySentry--javascript_configure_scope_set_tag.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/sentry/.snapshots/TestJavascriptThirdPartySentry--javascript_configure_scope_set_tag.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: javascript_third_parties_sentry
-      rule_description: Do not send sensitive data to Sentry.
+      rule_description: Sensitive data sent to Sentry detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_sentry
       line_number: 2
       filename: javascript_configure_scope_set_tag.js

--- a/pkg/commands/process/settings/rules/javascript/third_parties/sentry/.snapshots/TestJavascriptThirdPartySentry--javascript_configure_scope_set_user.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/sentry/.snapshots/TestJavascriptThirdPartySentry--javascript_configure_scope_set_user.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: javascript_third_parties_sentry
-      rule_description: Do not send sensitive data to Sentry.
+      rule_description: Sensitive data sent to Sentry detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_sentry
       line_number: 2
       filename: javascript_configure_scope_set_user.js

--- a/pkg/commands/process/settings/rules/ruby/lang/cookies.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/cookies.yml
@@ -32,7 +32,7 @@ severity:
   PHI: medium
   PD: high
 metadata:
-  description: "Do not store sensitive data in cookies."
+  description: "Sensitive data stored in a cookie detected."
   remediation_message: |
     ## Description
 

--- a/pkg/commands/process/settings/rules/ruby/lang/cookies/.snapshots/TestRubyLangCookies--datatype_in_signed_cookies.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/cookies/.snapshots/TestRubyLangCookies--datatype_in_signed_cookies.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-3
       rule_display_id: ruby_lang_cookies
-      rule_description: Do not store sensitive data in cookies.
+      rule_description: Sensitive data stored in a cookie detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_cookies
       line_number: 1
       filename: datatype_in_signed_cookies.rb
@@ -11,7 +11,7 @@ critical:
       parent_content: cookies.signed[:info] = user.email
     - rule_dsrid: DSR-3
       rule_display_id: ruby_lang_cookies
-      rule_description: Do not store sensitive data in cookies.
+      rule_description: Sensitive data stored in a cookie detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_cookies
       line_number: 2
       filename: datatype_in_signed_cookies.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/cookies/.snapshots/TestRubyLangCookies--datatype_object_in_cookie.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/cookies/.snapshots/TestRubyLangCookies--datatype_object_in_cookie.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-3
       rule_display_id: ruby_lang_cookies
-      rule_description: Do not store sensitive data in cookies.
+      rule_description: Sensitive data stored in a cookie detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_cookies
       line_number: 2
       filename: datatype_object_in_cookie.rb
@@ -11,7 +11,7 @@ critical:
       parent_content: 'cookies[:login] = { value: user.to_json, expires: 1.hour, secure: true }'
     - rule_dsrid: DSR-3
       rule_display_id: ruby_lang_cookies
-      rule_description: Do not store sensitive data in cookies.
+      rule_description: Sensitive data stored in a cookie detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_cookies
       line_number: 3
       filename: datatype_object_in_cookie.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/deserialization_of_user_input.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/deserialization_of_user_input.yml
@@ -37,7 +37,7 @@ trigger: presence
 severity:
   default: high # FIXME
 metadata:
-  description: "Do not pass user input to unsafe deserialization methods."
+  description: "User input detected in an unsafe deserialization method."
   remediation_message: |
     ## Description
 

--- a/pkg/commands/process/settings/rules/ruby/lang/deserialization_of_user_input/.snapshots/TestRubyLangDeserializationOfUserInput--unsafe_event.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/deserialization_of_user_input/.snapshots/TestRubyLangDeserializationOfUserInput--unsafe_event.yml
@@ -1,7 +1,7 @@
 high:
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: Do not pass user input to unsafe deserialization methods.
+      rule_description: User input detected in an unsafe deserialization method.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 2
       filename: unsafe_event.rb
@@ -9,7 +9,7 @@ high:
       parent_content: YAML.load(event["oops"])
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: Do not pass user input to unsafe deserialization methods.
+      rule_description: User input detected in an unsafe deserialization method.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 4
       filename: unsafe_event.rb
@@ -17,7 +17,7 @@ high:
       parent_content: Psych.load(event["oops"])
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: Do not pass user input to unsafe deserialization methods.
+      rule_description: User input detected in an unsafe deserialization method.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 6
       filename: unsafe_event.rb
@@ -25,7 +25,7 @@ high:
       parent_content: Syck.load(event["oops"])
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: Do not pass user input to unsafe deserialization methods.
+      rule_description: User input detected in an unsafe deserialization method.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 8
       filename: unsafe_event.rb
@@ -33,7 +33,7 @@ high:
       parent_content: JSON.load(event["oops"])
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: Do not pass user input to unsafe deserialization methods.
+      rule_description: User input detected in an unsafe deserialization method.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 10
       filename: unsafe_event.rb
@@ -41,7 +41,7 @@ high:
       parent_content: Oj.load(event["oops"])
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: Do not pass user input to unsafe deserialization methods.
+      rule_description: User input detected in an unsafe deserialization method.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 11
       filename: unsafe_event.rb
@@ -51,7 +51,7 @@ high:
           end
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: Do not pass user input to unsafe deserialization methods.
+      rule_description: User input detected in an unsafe deserialization method.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 14
       filename: unsafe_event.rb
@@ -59,7 +59,7 @@ high:
       parent_content: Marshal.load(event["oops"])
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: Do not pass user input to unsafe deserialization methods.
+      rule_description: User input detected in an unsafe deserialization method.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 15
       filename: unsafe_event.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/deserialization_of_user_input/.snapshots/TestRubyLangDeserializationOfUserInput--unsafe_params.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/deserialization_of_user_input/.snapshots/TestRubyLangDeserializationOfUserInput--unsafe_params.yml
@@ -1,7 +1,7 @@
 high:
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: Do not pass user input to unsafe deserialization methods.
+      rule_description: User input detected in an unsafe deserialization method.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 1
       filename: unsafe_params.rb
@@ -9,7 +9,7 @@ high:
       parent_content: YAML.load(params[:oops])
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: Do not pass user input to unsafe deserialization methods.
+      rule_description: User input detected in an unsafe deserialization method.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 3
       filename: unsafe_params.rb
@@ -17,7 +17,7 @@ high:
       parent_content: Psych.load(params[:oops])
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: Do not pass user input to unsafe deserialization methods.
+      rule_description: User input detected in an unsafe deserialization method.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 5
       filename: unsafe_params.rb
@@ -25,7 +25,7 @@ high:
       parent_content: Syck.load(params[:oops])
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: Do not pass user input to unsafe deserialization methods.
+      rule_description: User input detected in an unsafe deserialization method.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 7
       filename: unsafe_params.rb
@@ -33,7 +33,7 @@ high:
       parent_content: JSON.load(params[:oops])
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: Do not pass user input to unsafe deserialization methods.
+      rule_description: User input detected in an unsafe deserialization method.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 9
       filename: unsafe_params.rb
@@ -43,7 +43,7 @@ high:
         end
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: Do not pass user input to unsafe deserialization methods.
+      rule_description: User input detected in an unsafe deserialization method.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 11
       filename: unsafe_params.rb
@@ -51,7 +51,7 @@ high:
       parent_content: Oj.object_load(params[:oops])
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: Do not pass user input to unsafe deserialization methods.
+      rule_description: User input detected in an unsafe deserialization method.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 13
       filename: unsafe_params.rb
@@ -59,7 +59,7 @@ high:
       parent_content: Marshal.load(params[:oops])
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: Do not pass user input to unsafe deserialization methods.
+      rule_description: User input detected in an unsafe deserialization method.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 14
       filename: unsafe_params.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/deserialization_of_user_input/.snapshots/TestRubyLangDeserializationOfUserInput--unsafe_request.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/deserialization_of_user_input/.snapshots/TestRubyLangDeserializationOfUserInput--unsafe_request.yml
@@ -1,7 +1,7 @@
 high:
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: Do not pass user input to unsafe deserialization methods.
+      rule_description: User input detected in an unsafe deserialization method.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 1
       filename: unsafe_request.rb
@@ -9,7 +9,7 @@ high:
       parent_content: YAML.load(request.env[:oops])
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: Do not pass user input to unsafe deserialization methods.
+      rule_description: User input detected in an unsafe deserialization method.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 3
       filename: unsafe_request.rb
@@ -17,7 +17,7 @@ high:
       parent_content: Psych.load(request.env[:oops])
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: Do not pass user input to unsafe deserialization methods.
+      rule_description: User input detected in an unsafe deserialization method.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 5
       filename: unsafe_request.rb
@@ -25,7 +25,7 @@ high:
       parent_content: Syck.load(request.env[:oops])
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: Do not pass user input to unsafe deserialization methods.
+      rule_description: User input detected in an unsafe deserialization method.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 7
       filename: unsafe_request.rb
@@ -33,7 +33,7 @@ high:
       parent_content: JSON.load(request.env[:oops])
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: Do not pass user input to unsafe deserialization methods.
+      rule_description: User input detected in an unsafe deserialization method.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 9
       filename: unsafe_request.rb
@@ -41,7 +41,7 @@ high:
       parent_content: Oj.load(request.env[:oops])
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: Do not pass user input to unsafe deserialization methods.
+      rule_description: User input detected in an unsafe deserialization method.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 10
       filename: unsafe_request.rb
@@ -51,7 +51,7 @@ high:
         end
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: Do not pass user input to unsafe deserialization methods.
+      rule_description: User input detected in an unsafe deserialization method.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 13
       filename: unsafe_request.rb
@@ -59,7 +59,7 @@ high:
       parent_content: Marshal.load(request.env[:oops])
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: Do not pass user input to unsafe deserialization methods.
+      rule_description: User input detected in an unsafe deserialization method.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 14
       filename: unsafe_request.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/eval_using_user_input.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/eval_using_user_input.yml
@@ -41,7 +41,7 @@ trigger: presence
 severity:
   default: high # FIXME
 metadata:
-  description: "Do not generate code using user input."
+  description: "Potential command injection with user input detected."
   remediation_message: |
     ## Description
 

--- a/pkg/commands/process/settings/rules/ruby/lang/eval_using_user_input/.snapshots/TestRubyLangEvalUsingUserInput--unsafe_event.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/eval_using_user_input/.snapshots/TestRubyLangEvalUsingUserInput--unsafe_event.yml
@@ -1,7 +1,7 @@
 high:
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Do not generate code using user input.
+      rule_description: Potential command injection with user input detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 2
       filename: unsafe_event.rb
@@ -9,7 +9,7 @@ high:
       parent_content: RubyVM::InstructionSequence.compile(event["oops"])
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Do not generate code using user input.
+      rule_description: Potential command injection with user input detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 4
       filename: unsafe_event.rb
@@ -17,7 +17,7 @@ high:
       parent_content: a.eval(event["oops"], "test")
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Do not generate code using user input.
+      rule_description: Potential command injection with user input detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 6
       filename: unsafe_event.rb
@@ -25,7 +25,7 @@ high:
       parent_content: a.instance_eval(event["oops"])
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Do not generate code using user input.
+      rule_description: Potential command injection with user input detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 8
       filename: unsafe_event.rb
@@ -33,7 +33,7 @@ high:
       parent_content: a.class_eval(event["oops"])
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Do not generate code using user input.
+      rule_description: Potential command injection with user input detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 10
       filename: unsafe_event.rb
@@ -41,7 +41,7 @@ high:
       parent_content: a.module_eval(event["oops"])
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Do not generate code using user input.
+      rule_description: Potential command injection with user input detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 12
       filename: unsafe_event.rb
@@ -49,7 +49,7 @@ high:
       parent_content: eval(event["oops"])
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Do not generate code using user input.
+      rule_description: Potential command injection with user input detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 14
       filename: unsafe_event.rb
@@ -57,7 +57,7 @@ high:
       parent_content: instance_eval(event["oops"], "test")
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Do not generate code using user input.
+      rule_description: Potential command injection with user input detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 16
       filename: unsafe_event.rb
@@ -65,7 +65,7 @@ high:
       parent_content: class_eval(event["oops"])
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Do not generate code using user input.
+      rule_description: Potential command injection with user input detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 18
       filename: unsafe_event.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/eval_using_user_input/.snapshots/TestRubyLangEvalUsingUserInput--unsafe_params.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/eval_using_user_input/.snapshots/TestRubyLangEvalUsingUserInput--unsafe_params.yml
@@ -1,7 +1,7 @@
 high:
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Do not generate code using user input.
+      rule_description: Potential command injection with user input detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 1
       filename: unsafe_params.rb
@@ -9,7 +9,7 @@ high:
       parent_content: RubyVM::InstructionSequence.compile(params["oops"])
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Do not generate code using user input.
+      rule_description: Potential command injection with user input detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 3
       filename: unsafe_params.rb
@@ -17,7 +17,7 @@ high:
       parent_content: a.eval(params["oops"], "test")
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Do not generate code using user input.
+      rule_description: Potential command injection with user input detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 5
       filename: unsafe_params.rb
@@ -25,7 +25,7 @@ high:
       parent_content: a.instance_eval(params["oops"])
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Do not generate code using user input.
+      rule_description: Potential command injection with user input detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 7
       filename: unsafe_params.rb
@@ -33,7 +33,7 @@ high:
       parent_content: a.class_eval(params["oops"])
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Do not generate code using user input.
+      rule_description: Potential command injection with user input detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 9
       filename: unsafe_params.rb
@@ -41,7 +41,7 @@ high:
       parent_content: a.module_eval(params["oops"])
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Do not generate code using user input.
+      rule_description: Potential command injection with user input detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 11
       filename: unsafe_params.rb
@@ -49,7 +49,7 @@ high:
       parent_content: eval(params["oops"])
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Do not generate code using user input.
+      rule_description: Potential command injection with user input detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 13
       filename: unsafe_params.rb
@@ -57,7 +57,7 @@ high:
       parent_content: instance_eval(params["oops"], "test")
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Do not generate code using user input.
+      rule_description: Potential command injection with user input detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 15
       filename: unsafe_params.rb
@@ -65,7 +65,7 @@ high:
       parent_content: class_eval(params["oops"])
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Do not generate code using user input.
+      rule_description: Potential command injection with user input detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 17
       filename: unsafe_params.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/eval_using_user_input/.snapshots/TestRubyLangEvalUsingUserInput--unsafe_request.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/eval_using_user_input/.snapshots/TestRubyLangEvalUsingUserInput--unsafe_request.yml
@@ -1,7 +1,7 @@
 high:
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Do not generate code using user input.
+      rule_description: Potential command injection with user input detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 1
       filename: unsafe_request.rb
@@ -9,7 +9,7 @@ high:
       parent_content: RubyVM::InstructionSequence.compile(request.env["oops"])
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Do not generate code using user input.
+      rule_description: Potential command injection with user input detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 3
       filename: unsafe_request.rb
@@ -17,7 +17,7 @@ high:
       parent_content: a.eval(request.env["oops"], "test")
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Do not generate code using user input.
+      rule_description: Potential command injection with user input detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 5
       filename: unsafe_request.rb
@@ -25,7 +25,7 @@ high:
       parent_content: a.instance_eval(request.env["oops"])
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Do not generate code using user input.
+      rule_description: Potential command injection with user input detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 7
       filename: unsafe_request.rb
@@ -33,7 +33,7 @@ high:
       parent_content: a.class_eval(request.env["oops"])
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Do not generate code using user input.
+      rule_description: Potential command injection with user input detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 9
       filename: unsafe_request.rb
@@ -41,7 +41,7 @@ high:
       parent_content: a.module_eval(request.env["oops"])
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Do not generate code using user input.
+      rule_description: Potential command injection with user input detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 11
       filename: unsafe_request.rb
@@ -49,7 +49,7 @@ high:
       parent_content: eval(request.env["oops"])
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Do not generate code using user input.
+      rule_description: Potential command injection with user input detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 13
       filename: unsafe_request.rb
@@ -57,7 +57,7 @@ high:
       parent_content: instance_eval(request.env["oops"], "test")
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Do not generate code using user input.
+      rule_description: Potential command injection with user input detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 15
       filename: unsafe_request.rb
@@ -65,7 +65,7 @@ high:
       parent_content: class_eval(request.env["oops"])
     - rule_dsrid: DSR-?
       rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Do not generate code using user input.
+      rule_description: Potential command injection with user input detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 17
       filename: unsafe_request.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/exception.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/exception.yml
@@ -15,7 +15,7 @@ severity:
 skip_data_types:
   - Unique Identifier
 metadata:
-  description: "Do not send sensitive data to exceptions."
+  description: "Sensitive data in a exception message detected."
   remediation_message: |
     ## Description
 

--- a/pkg/commands/process/settings/rules/ruby/lang/exception/.snapshots/TestRubyLangException--datatype_leak.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/exception/.snapshots/TestRubyLangException--datatype_leak.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-5
       rule_display_id: ruby_lang_exception
-      rule_description: Do not send sensitive data to exceptions.
+      rule_description: Sensitive data in a exception message detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_exception
       line_number: 1
       filename: datatype_leak.rb
@@ -11,7 +11,7 @@ critical:
       parent_content: raise CustomException.new(user.email)
     - rule_dsrid: DSR-5
       rule_display_id: ruby_lang_exception
-      rule_description: Do not send sensitive data to exceptions.
+      rule_description: Sensitive data in a exception message detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_exception
       line_number: 2
       filename: datatype_leak.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/file_generation.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/file_generation.yml
@@ -45,7 +45,7 @@ severity:
   PHI: medium
   PD: high
 metadata:
-  description: "Do not write sensitive data to static files."
+  description: "Sensitive data detected as part of a dynamic file generation."
   remediation_message: |
     ## Description
 

--- a/pkg/commands/process/settings/rules/ruby/lang/file_generation/.snapshots/TestRubyLangFileGeneration--datatype_in_csv_generate.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/file_generation/.snapshots/TestRubyLangFileGeneration--datatype_in_csv_generate.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-4
       rule_display_id: ruby_lang_file_generation
-      rule_description: Do not write sensitive data to static files.
+      rule_description: Sensitive data detected as part of a dynamic file generation.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_file_generation
       line_number: 5
       filename: datatype_in_csv_generate.rb
@@ -16,7 +16,7 @@ critical:
         		]
     - rule_dsrid: DSR-4
       rule_display_id: ruby_lang_file_generation
-      rule_description: Do not write sensitive data to static files.
+      rule_description: Sensitive data detected as part of a dynamic file generation.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_file_generation
       line_number: 6
       filename: datatype_in_csv_generate.rb
@@ -31,7 +31,7 @@ critical:
         		]
     - rule_dsrid: DSR-4
       rule_display_id: ruby_lang_file_generation
-      rule_description: Do not write sensitive data to static files.
+      rule_description: Sensitive data detected as part of a dynamic file generation.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_file_generation
       line_number: 7
       filename: datatype_in_csv_generate.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/file_generation/.snapshots/TestRubyLangFileGeneration--datatype_in_csv_open.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/file_generation/.snapshots/TestRubyLangFileGeneration--datatype_in_csv_open.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-4
       rule_display_id: ruby_lang_file_generation
-      rule_description: Do not write sensitive data to static files.
+      rule_description: Sensitive data detected as part of a dynamic file generation.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_file_generation
       line_number: 5
       filename: datatype_in_csv_open.rb
@@ -16,7 +16,7 @@ critical:
         		]
     - rule_dsrid: DSR-4
       rule_display_id: ruby_lang_file_generation
-      rule_description: Do not write sensitive data to static files.
+      rule_description: Sensitive data detected as part of a dynamic file generation.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_file_generation
       line_number: 6
       filename: datatype_in_csv_open.rb
@@ -31,7 +31,7 @@ critical:
         		]
     - rule_dsrid: DSR-4
       rule_display_id: ruby_lang_file_generation
-      rule_description: Do not write sensitive data to static files.
+      rule_description: Sensitive data detected as part of a dynamic file generation.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_file_generation
       line_number: 7
       filename: datatype_in_csv_open.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/file_generation/.snapshots/TestRubyLangFileGeneration--datatype_in_file_open.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/file_generation/.snapshots/TestRubyLangFileGeneration--datatype_in_file_open.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-4
       rule_display_id: ruby_lang_file_generation
-      rule_description: Do not write sensitive data to static files.
+      rule_description: Sensitive data detected as part of a dynamic file generation.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_file_generation
       line_number: 1
       filename: datatype_in_file_open.rb
@@ -11,7 +11,7 @@ critical:
       parent_content: 'f.write "#{Time.now} - User #{user.email} logged in\n"'
     - rule_dsrid: DSR-4
       rule_display_id: ruby_lang_file_generation
-      rule_description: Do not write sensitive data to static files.
+      rule_description: Sensitive data detected as part of a dynamic file generation.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_file_generation
       line_number: 5
       filename: datatype_in_file_open.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/file_generation/.snapshots/TestRubyLangFileGeneration--datatype_in_io_sysopen.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/file_generation/.snapshots/TestRubyLangFileGeneration--datatype_in_io_sysopen.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-4
       rule_display_id: ruby_lang_file_generation
-      rule_description: Do not write sensitive data to static files.
+      rule_description: Sensitive data detected as part of a dynamic file generation.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_file_generation
       line_number: 3
       filename: datatype_in_io_sysopen.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/http_get_params.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/http_get_params.yml
@@ -33,7 +33,7 @@ severity:
   PHI: medium
   PD: high
 metadata:
-  description: "Do not send sensitive data as HTTP GET parameters."
+  description: "Sensitive data communicated through GET parameters detected."
   remediation_message: |
     ## Description
     Sensitive data should never be sent as part of the query string in HTTP GET requests. This rule checks if sensitive data types are sent as GET parameters.

--- a/pkg/commands/process/settings/rules/ruby/lang/http_get_params/.snapshots/TestRubyLangHttpGetParams--datatype_in_param_hash.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/http_get_params/.snapshots/TestRubyLangHttpGetParams--datatype_in_param_hash.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-2
       rule_display_id: ruby_lang_http_get_params
-      rule_description: Do not send sensitive data as HTTP GET parameters.
+      rule_description: Sensitive data communicated through GET parameters detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_get_params
       line_number: 1
       filename: datatype_in_param_hash.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/http_get_params/.snapshots/TestRubyLangHttpGetParams--datatype_in_params.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/http_get_params/.snapshots/TestRubyLangHttpGetParams--datatype_in_params.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-2
       rule_display_id: ruby_lang_http_get_params
-      rule_description: Do not send sensitive data as HTTP GET parameters.
+      rule_description: Sensitive data communicated through GET parameters detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_get_params
       line_number: 1
       filename: datatype_in_params.rb
@@ -12,7 +12,7 @@ critical:
       parent_content: URI("https://my.api.com/users/search?ethnic_origin=#{user.ethnic_origin}")
     - rule_dsrid: DSR-2
       rule_display_id: ruby_lang_http_get_params
-      rule_description: Do not send sensitive data as HTTP GET parameters.
+      rule_description: Sensitive data communicated through GET parameters detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_get_params
       line_number: 3
       filename: datatype_in_params.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/http_insecure.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/http_insecure.yml
@@ -45,7 +45,7 @@ trigger: presence
 severity:
   default: low
 metadata:
-  description: "Only communicate using HTTPS connections."
+  description: "Connection through an unsecure HTTP communication detected."
   remediation_message: |
     ## Description
 

--- a/pkg/commands/process/settings/rules/ruby/lang/http_insecure/.snapshots/TestRubyLangHttpInsecure--insecure_get.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/http_insecure/.snapshots/TestRubyLangHttpInsecure--insecure_get.yml
@@ -1,7 +1,7 @@
 low:
     - rule_dsrid: DSR-2
       rule_display_id: ruby_lang_http_insecure
-      rule_description: Only communicate using HTTPS connections.
+      rule_description: Connection through an unsecure HTTP communication detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
       line_number: 1
       filename: insecure_get.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/http_insecure/.snapshots/TestRubyLangHttpInsecure--insecure_post.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/http_insecure/.snapshots/TestRubyLangHttpInsecure--insecure_post.yml
@@ -1,7 +1,7 @@
 low:
     - rule_dsrid: DSR-2
       rule_display_id: ruby_lang_http_insecure
-      rule_description: Only communicate using HTTPS connections.
+      rule_description: Connection through an unsecure HTTP communication detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
       line_number: 1
       filename: insecure_post.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/http_insecure/.snapshots/TestRubyLangHttpInsecure--insecure_post_form.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/http_insecure/.snapshots/TestRubyLangHttpInsecure--insecure_post_form.yml
@@ -1,7 +1,7 @@
 low:
     - rule_dsrid: DSR-2
       rule_display_id: ruby_lang_http_insecure
-      rule_description: Only communicate using HTTPS connections.
+      rule_description: Connection through an unsecure HTTP communication detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
       line_number: 1
       filename: insecure_post_form.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/http_insecure/.snapshots/TestRubyLangHttpInsecure--uri_encode_form.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/http_insecure/.snapshots/TestRubyLangHttpInsecure--uri_encode_form.yml
@@ -1,7 +1,7 @@
 low:
     - rule_dsrid: DSR-2
       rule_display_id: ruby_lang_http_insecure
-      rule_description: Only communicate using HTTPS connections.
+      rule_description: Connection through an unsecure HTTP communication detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
       line_number: 1
       filename: uri_encode_form.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/http_post_insecure_with_data.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/http_post_insecure_with_data.yml
@@ -32,7 +32,7 @@ severity:
   PHI: medium
   PD: high
 metadata:
-  description: "Only send sensitive data through HTTPS connections."
+  description: "Sensitive data sent through an an unsecure HTTP communication detected."
   remediation_message: |
     ## Description
 

--- a/pkg/commands/process/settings/rules/ruby/lang/http_post_insecure_with_data/.snapshots/TestRubyLangHttpPostInsecureWithData--insecure_post_form_with_datatype.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/http_post_insecure_with_data/.snapshots/TestRubyLangHttpPostInsecureWithData--insecure_post_form_with_datatype.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-2
       rule_display_id: ruby_lang_http_post_insecure_with_data
-      rule_description: Only send sensitive data through HTTPS connections.
+      rule_description: Sensitive data sent through an an unsecure HTTP communication detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_post_insecure_with_data
       line_number: 1
       filename: insecure_post_form_with_datatype.rb
@@ -12,7 +12,7 @@ critical:
 low:
     - rule_dsrid: DSR-2
       rule_display_id: ruby_lang_http_insecure
-      rule_description: Only communicate using HTTPS connections.
+      rule_description: Connection through an unsecure HTTP communication detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
       line_number: 1
       filename: insecure_post_form_with_datatype.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/http_post_insecure_with_data/.snapshots/TestRubyLangHttpPostInsecureWithData--insecure_post_with_datatype.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/http_post_insecure_with_data/.snapshots/TestRubyLangHttpPostInsecureWithData--insecure_post_with_datatype.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-2
       rule_display_id: ruby_lang_http_post_insecure_with_data
-      rule_description: Only send sensitive data through HTTPS connections.
+      rule_description: Sensitive data sent through an an unsecure HTTP communication detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_post_insecure_with_data
       line_number: 1
       filename: insecure_post_with_datatype.rb
@@ -12,7 +12,7 @@ critical:
 low:
     - rule_dsrid: DSR-2
       rule_display_id: ruby_lang_http_insecure
-      rule_description: Only communicate using HTTPS connections.
+      rule_description: Connection through an unsecure HTTP communication detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
       line_number: 1
       filename: insecure_post_with_datatype.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/insecure_ftp.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/insecure_ftp.yml
@@ -19,7 +19,7 @@ severity:
   PII: critical
   PD: high
 metadata:
-  description: "Only communicate using SFTP connections."
+  description: "Communication with an unsecure FTP server detected."
   remediation_message: |
     ## Description
 

--- a/pkg/commands/process/settings/rules/ruby/lang/insecure_ftp/.snapshots/TestRubyLangInsecureFtp--ftp_new.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/insecure_ftp/.snapshots/TestRubyLangInsecureFtp--ftp_new.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-2
       rule_display_id: ruby_lang_insecure_ftp
-      rule_description: Only communicate using SFTP connections.
+      rule_description: Communication with an unsecure FTP server detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_insecure_ftp
       line_number: 8
       filename: ftp_new.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/insecure_ftp/.snapshots/TestRubyLangInsecureFtp--ftp_open.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/insecure_ftp/.snapshots/TestRubyLangInsecureFtp--ftp_open.yml
@@ -1,7 +1,7 @@
 low:
     - rule_dsrid: DSR-2
       rule_display_id: ruby_lang_insecure_ftp
-      rule_description: Only communicate using SFTP connections.
+      rule_description: Communication with an unsecure FTP server detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_insecure_ftp
       line_number: 3
       filename: ftp_open.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/insecure_ftp/.snapshots/TestRubyLangInsecureFtp--ftp_open_with_datatype.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/insecure_ftp/.snapshots/TestRubyLangInsecureFtp--ftp_open_with_datatype.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-2
       rule_display_id: ruby_lang_insecure_ftp
-      rule_description: Only communicate using SFTP connections.
+      rule_description: Communication with an unsecure FTP server detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_insecure_ftp
       line_number: 3
       filename: ftp_open_with_datatype.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/jwt.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/jwt.yml
@@ -13,7 +13,7 @@ severity:
   PHI: medium
   PD: high
 metadata:
-  description: "Do not store sensitive data in JWTs."
+  description: "Sensitive data in a JWT detected."
   remediation_message: |
     ## Description
 

--- a/pkg/commands/process/settings/rules/ruby/lang/jwt/.snapshots/TestRubyLangJwt--datatype_in_jwt.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/jwt/.snapshots/TestRubyLangJwt--datatype_in_jwt.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-3
       rule_display_id: ruby_lang_jwt
-      rule_description: Do not store sensitive data in JWTs.
+      rule_description: Sensitive data in a JWT detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_jwt
       line_number: 1
       filename: datatype_in_jwt.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/jwt/.snapshots/TestRubyLangJwt--datatype_object_in_jwt.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/jwt/.snapshots/TestRubyLangJwt--datatype_object_in_jwt.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-3
       rule_display_id: ruby_lang_jwt
-      rule_description: Do not store sensitive data in JWTs.
+      rule_description: Sensitive data in a JWT detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_jwt
       line_number: 3
       filename: datatype_object_in_jwt.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/jwt/.snapshots/TestRubyLangJwt--datatypes_with_encrypted_jwt.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/jwt/.snapshots/TestRubyLangJwt--datatypes_with_encrypted_jwt.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-3
       rule_display_id: ruby_lang_jwt
-      rule_description: Do not store sensitive data in JWTs.
+      rule_description: Sensitive data in a JWT detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_jwt
       line_number: 2
       filename: datatypes_with_encrypted_jwt.rb
@@ -11,7 +11,7 @@ critical:
       parent_content: 'JWT.encode({ user: current_user.email }, private_key, ''HS256'', {})'
     - rule_dsrid: DSR-3
       rule_display_id: ruby_lang_jwt
-      rule_description: Do not store sensitive data in JWTs.
+      rule_description: Sensitive data in a JWT detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_jwt
       line_number: 4
       filename: datatypes_with_encrypted_jwt.rb
@@ -21,7 +21,7 @@ critical:
       parent_content: 'JWT.encode({ user: current_user.email }, ENV["SECRET_KEY"])'
     - rule_dsrid: DSR-3
       rule_display_id: ruby_lang_jwt
-      rule_description: Do not store sensitive data in JWTs.
+      rule_description: Sensitive data in a JWT detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_jwt
       line_number: 6
       filename: datatypes_with_encrypted_jwt.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/logger.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/logger.yml
@@ -23,7 +23,7 @@ severity:
 skip_data_types:
   - "Unique Identifier"
 metadata:
-  description: "Do not send sensitive data to loggers."
+  description: "Sensitive data in a logger message detected."
   remediation_message: |
     ## Description
 

--- a/pkg/commands/process/settings/rules/ruby/lang/logger/.snapshots/TestRubyLangLogger--datatype_leak.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/logger/.snapshots/TestRubyLangLogger--datatype_leak.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-5
       rule_display_id: ruby_lang_logger
-      rule_description: Do not send sensitive data to loggers.
+      rule_description: Sensitive data in a logger message detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_logger
       line_number: 1
       filename: datatype_leak.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/ssl_verification.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/ssl_verification.yml
@@ -11,7 +11,7 @@ trigger: presence
 severity:
   default: low
 metadata:
-  description: "Enable SSL Certificate Verification."
+  description: "Missing SSL certificate verification detected."
   remediation_message: |
     ## Description
 

--- a/pkg/commands/process/settings/rules/ruby/lang/ssl_verification/.snapshots/TestRubyLangSslVerification--verification_disabled.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/ssl_verification/.snapshots/TestRubyLangSslVerification--verification_disabled.yml
@@ -1,7 +1,7 @@
 low:
     - rule_dsrid: DSR-2
       rule_display_id: ruby_lang_ssl_verification
-      rule_description: Enable SSL Certificate Verification.
+      rule_description: Missing SSL certificate verification detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_ssl_verification
       line_number: 1
       filename: verification_disabled.rb
@@ -9,7 +9,7 @@ low:
       parent_content: http.verify_mode = OpenSSL::SSL::VERIFY_NONE
     - rule_dsrid: DSR-2
       rule_display_id: ruby_lang_ssl_verification
-      rule_description: Enable SSL Certificate Verification.
+      rule_description: Missing SSL certificate verification detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_ssl_verification
       line_number: 4
       filename: verification_disabled.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption.yml
@@ -89,7 +89,7 @@ trigger: presence
 severity:
   default: low
 metadata:
-  description: "Avoid weak encryption libraries."
+  description: "Weak encryption library usage detected."
   remediation_message: |
     ## Description
 

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryption--blowfish.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryption--blowfish.yml
@@ -1,7 +1,7 @@
 low:
     - rule_dsrid: DSR-7
       rule_display_id: ruby_lang_weak_encryption
-      rule_description: Avoid weak encryption libraries.
+      rule_description: Weak encryption library usage detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
       line_number: 2
       filename: blowfish.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryption--digest_md5.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryption--digest_md5.yml
@@ -1,7 +1,7 @@
 low:
     - rule_dsrid: DSR-7
       rule_display_id: ruby_lang_weak_encryption
-      rule_description: Avoid weak encryption libraries.
+      rule_description: Weak encryption library usage detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
       line_number: 1
       filename: digest_md5.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryption--digest_sha1.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryption--digest_sha1.yml
@@ -1,7 +1,7 @@
 low:
     - rule_dsrid: DSR-7
       rule_display_id: ruby_lang_weak_encryption
-      rule_description: Avoid weak encryption libraries.
+      rule_description: Weak encryption library usage detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
       line_number: 1
       filename: digest_sha1.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryption--openssl_dsa.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryption--openssl_dsa.yml
@@ -1,7 +1,7 @@
 low:
     - rule_dsrid: DSR-7
       rule_display_id: ruby_lang_weak_encryption
-      rule_description: Avoid weak encryption libraries.
+      rule_description: Weak encryption library usage detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
       line_number: 3
       filename: openssl_dsa.rb
@@ -9,7 +9,7 @@ low:
       parent_content: dsa_encrypt.export(cipher, "hello world")
     - rule_dsrid: DSR-7
       rule_display_id: ruby_lang_weak_encryption
-      rule_description: Avoid weak encryption libraries.
+      rule_description: Weak encryption library usage detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
       line_number: 5
       filename: openssl_dsa.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryption--openssl_rsa.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryption--openssl_rsa.yml
@@ -1,7 +1,7 @@
 low:
     - rule_dsrid: DSR-7
       rule_display_id: ruby_lang_weak_encryption
-      rule_description: Avoid weak encryption libraries.
+      rule_description: Weak encryption library usage detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
       line_number: 1
       filename: openssl_rsa.rb
@@ -9,7 +9,7 @@ low:
       parent_content: OpenSSL::PKey::RSA.new(File.read('rsa.pem')).private_encrypt("test")
     - rule_dsrid: DSR-7
       rule_display_id: ruby_lang_weak_encryption
-      rule_description: Avoid weak encryption libraries.
+      rule_description: Weak encryption library usage detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
       line_number: 5
       filename: openssl_rsa.rb
@@ -17,7 +17,7 @@ low:
       parent_content: rsa_encrypt.export(cipher, "hello world")
     - rule_dsrid: DSR-7
       rule_display_id: ruby_lang_weak_encryption
-      rule_description: Avoid weak encryption libraries.
+      rule_description: Weak encryption library usage detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
       line_number: 7
       filename: openssl_rsa.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryption--rc4_encrypt.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryption--rc4_encrypt.yml
@@ -1,7 +1,7 @@
 low:
     - rule_dsrid: DSR-7
       rule_display_id: ruby_lang_weak_encryption
-      rule_description: Avoid weak encryption libraries.
+      rule_description: Weak encryption library usage detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
       line_number: 1
       filename: rc4_encrypt.rb
@@ -9,7 +9,7 @@ low:
       parent_content: RC4.new("insecure").encrypt("hello world")
     - rule_dsrid: DSR-7
       rule_display_id: ruby_lang_weak_encryption
-      rule_description: Avoid weak encryption libraries.
+      rule_description: Weak encryption library usage detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
       line_number: 4
       filename: rc4_encrypt.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data.yml
@@ -119,7 +119,7 @@ severity:
   PHI: medium
   PD: high
 metadata:
-  description: "Do not use weak encryption libraries to encrypt sensitive data."
+  description: "Sensitive data encrypted with a weak encryption library detected."
   remediation_message: |
     ## Description
 

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithData--blowfish_data.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithData--blowfish_data.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-7
       rule_display_id: ruby_lang_weak_encryption_with_data
-      rule_description: Do not use weak encryption libraries to encrypt sensitive data.
+      rule_description: Sensitive data encrypted with a weak encryption library detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption_with_data
       line_number: 2
       filename: blowfish_data.rb
@@ -14,7 +14,7 @@ critical:
         }
     - rule_dsrid: DSR-7
       rule_display_id: ruby_lang_weak_encryption_with_data
-      rule_description: Do not use weak encryption libraries to encrypt sensitive data.
+      rule_description: Sensitive data encrypted with a weak encryption library detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption_with_data
       line_number: 6
       filename: blowfish_data.rb
@@ -27,7 +27,7 @@ critical:
         end
     - rule_dsrid: DSR-7
       rule_display_id: ruby_lang_weak_encryption_with_data
-      rule_description: Do not use weak encryption libraries to encrypt sensitive data.
+      rule_description: Sensitive data encrypted with a weak encryption library detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption_with_data
       line_number: 9
       filename: blowfish_data.rb
@@ -38,7 +38,7 @@ critical:
 low:
     - rule_dsrid: DSR-7
       rule_display_id: ruby_lang_weak_encryption
-      rule_description: Avoid weak encryption libraries.
+      rule_description: Weak encryption library usage detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
       line_number: 1
       filename: blowfish_data.rb
@@ -51,7 +51,7 @@ low:
         }
     - rule_dsrid: DSR-7
       rule_display_id: ruby_lang_weak_encryption
-      rule_description: Avoid weak encryption libraries.
+      rule_description: Weak encryption library usage detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
       line_number: 5
       filename: blowfish_data.rb
@@ -64,7 +64,7 @@ low:
         end
     - rule_dsrid: DSR-7
       rule_display_id: ruby_lang_weak_encryption
-      rule_description: Avoid weak encryption libraries.
+      rule_description: Weak encryption library usage detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
       line_number: 9
       filename: blowfish_data.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithData--digest_md5.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithData--digest_md5.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-7
       rule_display_id: ruby_lang_weak_encryption_with_data
-      rule_description: Do not use weak encryption libraries to encrypt sensitive data.
+      rule_description: Sensitive data encrypted with a weak encryption library detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption_with_data
       line_number: 1
       filename: digest_md5.rb
@@ -12,7 +12,7 @@ critical:
 low:
     - rule_dsrid: DSR-7
       rule_display_id: ruby_lang_weak_encryption
-      rule_description: Avoid weak encryption libraries.
+      rule_description: Weak encryption library usage detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
       line_number: 1
       filename: digest_md5.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithData--digest_sha1.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithData--digest_sha1.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-7
       rule_display_id: ruby_lang_weak_encryption_with_data
-      rule_description: Do not use weak encryption libraries to encrypt sensitive data.
+      rule_description: Sensitive data encrypted with a weak encryption library detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption_with_data
       line_number: 1
       filename: digest_sha1.rb
@@ -12,7 +12,7 @@ critical:
 low:
     - rule_dsrid: DSR-7
       rule_display_id: ruby_lang_weak_encryption
-      rule_description: Avoid weak encryption libraries.
+      rule_description: Weak encryption library usage detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
       line_number: 1
       filename: digest_sha1.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithData--openssl_dsa_data.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithData--openssl_dsa_data.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-7
       rule_display_id: ruby_lang_weak_encryption_with_data
-      rule_description: Do not use weak encryption libraries to encrypt sensitive data.
+      rule_description: Sensitive data encrypted with a weak encryption library detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption_with_data
       line_number: 3
       filename: openssl_dsa_data.rb
@@ -11,7 +11,7 @@ critical:
       parent_content: dsa_encrypt.export(cipher, user.email)
     - rule_dsrid: DSR-7
       rule_display_id: ruby_lang_weak_encryption_with_data
-      rule_description: Do not use weak encryption libraries to encrypt sensitive data.
+      rule_description: Sensitive data encrypted with a weak encryption library detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption_with_data
       line_number: 5
       filename: openssl_dsa_data.rb
@@ -22,7 +22,7 @@ critical:
 low:
     - rule_dsrid: DSR-7
       rule_display_id: ruby_lang_weak_encryption
-      rule_description: Avoid weak encryption libraries.
+      rule_description: Weak encryption library usage detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
       line_number: 3
       filename: openssl_dsa_data.rb
@@ -32,7 +32,7 @@ low:
       parent_content: dsa_encrypt.export(cipher, user.email)
     - rule_dsrid: DSR-7
       rule_display_id: ruby_lang_weak_encryption
-      rule_description: Avoid weak encryption libraries.
+      rule_description: Weak encryption library usage detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
       line_number: 5
       filename: openssl_dsa_data.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithData--openssl_rsa_data.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithData--openssl_rsa_data.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-7
       rule_display_id: ruby_lang_weak_encryption_with_data
-      rule_description: Do not use weak encryption libraries to encrypt sensitive data.
+      rule_description: Sensitive data encrypted with a weak encryption library detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption_with_data
       line_number: 1
       filename: openssl_rsa_data.rb
@@ -11,7 +11,7 @@ critical:
       parent_content: OpenSSL::PKey::RSA.new(File.read('rsa.pem')).private_encrypt(user.password)
     - rule_dsrid: DSR-7
       rule_display_id: ruby_lang_weak_encryption_with_data
-      rule_description: Do not use weak encryption libraries to encrypt sensitive data.
+      rule_description: Sensitive data encrypted with a weak encryption library detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption_with_data
       line_number: 5
       filename: openssl_rsa_data.rb
@@ -21,7 +21,7 @@ critical:
       parent_content: rsa_encrypt.export(cipher, user.password)
     - rule_dsrid: DSR-7
       rule_display_id: ruby_lang_weak_encryption_with_data
-      rule_description: Do not use weak encryption libraries to encrypt sensitive data.
+      rule_description: Sensitive data encrypted with a weak encryption library detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption_with_data
       line_number: 7
       filename: openssl_rsa_data.rb
@@ -32,7 +32,7 @@ critical:
 low:
     - rule_dsrid: DSR-7
       rule_display_id: ruby_lang_weak_encryption
-      rule_description: Avoid weak encryption libraries.
+      rule_description: Weak encryption library usage detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
       line_number: 1
       filename: openssl_rsa_data.rb
@@ -42,7 +42,7 @@ low:
       parent_content: OpenSSL::PKey::RSA.new(File.read('rsa.pem')).private_encrypt(user.password)
     - rule_dsrid: DSR-7
       rule_display_id: ruby_lang_weak_encryption
-      rule_description: Avoid weak encryption libraries.
+      rule_description: Weak encryption library usage detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
       line_number: 5
       filename: openssl_rsa_data.rb
@@ -52,7 +52,7 @@ low:
       parent_content: rsa_encrypt.export(cipher, user.password)
     - rule_dsrid: DSR-7
       rule_display_id: ruby_lang_weak_encryption
-      rule_description: Avoid weak encryption libraries.
+      rule_description: Weak encryption library usage detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
       line_number: 7
       filename: openssl_rsa_data.rb

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithData--rc4_data.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithData--rc4_data.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-7
       rule_display_id: ruby_lang_weak_encryption_with_data
-      rule_description: Do not use weak encryption libraries to encrypt sensitive data.
+      rule_description: Sensitive data encrypted with a weak encryption library detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption_with_data
       line_number: 1
       filename: rc4_data.rb
@@ -11,7 +11,7 @@ critical:
       parent_content: RC4.new("insecure").encrypt(user.password)
     - rule_dsrid: DSR-7
       rule_display_id: ruby_lang_weak_encryption_with_data
-      rule_description: Do not use weak encryption libraries to encrypt sensitive data.
+      rule_description: Sensitive data encrypted with a weak encryption library detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption_with_data
       line_number: 4
       filename: rc4_data.rb
@@ -22,7 +22,7 @@ critical:
 low:
     - rule_dsrid: DSR-7
       rule_display_id: ruby_lang_weak_encryption
-      rule_description: Avoid weak encryption libraries.
+      rule_description: Weak encryption library usage detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
       line_number: 1
       filename: rc4_data.rb
@@ -32,7 +32,7 @@ low:
       parent_content: RC4.new("insecure").encrypt(user.password)
     - rule_dsrid: DSR-7
       rule_display_id: ruby_lang_weak_encryption
-      rule_description: Avoid weak encryption libraries.
+      rule_description: Weak encryption library usage detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
       line_number: 4
       filename: rc4_data.rb

--- a/pkg/commands/process/settings/rules/ruby/rails/default_encryption.yml
+++ b/pkg/commands/process/settings/rules/ruby/rails/default_encryption.yml
@@ -19,7 +19,7 @@ trigger: stored_data_types
 severity:
   default: warning
 metadata:
-  description: "Force application-level encryption when processing sensitive data."
+  description: "Missing application-level encryption of sensitive data detected."
   remediation_message: |
     ## Description
     Application-level encryption greatly reduces the risk of a data breach or data leak by making data unreadable. This rule checks if sensitive data types found in records are encrypted.

--- a/pkg/commands/process/settings/rules/ruby/rails/default_encryption/.snapshots/TestRubyRailsDefaultEncryption--application_level_encryption_missing-schema_rb-db-schema.yml
+++ b/pkg/commands/process/settings/rules/ruby/rails/default_encryption/.snapshots/TestRubyRailsDefaultEncryption--application_level_encryption_missing-schema_rb-db-schema.yml
@@ -1,7 +1,7 @@
 warning:
     - rule_dsrid: DSR-10
       rule_display_id: ruby_rails_default_encryption
-      rule_description: Force application-level encryption when processing sensitive data.
+      rule_description: Missing application-level encryption of sensitive data detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_default_encryption
       line_number: 3
       filename: application_level_encryption_missing/schema_rb/db/schema.rb
@@ -18,7 +18,7 @@ warning:
           end
     - rule_dsrid: DSR-10
       rule_display_id: ruby_rails_default_encryption
-      rule_description: Force application-level encryption when processing sensitive data.
+      rule_description: Missing application-level encryption of sensitive data detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_default_encryption
       line_number: 4
       filename: application_level_encryption_missing/schema_rb/db/schema.rb

--- a/pkg/commands/process/settings/rules/ruby/rails/default_encryption/.snapshots/TestRubyRailsDefaultEncryption--application_level_encryption_missing-structure_sql-db-structure.yml
+++ b/pkg/commands/process/settings/rules/ruby/rails/default_encryption/.snapshots/TestRubyRailsDefaultEncryption--application_level_encryption_missing-structure_sql-db-structure.yml
@@ -1,7 +1,7 @@
 warning:
     - rule_dsrid: DSR-10
       rule_display_id: ruby_rails_default_encryption
-      rule_description: Force application-level encryption when processing sensitive data.
+      rule_description: Missing application-level encryption of sensitive data detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_default_encryption
       line_number: 3
       filename: application_level_encryption_missing/structure_sql/db/structure.sql
@@ -19,7 +19,7 @@ warning:
         )
     - rule_dsrid: DSR-10
       rule_display_id: ruby_rails_default_encryption
-      rule_description: Force application-level encryption when processing sensitive data.
+      rule_description: Missing application-level encryption of sensitive data detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_default_encryption
       line_number: 7
       filename: application_level_encryption_missing/structure_sql/db/structure.sql

--- a/pkg/commands/process/settings/rules/ruby/rails/devise_password_length.yml
+++ b/pkg/commands/process/settings/rules/ruby/rails/devise_password_length.yml
@@ -30,7 +30,7 @@ trigger: global
 severity:
   default: high
 metadata:
-  description: "Enforce stronger password requirements."
+  description: "Password length (< 8) requirement is too short."
   remediation_message: |
     ## Description
 

--- a/pkg/commands/process/settings/rules/ruby/rails/insecure_communication.yml
+++ b/pkg/commands/process/settings/rules/ruby/rails/insecure_communication.yml
@@ -9,7 +9,7 @@ trigger: presence
 severity:
   default: low
 metadata:
-  description: "Force all incoming communication through SSL."
+  description: "Missing force SSL configuration for incoming communication detected."
   remediation_message: |
     ## Description
     When applications process sensitive data, they should default to always use SSL when available. This rule checks if force SSL is enabled at the application level.

--- a/pkg/commands/process/settings/rules/ruby/rails/insecure_communication/.snapshots/TestRubyRailsInsecureCommunication--no_datatypes.yml
+++ b/pkg/commands/process/settings/rules/ruby/rails/insecure_communication/.snapshots/TestRubyRailsInsecureCommunication--no_datatypes.yml
@@ -1,7 +1,7 @@
 low:
     - rule_dsrid: DSR-2
       rule_display_id: ruby_rails_insecure_communication
-      rule_description: Force all incoming communication through SSL.
+      rule_description: Missing force SSL configuration for incoming communication detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_insecure_communication
       line_number: 2
       filename: no_datatypes.rb

--- a/pkg/commands/process/settings/rules/ruby/rails/insecure_communication/.snapshots/TestRubyRailsInsecureCommunication--ssl_disabled.yml
+++ b/pkg/commands/process/settings/rules/ruby/rails/insecure_communication/.snapshots/TestRubyRailsInsecureCommunication--ssl_disabled.yml
@@ -1,7 +1,7 @@
 low:
     - rule_dsrid: DSR-2
       rule_display_id: ruby_rails_insecure_communication
-      rule_description: Force all incoming communication through SSL.
+      rule_description: Missing force SSL configuration for incoming communication detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_insecure_communication
       line_number: 7
       filename: ssl_disabled.rb

--- a/pkg/commands/process/settings/rules/ruby/rails/insecure_smtp.yml
+++ b/pkg/commands/process/settings/rules/ruby/rails/insecure_smtp.yml
@@ -20,7 +20,7 @@ severity:
   PHI: medium
   PD: high
 metadata:
-  description: "Only communicate with secure SMTP connections."
+  description: "Communication with an unsecure SMTP connection detected."
   remediation_message: |
     ## Description
 

--- a/pkg/commands/process/settings/rules/ruby/rails/insecure_smtp/.snapshots/TestRubyRailsInsecureSmtp--verify_none.yml
+++ b/pkg/commands/process/settings/rules/ruby/rails/insecure_smtp/.snapshots/TestRubyRailsInsecureSmtp--verify_none.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-2
       rule_display_id: ruby_rails_insecure_smtp
-      rule_description: Only communicate with secure SMTP connections.
+      rule_description: Communication with an unsecure SMTP connection detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_insecure_smtp
       line_number: 8
       filename: verify_none.rb

--- a/pkg/commands/process/settings/rules/ruby/rails/insecure_smtp/.snapshots/TestRubyRailsInsecureSmtp--verify_none_ssl_var.yml
+++ b/pkg/commands/process/settings/rules/ruby/rails/insecure_smtp/.snapshots/TestRubyRailsInsecureSmtp--verify_none_ssl_var.yml
@@ -1,7 +1,7 @@
 low:
     - rule_dsrid: DSR-2
       rule_display_id: ruby_rails_insecure_smtp
-      rule_description: Only communicate with secure SMTP connections.
+      rule_description: Communication with an unsecure SMTP connection detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_insecure_smtp
       line_number: 3
       filename: verify_none_ssl_var.rb

--- a/pkg/commands/process/settings/rules/ruby/rails/logger.yml
+++ b/pkg/commands/process/settings/rules/ruby/rails/logger.yml
@@ -23,7 +23,7 @@ severity:
 skip_data_types:
   - "Unique Identifier"
 metadata:
-  description: "Do not send sensitive data to Rails loggers."
+  description: "Sensitive data sent to Rails loggers detected."
   remediation_message: |
     ## Description
     Leaking sensitive data to loggers is a common cause of data leaks and can lead to data breaches. This rule looks for instances of sensitive data sent to rails loggers.

--- a/pkg/commands/process/settings/rules/ruby/rails/logger/.snapshots/TestRubyRailsLogger--datatype_leak.yml
+++ b/pkg/commands/process/settings/rules/ruby/rails/logger/.snapshots/TestRubyRailsLogger--datatype_leak.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-5
       rule_display_id: ruby_rails_logger
-      rule_description: Do not send sensitive data to Rails loggers.
+      rule_description: Sensitive data sent to Rails loggers detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_logger
       line_number: 1
       filename: datatype_leak.rb

--- a/pkg/commands/process/settings/rules/ruby/rails/password_length.yml
+++ b/pkg/commands/process/settings/rules/ruby/rails/password_length.yml
@@ -37,7 +37,7 @@ trigger: global
 severity:
   default: high
 metadata:
-  description: "Enforce stronger password requirements."
+  description: "Password length (< 8) requirement is too short."
   remediation_message: |
     ## Description
 

--- a/pkg/commands/process/settings/rules/ruby/rails/password_length/.snapshots/TestRubyRailsPasswordLength--password_too_short.yml
+++ b/pkg/commands/process/settings/rules/ruby/rails/password_length/.snapshots/TestRubyRailsPasswordLength--password_too_short.yml
@@ -1,7 +1,7 @@
 high:
     - rule_dsrid: DSR-8
       rule_display_id: ruby_rails_password_length
-      rule_description: Enforce stronger password requirements.
+      rule_description: Password length (< 8) requirement is too short.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_password_length
       line_number: 3
       filename: password_too_short.rb

--- a/pkg/commands/process/settings/rules/ruby/rails/session.yml
+++ b/pkg/commands/process/settings/rules/ruby/rails/session.yml
@@ -15,7 +15,7 @@ severity:
 skip_data_types:
   - "Unique Identifier"
 metadata:
-  description: "Do not store sensitive data in session cookies."
+  description: "Sensitive data stored in a session cookie detected."
   remediation_message: |
     ## Description
 

--- a/pkg/commands/process/settings/rules/ruby/rails/session/.snapshots/TestRubyRailsSession--datatype_in_session.yml
+++ b/pkg/commands/process/settings/rules/ruby/rails/session/.snapshots/TestRubyRailsSession--datatype_in_session.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-3
       rule_display_id: ruby_rails_session
-      rule_description: Do not store sensitive data in session cookies.
+      rule_description: Sensitive data stored in a session cookie detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_session
       line_number: 1
       filename: datatype_in_session.rb

--- a/pkg/commands/process/settings/rules/ruby/rails/session_key_using_user_input.yml
+++ b/pkg/commands/process/settings/rules/ruby/rails/session_key_using_user_input.yml
@@ -16,7 +16,7 @@ trigger: presence
 severity:
   default: high # FIXME
 metadata:
-  description: "Do not use user input in a session key."
+  description: "User input detected in a session key."
   remediation_message: |
     ## Description
 

--- a/pkg/commands/process/settings/rules/ruby/rails/session_key_using_user_input/.snapshots/TestRubyRailsSessionKeyUsingUserInput--unsafe.yml
+++ b/pkg/commands/process/settings/rules/ruby/rails/session_key_using_user_input/.snapshots/TestRubyRailsSessionKeyUsingUserInput--unsafe.yml
@@ -1,7 +1,7 @@
 high:
     - rule_dsrid: DSR-?
       rule_display_id: ruby_rails_session_key_using_user_input
-      rule_description: Do not use user input in a session key.
+      rule_description: User input detected in a session key.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_session_key_using_user_input
       line_number: 1
       filename: unsafe.rb
@@ -9,7 +9,7 @@ high:
       parent_content: session[params[:key]]
     - rule_dsrid: DSR-?
       rule_display_id: ruby_rails_session_key_using_user_input
-      rule_description: Do not use user input in a session key.
+      rule_description: User input detected in a session key.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_session_key_using_user_input
       line_number: 3
       filename: unsafe.rb
@@ -17,7 +17,7 @@ high:
       parent_content: session[request.env[:key]]
     - rule_dsrid: DSR-?
       rule_display_id: ruby_rails_session_key_using_user_input
-      rule_description: Do not use user input in a session key.
+      rule_description: User input detected in a session key.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_session_key_using_user_input
       line_number: 5
       filename: unsafe.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/airbrake.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/airbrake.yml
@@ -58,7 +58,7 @@ severity:
 skip_data_types:
   - "Unique Identifier"
 metadata:
-  description: "Do not send sensitive data to Airbrake."
+  description: "Sensitive data sent to Airbrake detected."
   remediation_message: |
     ## Description
     Leaking sensitive data to third-party loggers is a common cause of data leaks and can lead to data breaches. This rule looks for instances of sensitive data sent to Airbrake.

--- a/pkg/commands/process/settings/rules/ruby/third_parties/airbrake/.snapshots/TestRubyThirdPartiesAirbrake--datatype_in_custom_notice.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/airbrake/.snapshots/TestRubyThirdPartiesAirbrake--datatype_in_custom_notice.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_airbrake
-      rule_description: Do not send sensitive data to Airbrake.
+      rule_description: Sensitive data sent to Airbrake detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
       line_number: 5
       filename: datatype_in_custom_notice.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/airbrake/.snapshots/TestRubyThirdPartiesAirbrake--datatype_in_extended_notify_methods.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/airbrake/.snapshots/TestRubyThirdPartiesAirbrake--datatype_in_extended_notify_methods.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_airbrake
-      rule_description: Do not send sensitive data to Airbrake.
+      rule_description: Sensitive data sent to Airbrake detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
       line_number: 3
       filename: datatype_in_extended_notify_methods.rb
@@ -17,7 +17,7 @@ critical:
         )
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_airbrake
-      rule_description: Do not send sensitive data to Airbrake.
+      rule_description: Sensitive data sent to Airbrake detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
       line_number: 9
       filename: datatype_in_extended_notify_methods.rb
@@ -33,7 +33,7 @@ critical:
         )
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_airbrake
-      rule_description: Do not send sensitive data to Airbrake.
+      rule_description: Sensitive data sent to Airbrake detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
       line_number: 17
       filename: datatype_in_extended_notify_methods.rb
@@ -49,7 +49,7 @@ critical:
         )
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_airbrake
-      rule_description: Do not send sensitive data to Airbrake.
+      rule_description: Sensitive data sent to Airbrake detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
       line_number: 23
       filename: datatype_in_extended_notify_methods.rb
@@ -65,7 +65,7 @@ critical:
         )
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_airbrake
-      rule_description: Do not send sensitive data to Airbrake.
+      rule_description: Sensitive data sent to Airbrake detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
       line_number: 31
       filename: datatype_in_extended_notify_methods.rb
@@ -80,7 +80,7 @@ critical:
         )
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_airbrake
-      rule_description: Do not send sensitive data to Airbrake.
+      rule_description: Sensitive data sent to Airbrake detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
       line_number: 36
       filename: datatype_in_extended_notify_methods.rb
@@ -95,7 +95,7 @@ critical:
         )
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_airbrake
-      rule_description: Do not send sensitive data to Airbrake.
+      rule_description: Sensitive data sent to Airbrake detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
       line_number: 43
       filename: datatype_in_extended_notify_methods.rb
@@ -111,7 +111,7 @@ critical:
         )
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_airbrake
-      rule_description: Do not send sensitive data to Airbrake.
+      rule_description: Sensitive data sent to Airbrake detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
       line_number: 49
       filename: datatype_in_extended_notify_methods.rb
@@ -127,7 +127,7 @@ critical:
         )
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_airbrake
-      rule_description: Do not send sensitive data to Airbrake.
+      rule_description: Sensitive data sent to Airbrake detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
       line_number: 57
       filename: datatype_in_extended_notify_methods.rb
@@ -144,7 +144,7 @@ critical:
         )
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_airbrake
-      rule_description: Do not send sensitive data to Airbrake.
+      rule_description: Sensitive data sent to Airbrake detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
       line_number: 64
       filename: datatype_in_extended_notify_methods.rb
@@ -161,7 +161,7 @@ critical:
         )
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_airbrake
-      rule_description: Do not send sensitive data to Airbrake.
+      rule_description: Sensitive data sent to Airbrake detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
       line_number: 73
       filename: datatype_in_extended_notify_methods.rb
@@ -177,7 +177,7 @@ critical:
         )
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_airbrake
-      rule_description: Do not send sensitive data to Airbrake.
+      rule_description: Sensitive data sent to Airbrake detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
       line_number: 79
       filename: datatype_in_extended_notify_methods.rb
@@ -193,7 +193,7 @@ critical:
         )
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_airbrake
-      rule_description: Do not send sensitive data to Airbrake.
+      rule_description: Sensitive data sent to Airbrake detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
       line_number: 101
       filename: datatype_in_extended_notify_methods.rb
@@ -209,7 +209,7 @@ critical:
         )
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_airbrake
-      rule_description: Do not send sensitive data to Airbrake.
+      rule_description: Sensitive data sent to Airbrake detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
       line_number: 107
       filename: datatype_in_extended_notify_methods.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/airbrake/.snapshots/TestRubyThirdPartiesAirbrake--datatype_in_merge_context.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/airbrake/.snapshots/TestRubyThirdPartiesAirbrake--datatype_in_merge_context.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_airbrake
-      rule_description: Do not send sensitive data to Airbrake.
+      rule_description: Sensitive data sent to Airbrake detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
       line_number: 1
       filename: datatype_in_merge_context.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/airbrake/.snapshots/TestRubyThirdPartiesAirbrake--datatype_in_notify.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/airbrake/.snapshots/TestRubyThirdPartiesAirbrake--datatype_in_notify.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_airbrake
-      rule_description: Do not send sensitive data to Airbrake.
+      rule_description: Sensitive data sent to Airbrake detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
       line_number: 1
       filename: datatype_in_notify.rb
@@ -11,7 +11,7 @@ critical:
       parent_content: Airbrake.notify(user.first_name)
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_airbrake
-      rule_description: Do not send sensitive data to Airbrake.
+      rule_description: Sensitive data sent to Airbrake detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
       line_number: 4
       filename: datatype_in_notify.rb
@@ -24,7 +24,7 @@ critical:
         })
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_airbrake
-      rule_description: Do not send sensitive data to Airbrake.
+      rule_description: Sensitive data sent to Airbrake detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
       line_number: 8
       filename: datatype_in_notify.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/airbrake/.snapshots/TestRubyThirdPartiesAirbrake--datatype_in_rescue_block.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/airbrake/.snapshots/TestRubyThirdPartiesAirbrake--datatype_in_rescue_block.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_airbrake
-      rule_description: Do not send sensitive data to Airbrake.
+      rule_description: Sensitive data sent to Airbrake detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
       line_number: 4
       filename: datatype_in_rescue_block.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/algolia.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/algolia.yml
@@ -33,7 +33,7 @@ severity:
 skip_data_types:
   - "Unique Identifier"
 metadata:
-  description: "Do not store sensitive data in Algolia."
+  description: "Sensitive data sent to Algolia detected."
   remediation_message: |
     ## Description
     Leaking sensitive data to third-party data tools is a common cause of data leaks and can lead to data breaches. This rule looks for instances of sensitive data sent to Algolia.

--- a/pkg/commands/process/settings/rules/ruby/third_parties/algolia/.snapshots/TestRubyThirdPartiesAlgolia--datatype_in_save_object.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/algolia/.snapshots/TestRubyThirdPartiesAlgolia--datatype_in_save_object.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-6
       rule_display_id: ruby_third_parties_algolia
-      rule_description: Do not store sensitive data in Algolia.
+      rule_description: Sensitive data sent to Algolia detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_algolia
       line_number: 4
       filename: datatype_in_save_object.rb
@@ -11,7 +11,7 @@ critical:
       parent_content: 'index.save_object({ email: user.email }, { auto_generate_object_id_if_not_exist: true })'
     - rule_dsrid: DSR-6
       rule_display_id: ruby_third_parties_algolia
-      rule_description: Do not store sensitive data in Algolia.
+      rule_description: Sensitive data sent to Algolia detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_algolia
       line_number: 6
       filename: datatype_in_save_object.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/bigquery.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/bigquery.yml
@@ -66,7 +66,7 @@ severity:
 skip_data_types:
   - "Unique Identifier"
 metadata:
-  description: "Do not store sensitive data in BigQuery."
+  description: "Sensitive data sent to BigQuery detected."
   remediation_message: |
     ## Description
     Leaking sensitive data to third-party data tools is a common cause of data leaks and can lead to data breaches. This rule looks for instances of sensitive data sent to BigQuery.

--- a/pkg/commands/process/settings/rules/ruby/third_parties/bigquery/.snapshots/TestRubyThirdPartiesBigQuery--datatype_in_insert.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/bigquery/.snapshots/TestRubyThirdPartiesBigQuery--datatype_in_insert.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-6
       rule_display_id: ruby_third_parties_bigquery
-      rule_description: Do not store sensitive data in BigQuery.
+      rule_description: Sensitive data sent to BigQuery detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_bigquery
       line_number: 4
       filename: datatype_in_insert.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/bigquery/.snapshots/TestRubyThirdPartiesBigQuery--datatype_in_insert_async.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/bigquery/.snapshots/TestRubyThirdPartiesBigQuery--datatype_in_insert_async.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-6
       rule_display_id: ruby_third_parties_bigquery
-      rule_description: Do not store sensitive data in BigQuery.
+      rule_description: Sensitive data sent to BigQuery detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_bigquery
       line_number: 8
       filename: datatype_in_insert_async.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/bigquery/.snapshots/TestRubyThirdPartiesBigQuery--datatype_in_table_insert.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/bigquery/.snapshots/TestRubyThirdPartiesBigQuery--datatype_in_table_insert.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-6
       rule_display_id: ruby_third_parties_bigquery
-      rule_description: Do not store sensitive data in BigQuery.
+      rule_description: Sensitive data sent to BigQuery detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_bigquery
       line_number: 5
       filename: datatype_in_table_insert.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/bigquery/.snapshots/TestRubyThirdPartiesBigQuery--datatype_in_table_insert_async.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/bigquery/.snapshots/TestRubyThirdPartiesBigQuery--datatype_in_table_insert_async.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-6
       rule_display_id: ruby_third_parties_bigquery
-      rule_description: Do not store sensitive data in BigQuery.
+      rule_description: Sensitive data sent to BigQuery detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_bigquery
       line_number: 9
       filename: datatype_in_table_insert_async.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/bugsnag.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/bugsnag.yml
@@ -35,7 +35,7 @@ severity:
 skip_data_types:
   - "Unique Identifier"
 metadata:
-  description: "Do not send sensitive data to Bugsnag."
+  description: "Sensitive data sent to Bugsnag detected."
   remediation_message: |
     ## Description
     Leaking sensitive data to third-party loggers is a common cause of data leaks and can lead to data breaches. This rule looks for instances of sensitive data sent to Bugsnag.

--- a/pkg/commands/process/settings/rules/ruby/third_parties/bugsnag/.snapshots/TestRubyThirdPartiesBugsnag--breadcrumb.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/bugsnag/.snapshots/TestRubyThirdPartiesBugsnag--breadcrumb.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_bugsnag
-      rule_description: Do not send sensitive data to Bugsnag.
+      rule_description: Sensitive data sent to Bugsnag detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_bugsnag
       line_number: 2
       filename: breadcrumb.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/bugsnag/.snapshots/TestRubyThirdPartiesBugsnag--bugsnag_notify.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/bugsnag/.snapshots/TestRubyThirdPartiesBugsnag--bugsnag_notify.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-5
       rule_display_id: ruby_lang_exception
-      rule_description: Do not send sensitive data to exceptions.
+      rule_description: Sensitive data in a exception message detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_exception
       line_number: 2
       filename: bugsnag_notify.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/clickhouse.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/clickhouse.yml
@@ -22,7 +22,7 @@ severity:
 skip_data_types:
   - "Unique Identifier"
 metadata:
-  description: "Do not store sensitive data in ClickHouse."
+  description: "Sensitive data sent to ClickHouse detected."
   remediation_message: |
     ## Description
     Leaking sensitive data to a third-party service is a common cause of data leaks and can lead to data breaches. This rule looks for instances of sensitive data sent to ClickHouse.

--- a/pkg/commands/process/settings/rules/ruby/third_parties/clickhouse/.snapshots/TestRubyThirdPartiesClickHouse--datatype_in_insert_rows.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/clickhouse/.snapshots/TestRubyThirdPartiesClickHouse--datatype_in_insert_rows.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-6
       rule_display_id: ruby_third_parties_clickhouse
-      rule_description: Do not store sensitive data in ClickHouse.
+      rule_description: Sensitive data sent to ClickHouse detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_clickhouse
       line_number: 6
       filename: datatype_in_insert_rows.rb
@@ -17,7 +17,7 @@ critical:
             ]
     - rule_dsrid: DSR-6
       rule_display_id: ruby_third_parties_clickhouse
-      rule_description: Do not store sensitive data in ClickHouse.
+      rule_description: Sensitive data sent to ClickHouse detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_clickhouse
       line_number: 7
       filename: datatype_in_insert_rows.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/datadog.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/datadog.yml
@@ -38,7 +38,7 @@ severity:
 skip_data_types:
   - "Unique Identifier"
 metadata:
-  description: "Do not send sensitive data to Datadog."
+  description: "Sensitive data sent to Datadog detected."
   remediation_message: |
     ## Description
     Leaking sensitive data to third-party loggers is a common cause of data leaks and can lead to data breaches. This rule looks for instances of sensitive data sent to Datadog.

--- a/pkg/commands/process/settings/rules/ruby/third_parties/datadog/.snapshots/TestRubyThirdPartiesDatadog--datatype_in_tags.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/datadog/.snapshots/TestRubyThirdPartiesDatadog--datatype_in_tags.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_datadog
-      rule_description: Do not send sensitive data to Datadog.
+      rule_description: Sensitive data sent to Datadog detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_datadog
       line_number: 2
       filename: datatype_in_tags.rb
@@ -11,7 +11,7 @@ critical:
       parent_content: c.tags = user
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_datadog
-      rule_description: Do not send sensitive data to Datadog.
+      rule_description: Sensitive data sent to Datadog detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_datadog
       line_number: 7
       filename: datatype_in_tags.rb
@@ -21,7 +21,7 @@ critical:
       parent_content: span.set_tag('user.email', user.email)
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_datadog
-      rule_description: Do not send sensitive data to Datadog.
+      rule_description: Sensitive data sent to Datadog detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_datadog
       line_number: 9
       filename: datatype_in_tags.rb
@@ -31,7 +31,7 @@ critical:
       parent_content: Datadog::Tracing.active_span&.set_tag('customer.id', user.email)
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_datadog
-      rule_description: Do not send sensitive data to Datadog.
+      rule_description: Sensitive data sent to Datadog detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_datadog
       line_number: 10
       filename: datatype_in_tags.rb
@@ -41,7 +41,7 @@ critical:
       parent_content: Datadog::Tracing.active_span.set_tag('customer.id', user.email)
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_datadog
-      rule_description: Do not send sensitive data to Datadog.
+      rule_description: Sensitive data sent to Datadog detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_datadog
       line_number: 12
       filename: datatype_in_tags.rb
@@ -54,7 +54,7 @@ critical:
         end
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_datadog
-      rule_description: Do not send sensitive data to Datadog.
+      rule_description: Sensitive data sent to Datadog detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_datadog
       line_number: 17
       filename: datatype_in_tags.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/elasticsearch.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/elasticsearch.yml
@@ -41,7 +41,7 @@ severity:
 skip_data_types:
   - "Unique Identifier"
 metadata:
-  description: "Do not store sensitive data in Elasticsearch."
+  description: "Sensitive data sent to Elasticsearch detected."
   remediation_message: |
     ## Description
     Leaking sensitive data to third-party data tools is a common cause of data leaks and can lead to data breaches. This rule looks for instances of sensitive data sent to Elasticsearch.

--- a/pkg/commands/process/settings/rules/ruby/third_parties/elasticsearch/.snapshots/TestRubyThirdPartiesElasticsearch--datatype_in_bulk.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/elasticsearch/.snapshots/TestRubyThirdPartiesElasticsearch--datatype_in_bulk.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-6
       rule_display_id: ruby_third_parties_elasticsearch
-      rule_description: Do not store sensitive data in Elasticsearch.
+      rule_description: Sensitive data sent to Elasticsearch detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_elasticsearch
       line_number: 3
       filename: datatype_in_bulk.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/elasticsearch/.snapshots/TestRubyThirdPartiesElasticsearch--datatype_in_index.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/elasticsearch/.snapshots/TestRubyThirdPartiesElasticsearch--datatype_in_index.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-6
       rule_display_id: ruby_third_parties_elasticsearch
-      rule_description: Do not store sensitive data in Elasticsearch.
+      rule_description: Sensitive data sent to Elasticsearch detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_elasticsearch
       line_number: 3
       filename: datatype_in_index.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/elasticsearch/.snapshots/TestRubyThirdPartiesElasticsearch--datatype_in_update.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/elasticsearch/.snapshots/TestRubyThirdPartiesElasticsearch--datatype_in_update.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-6
       rule_display_id: ruby_third_parties_elasticsearch
-      rule_description: Do not store sensitive data in Elasticsearch.
+      rule_description: Sensitive data sent to Elasticsearch detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_elasticsearch
       line_number: 1
       filename: datatype_in_update.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/google_analytics.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/google_analytics.yml
@@ -29,7 +29,7 @@ severity:
 skip_data_types:
   - Unique Identifier
 metadata:
-  description: "Do not send sensitive data to Google Analytics."
+  description: "Sensitive data sent to Google Analytics detected."
   remediation_message: |
     ## Description
     Leaking sensitive data to third-party analytics tools is a common cause of data leaks and can lead to data breaches. This rule looks for instances of sensitive data sent to Google Analytics.

--- a/pkg/commands/process/settings/rules/ruby/third_parties/google_analytics/.snapshots/TestRubyThirdPartiesGoogleAnalytics--datatype_in_cohort.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/google_analytics/.snapshots/TestRubyThirdPartiesGoogleAnalytics--datatype_in_cohort.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_google_analytics
-      rule_description: Do not send sensitive data to Google Analytics.
+      rule_description: Sensitive data sent to Google Analytics detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_analytics
       line_number: 1
       filename: datatype_in_cohort.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/google_analytics/.snapshots/TestRubyThirdPartiesGoogleAnalytics--datatype_in_custom_dimension.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/google_analytics/.snapshots/TestRubyThirdPartiesGoogleAnalytics--datatype_in_custom_dimension.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_google_analytics
-      rule_description: Do not send sensitive data to Google Analytics.
+      rule_description: Sensitive data sent to Google Analytics detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_analytics
       line_number: 2
       filename: datatype_in_custom_dimension.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/google_analytics/.snapshots/TestRubyThirdPartiesGoogleAnalytics--datatype_in_event_data.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/google_analytics/.snapshots/TestRubyThirdPartiesGoogleAnalytics--datatype_in_event_data.yml
@@ -1,7 +1,7 @@
 high:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_google_analytics
-      rule_description: Do not send sensitive data to Google Analytics.
+      rule_description: Sensitive data sent to Google Analytics detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_analytics
       line_number: 2
       filename: datatype_in_event_data.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/google_analytics/.snapshots/TestRubyThirdPartiesGoogleAnalytics--datatype_in_transaction_data.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/google_analytics/.snapshots/TestRubyThirdPartiesGoogleAnalytics--datatype_in_transaction_data.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_google_analytics
-      rule_description: Do not send sensitive data to Google Analytics.
+      rule_description: Sensitive data sent to Google Analytics detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_analytics
       line_number: 1
       filename: datatype_in_transaction_data.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/google_analytics/.snapshots/TestRubyThirdPartiesGoogleAnalytics--datatype_in_user_classes.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/google_analytics/.snapshots/TestRubyThirdPartiesGoogleAnalytics--datatype_in_user_classes.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_google_analytics
-      rule_description: Do not send sensitive data to Google Analytics.
+      rule_description: Sensitive data sent to Google Analytics detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_analytics
       line_number: 1
       filename: datatype_in_user_classes.rb
@@ -12,7 +12,7 @@ critical:
       parent_content: 'Google::Apis::AnalyticsreportingV4::User.new(user_id: user.email)'
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_google_analytics
-      rule_description: Do not send sensitive data to Google Analytics.
+      rule_description: Sensitive data sent to Google Analytics detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_analytics
       line_number: 4
       filename: datatype_in_user_classes.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/google_dataflow.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/google_dataflow.yml
@@ -125,7 +125,7 @@ severity:
 skip_data_types:
   - "Unique Identifier"
 metadata:
-  description: "Do not send sensitive data to Google Dataflow."
+  description: "Sensitive data sent to Google Dataflow detected."
   remediation_message: |
     ## Description
     Leaking sensitive data to a third-party service is a common cause of data leaks and can lead to data breaches. This rule looks for instances of sensitive data sent to Google Dataflow.

--- a/pkg/commands/process/settings/rules/ruby/third_parties/google_dataflow/.snapshots/TestRubyThirdPartiesGoogleDataflow--datatype_in_config.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/google_dataflow/.snapshots/TestRubyThirdPartiesGoogleDataflow--datatype_in_config.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_google_dataflow
-      rule_description: Do not send sensitive data to Google Dataflow.
+      rule_description: Sensitive data sent to Google Dataflow detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_dataflow
       line_number: 8
       filename: datatype_in_config.rb
@@ -11,7 +11,7 @@ critical:
       parent_content: 'config.metadata = { current_user_id: current_user.email }'
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_google_dataflow
-      rule_description: Do not send sensitive data to Google Dataflow.
+      rule_description: Sensitive data sent to Google Dataflow detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_dataflow
       line_number: 14
       filename: datatype_in_config.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/google_dataflow/.snapshots/TestRubyThirdPartiesGoogleDataflow--datatype_in_job_message.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/google_dataflow/.snapshots/TestRubyThirdPartiesGoogleDataflow--datatype_in_job_message.yml
@@ -1,7 +1,7 @@
 high:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_google_dataflow
-      rule_description: Do not send sensitive data to Google Dataflow.
+      rule_description: Sensitive data sent to Google Dataflow detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_dataflow
       line_number: 2
       filename: datatype_in_job_message.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/google_dataflow/.snapshots/TestRubyThirdPartiesGoogleDataflow--datatype_in_metadata.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/google_dataflow/.snapshots/TestRubyThirdPartiesGoogleDataflow--datatype_in_metadata.yml
@@ -1,7 +1,7 @@
 high:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_google_dataflow
-      rule_description: Do not send sensitive data to Google Dataflow.
+      rule_description: Sensitive data sent to Google Dataflow detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_dataflow
       line_number: 2
       filename: datatype_in_metadata.rb
@@ -11,7 +11,7 @@ high:
       parent_content: 'custom_metadata.value = "ip: #{customer.ip_address}"'
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_google_dataflow
-      rule_description: Do not send sensitive data to Google Dataflow.
+      rule_description: Sensitive data sent to Google Dataflow detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_dataflow
       line_number: 5
       filename: datatype_in_metadata.rb
@@ -21,7 +21,7 @@ high:
       parent_content: 'template_metadata.description ="ip: #{customer.ip_address}"'
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_google_dataflow
-      rule_description: Do not send sensitive data to Google Dataflow.
+      rule_description: Sensitive data sent to Google Dataflow detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_dataflow
       line_number: 6
       filename: datatype_in_metadata.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/google_dataflow/.snapshots/TestRubyThirdPartiesGoogleDataflow--datatype_in_params_entry.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/google_dataflow/.snapshots/TestRubyThirdPartiesGoogleDataflow--datatype_in_params_entry.yml
@@ -1,7 +1,7 @@
 high:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_google_dataflow
-      rule_description: Do not send sensitive data to Google Dataflow.
+      rule_description: Sensitive data sent to Google Dataflow detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_dataflow
       line_number: 2
       filename: datatype_in_params_entry.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/google_dataflow/.snapshots/TestRubyThirdPartiesGoogleDataflow--datatype_in_snapshot_job_request.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/google_dataflow/.snapshots/TestRubyThirdPartiesGoogleDataflow--datatype_in_snapshot_job_request.yml
@@ -1,7 +1,7 @@
 high:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_google_dataflow
-      rule_description: Do not send sensitive data to Google Dataflow.
+      rule_description: Sensitive data sent to Google Dataflow detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_dataflow
       line_number: 2
       filename: datatype_in_snapshot_job_request.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/google_dataflow/.snapshots/TestRubyThirdPartiesGoogleDataflow--datatype_in_snapshot_setter.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/google_dataflow/.snapshots/TestRubyThirdPartiesGoogleDataflow--datatype_in_snapshot_setter.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_google_dataflow
-      rule_description: Do not send sensitive data to Google Dataflow.
+      rule_description: Sensitive data sent to Google Dataflow detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_dataflow
       line_number: 9
       filename: datatype_in_snapshot_setter.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/google_dataflow/.snapshots/TestRubyThirdPartiesGoogleDataflow--datatype_in_structured_message.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/google_dataflow/.snapshots/TestRubyThirdPartiesGoogleDataflow--datatype_in_structured_message.yml
@@ -1,7 +1,7 @@
 high:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_google_dataflow
-      rule_description: Do not send sensitive data to Google Dataflow.
+      rule_description: Sensitive data sent to Google Dataflow detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_dataflow
       line_number: 4
       filename: datatype_in_structured_message.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/google_dataflow/.snapshots/TestRubyThirdPartiesGoogleDataflow--datatype_in_structured_message_param.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/google_dataflow/.snapshots/TestRubyThirdPartiesGoogleDataflow--datatype_in_structured_message_param.yml
@@ -1,7 +1,7 @@
 high:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_google_dataflow
-      rule_description: Do not send sensitive data to Google Dataflow.
+      rule_description: Sensitive data sent to Google Dataflow detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_dataflow
       line_number: 2
       filename: datatype_in_structured_message_param.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/google_dataflow/.snapshots/TestRubyThirdPartiesGoogleDataflow--datatype_in_template_job_creation.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/google_dataflow/.snapshots/TestRubyThirdPartiesGoogleDataflow--datatype_in_template_job_creation.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_google_dataflow
-      rule_description: Do not send sensitive data to Google Dataflow.
+      rule_description: Sensitive data sent to Google Dataflow detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_dataflow
       line_number: 5
       filename: datatype_in_template_job_creation.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/google_dataflow/.snapshots/TestRubyThirdPartiesGoogleDataflow--fail_with_different_version.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/google_dataflow/.snapshots/TestRubyThirdPartiesGoogleDataflow--fail_with_different_version.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_google_dataflow
-      rule_description: Do not send sensitive data to Google Dataflow.
+      rule_description: Sensitive data sent to Google Dataflow detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_dataflow
       line_number: 5
       filename: fail_with_different_version.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/honeybadger.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/honeybadger.yml
@@ -32,7 +32,7 @@ severity:
 skip_data_types:
   - "Unique Identifier"
 metadata:
-  description: "Do not send sensitive data to Honeybadger."
+  description: "Sensitive data sent to Honeybadger detected."
   remediation_message: |
     ## Description
     Leaking sensitive data to third-party loggers is a common cause of data leaks and can lead to data breaches. This rule looks for instances of sensitive data sent to Honeybadger.

--- a/pkg/commands/process/settings/rules/ruby/third_parties/honeybadger/.snapshots/TestRubyThirdPartiesHoneybadger--honeybadger_breadcrumb.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/honeybadger/.snapshots/TestRubyThirdPartiesHoneybadger--honeybadger_breadcrumb.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_honeybadger
-      rule_description: Do not send sensitive data to Honeybadger.
+      rule_description: Sensitive data sent to Honeybadger detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_honeybadger
       line_number: 1
       filename: honeybadger_breadcrumb.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/honeybadger/.snapshots/TestRubyThirdPartiesHoneybadger--honeybadger_context.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/honeybadger/.snapshots/TestRubyThirdPartiesHoneybadger--honeybadger_context.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_honeybadger
-      rule_description: Do not send sensitive data to Honeybadger.
+      rule_description: Sensitive data sent to Honeybadger detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_honeybadger
       line_number: 1
       filename: honeybadger_context.rb
@@ -14,7 +14,7 @@ critical:
         })
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_honeybadger
-      rule_description: Do not send sensitive data to Honeybadger.
+      rule_description: Sensitive data sent to Honeybadger detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_honeybadger
       line_number: 8
       filename: honeybadger_context.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/honeybadger/.snapshots/TestRubyThirdPartiesHoneybadger--honeybadger_methods.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/honeybadger/.snapshots/TestRubyThirdPartiesHoneybadger--honeybadger_methods.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_honeybadger
-      rule_description: Do not send sensitive data to Honeybadger.
+      rule_description: Sensitive data sent to Honeybadger detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_honeybadger
       line_number: 3
       filename: honeybadger_methods.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/honeybadger/.snapshots/TestRubyThirdPartiesHoneybadger--honeybadger_notify.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/honeybadger/.snapshots/TestRubyThirdPartiesHoneybadger--honeybadger_notify.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_honeybadger
-      rule_description: Do not send sensitive data to Honeybadger.
+      rule_description: Sensitive data sent to Honeybadger detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_honeybadger
       line_number: 2
       filename: honeybadger_notify.rb
@@ -19,7 +19,7 @@ critical:
         )
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_honeybadger
-      rule_description: Do not send sensitive data to Honeybadger.
+      rule_description: Sensitive data sent to Honeybadger detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_honeybadger
       line_number: 9
       filename: honeybadger_notify.rb
@@ -37,7 +37,7 @@ critical:
         )
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_honeybadger
-      rule_description: Do not send sensitive data to Honeybadger.
+      rule_description: Sensitive data sent to Honeybadger detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_honeybadger
       line_number: 13
       filename: honeybadger_notify.rb
@@ -55,7 +55,7 @@ critical:
         )
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_honeybadger
-      rule_description: Do not send sensitive data to Honeybadger.
+      rule_description: Sensitive data sent to Honeybadger detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_honeybadger
       line_number: 14
       filename: honeybadger_notify.rb
@@ -73,7 +73,7 @@ critical:
         )
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_honeybadger
-      rule_description: Do not send sensitive data to Honeybadger.
+      rule_description: Sensitive data sent to Honeybadger detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_honeybadger
       line_number: 22
       filename: honeybadger_notify.rb
@@ -91,7 +91,7 @@ critical:
         )
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_honeybadger
-      rule_description: Do not send sensitive data to Honeybadger.
+      rule_description: Sensitive data sent to Honeybadger detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_honeybadger
       line_number: 29
       filename: honeybadger_notify.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/new_relic.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/new_relic.yml
@@ -25,7 +25,7 @@ severity:
 skip_data_types:
   - "Unique Identifier"
 metadata:
-  description: "Do not send sensitive data to New Relic."
+  description: "Sensitive data sent to New Relic detected."
   remediation_message: |
     ## Description
     Leaking sensitive data to third-party loggers is a common cause of data leaks and can lead to data breaches. This rule looks for instances of sensitive data sent to New Relic.

--- a/pkg/commands/process/settings/rules/ruby/third_parties/new_relic/.snapshots/TestRubyThirdPartiesNewRelic--datatype_in_add_custom_attributes.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/new_relic/.snapshots/TestRubyThirdPartiesNewRelic--datatype_in_add_custom_attributes.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_new_relic
-      rule_description: Do not send sensitive data to New Relic.
+      rule_description: Sensitive data sent to New Relic detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_new_relic
       line_number: 1
       filename: datatype_in_add_custom_attributes.rb
@@ -11,7 +11,7 @@ critical:
       parent_content: NewRelic::Agent.add_custom_attributes(user)
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_new_relic
-      rule_description: Do not send sensitive data to New Relic.
+      rule_description: Sensitive data sent to New Relic detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_new_relic
       line_number: 3
       filename: datatype_in_add_custom_attributes.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/new_relic/.snapshots/TestRubyThirdPartiesNewRelic--datatype_in_add_custom_parameters.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/new_relic/.snapshots/TestRubyThirdPartiesNewRelic--datatype_in_add_custom_parameters.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_new_relic
-      rule_description: Do not send sensitive data to New Relic.
+      rule_description: Sensitive data sent to New Relic detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_new_relic
       line_number: 1
       filename: datatype_in_add_custom_parameters.rb
@@ -11,7 +11,7 @@ critical:
       parent_content: NewRelic::Agent.add_custom_parameters(user)
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_new_relic
-      rule_description: Do not send sensitive data to New Relic.
+      rule_description: Sensitive data sent to New Relic detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_new_relic
       line_number: 3
       filename: datatype_in_add_custom_parameters.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/new_relic/.snapshots/TestRubyThirdPartiesNewRelic--datatype_in_notice_error.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/new_relic/.snapshots/TestRubyThirdPartiesNewRelic--datatype_in_notice_error.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_new_relic
-      rule_description: Do not send sensitive data to New Relic.
+      rule_description: Sensitive data sent to New Relic detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_new_relic
       line_number: 1
       filename: datatype_in_notice_error.rb
@@ -11,7 +11,7 @@ critical:
       parent_content: 'NewRelic::Agent.notice_error(exception, { custom_params: user })'
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_new_relic
-      rule_description: Do not send sensitive data to New Relic.
+      rule_description: Sensitive data sent to New Relic detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_new_relic
       line_number: 3
       filename: datatype_in_notice_error.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry.yml
@@ -42,7 +42,7 @@ severity:
 skip_data_types:
   - "Unique Identifier"
 metadata:
-  description: "Do not send sensitive data to Open Telemetry."
+  description: "Sensitive data sent to Open Telemetry detected."
   remediation_message: |
     ## Description
     Leaking sensitive data to third-party loggers is a common cause of data leaks and can lead to data breaches. This rule looks for instances of sensitive data sent to Open Telemetry.

--- a/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/.snapshots/TestRubyThirdPartiesOpenTelemetry--datatype_in_record_exception.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/.snapshots/TestRubyThirdPartiesOpenTelemetry--datatype_in_record_exception.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_open_telemetry
-      rule_description: Do not send sensitive data to Open Telemetry.
+      rule_description: Sensitive data sent to Open Telemetry detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_open_telemetry
       line_number: 7
       filename: datatype_in_record_exception.rb
@@ -12,7 +12,7 @@ critical:
       parent_content: 'current_span.status = OpenTelemetry::Trace::Status.error("error for user #{current_user.email}")'
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_open_telemetry
-      rule_description: Do not send sensitive data to Open Telemetry.
+      rule_description: Sensitive data sent to Open Telemetry detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_open_telemetry
       line_number: 17
       filename: datatype_in_record_exception.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/.snapshots/TestRubyThirdPartiesOpenTelemetry--datatype_in_span_attributes.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/.snapshots/TestRubyThirdPartiesOpenTelemetry--datatype_in_span_attributes.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_open_telemetry
-      rule_description: Do not send sensitive data to Open Telemetry.
+      rule_description: Sensitive data sent to Open Telemetry detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_open_telemetry
       line_number: 7
       filename: datatype_in_span_attributes.rb
@@ -15,7 +15,7 @@ critical:
           })
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_open_telemetry
-      rule_description: Do not send sensitive data to Open Telemetry.
+      rule_description: Sensitive data sent to Open Telemetry detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_open_telemetry
       line_number: 13
       filename: datatype_in_span_attributes.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/.snapshots/TestRubyThirdPartiesOpenTelemetry--datatype_in_span_event.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/.snapshots/TestRubyThirdPartiesOpenTelemetry--datatype_in_span_event.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_open_telemetry
-      rule_description: Do not send sensitive data to Open Telemetry.
+      rule_description: Sensitive data sent to Open Telemetry detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_open_telemetry
       line_number: 2
       filename: datatype_in_span_event.rb
@@ -11,7 +11,7 @@ critical:
       parent_content: 'span.add_event("Schedule job for user: #{current_user.email}")'
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_open_telemetry
-      rule_description: Do not send sensitive data to Open Telemetry.
+      rule_description: Sensitive data sent to Open Telemetry detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_open_telemetry
       line_number: 4
       filename: datatype_in_span_event.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/.snapshots/TestRubyThirdPartiesOpenTelemetry--datatypes_in_span_init_block.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/.snapshots/TestRubyThirdPartiesOpenTelemetry--datatypes_in_span_init_block.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_open_telemetry
-      rule_description: Do not send sensitive data to Open Telemetry.
+      rule_description: Sensitive data sent to Open Telemetry detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_open_telemetry
       line_number: 2
       filename: datatypes_in_span_init_block.rb
@@ -14,7 +14,7 @@ critical:
         end
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_open_telemetry
-      rule_description: Do not send sensitive data to Open Telemetry.
+      rule_description: Sensitive data sent to Open Telemetry detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_open_telemetry
       line_number: 6
       filename: datatypes_in_span_init_block.rb
@@ -27,7 +27,7 @@ critical:
         end
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_open_telemetry
-      rule_description: Do not send sensitive data to Open Telemetry.
+      rule_description: Sensitive data sent to Open Telemetry detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_open_telemetry
       line_number: 7
       filename: datatypes_in_span_init_block.rb
@@ -37,7 +37,7 @@ critical:
       parent_content: span.add_attributes(user.email)
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_open_telemetry
-      rule_description: Do not send sensitive data to Open Telemetry.
+      rule_description: Sensitive data sent to Open Telemetry detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_open_telemetry
       line_number: 11
       filename: datatypes_in_span_init_block.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/rollbar.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/rollbar.yml
@@ -51,7 +51,7 @@ severity:
 skip_data_types:
   - "Unique Identifier"
 metadata:
-  description: "Do not send sensitive data to Rollbar."
+  description: "Sensitive data sent to Rollbar detected."
   remediation_message: |
     ## Description
     Leaking sensitive data to third-party loggers is a common cause of data leaks and can lead to data breaches. This rule looks for instances of sensitive data sent to Rollbar.

--- a/pkg/commands/process/settings/rules/ruby/third_parties/rollbar/.snapshots/TestRubyThirdPartiesRollbar--datatype_in_context.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/rollbar/.snapshots/TestRubyThirdPartiesRollbar--datatype_in_context.yml
@@ -1,7 +1,7 @@
 low:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_rollbar
-      rule_description: Do not send sensitive data to Rollbar.
+      rule_description: Sensitive data sent to Rollbar detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
       line_number: 1
       filename: datatype_in_context.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/rollbar/.snapshots/TestRubyThirdPartiesRollbar--datatype_in_log.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/rollbar/.snapshots/TestRubyThirdPartiesRollbar--datatype_in_log.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_rollbar
-      rule_description: Do not send sensitive data to Rollbar.
+      rule_description: Sensitive data sent to Rollbar detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
       line_number: 1
       filename: datatype_in_log.rb
@@ -11,7 +11,7 @@ critical:
       parent_content: 'Rollbar.log("error", "oops #{user.email}")'
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_rollbar
-      rule_description: Do not send sensitive data to Rollbar.
+      rule_description: Sensitive data sent to Rollbar detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
       line_number: 2
       filename: datatype_in_log.rb
@@ -21,7 +21,7 @@ critical:
       parent_content: 'Rollbar.log("error", "oops", user: { email: "someone@example.com" })'
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_rollbar
-      rule_description: Do not send sensitive data to Rollbar.
+      rule_description: Sensitive data sent to Rollbar detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
       line_number: 3
       filename: datatype_in_log.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/rollbar/.snapshots/TestRubyThirdPartiesRollbar--datatype_in_log_helper.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/rollbar/.snapshots/TestRubyThirdPartiesRollbar--datatype_in_log_helper.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_rollbar
-      rule_description: Do not send sensitive data to Rollbar.
+      rule_description: Sensitive data sent to Rollbar detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
       line_number: 1
       filename: datatype_in_log_helper.rb
@@ -11,7 +11,7 @@ critical:
       parent_content: 'Rollbar.critical("oops #{user.email}")'
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_rollbar
-      rule_description: Do not send sensitive data to Rollbar.
+      rule_description: Sensitive data sent to Rollbar detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
       line_number: 2
       filename: datatype_in_log_helper.rb
@@ -21,7 +21,7 @@ critical:
       parent_content: 'Rollbar.critical(e, "oops #{user.email}")'
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_rollbar
-      rule_description: Do not send sensitive data to Rollbar.
+      rule_description: Sensitive data sent to Rollbar detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
       line_number: 3
       filename: datatype_in_log_helper.rb
@@ -31,7 +31,7 @@ critical:
       parent_content: 'Rollbar.critical(e, user: { email: "someone@example.com" })'
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_rollbar
-      rule_description: Do not send sensitive data to Rollbar.
+      rule_description: Sensitive data sent to Rollbar detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
       line_number: 4
       filename: datatype_in_log_helper.rb
@@ -41,7 +41,7 @@ critical:
       parent_content: 'Rollbar.critical(e, { user: { first_name: "someone" } })'
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_rollbar
-      rule_description: Do not send sensitive data to Rollbar.
+      rule_description: Sensitive data sent to Rollbar detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
       line_number: 6
       filename: datatype_in_log_helper.rb
@@ -51,7 +51,7 @@ critical:
       parent_content: 'Rollbar.error("oops #{user.email}")'
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_rollbar
-      rule_description: Do not send sensitive data to Rollbar.
+      rule_description: Sensitive data sent to Rollbar detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
       line_number: 8
       filename: datatype_in_log_helper.rb
@@ -61,7 +61,7 @@ critical:
       parent_content: 'Rollbar.debug("oops #{user.email}")'
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_rollbar
-      rule_description: Do not send sensitive data to Rollbar.
+      rule_description: Sensitive data sent to Rollbar detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
       line_number: 10
       filename: datatype_in_log_helper.rb
@@ -71,7 +71,7 @@ critical:
       parent_content: 'Rollbar.info("oops #{user.email}")'
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_rollbar
-      rule_description: Do not send sensitive data to Rollbar.
+      rule_description: Sensitive data sent to Rollbar detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
       line_number: 12
       filename: datatype_in_log_helper.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/rollbar/.snapshots/TestRubyThirdPartiesRollbar--datatype_in_scope.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/rollbar/.snapshots/TestRubyThirdPartiesRollbar--datatype_in_scope.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_rollbar
-      rule_description: Do not send sensitive data to Rollbar.
+      rule_description: Sensitive data sent to Rollbar detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
       line_number: 1
       filename: datatype_in_scope.rb
@@ -11,7 +11,7 @@ critical:
       parent_content: 'Rollbar.scope!({ user: { email: "someone@example.com" }})'
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_rollbar
-      rule_description: Do not send sensitive data to Rollbar.
+      rule_description: Sensitive data sent to Rollbar detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
       line_number: 3
       filename: datatype_in_scope.rb
@@ -21,7 +21,7 @@ critical:
       parent_content: Rollbar.scope(user)
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_rollbar
-      rule_description: Do not send sensitive data to Rollbar.
+      rule_description: Sensitive data sent to Rollbar detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
       line_number: 7
       filename: datatype_in_scope.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/rollbar/.snapshots/TestRubyThirdPartiesRollbar--datatype_in_scoped.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/rollbar/.snapshots/TestRubyThirdPartiesRollbar--datatype_in_scoped.yml
@@ -1,7 +1,7 @@
 low:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_rollbar
-      rule_description: Do not send sensitive data to Rollbar.
+      rule_description: Sensitive data sent to Rollbar detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
       line_number: 1
       filename: datatype_in_scoped.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/scout_apm.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/scout_apm.yml
@@ -20,7 +20,7 @@ severity:
 skip_data_types:
   - "Unique Identifier"
 metadata:
-  description: "Do not send sensitive data to Scout APM."
+  description: "Sensitive data sent to Scout APM detected."
   remediation_message: |
     ## Description
     Leaking sensitive data to third-party loggers is a common cause of data leaks and can lead to data breaches. This rule looks for instances of sensitive data sent to Scout APM.

--- a/pkg/commands/process/settings/rules/ruby/third_parties/scout_apm/.snapshots/TestRubyThirdPartiesScoutAPM--datatype_in_add.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/scout_apm/.snapshots/TestRubyThirdPartiesScoutAPM--datatype_in_add.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_scout_apm
-      rule_description: Do not send sensitive data to Scout APM.
+      rule_description: Sensitive data sent to Scout APM detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_scout_apm
       line_number: 1
       filename: datatype_in_add.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/scout_apm/.snapshots/TestRubyThirdPartiesScoutAPM--datatype_in_add_user.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/scout_apm/.snapshots/TestRubyThirdPartiesScoutAPM--datatype_in_add_user.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_scout_apm
-      rule_description: Do not send sensitive data to Scout APM.
+      rule_description: Sensitive data sent to Scout APM detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_scout_apm
       line_number: 1
       filename: datatype_in_add_user.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/segment.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/segment.yml
@@ -29,7 +29,7 @@ severity:
 skip_data_types:
   - "Unique Identifier"
 metadata:
-  description: "Do not send sensitive data to Segment."
+  description: "Sensitive data sent to Segment detected.."
   remediation_message: |
     ## Description
     Leaking sensitive data to third-party analytics tools is a common cause of data leaks and can lead to data breaches. This rule looks for instances of sensitive data sent to Segment.

--- a/pkg/commands/process/settings/rules/ruby/third_parties/segment/.snapshots/TestRubyThirdPartiesSegment--datatype_as_user_id.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/segment/.snapshots/TestRubyThirdPartiesSegment--datatype_as_user_id.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_segment
-      rule_description: Do not send sensitive data to Segment.
+      rule_description: Sensitive data sent to Segment detected..
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_segment
       line_number: 2
       filename: datatype_as_user_id.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/segment/.snapshots/TestRubyThirdPartiesSegment--datatype_in_nested_attribute.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/segment/.snapshots/TestRubyThirdPartiesSegment--datatype_in_nested_attribute.yml
@@ -1,7 +1,7 @@
 high:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_segment
-      rule_description: Do not send sensitive data to Segment.
+      rule_description: Sensitive data sent to Segment detected..
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_segment
       line_number: 2
       filename: datatype_in_nested_attribute.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/sentry.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/sentry.yml
@@ -133,7 +133,7 @@ severity:
 skip_data_types:
   - "Unique Identifier"
 metadata:
-  description: "Do not send sensitive data to Sentry."
+  description: "Sensitive data sent to Sentry detected."
   remediation_message: |
     ## Description
     Leaking sensitive data to third-party loggers is a common cause of data leaks and can lead to data breaches. This rule looks for instances of sensitive data sent to Sentry.

--- a/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentry--datatype_in_breadcrumb.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentry--datatype_in_breadcrumb.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_sentry
-      rule_description: Do not send sensitive data to Sentry.
+      rule_description: Sensitive data sent to Sentry detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
       line_number: 3
       filename: datatype_in_breadcrumb.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentry--datatype_in_capture_message.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentry--datatype_in_capture_message.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_sentry
-      rule_description: Do not send sensitive data to Sentry.
+      rule_description: Sensitive data sent to Sentry detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
       line_number: 1
       filename: datatype_in_capture_message.rb
@@ -11,7 +11,7 @@ critical:
       parent_content: 'Sentry.capture_message("test: #{user.email}")'
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_sentry
-      rule_description: Do not send sensitive data to Sentry.
+      rule_description: Sensitive data sent to Sentry detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
       line_number: 2
       filename: datatype_in_capture_message.rb
@@ -21,7 +21,7 @@ critical:
       parent_content: 'Sentry.capture_message("test", extra: { email: user.email })'
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_sentry
-      rule_description: Do not send sensitive data to Sentry.
+      rule_description: Sensitive data sent to Sentry detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
       line_number: 3
       filename: datatype_in_capture_message.rb
@@ -31,7 +31,7 @@ critical:
       parent_content: 'Sentry.capture_message("test", tags: { email: user.email })'
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_sentry
-      rule_description: Do not send sensitive data to Sentry.
+      rule_description: Sensitive data sent to Sentry detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
       line_number: 4
       filename: datatype_in_capture_message.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentry--datatype_in_init.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentry--datatype_in_init.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_sentry
-      rule_description: Do not send sensitive data to Sentry.
+      rule_description: Sensitive data sent to Sentry detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
       line_number: 3
       filename: datatype_in_init.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentry--datatype_in_set_context.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentry--datatype_in_set_context.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_sentry
-      rule_description: Do not send sensitive data to Sentry.
+      rule_description: Sensitive data sent to Sentry detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
       line_number: 1
       filename: datatype_in_set_context.rb
@@ -11,7 +11,7 @@ critical:
       parent_content: 'Sentry.set_context(''email'', { email: user.email })'
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_sentry
-      rule_description: Do not send sensitive data to Sentry.
+      rule_description: Sensitive data sent to Sentry detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
       line_number: 4
       filename: datatype_in_set_context.rb
@@ -21,7 +21,7 @@ critical:
       parent_content: 'scope.set_context(''email'', { email: user.email })'
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_sentry
-      rule_description: Do not send sensitive data to Sentry.
+      rule_description: Sensitive data sent to Sentry detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
       line_number: 8
       filename: datatype_in_set_context.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentry--datatype_in_set_extra.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentry--datatype_in_set_extra.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_sentry
-      rule_description: Do not send sensitive data to Sentry.
+      rule_description: Sensitive data sent to Sentry detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
       line_number: 2
       filename: datatype_in_set_extra.rb
@@ -11,7 +11,7 @@ critical:
       parent_content: scope.set_extra(:email, user.email)
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_sentry
-      rule_description: Do not send sensitive data to Sentry.
+      rule_description: Sensitive data sent to Sentry detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
       line_number: 6
       filename: datatype_in_set_extra.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentry--datatype_in_set_extras.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentry--datatype_in_set_extras.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_sentry
-      rule_description: Do not send sensitive data to Sentry.
+      rule_description: Sensitive data sent to Sentry detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
       line_number: 1
       filename: datatype_in_set_extras.rb
@@ -11,7 +11,7 @@ critical:
       parent_content: 'Sentry.set_extras(email: user.email)'
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_sentry
-      rule_description: Do not send sensitive data to Sentry.
+      rule_description: Sensitive data sent to Sentry detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
       line_number: 4
       filename: datatype_in_set_extras.rb
@@ -21,7 +21,7 @@ critical:
       parent_content: 'scope.set_extras(email: user.email)'
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_sentry
-      rule_description: Do not send sensitive data to Sentry.
+      rule_description: Sensitive data sent to Sentry detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
       line_number: 8
       filename: datatype_in_set_extras.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentry--datatype_in_set_tag.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentry--datatype_in_set_tag.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_sentry
-      rule_description: Do not send sensitive data to Sentry.
+      rule_description: Sensitive data sent to Sentry detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
       line_number: 2
       filename: datatype_in_set_tag.rb
@@ -11,7 +11,7 @@ critical:
       parent_content: scope.set_tag(:email, user.email)
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_sentry
-      rule_description: Do not send sensitive data to Sentry.
+      rule_description: Sensitive data sent to Sentry detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
       line_number: 6
       filename: datatype_in_set_tag.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentry--datatype_in_set_tags.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentry--datatype_in_set_tags.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_sentry
-      rule_description: Do not send sensitive data to Sentry.
+      rule_description: Sensitive data sent to Sentry detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
       line_number: 1
       filename: datatype_in_set_tags.rb
@@ -11,7 +11,7 @@ critical:
       parent_content: 'Sentry.set_tags(email: user.email)'
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_sentry
-      rule_description: Do not send sensitive data to Sentry.
+      rule_description: Sensitive data sent to Sentry detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
       line_number: 4
       filename: datatype_in_set_tags.rb
@@ -21,7 +21,7 @@ critical:
       parent_content: 'scope.set_tags(email: user.email)'
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_sentry
-      rule_description: Do not send sensitive data to Sentry.
+      rule_description: Sensitive data sent to Sentry detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
       line_number: 8
       filename: datatype_in_set_tags.rb

--- a/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentry--datatype_in_set_user.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentry--datatype_in_set_user.yml
@@ -1,7 +1,7 @@
 critical:
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_sentry
-      rule_description: Do not send sensitive data to Sentry.
+      rule_description: Sensitive data sent to Sentry detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
       line_number: 3
       filename: datatype_in_set_user.rb
@@ -11,7 +11,7 @@ critical:
       parent_content: 'Sentry.set_user(email: user.email)'
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_sentry
-      rule_description: Do not send sensitive data to Sentry.
+      rule_description: Sensitive data sent to Sentry detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
       line_number: 6
       filename: datatype_in_set_user.rb
@@ -21,7 +21,7 @@ critical:
       parent_content: 'scope.set_user(email: user.email)'
     - rule_dsrid: DSR-1
       rule_display_id: ruby_third_parties_sentry
-      rule_description: Do not send sensitive data to Sentry.
+      rule_description: Sensitive data sent to Sentry detected.
       rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
       line_number: 10
       filename: datatype_in_set_user.rb

--- a/pkg/report/output/summary/.snapshots/TestBuildReportString
+++ b/pkg/report/output/summary/.snapshots/TestBuildReportString
@@ -5,12 +5,12 @@ Summary Report
 =====================================
 Checks: 
 
-- Do not send sensitive data to Rails loggers. (ruby_rails_logger) [DSR-5]
-- Enable SSL Certificate Verification. (ruby_lang_ssl_verification) [DSR-2]
 - Its a test! (custom_test_rule)
+- Missing SSL certificate verification detected. (ruby_lang_ssl_verification) [DSR-2]
+- Sensitive data sent to Rails loggers detected. (ruby_rails_logger) [DSR-5]
 
 
-CRITICAL: Do not send sensitive data to Rails loggers. [DSR-5]
+CRITICAL: Sensitive data sent to Rails loggers detected. [DSR-5]
 https://docs.bearer.com/reference/rules/ruby_rails_logger
 To skip this rule, use the flag --skip-rule=ruby_rails_logger
 
@@ -18,7 +18,7 @@ File: pkg/datatype_leak.rb:1
 
 
 
-LOW: Enable SSL Certificate Verification. [DSR-2]
+LOW: Missing SSL certificate verification detected. [DSR-2]
 https://docs.bearer.com/reference/rules/ruby_lang_ssl_verification
 To skip this rule, use the flag --skip-rule=ruby_lang_ssl_verification
 

--- a/pkg/report/output/summary/.snapshots/TestGetOutput
+++ b/pkg/report/output/summary/.snapshots/TestGetOutput
@@ -3,7 +3,7 @@
     (summary.Result) {
       RuleDSRID: (string) (len=5) "DSR-5",
       RuleDisplayId: (string) (len=17) "ruby_rails_logger",
-      RuleDescription: (string) (len=44) "Do not send sensitive data to Rails loggers.",
+      RuleDescription: (string) (len=46) "Sensitive data sent to Rails loggers detected.",
       RuleDocumentationUrl: (string) (len=57) "https://docs.bearer.com/reference/rules/ruby_rails_logger",
       LineNumber: (int) 1,
       Filename: (string) (len=20) "pkg/datatype_leak.rb",
@@ -20,7 +20,7 @@
     (summary.Result) {
       RuleDSRID: (string) (len=5) "DSR-2",
       RuleDisplayId: (string) (len=26) "ruby_lang_ssl_verification",
-      RuleDescription: (string) (len=36) "Enable SSL Certificate Verification.",
+      RuleDescription: (string) (len=46) "Missing SSL certificate verification detected.",
       RuleDocumentationUrl: (string) (len=66) "https://docs.bearer.com/reference/rules/ruby_lang_ssl_verification",
       LineNumber: (int) 2,
       Filename: (string) (len=21) "config/application.rb",

--- a/pkg/report/output/summary/.snapshots/TestTestGetOutputWithSeverity
+++ b/pkg/report/output/summary/.snapshots/TestTestGetOutputWithSeverity
@@ -3,7 +3,7 @@
     (summary.Result) {
       RuleDSRID: (string) (len=5) "DSR-5",
       RuleDisplayId: (string) (len=17) "ruby_rails_logger",
-      RuleDescription: (string) (len=44) "Do not send sensitive data to Rails loggers.",
+      RuleDescription: (string) (len=46) "Sensitive data sent to Rails loggers detected.",
       RuleDocumentationUrl: (string) (len=57) "https://docs.bearer.com/reference/rules/ruby_rails_logger",
       LineNumber: (int) 1,
       Filename: (string) (len=20) "pkg/datatype_leak.rb",


### PR DESCRIPTION
## Description
The format of the rules description was done in a way that didn't explicitly mention what was the problem,  but what was the overall expectation. Considering we use it in the CLI output with associated snippet code in errors, it makes more sense to format it in a way that explain what is the problem.