### PR TITLE
ci: only push canary to dockerhub

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -71,12 +71,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Login to ghcr.io registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ env.GH_USER }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: goreleaser/goreleaser-action@v4
         if: steps.cache.outputs.cache-hit != 'true' # do not run if cache hit
         name: Run GoReleaser

--- a/.goreleaser/canary.yaml
+++ b/.goreleaser/canary.yaml
@@ -14,7 +14,6 @@ release:
 dockers:
   - image_templates:
       - "docker.io/bearer/bearer:canary-amd64"
-      - "ghcr.io/bearer/bearer:canary-amd64"
     use: buildx
     goos: linux
     goarch: amd64


### PR DESCRIPTION
## Description
Github advertises the latest push as the latest version which is not correct and could be confusing. This is handled much better on dockerhub and we can do any testing using that version.

<img width="808" alt="Screenshot 2023-02-21 at 11 49 58" src="https://user-images.githubusercontent.com/699436/220337448-88ae0a5c-0b0d-44c6-9e30-81d1546f15ff.png">


<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
