### PR TITLE
feat(summary): condense rule list and show CWE

### DIFF
--- a/battle_tests/metrics_scan/metrics_scan.go
+++ b/battle_tests/metrics_scan/metrics_scan.go
@@ -23,8 +23,8 @@ type ScanReport struct {
 
 type PolicyScanReport struct {
 	// PolicyName      string `json:"policy_name" yaml:"policy_name"`
-	PolicyDsrid     string `json:"rule_dsrid" yaml:"rule_dsrid"`
-	PolicyDisplayId string `json:"rule_display_id" yaml:"rule_display_id"`
+	CWEIDs          []string `json:"rule_cwe_ids" yaml:"rule_cwe_ids"`
+	PolicyDisplayId string   `json:"rule_display_id" yaml:"rule_display_id"`
 	// PolicyDescription string   `json:"policy_description" yaml:"policy_description"`
 	LineNumber     int      `json:"line_number,omitempty" yaml:"line_number,omitempty"`
 	Filename       string   `json:"filename,omitempty" yaml:"filename,omitempty"`
@@ -112,7 +112,6 @@ func ScanRepository(repositoryUrl string, language string, reportingChan chan *M
 	metrics.NumberOfDataTypes = float64(reportData.NumberOfDataTypes)
 	metrics.NumberOfLineOfCode = float64(reportData.NumberOfLines)
 	metrics.DataTypes = reportData.DataTypes
-
 
 	// Run summary
 	policiesOutput, _, err := scanner.Start("summary")

--- a/e2e/rules/.snapshots/TestAuxilary-unsecure
+++ b/e2e/rules/.snapshots/TestAuxilary-unsecure
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_third_parties_datadog_test
-      rule_description: Do not send sensitive data to Datadog.
-      rule_documentation_url: ""
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_third_parties_datadog_test
+        description: Do not send sensitive data to Datadog.
+        documentation_url: ""
       line_number: 3
       filename: e2e/rules/testdata/data/auxilary/unsecure.js
       category_groups:

--- a/e2e/rules/.snapshots/TestSimpleRuby-unsecure
+++ b/e2e/rules/.snapshots/TestSimpleRuby-unsecure
@@ -1,8 +1,10 @@
 low:
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_rails_insecure_communication_test
-      rule_description: Force all incoming communication through SSL.
-      rule_documentation_url: ""
+    - rule:
+        cwe_ids:
+            - "319"
+        id: ruby_rails_insecure_communication_test
+        description: Force all incoming communication through SSL.
+        documentation_url: ""
       line_number: 7
       filename: e2e/rules/testdata/data/simple_ruby/unsecure.rb
       category_groups:

--- a/e2e/rules/testdata/rules/auxilary.yml
+++ b/e2e/rules/testdata/rules/auxilary.yml
@@ -37,7 +37,6 @@ metadata:
     ## Resources
     - [Datadog docs](https://docs.datadoghq.com)
     - [Scrubbing data](https://docs.datadoghq.com/tracing/configure_data_security/?tab=mongodb#scrub-sensitive-data-from-your-spans)
-  dsr_id: DSR-1
   cwe_id:
     - 201
   associated_recipe: Datadog

--- a/e2e/rules/testdata/rules/simple_ruby.yml
+++ b/e2e/rules/testdata/rules/simple_ruby.yml
@@ -27,7 +27,6 @@ metadata:
 
     ## Resources
     - [Configuring Rails Applications - Ruby on Rails Guides](https://guides.rubyonrails.org/configuring.html#config-force-ssl)
-  dsr_id: DSR-2
   cwe_id:
     - 319
   id: ruby_rails_insecure_communication_test

--- a/pkg/commands/process/settings/rules.go
+++ b/pkg/commands/process/settings/rules.go
@@ -181,7 +181,7 @@ func buildRules(definitions map[string]RuleDefinition, enabledRules map[string]s
 			Detectors:          definition.Detectors,
 			Processors:         definition.Processors,
 			AutoEncrytPrefix:   definition.AutoEncrytPrefix,
-			DSRID:              definition.Metadata.DSRID,
+			CWEIDs:             definition.Metadata.CWEIDs,
 			Languages:          definition.Languages,
 			ParamParenting:     definition.ParamParenting,
 			Patterns:           definition.Patterns,

--- a/pkg/commands/process/settings/rules/internal/internal/secret_detection.yml
+++ b/pkg/commands/process/settings/rules/internal/internal/secret_detection.yml
@@ -17,7 +17,6 @@ metadata:
 
     ## Resources
     - [Gitleaks](https://gitleaks.io/)
-  dsr_id: "DSR-4"
   cwe_id:
     - 798
   id: "secret_detection"

--- a/pkg/commands/process/settings/rules/javascript/express/cross_site_scripting/.snapshots/TestJavascriptExpressCrossSiteScripting--res_send_xss.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/cross_site_scripting/.snapshots/TestJavascriptExpressCrossSiteScripting--res_send_xss.yml
@@ -1,8 +1,10 @@
 low:
-    - rule_dsrid: ""
-      rule_display_id: javascript_express_cross_site_scripting
-      rule_description: Cross-site scripting (XSS) vulnerability detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_express_cross_site_scripting
+    - rule:
+        cwe_ids:
+            - "79"
+        id: javascript_express_cross_site_scripting
+        description: Cross-site scripting (XSS) vulnerability detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_express_cross_site_scripting
       line_number: 5
       filename: res_send_xss.js
       parent_line_number: 5

--- a/pkg/commands/process/settings/rules/javascript/express/cross_site_scripting/.snapshots/TestJavascriptExpressCrossSiteScripting--res_write_xss.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/cross_site_scripting/.snapshots/TestJavascriptExpressCrossSiteScripting--res_write_xss.yml
@@ -1,8 +1,10 @@
 low:
-    - rule_dsrid: ""
-      rule_display_id: javascript_express_cross_site_scripting
-      rule_description: Cross-site scripting (XSS) vulnerability detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_express_cross_site_scripting
+    - rule:
+        cwe_ids:
+            - "79"
+        id: javascript_express_cross_site_scripting
+        description: Cross-site scripting (XSS) vulnerability detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_express_cross_site_scripting
       line_number: 6
       filename: res_write_xss.js
       parent_line_number: 6

--- a/pkg/commands/process/settings/rules/javascript/express/exposed_dir_listing/.snapshots/TestJavascriptExpressExposedDirListing--serve_index_in_app_use.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/exposed_dir_listing/.snapshots/TestJavascriptExpressExposedDirListing--serve_index_in_app_use.yml
@@ -1,8 +1,10 @@
 warning:
-    - rule_dsrid: ""
-      rule_display_id: javascript_express_exposed_dir_listing
-      rule_description: Missing access restriction to directory listing detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_express_exposed_dir_listing
+    - rule:
+        cwe_ids:
+            - "548"
+        id: javascript_express_exposed_dir_listing
+        description: Missing access restriction to directory listing detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_express_exposed_dir_listing
       line_number: 5
       filename: serve_index_in_app_use.js
       parent_line_number: 5

--- a/pkg/commands/process/settings/rules/javascript/express/insecure_cookie.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/insecure_cookie.yml
@@ -34,7 +34,6 @@ metadata:
 
     ## Resources
     - [Express Security Best Practices](https://expressjs.com/en/advanced/best-practice-security.html#use-cookies-securely)
-  dsr_id: "DSR-3"
   cwe_id:
     - 1004
     - 614

--- a/pkg/commands/process/settings/rules/javascript/express/insecure_cookie/.snapshots/TestExpressSecureCookie--http_only.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/insecure_cookie/.snapshots/TestExpressSecureCookie--http_only.yml
@@ -1,8 +1,11 @@
 low:
-    - rule_dsrid: DSR-3
-      rule_display_id: express_insecure_cookie
-      rule_description: Missing secure options for cookie detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/express_insecure_cookie
+    - rule:
+        cwe_ids:
+            - "1004"
+            - "614"
+        id: express_insecure_cookie
+        description: Missing secure options for cookie detected.
+        documentation_url: https://docs.bearer.com/reference/rules/express_insecure_cookie
       line_number: 9
       filename: http_only.js
       parent_line_number: 9

--- a/pkg/commands/process/settings/rules/javascript/express/insecure_cookie/.snapshots/TestExpressSecureCookie--insecure_cookie.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/insecure_cookie/.snapshots/TestExpressSecureCookie--insecure_cookie.yml
@@ -1,8 +1,11 @@
 low:
-    - rule_dsrid: DSR-3
-      rule_display_id: express_insecure_cookie
-      rule_description: Missing secure options for cookie detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/express_insecure_cookie
+    - rule:
+        cwe_ids:
+            - "1004"
+            - "614"
+        id: express_insecure_cookie
+        description: Missing secure options for cookie detected.
+        documentation_url: https://docs.bearer.com/reference/rules/express_insecure_cookie
       line_number: 9
       filename: insecure_cookie.js
       parent_line_number: 9

--- a/pkg/commands/process/settings/rules/javascript/express/insecure_ref_resolution/.snapshots/TestJavascriptExpressInsecureRefResolution--render_external_resource.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/insecure_ref_resolution/.snapshots/TestJavascriptExpressInsecureRefResolution--render_external_resource.yml
@@ -1,8 +1,10 @@
 low:
-    - rule_dsrid: ""
-      rule_display_id: javascript_express_external_resource
-      rule_description: Avoid rendering resources resolved from external names or references.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_express_external_resource
+    - rule:
+        cwe_ids:
+            - "706"
+        id: javascript_express_external_resource
+        description: Avoid rendering resources resolved from external names or references.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_express_external_resource
       line_number: 5
       filename: render_external_resource.js
       parent_line_number: 5

--- a/pkg/commands/process/settings/rules/javascript/express/insecure_ref_resolution/.snapshots/TestJavascriptExpressInsecureRefResolution--require_external_resource.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/insecure_ref_resolution/.snapshots/TestJavascriptExpressInsecureRefResolution--require_external_resource.yml
@@ -1,8 +1,10 @@
 low:
-    - rule_dsrid: ""
-      rule_display_id: javascript_express_external_resource
-      rule_description: Avoid rendering resources resolved from external names or references.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_express_external_resource
+    - rule:
+        cwe_ids:
+            - "706"
+        id: javascript_express_external_resource
+        description: Avoid rendering resources resolved from external names or references.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_express_external_resource
       line_number: 6
       filename: require_external_resource.js
       parent_line_number: 6

--- a/pkg/commands/process/settings/rules/javascript/express/open_redirect/.snapshots/TestJavascriptExpressOpenRedirect--open_redirect.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/open_redirect/.snapshots/TestJavascriptExpressOpenRedirect--open_redirect.yml
@@ -1,32 +1,40 @@
 low:
-    - rule_dsrid: ""
-      rule_display_id: javascript_express_open_redirect
-      rule_description: Open redirect detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_express_open_redirect
+    - rule:
+        cwe_ids:
+            - "601"
+        id: javascript_express_open_redirect
+        description: Open redirect detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_express_open_redirect
       line_number: 2
       filename: open_redirect.js
       parent_line_number: 2
       parent_content: res.redirect(req.params.url)
-    - rule_dsrid: ""
-      rule_display_id: javascript_express_open_redirect
-      rule_description: Open redirect detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_express_open_redirect
+    - rule:
+        cwe_ids:
+            - "601"
+        id: javascript_express_open_redirect
+        description: Open redirect detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_express_open_redirect
       line_number: 3
       filename: open_redirect.js
       parent_line_number: 3
       parent_content: res.redirect(req.query.url + "/bar")
-    - rule_dsrid: ""
-      rule_display_id: javascript_express_open_redirect
-      rule_description: Open redirect detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_express_open_redirect
+    - rule:
+        cwe_ids:
+            - "601"
+        id: javascript_express_open_redirect
+        description: Open redirect detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_express_open_redirect
       line_number: 4
       filename: open_redirect.js
       parent_line_number: 4
       parent_content: res.redirect("https://" + req.params.url + "/bar")
-    - rule_dsrid: ""
-      rule_display_id: javascript_express_open_redirect
-      rule_description: Open redirect detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_express_open_redirect
+    - rule:
+        cwe_ids:
+            - "601"
+        id: javascript_express_open_redirect
+        description: Open redirect detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_express_open_redirect
       line_number: 5
       filename: open_redirect.js
       parent_line_number: 5

--- a/pkg/commands/process/settings/rules/javascript/express/path_traversal/.snapshots/TestJavascriptExpressPathTraversal--path_traversal_vulnerability.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/path_traversal/.snapshots/TestJavascriptExpressPathTraversal--path_traversal_vulnerability.yml
@@ -1,16 +1,20 @@
 warning:
-    - rule_dsrid: ""
-      rule_display_id: javascript_express_path_traversal
-      rule_description: Possible path traversal vulnerability detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_express_path_traversal
+    - rule:
+        cwe_ids:
+            - "22"
+        id: javascript_express_path_traversal
+        description: Possible path traversal vulnerability detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_express_path_traversal
       line_number: 5
       filename: path_traversal_vulnerability.js
       parent_line_number: 5
       parent_content: path.join("/public/" + req.query.path)
-    - rule_dsrid: ""
-      rule_display_id: javascript_express_path_traversal
-      rule_description: Possible path traversal vulnerability detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_express_path_traversal
+    - rule:
+        cwe_ids:
+            - "22"
+        id: javascript_express_path_traversal
+        description: Possible path traversal vulnerability detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_express_path_traversal
       line_number: 6
       filename: path_traversal_vulnerability.js
       parent_line_number: 6

--- a/pkg/commands/process/settings/rules/javascript/express/server_side_request_forgery/.snapshots/TestJavascriptExpressServerSideRequestForgery--axios_ssrf_injection.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/server_side_request_forgery/.snapshots/TestJavascriptExpressServerSideRequestForgery--axios_ssrf_injection.yml
@@ -1,8 +1,10 @@
 medium:
-    - rule_dsrid: ""
-      rule_display_id: javascript_express_server_side_request_forgery
-      rule_description: Risk of server-side request forgery detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_express_server_side_request_forgery
+    - rule:
+        cwe_ids:
+            - "918"
+        id: javascript_express_server_side_request_forgery
+        description: Risk of server-side request forgery detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_express_server_side_request_forgery
       line_number: 7
       filename: axios_ssrf_injection.js
       parent_line_number: 7

--- a/pkg/commands/process/settings/rules/javascript/express/server_side_request_forgery/.snapshots/TestJavascriptExpressServerSideRequestForgery--node_fetch_ssrf_injection.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/server_side_request_forgery/.snapshots/TestJavascriptExpressServerSideRequestForgery--node_fetch_ssrf_injection.yml
@@ -1,8 +1,10 @@
 medium:
-    - rule_dsrid: ""
-      rule_display_id: javascript_express_server_side_request_forgery
-      rule_description: Risk of server-side request forgery detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_express_server_side_request_forgery
+    - rule:
+        cwe_ids:
+            - "918"
+        id: javascript_express_server_side_request_forgery
+        description: Risk of server-side request forgery detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_express_server_side_request_forgery
       line_number: 7
       filename: node_fetch_ssrf_injection.js
       parent_line_number: 7

--- a/pkg/commands/process/settings/rules/javascript/express/server_side_request_forgery/.snapshots/TestJavascriptExpressServerSideRequestForgery--puppeteer_ssrf_injection.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/server_side_request_forgery/.snapshots/TestJavascriptExpressServerSideRequestForgery--puppeteer_ssrf_injection.yml
@@ -1,16 +1,20 @@
 medium:
-    - rule_dsrid: ""
-      rule_display_id: javascript_express_server_side_request_forgery
-      rule_description: Risk of server-side request forgery detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_express_server_side_request_forgery
+    - rule:
+        cwe_ids:
+            - "918"
+        id: javascript_express_server_side_request_forgery
+        description: Risk of server-side request forgery detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_express_server_side_request_forgery
       line_number: 11
       filename: puppeteer_ssrf_injection.js
       parent_line_number: 11
       parent_content: page.setContent(content)
-    - rule_dsrid: ""
-      rule_display_id: javascript_express_server_side_request_forgery
-      rule_description: Risk of server-side request forgery detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_express_server_side_request_forgery
+    - rule:
+        cwe_ids:
+            - "918"
+        id: javascript_express_server_side_request_forgery
+        description: Risk of server-side request forgery detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_express_server_side_request_forgery
       line_number: 12
       filename: puppeteer_ssrf_injection.js
       parent_line_number: 12

--- a/pkg/commands/process/settings/rules/javascript/express/sql_injection/.snapshots/TestJavascriptExpressSqlInjection--sequelize_sql_injection.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/sql_injection/.snapshots/TestJavascriptExpressSqlInjection--sequelize_sql_injection.yml
@@ -1,8 +1,10 @@
 low:
-    - rule_dsrid: ""
-      rule_display_id: javascript_express_sql_injection
-      rule_description: SQL injection vulnerability detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_express_sql_injection
+    - rule:
+        cwe_ids:
+            - "89"
+        id: javascript_express_sql_injection
+        description: SQL injection vulnerability detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_express_sql_injection
       line_number: 6
       filename: sequelize_sql_injection.js
       parent_line_number: 6

--- a/pkg/commands/process/settings/rules/javascript/express/unsafe_deserialization/.snapshots/TestJavascriptExpressUnsafeDeserialization--node_serialize.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/unsafe_deserialization/.snapshots/TestJavascriptExpressUnsafeDeserialization--node_serialize.yml
@@ -1,8 +1,10 @@
 warning:
-    - rule_dsrid: ""
-      rule_display_id: javascript_express_unsafe_deserialization
-      rule_description: Deserialization of untrusted data detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_express_unsafe_deserialization
+    - rule:
+        cwe_ids:
+            - "502"
+        id: javascript_express_unsafe_deserialization
+        description: Deserialization of untrusted data detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_express_unsafe_deserialization
       line_number: 5
       filename: node_serialize.js
       parent_line_number: 5

--- a/pkg/commands/process/settings/rules/javascript/express/unsafe_deserialization/.snapshots/TestJavascriptExpressUnsafeDeserialization--serialize_error.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/unsafe_deserialization/.snapshots/TestJavascriptExpressUnsafeDeserialization--serialize_error.yml
@@ -1,8 +1,10 @@
 warning:
-    - rule_dsrid: ""
-      rule_display_id: javascript_express_unsafe_deserialization
-      rule_description: Deserialization of untrusted data detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_express_unsafe_deserialization
+    - rule:
+        cwe_ids:
+            - "502"
+        id: javascript_express_unsafe_deserialization
+        description: Deserialization of untrusted data detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_express_unsafe_deserialization
       line_number: 4
       filename: serialize_error.js
       parent_line_number: 4

--- a/pkg/commands/process/settings/rules/javascript/express/xml_external_entity_vulnerability/.snapshots/TestExpressXXEVulnerability--lib_xml_with_noent_true.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/xml_external_entity_vulnerability/.snapshots/TestExpressXXEVulnerability--lib_xml_with_noent_true.yml
@@ -1,8 +1,10 @@
 low:
-    - rule_dsrid: ""
-      rule_display_id: javascript_express_xxe_vulnerability
-      rule_description: XML External Entity vulnerability detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_express_xxe_vulnerability
+    - rule:
+        cwe_ids:
+            - "611"
+        id: javascript_express_xxe_vulnerability
+        description: XML External Entity vulnerability detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_express_xxe_vulnerability
       line_number: 4
       filename: lib_xml_with_noent_true.js
       parent_line_number: 4

--- a/pkg/commands/process/settings/rules/javascript/express/xml_external_entity_vulnerability/.snapshots/TestExpressXXEVulnerability--xxe_vuln_with_node_expat.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/xml_external_entity_vulnerability/.snapshots/TestExpressXXEVulnerability--xxe_vuln_with_node_expat.yml
@@ -1,8 +1,10 @@
 low:
-    - rule_dsrid: ""
-      rule_display_id: javascript_express_xxe_vulnerability
-      rule_description: XML External Entity vulnerability detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_express_xxe_vulnerability
+    - rule:
+        cwe_ids:
+            - "611"
+        id: javascript_express_xxe_vulnerability
+        description: XML External Entity vulnerability detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_express_xxe_vulnerability
       line_number: 6
       filename: xxe_vuln_with_node_expat.js
       parent_line_number: 6

--- a/pkg/commands/process/settings/rules/javascript/express/xml_external_entity_vulnerability/.snapshots/TestExpressXXEVulnerability--xxe_vuln_with_xml2js.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/xml_external_entity_vulnerability/.snapshots/TestExpressXXEVulnerability--xxe_vuln_with_xml2js.yml
@@ -1,8 +1,10 @@
 low:
-    - rule_dsrid: ""
-      rule_display_id: javascript_express_xxe_vulnerability
-      rule_description: XML External Entity vulnerability detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_express_xxe_vulnerability
+    - rule:
+        cwe_ids:
+            - "611"
+        id: javascript_express_xxe_vulnerability
+        description: XML External Entity vulnerability detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_express_xxe_vulnerability
       line_number: 5
       filename: xxe_vuln_with_xml2js.js
       parent_line_number: 5

--- a/pkg/commands/process/settings/rules/javascript/express/xml_external_entity_vulnerability/.snapshots/TestExpressXXEVulnerability--xxe_vuln_with_xml2json.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/xml_external_entity_vulnerability/.snapshots/TestExpressXXEVulnerability--xxe_vuln_with_xml2json.yml
@@ -1,8 +1,10 @@
 low:
-    - rule_dsrid: ""
-      rule_display_id: javascript_express_xxe_vulnerability
-      rule_description: XML External Entity vulnerability detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_express_xxe_vulnerability
+    - rule:
+        cwe_ids:
+            - "611"
+        id: javascript_express_xxe_vulnerability
+        description: XML External Entity vulnerability detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_express_xxe_vulnerability
       line_number: 4
       filename: xxe_vuln_with_xml2json.js
       parent_line_number: 4

--- a/pkg/commands/process/settings/rules/javascript/lang/exception.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/exception.yml
@@ -57,7 +57,6 @@ metadata:
     ## Resources
     Coming soon.
     -->
-  dsr_id: DSR-5
   cwe_id:
     - 210
   id: javascript_lang_exception

--- a/pkg/commands/process/settings/rules/javascript/lang/exception/.snapshots/TestJavascriptLangException--promise_reject.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/exception/.snapshots/TestJavascriptLangException--promise_reject.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-5
-      rule_display_id: javascript_lang_exception
-      rule_description: Sensitive data in a exception message detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_exception
+    - rule:
+        cwe_ids:
+            - "210"
+        id: javascript_lang_exception
+        description: Sensitive data in a exception message detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_exception
       line_number: 5
       filename: promise_reject.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/lang/exception/.snapshots/TestJavascriptLangException--reject.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/exception/.snapshots/TestJavascriptLangException--reject.yml
@@ -1,18 +1,22 @@
 critical:
-    - rule_dsrid: DSR-5
-      rule_display_id: javascript_lang_exception
-      rule_description: Sensitive data in a exception message detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_exception
+    - rule:
+        cwe_ids:
+            - "210"
+        id: javascript_lang_exception
+        description: Sensitive data in a exception message detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_exception
       line_number: 5
       filename: reject.js
       category_groups:
         - PII
       parent_line_number: 7
       parent_content: reject("Error with user " + user)
-    - rule_dsrid: DSR-5
-      rule_display_id: javascript_lang_exception
-      rule_description: Sensitive data in a exception message detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_exception
+    - rule:
+        cwe_ids:
+            - "210"
+        id: javascript_lang_exception
+        description: Sensitive data in a exception message detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_exception
       line_number: 14
       filename: reject.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/lang/exception/.snapshots/TestJavascriptLangException--throw_custom_exception.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/exception/.snapshots/TestJavascriptLangException--throw_custom_exception.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-5
-      rule_display_id: javascript_lang_exception
-      rule_description: Sensitive data in a exception message detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_exception
+    - rule:
+        cwe_ids:
+            - "210"
+        id: javascript_lang_exception
+        description: Sensitive data in a exception message detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_exception
       line_number: 5
       filename: throw_custom_exception.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/lang/exception/.snapshots/TestJavascriptLangException--throw_string.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/exception/.snapshots/TestJavascriptLangException--throw_string.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-5
-      rule_display_id: javascript_lang_exception
-      rule_description: Sensitive data in a exception message detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_exception
+    - rule:
+        cwe_ids:
+            - "210"
+        id: javascript_lang_exception
+        description: Sensitive data in a exception message detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_exception
       line_number: 5
       filename: throw_string.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/lang/file_generation.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/file_generation.yml
@@ -32,7 +32,6 @@ metadata:
     ## Resources
     Coming soon.
     -->
-  dsr_id: DSR-4
   cwe_id:
     - 313
   id: javascript_lang_file_generation

--- a/pkg/commands/process/settings/rules/javascript/lang/file_generation/.snapshots/TestJavascriptLangFileGeneration--file_generation.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/file_generation/.snapshots/TestJavascriptLangFileGeneration--file_generation.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-4
-      rule_display_id: javascript_lang_file_generation
-      rule_description: Sensitive data detected as part of a dynamic file generation.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_file_generation
+    - rule:
+        cwe_ids:
+            - "313"
+        id: javascript_lang_file_generation
+        description: Sensitive data detected as part of a dynamic file generation.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_file_generation
       line_number: 8
       filename: file_generation.js
       category_groups:
@@ -13,10 +15,12 @@ critical:
           if (err) console.log(err)
           else console.log("Data saved")
         })
-    - rule_dsrid: DSR-4
-      rule_display_id: javascript_lang_file_generation
-      rule_description: Sensitive data detected as part of a dynamic file generation.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_file_generation
+    - rule:
+        cwe_ids:
+            - "313"
+        id: javascript_lang_file_generation
+        description: Sensitive data detected as part of a dynamic file generation.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_file_generation
       line_number: 11
       filename: file_generation.js
       category_groups:
@@ -27,10 +31,12 @@ critical:
           if (err) console.log(err)
           else console.log("Data saved")
         })
-    - rule_dsrid: DSR-4
-      rule_display_id: javascript_lang_file_generation
-      rule_description: Sensitive data detected as part of a dynamic file generation.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_file_generation
+    - rule:
+        cwe_ids:
+            - "313"
+        id: javascript_lang_file_generation
+        description: Sensitive data detected as part of a dynamic file generation.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_file_generation
       line_number: 12
       filename: file_generation.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/lang/http_insecure.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/http_insecure.yml
@@ -57,7 +57,6 @@ metadata:
     ## Resources
     Coming soon.
     -->
-  dsr_id: "DSR-5"
   cwe_id:
     - 319
   id: "javascript_http_insecure"

--- a/pkg/commands/process/settings/rules/javascript/lang/http_insecure/.snapshots/TestJavascriptHTTPInsecure--axios_insecure.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/http_insecure/.snapshots/TestJavascriptHTTPInsecure--axios_insecure.yml
@@ -1,8 +1,10 @@
 low:
-    - rule_dsrid: DSR-5
-      rule_display_id: javascript_http_insecure
-      rule_description: Connection with an unsecure HTTP communication detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_http_insecure
+    - rule:
+        cwe_ids:
+            - "319"
+        id: javascript_http_insecure
+        description: Connection with an unsecure HTTP communication detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_http_insecure
       line_number: 2
       filename: axios_insecure.js
       parent_line_number: 2

--- a/pkg/commands/process/settings/rules/javascript/lang/http_insecure/.snapshots/TestJavascriptHTTPInsecure--fetch_insecure.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/http_insecure/.snapshots/TestJavascriptHTTPInsecure--fetch_insecure.yml
@@ -1,8 +1,10 @@
 low:
-    - rule_dsrid: DSR-5
-      rule_display_id: javascript_http_insecure
-      rule_description: Connection with an unsecure HTTP communication detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_http_insecure
+    - rule:
+        cwe_ids:
+            - "319"
+        id: javascript_http_insecure
+        description: Connection with an unsecure HTTP communication detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_http_insecure
       line_number: 3
       filename: fetch_insecure.js
       parent_line_number: 3

--- a/pkg/commands/process/settings/rules/javascript/lang/http_insecure/.snapshots/TestJavascriptHTTPInsecure--request_insecure.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/http_insecure/.snapshots/TestJavascriptHTTPInsecure--request_insecure.yml
@@ -1,8 +1,10 @@
 low:
-    - rule_dsrid: DSR-5
-      rule_display_id: javascript_http_insecure
-      rule_description: Connection with an unsecure HTTP communication detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_http_insecure
+    - rule:
+        cwe_ids:
+            - "319"
+        id: javascript_http_insecure
+        description: Connection with an unsecure HTTP communication detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_http_insecure
       line_number: 5
       filename: request_insecure.js
       parent_line_number: 5

--- a/pkg/commands/process/settings/rules/javascript/lang/jwt.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/jwt.yml
@@ -42,7 +42,6 @@ metadata:
     ## Resources
     Coming soon.
     -->
-  dsr_id: "DSR-5"
   cwe_id:
     - 312
   id: "javascript_jwt"

--- a/pkg/commands/process/settings/rules/javascript/lang/jwt/.snapshots/TestJavascriptJWT--unsecure.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/jwt/.snapshots/TestJavascriptJWT--unsecure.yml
@@ -1,8 +1,10 @@
 low:
-    - rule_dsrid: DSR-5
-      rule_display_id: javascript_jwt
-      rule_description: Sensitive data in a JWT detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_jwt
+    - rule:
+        cwe_ids:
+            - "312"
+        id: javascript_jwt
+        description: Sensitive data in a JWT detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_jwt
       line_number: 3
       filename: unsecure.js
       parent_line_number: 2

--- a/pkg/commands/process/settings/rules/javascript/lang/jwt_hardcoded_secret/.snapshots/TestJavascriptJWTHardcodedSecret--unsecure.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/jwt_hardcoded_secret/.snapshots/TestJavascriptJWTHardcodedSecret--unsecure.yml
@@ -1,8 +1,10 @@
 medium:
-    - rule_dsrid: DSR-5
-      rule_display_id: javascript_jwt_hardcoded_secret
-      rule_description: Hardocded jwt secret deteted
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_jwt_hardcoded_secret
+    - rule:
+        cwe_ids:
+            - "798"
+        id: javascript_jwt_hardcoded_secret
+        description: Hardocded jwt secret deteted
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_jwt_hardcoded_secret
       line_number: 3
       filename: unsecure.js
       parent_line_number: 3

--- a/pkg/commands/process/settings/rules/javascript/lang/jwt_weak_encryption/.snapshots/TestJavascriptJWTWeakEncryption--unsecure.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/jwt_weak_encryption/.snapshots/TestJavascriptJWTWeakEncryption--unsecure.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-5
-      rule_display_id: javascript_jwt_weak_encryption
-      rule_description: Weak jwt encryption deceted
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_jwt_weak_encryption
+    - rule:
+        cwe_ids:
+            - "327"
+        id: javascript_jwt_weak_encryption
+        description: Weak jwt encryption deceted
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_jwt_weak_encryption
       line_number: 3
       filename: unsecure.js
       parent_line_number: 3

--- a/pkg/commands/process/settings/rules/javascript/lang/logger.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/logger.yml
@@ -94,7 +94,6 @@ metadata:
     ## Resources
     Coming soon.
     -->
-  dsr_id: "DSR-5"
   cwe_id:
     - 1295
     - 532

--- a/pkg/commands/process/settings/rules/javascript/lang/logger/.snapshots/TestJavascriptLangLogger--child.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/logger/.snapshots/TestJavascriptLangLogger--child.yml
@@ -1,8 +1,11 @@
 low:
-    - rule_dsrid: DSR-5
-      rule_display_id: javascript_lang_logger
-      rule_description: Sensitive data in a logger message detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_logger
+    - rule:
+        cwe_ids:
+            - "1295"
+            - "532"
+        id: javascript_lang_logger
+        description: Sensitive data in a logger message detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_logger
       line_number: 3
       filename: child.js
       parent_line_number: 7

--- a/pkg/commands/process/settings/rules/javascript/lang/logger/.snapshots/TestJavascriptLangLogger--child_level.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/logger/.snapshots/TestJavascriptLangLogger--child_level.yml
@@ -1,18 +1,24 @@
 critical:
-    - rule_dsrid: DSR-5
-      rule_display_id: javascript_lang_logger
-      rule_description: Sensitive data in a logger message detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_logger
+    - rule:
+        cwe_ids:
+            - "1295"
+            - "532"
+        id: javascript_lang_logger
+        description: Sensitive data in a logger message detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_logger
       line_number: 3
       filename: child_level.js
       category_groups:
         - PII
       parent_line_number: 7
       parent_content: logger.child(ctx)
-    - rule_dsrid: DSR-5
-      rule_display_id: javascript_lang_logger
-      rule_description: Sensitive data in a logger message detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_logger
+    - rule:
+        cwe_ids:
+            - "1295"
+            - "532"
+        id: javascript_lang_logger
+        description: Sensitive data in a logger message detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_logger
       line_number: 7
       filename: child_level.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/lang/logger/.snapshots/TestJavascriptLangLogger--console.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/logger/.snapshots/TestJavascriptLangLogger--console.yml
@@ -1,8 +1,11 @@
 critical:
-    - rule_dsrid: DSR-5
-      rule_display_id: javascript_lang_logger
-      rule_description: Sensitive data in a logger message detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_logger
+    - rule:
+        cwe_ids:
+            - "1295"
+            - "532"
+        id: javascript_lang_logger
+        description: Sensitive data in a logger message detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_logger
       line_number: 1
       filename: console.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/lang/logger/.snapshots/TestJavascriptLangLogger--datatype_leak.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/logger/.snapshots/TestJavascriptLangLogger--datatype_leak.yml
@@ -1,8 +1,11 @@
 critical:
-    - rule_dsrid: DSR-5
-      rule_display_id: javascript_lang_logger
-      rule_description: Sensitive data in a logger message detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_logger
+    - rule:
+        cwe_ids:
+            - "1295"
+            - "532"
+        id: javascript_lang_logger
+        description: Sensitive data in a logger message detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_logger
       line_number: 1
       filename: datatype_leak.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/lang/logger/.snapshots/TestJavascriptLangLogger--log.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/logger/.snapshots/TestJavascriptLangLogger--log.yml
@@ -1,8 +1,11 @@
 critical:
-    - rule_dsrid: DSR-5
-      rule_display_id: javascript_lang_logger
-      rule_description: Sensitive data in a logger message detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_logger
+    - rule:
+        cwe_ids:
+            - "1295"
+            - "532"
+        id: javascript_lang_logger
+        description: Sensitive data in a logger message detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_logger
       line_number: 1
       filename: log.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/lang/session.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/session.yml
@@ -41,7 +41,6 @@ metadata:
     ## Resources
     Coming soon.
     -->
-  dsr_id: "DSR-5"
   cwe_id:
     - 312
   id: "javascript_session"

--- a/pkg/commands/process/settings/rules/javascript/lang/session/.snapshots/TestJavascriptLangSession--session_leak.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/session/.snapshots/TestJavascriptLangSession--session_leak.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-5
-      rule_display_id: javascript_session
-      rule_description: Sensitive data stored in HTML local storage detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_session
+    - rule:
+        cwe_ids:
+            - "312"
+        id: javascript_session
+        description: Sensitive data stored in HTML local storage detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_session
       line_number: 1
       filename: session_leak.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/lang/weak_encryption.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/weak_encryption.yml
@@ -52,7 +52,6 @@ metadata:
 
     ## Resources
     - [NodeJS Crypto Module](https://nodejs.org/api/crypto.html#cryptocreatehmacalgorithm-key-options)
-  dsr_id: "DSR-5"
   cwe_id:
     - 327
   id: "javascript_weak_encryption"

--- a/pkg/commands/process/settings/rules/javascript/lang/weak_encryption/.snapshots/TestJavascriptWeakEncryption--md5.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/weak_encryption/.snapshots/TestJavascriptWeakEncryption--md5.yml
@@ -1,18 +1,22 @@
 critical:
-    - rule_dsrid: DSR-5
-      rule_display_id: javascript_weak_encryption
-      rule_description: Weak encryption library usage detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_weak_encryption
+    - rule:
+        cwe_ids:
+            - "327"
+        id: javascript_weak_encryption
+        description: Weak encryption library usage detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_weak_encryption
       line_number: 4
       filename: md5.js
       category_groups:
         - PII
       parent_line_number: 4
       parent_content: crypto.createHmac("md5", key).update(user.password)
-    - rule_dsrid: DSR-5
-      rule_display_id: javascript_weak_encryption
-      rule_description: Weak encryption library usage detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_weak_encryption
+    - rule:
+        cwe_ids:
+            - "327"
+        id: javascript_weak_encryption
+        description: Weak encryption library usage detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_weak_encryption
       line_number: 5
       filename: md5.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/lang/weak_encryption/.snapshots/TestJavascriptWeakEncryption--sha1.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/weak_encryption/.snapshots/TestJavascriptWeakEncryption--sha1.yml
@@ -1,18 +1,22 @@
 critical:
-    - rule_dsrid: DSR-5
-      rule_display_id: javascript_weak_encryption
-      rule_description: Weak encryption library usage detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_weak_encryption
+    - rule:
+        cwe_ids:
+            - "327"
+        id: javascript_weak_encryption
+        description: Weak encryption library usage detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_weak_encryption
       line_number: 4
       filename: sha1.js
       category_groups:
         - PII
       parent_line_number: 4
       parent_content: crypto.createHmac("sha1", key).update(user.password)
-    - rule_dsrid: DSR-5
-      rule_display_id: javascript_weak_encryption
-      rule_description: Weak encryption library usage detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_weak_encryption
+    - rule:
+        cwe_ids:
+            - "327"
+        id: javascript_weak_encryption
+        description: Weak encryption library usage detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_weak_encryption
       line_number: 5
       filename: sha1.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/react/google_analytics.yml
+++ b/pkg/commands/process/settings/rules/javascript/react/google_analytics.yml
@@ -27,7 +27,6 @@ metadata:
     ## Resources
     Coming soon.
     -->
-  dsr_id: DSR-1
   cwe_id:
     - 201
   id: "javascript_react_google_analytics"

--- a/pkg/commands/process/settings/rules/javascript/react/google_analytics/.snapshots/TestJavascriptReactGoogleAnalytics--insecure.yml
+++ b/pkg/commands/process/settings/rules/javascript/react/google_analytics/.snapshots/TestJavascriptReactGoogleAnalytics--insecure.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_react_google_analytics
-      rule_description: Sensitive data sent to Google Analytics detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_react_google_analytics
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_react_google_analytics
+        description: Sensitive data sent to Google Analytics detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_react_google_analytics
       line_number: 1
       filename: insecure.js
       category_groups:
@@ -14,10 +16,12 @@ critical:
         	action: "logged_in",
         	value: user.email,
         })
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_react_google_analytics
-      rule_description: Sensitive data sent to Google Analytics detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_react_google_analytics
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_react_google_analytics
+        description: Sensitive data sent to Google Analytics detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_react_google_analytics
       line_number: 5
       filename: insecure.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/third_parties/airbrake.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/airbrake.yml
@@ -33,7 +33,6 @@ metadata:
 
     ## Resources
     - [Airbrake Docs](https://docs.airbrake.io/)
-  dsr_id: DSR-1
   cwe_id:
     - 201
   associated_recipe: Airbrake

--- a/pkg/commands/process/settings/rules/javascript/third_parties/airbrake/.snapshots/TestJavascriptAirbrake--datatype_in_notify.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/airbrake/.snapshots/TestJavascriptAirbrake--datatype_in_notify.yml
@@ -1,8 +1,10 @@
 high:
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_third_parties_airbrake
-      rule_description: Sensitive data sent to Airbrake detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_airbrake
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_third_parties_airbrake
+        description: Sensitive data sent to Airbrake detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_airbrake
       line_number: 18
       filename: datatype_in_notify.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/third_parties/algolia.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/algolia.yml
@@ -56,7 +56,6 @@ metadata:
     -->
     ## Resources
     - [Algolia docs](https://www.algolia.com/doc/)
-  dsr_id: DSR-6
   cwe_id:
     - 201
   associated_recipe: Algolia

--- a/pkg/commands/process/settings/rules/javascript/third_parties/algolia/.snapshots/TestJavascriptAlgolia--datatype_in_index.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/algolia/.snapshots/TestJavascriptAlgolia--datatype_in_index.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-6
-      rule_display_id: javascript_third_parties_algolia
-      rule_description: Sensitive data sent to Algolia detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_algolia
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_third_parties_algolia
+        description: Sensitive data sent to Algolia detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_algolia
       line_number: 4
       filename: datatype_in_index.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/third_parties/algolia/.snapshots/TestJavascriptAlgolia--datatype_in_save_object.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/algolia/.snapshots/TestJavascriptAlgolia--datatype_in_save_object.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-6
-      rule_display_id: javascript_third_parties_algolia
-      rule_description: Sensitive data sent to Algolia detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_algolia
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_third_parties_algolia
+        description: Sensitive data sent to Algolia detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_algolia
       line_number: 7
       filename: datatype_in_save_object.js
       category_groups:
@@ -12,10 +14,12 @@ critical:
       parent_content: |-
         index
           .saveObject(userObj, { autoGenerateObjectIDIfNotExist: true })
-    - rule_dsrid: DSR-6
-      rule_display_id: javascript_third_parties_algolia
-      rule_description: Sensitive data sent to Algolia detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_algolia
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_third_parties_algolia
+        description: Sensitive data sent to Algolia detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_algolia
       line_number: 12
       filename: datatype_in_save_object.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/third_parties/bugsnag.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/bugsnag.yml
@@ -53,7 +53,6 @@ metadata:
 
     ## Resources
     - [Bugsnag Docs](https://docs.bugsnag.com/platforms/javascript/)
-  dsr_id: DSR-1
   cwe_id:
     - 201
   associated_recipe: Bugsnag

--- a/pkg/commands/process/settings/rules/javascript/third_parties/bugsnag/.snapshots/TestJavascriptBugsnag--datatype_in_breadcrumb.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/bugsnag/.snapshots/TestJavascriptBugsnag--datatype_in_breadcrumb.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_third_parties_bugsnag
-      rule_description: Sensitive data sent to Bugsnag detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_bugsnag
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_third_parties_bugsnag
+        description: Sensitive data sent to Bugsnag detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_bugsnag
       line_number: 1
       filename: datatype_in_breadcrumb.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/third_parties/bugsnag/.snapshots/TestJavascriptBugsnag--datatype_in_notify.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/bugsnag/.snapshots/TestJavascriptBugsnag--datatype_in_notify.yml
@@ -1,8 +1,10 @@
 high:
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_third_parties_bugsnag
-      rule_description: Sensitive data sent to Bugsnag detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_bugsnag
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_third_parties_bugsnag
+        description: Sensitive data sent to Bugsnag detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_bugsnag
       line_number: 5
       filename: datatype_in_notify.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/third_parties/bugsnag/.snapshots/TestJavascriptBugsnag--datatype_in_session.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/bugsnag/.snapshots/TestJavascriptBugsnag--datatype_in_session.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_third_parties_bugsnag
-      rule_description: Sensitive data sent to Bugsnag detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_bugsnag
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_third_parties_bugsnag
+        description: Sensitive data sent to Bugsnag detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_bugsnag
       line_number: 4
       filename: datatype_in_session.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/third_parties/bugsnag/.snapshots/TestJavascriptBugsnag--datatype_in_start.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/bugsnag/.snapshots/TestJavascriptBugsnag--datatype_in_start.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_third_parties_bugsnag
-      rule_description: Sensitive data sent to Bugsnag detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_bugsnag
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_third_parties_bugsnag
+        description: Sensitive data sent to Bugsnag detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_bugsnag
       line_number: 3
       filename: datatype_in_start.js
       category_groups:
@@ -20,10 +22,12 @@ critical:
             session.setUser(user.email)
           }
         })
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_third_parties_bugsnag
-      rule_description: Sensitive data sent to Bugsnag detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_bugsnag
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_third_parties_bugsnag
+        description: Sensitive data sent to Bugsnag detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_bugsnag
       line_number: 5
       filename: datatype_in_start.js
       category_groups:
@@ -41,10 +45,12 @@ critical:
             session.setUser(user.email)
           }
         })
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_third_parties_bugsnag
-      rule_description: Sensitive data sent to Bugsnag detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_bugsnag
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_third_parties_bugsnag
+        description: Sensitive data sent to Bugsnag detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_bugsnag
       line_number: 9
       filename: datatype_in_start.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/third_parties/datadog.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/datadog.yml
@@ -40,7 +40,6 @@ metadata:
     ## Resources
     - [Datadog docs](https://docs.datadoghq.com)
     - [Scrubbing data](https://docs.datadoghq.com/tracing/configure_data_security/?tab=mongodb#scrub-sensitive-data-from-your-spans)
-  dsr_id: DSR-1
   cwe_id:
     - 201
   associated_recipe: Datadog

--- a/pkg/commands/process/settings/rules/javascript/third_parties/datadog/.snapshots/TestJavascriptDataDog--unsecure.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/datadog/.snapshots/TestJavascriptDataDog--unsecure.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_third_parties_datadog
-      rule_description: Sensitive data sent to Datadog detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_datadog
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_third_parties_datadog
+        description: Sensitive data sent to Datadog detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_datadog
       line_number: 3
       filename: unsecure.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/third_parties/datadog_browser.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/datadog_browser.yml
@@ -25,7 +25,6 @@ metadata:
     ## Resources
     - [Datadog docs](https://docs.datadoghq.com)
     - [Scrubbing data](https://docs.datadoghq.com/real_user_monitoring/browser/modifying_data_and_context/?tab=npm)
-  dsr_id: DSR-1
   cwe_id:
     - 201
   associated_recipe: Datadog

--- a/pkg/commands/process/settings/rules/javascript/third_parties/datadog_browser/.snapshots/TestJavascriptDataDogBrowser--unsecure.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/datadog_browser/.snapshots/TestJavascriptDataDogBrowser--unsecure.yml
@@ -1,8 +1,10 @@
 low:
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_third_parties_datadog_browser
-      rule_description: Sensitive data sent to Datadog detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_datadog_browser
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_third_parties_datadog_browser
+        description: Sensitive data sent to Datadog detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_datadog_browser
       line_number: 2
       filename: unsecure.js
       parent_line_number: 2

--- a/pkg/commands/process/settings/rules/javascript/third_parties/elasticsearch.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/elasticsearch.yml
@@ -30,7 +30,6 @@ metadata:
     ## Resources
     Coming soon.
     -->
-  dsr_id: DSR-1
   cwe_id:
     - 201
   id: "javascript_elasticsearch"

--- a/pkg/commands/process/settings/rules/javascript/third_parties/elasticsearch/.snapshots/TestJavascriptElasticSearch--unsecure.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/elasticsearch/.snapshots/TestJavascriptElasticSearch--unsecure.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_elasticsearch
-      rule_description: Sensitive data sent to ElasticSearch detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_elasticsearch
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_elasticsearch
+        description: Sensitive data sent to ElasticSearch detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_elasticsearch
       line_number: 1
       filename: unsecure.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/third_parties/google_analytics.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/google_analytics.yml
@@ -27,7 +27,6 @@ metadata:
     ## Resources
     Coming soon.
     -->
-  dsr_id: DSR-1
   cwe_id:
     - 201
   id: "javascript_google_analytics"

--- a/pkg/commands/process/settings/rules/javascript/third_parties/google_analytics/.snapshots/TestJavascriptGoogleAnalytics--unsecure.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/google_analytics/.snapshots/TestJavascriptGoogleAnalytics--unsecure.yml
@@ -1,8 +1,10 @@
 low:
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_google_analytics
-      rule_description: Sensitive data sent to Google Analytic detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_google_analytics
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_google_analytics
+        description: Sensitive data sent to Google Analytic detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_google_analytics
       line_number: 3
       filename: unsecure.js
       parent_line_number: 1

--- a/pkg/commands/process/settings/rules/javascript/third_parties/google_tag_manager.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/google_tag_manager.yml
@@ -48,7 +48,6 @@ metadata:
     ## Resources
     Coming soon.
     -->
-  dsr_id: DSR-1
   cwe_id:
     - 201
   id: "javascript_google_tag_manager"

--- a/pkg/commands/process/settings/rules/javascript/third_parties/google_tag_manager/.snapshots/TestJavascriptGTM--unsecure.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/google_tag_manager/.snapshots/TestJavascriptGTM--unsecure.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_google_tag_manager
-      rule_description: Sensitive data sent to Google Tag Manager detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_google_tag_manager
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_google_tag_manager
+        description: Sensitive data sent to Google Tag Manager detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_google_tag_manager
       line_number: 1
       filename: unsecure.js
       category_groups:
@@ -12,10 +14,12 @@ critical:
         window.dataLayer.push({
         	email: user.email,
         })
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_google_tag_manager
-      rule_description: Sensitive data sent to Google Tag Manager detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_google_tag_manager
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_google_tag_manager
+        description: Sensitive data sent to Google Tag Manager detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_google_tag_manager
       line_number: 4
       filename: unsecure.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/third_parties/honeybadger.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/honeybadger.yml
@@ -36,7 +36,6 @@ metadata:
     ## Resources
     Coming soon.
     -->
-  dsr_id: DSR-1
   cwe_id:
     - 201
   id: "javascript_honeybadger"

--- a/pkg/commands/process/settings/rules/javascript/third_parties/honeybadger/.snapshots/TestJavascriptHoneybadger--unsecure.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/honeybadger/.snapshots/TestJavascriptHoneybadger--unsecure.yml
@@ -1,8 +1,10 @@
 low:
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_honeybadger
-      rule_description: Sensitive data sent to Honeybadger detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_honeybadger
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_honeybadger
+        description: Sensitive data sent to Honeybadger detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_honeybadger
       line_number: 3
       filename: unsecure.js
       parent_line_number: 5

--- a/pkg/commands/process/settings/rules/javascript/third_parties/new_relic.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/new_relic.yml
@@ -65,7 +65,6 @@ metadata:
     ## Resources
     - [New Relic Docs](https://docs.newrelic.com/)
     - [Log obfuscation](https://docs.newrelic.com/docs/logs/ui-data/obfuscation-ui/)
-  dsr_id: DSR-1
   cwe_id:
     - 201
   id: "javascript_third_parties_new_relic"

--- a/pkg/commands/process/settings/rules/javascript/third_parties/new_relic/.snapshots/TestJavascriptNewRelic--datatype_in_interaction_set_attribute.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/new_relic/.snapshots/TestJavascriptNewRelic--datatype_in_interaction_set_attribute.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_third_parties_new_relic
-      rule_description: Sensitive data sent to New Relic detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_new_relic
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_third_parties_new_relic
+        description: Sensitive data sent to New Relic detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_new_relic
       line_number: 6
       filename: datatype_in_interaction_set_attribute.js
       category_groups:
@@ -11,10 +13,12 @@ critical:
       parent_content: |-
         newrelic.interaction()
             .setAttribute("username", user.first_name)
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_third_parties_new_relic
-      rule_description: Sensitive data sent to New Relic detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_new_relic
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_third_parties_new_relic
+        description: Sensitive data sent to New Relic detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_new_relic
       line_number: 7
       filename: datatype_in_interaction_set_attribute.js
       category_groups:
@@ -24,10 +28,12 @@ critical:
         newrelic.interaction()
             .setAttribute("username", user.first_name)
             .setAttribute("postal-code", user.post_code)
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_third_parties_new_relic
-      rule_description: Sensitive data sent to New Relic detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_new_relic
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_third_parties_new_relic
+        description: Sensitive data sent to New Relic detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_new_relic
       line_number: 13
       filename: datatype_in_interaction_set_attribute.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/third_parties/new_relic/.snapshots/TestJavascriptNewRelic--datatype_in_notice_error.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/new_relic/.snapshots/TestJavascriptNewRelic--datatype_in_notice_error.yml
@@ -1,8 +1,10 @@
 high:
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_third_parties_new_relic
-      rule_description: Sensitive data sent to New Relic detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_new_relic
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_third_parties_new_relic
+        description: Sensitive data sent to New Relic detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_new_relic
       line_number: 7
       filename: datatype_in_notice_error.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/third_parties/new_relic/.snapshots/TestJavascriptNewRelic--datatype_in_set_custom_attribute.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/new_relic/.snapshots/TestJavascriptNewRelic--datatype_in_set_custom_attribute.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_third_parties_new_relic
-      rule_description: Sensitive data sent to New Relic detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_new_relic
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_third_parties_new_relic
+        description: Sensitive data sent to New Relic detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_new_relic
       line_number: 3
       filename: datatype_in_set_custom_attribute.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/third_parties/new_relic/.snapshots/TestJavascriptNewRelic--datatype_in_set_page_view_name.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/new_relic/.snapshots/TestJavascriptNewRelic--datatype_in_set_page_view_name.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_third_parties_new_relic
-      rule_description: Sensitive data sent to New Relic detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_new_relic
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_third_parties_new_relic
+        description: Sensitive data sent to New Relic detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_new_relic
       line_number: 3
       filename: datatype_in_set_page_view_name.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/third_parties/open_telemetry.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/open_telemetry.yml
@@ -39,7 +39,6 @@ metadata:
 
     ## Resources
     - [Open Telemetry Docs](https://opentelemetry.io/docs/)
-  dsr_id: DSR-1
   cwe_id:
     - 201
   id: javascript_third_parties_open_telemetry

--- a/pkg/commands/process/settings/rules/javascript/third_parties/open_telemetry/.snapshots/TestJavascriptOpenTelemetry--datatype_in_add_event.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/open_telemetry/.snapshots/TestJavascriptOpenTelemetry--datatype_in_add_event.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_third_parties_open_telemetry
-      rule_description: Sensitive data sent to Open Telemetry detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_open_telemetry
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_third_parties_open_telemetry
+        description: Sensitive data sent to Open Telemetry detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_open_telemetry
       line_number: 5
       filename: datatype_in_add_event.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/third_parties/open_telemetry/.snapshots/TestJavascriptOpenTelemetry--datatype_in_record_exception.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/open_telemetry/.snapshots/TestJavascriptOpenTelemetry--datatype_in_record_exception.yml
@@ -1,8 +1,10 @@
 high:
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_third_parties_open_telemetry
-      rule_description: Sensitive data sent to Open Telemetry detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_open_telemetry
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_third_parties_open_telemetry
+        description: Sensitive data sent to Open Telemetry detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_open_telemetry
       line_number: 9
       filename: datatype_in_record_exception.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/third_parties/open_telemetry/.snapshots/TestJavascriptOpenTelemetry--datatype_in_set_attribute.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/open_telemetry/.snapshots/TestJavascriptOpenTelemetry--datatype_in_set_attribute.yml
@@ -1,18 +1,22 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_third_parties_open_telemetry
-      rule_description: Sensitive data sent to Open Telemetry detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_open_telemetry
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_third_parties_open_telemetry
+        description: Sensitive data sent to Open Telemetry detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_open_telemetry
       line_number: 6
       filename: datatype_in_set_attribute.js
       category_groups:
         - PII
       parent_line_number: 6
       parent_content: span.setAttribute("current-user", currentUser.emailAddress)
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_third_parties_open_telemetry
-      rule_description: Sensitive data sent to Open Telemetry detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_open_telemetry
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_third_parties_open_telemetry
+        description: Sensitive data sent to Open Telemetry detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_open_telemetry
       line_number: 11
       filename: datatype_in_set_attribute.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/third_parties/open_telemetry/.snapshots/TestJavascriptOpenTelemetry--datatype_in_set_status.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/open_telemetry/.snapshots/TestJavascriptOpenTelemetry--datatype_in_set_status.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_third_parties_open_telemetry
-      rule_description: Sensitive data sent to Open Telemetry detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_open_telemetry
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_third_parties_open_telemetry
+        description: Sensitive data sent to Open Telemetry detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_open_telemetry
       line_number: 9
       filename: datatype_in_set_status.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/third_parties/rollbar.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/rollbar.yml
@@ -38,7 +38,6 @@ metadata:
     ## Resources
     Coming soon.
     -->
-  dsr_id: DSR-1
   cwe_id:
     - 201
   id: "javascript_rollbar"

--- a/pkg/commands/process/settings/rules/javascript/third_parties/rollbar/.snapshots/TestJavascriptRollbar--browser_unsecure.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/rollbar/.snapshots/TestJavascriptRollbar--browser_unsecure.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_rollbar
-      rule_description: Sensitive data sent to Rollbar detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_rollbar
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_rollbar
+        description: Sensitive data sent to Rollbar detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_rollbar
       line_number: 1
       filename: browser_unsecure.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/third_parties/segment.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/segment.yml
@@ -43,7 +43,6 @@ metadata:
     ## Resources
     - [Segment Node.js docs](https://segment.com/docs/connections/sources/catalog/libraries/server/node/)
     - [Segment JavaScript docs](https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/)
-  dsr_id: DSR-1
   cwe_id:
     - 201
   associated_recipe: Segment

--- a/pkg/commands/process/settings/rules/javascript/third_parties/segment/.snapshots/TestJavascriptSegmentDataflow--datatype_in_alias.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/segment/.snapshots/TestJavascriptSegmentDataflow--datatype_in_alias.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_third_parties_segment
-      rule_description: Sensitive data sent to Segment detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_segment
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_third_parties_segment
+        description: Sensitive data sent to Segment detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_segment
       line_number: 8
       filename: datatype_in_alias.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/third_parties/segment/.snapshots/TestJavascriptSegmentDataflow--datatype_in_group.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/segment/.snapshots/TestJavascriptSegmentDataflow--datatype_in_group.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_third_parties_segment
-      rule_description: Sensitive data sent to Segment detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_segment
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_third_parties_segment
+        description: Sensitive data sent to Segment detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_segment
       line_number: 8
       filename: datatype_in_group.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/third_parties/segment/.snapshots/TestJavascriptSegmentDataflow--datatype_in_identify.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/segment/.snapshots/TestJavascriptSegmentDataflow--datatype_in_identify.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_third_parties_segment
-      rule_description: Sensitive data sent to Segment detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_segment
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_third_parties_segment
+        description: Sensitive data sent to Segment detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_segment
       line_number: 8
       filename: datatype_in_identify.js
       category_groups:
@@ -18,10 +20,12 @@ critical:
             friends: user.friendCount
           }
         })
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_third_parties_segment
-      rule_description: Sensitive data sent to Segment detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_segment
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_third_parties_segment
+        description: Sensitive data sent to Segment detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_segment
       line_number: 9
       filename: datatype_in_identify.js
       category_groups:
@@ -37,10 +41,12 @@ critical:
             friends: user.friendCount
           }
         })
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_third_parties_segment
-      rule_description: Sensitive data sent to Segment detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_segment
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_third_parties_segment
+        description: Sensitive data sent to Segment detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_segment
       line_number: 11
       filename: datatype_in_identify.js
       category_groups:
@@ -56,10 +62,12 @@ critical:
             friends: user.friendCount
           }
         })
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_third_parties_segment
-      rule_description: Sensitive data sent to Segment detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_segment
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_third_parties_segment
+        description: Sensitive data sent to Segment detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_segment
       line_number: 18
       filename: datatype_in_identify.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/third_parties/segment/.snapshots/TestJavascriptSegmentDataflow--datatype_in_page.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/segment/.snapshots/TestJavascriptSegmentDataflow--datatype_in_page.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_third_parties_segment
-      rule_description: Sensitive data sent to Segment detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_segment
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_third_parties_segment
+        description: Sensitive data sent to Segment detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_segment
       line_number: 10
       filename: datatype_in_page.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/third_parties/segment/.snapshots/TestJavascriptSegmentDataflow--datatype_in_track.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/segment/.snapshots/TestJavascriptSegmentDataflow--datatype_in_track.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_third_parties_segment
-      rule_description: Sensitive data sent to Segment detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_segment
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_third_parties_segment
+        description: Sensitive data sent to Segment detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_segment
       line_number: 8
       filename: datatype_in_track.js
       category_groups:
@@ -15,10 +17,12 @@ critical:
           userId: user.id,
           userIpAddr: user.ip_address,
         })
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_third_parties_segment
-      rule_description: Sensitive data sent to Segment detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_segment
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_third_parties_segment
+        description: Sensitive data sent to Segment detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_segment
       line_number: 17
       filename: datatype_in_track.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/third_parties/sentry.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/sentry.yml
@@ -49,7 +49,6 @@ metadata:
 
     ## Resources
     - [Sentry Docs](https://docs.sentry.io/)
-  dsr_id: DSR-1
   cwe_id:
     - 201
   associated_recipe: Sentry

--- a/pkg/commands/process/settings/rules/javascript/third_parties/sentry/.snapshots/TestJavascriptThirdPartySentry--javascript_add_breadcrumb.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/sentry/.snapshots/TestJavascriptThirdPartySentry--javascript_add_breadcrumb.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_third_parties_sentry
-      rule_description: Sensitive data sent to Sentry detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_sentry
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_third_parties_sentry
+        description: Sensitive data sent to Sentry detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_sentry
       line_number: 2
       filename: javascript_add_breadcrumb.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/third_parties/sentry/.snapshots/TestJavascriptThirdPartySentry--javascript_capture_event.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/sentry/.snapshots/TestJavascriptThirdPartySentry--javascript_capture_event.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_third_parties_sentry
-      rule_description: Sensitive data sent to Sentry detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_sentry
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_third_parties_sentry
+        description: Sensitive data sent to Sentry detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_sentry
       line_number: 2
       filename: javascript_capture_event.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/third_parties/sentry/.snapshots/TestJavascriptThirdPartySentry--javascript_capture_exception.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/sentry/.snapshots/TestJavascriptThirdPartySentry--javascript_capture_exception.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_third_parties_sentry
-      rule_description: Sensitive data sent to Sentry detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_sentry
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_third_parties_sentry
+        description: Sensitive data sent to Sentry detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_sentry
       line_number: 2
       filename: javascript_capture_exception.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/third_parties/sentry/.snapshots/TestJavascriptThirdPartySentry--javascript_capture_message.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/sentry/.snapshots/TestJavascriptThirdPartySentry--javascript_capture_message.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_third_parties_sentry
-      rule_description: Sensitive data sent to Sentry detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_sentry
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_third_parties_sentry
+        description: Sensitive data sent to Sentry detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_sentry
       line_number: 1
       filename: javascript_capture_message.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/third_parties/sentry/.snapshots/TestJavascriptThirdPartySentry--javascript_configure_scope_set_extra.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/sentry/.snapshots/TestJavascriptThirdPartySentry--javascript_configure_scope_set_extra.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_third_parties_sentry
-      rule_description: Sensitive data sent to Sentry detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_sentry
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_third_parties_sentry
+        description: Sensitive data sent to Sentry detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_sentry
       line_number: 2
       filename: javascript_configure_scope_set_extra.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/third_parties/sentry/.snapshots/TestJavascriptThirdPartySentry--javascript_configure_scope_set_tag.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/sentry/.snapshots/TestJavascriptThirdPartySentry--javascript_configure_scope_set_tag.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_third_parties_sentry
-      rule_description: Sensitive data sent to Sentry detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_sentry
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_third_parties_sentry
+        description: Sensitive data sent to Sentry detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_sentry
       line_number: 2
       filename: javascript_configure_scope_set_tag.js
       category_groups:

--- a/pkg/commands/process/settings/rules/javascript/third_parties/sentry/.snapshots/TestJavascriptThirdPartySentry--javascript_configure_scope_set_user.yml
+++ b/pkg/commands/process/settings/rules/javascript/third_parties/sentry/.snapshots/TestJavascriptThirdPartySentry--javascript_configure_scope_set_user.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: javascript_third_parties_sentry
-      rule_description: Sensitive data sent to Sentry detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_sentry
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_third_parties_sentry
+        description: Sensitive data sent to Sentry detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_sentry
       line_number: 2
       filename: javascript_configure_scope_set_user.js
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/lang/cookies.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/cookies.yml
@@ -56,7 +56,6 @@ metadata:
 
     - Cookie object documentation: [ActionDispatch::Cookies](https://edgeapi.rubyonrails.org/classes/ActionDispatch/Cookies.html)
     - [Demystifying cookie security in rails 6](https://dev.to/ayushn21/demystifying-cookie-security-in-rails-6-1j2f#:~:text=Rails%20provides%20a%20special%20kind,data%20in%20the%20session%20cookie)
-  dsr_id: DSR-3
   cwe_id:
     - 315
     - 539

--- a/pkg/commands/process/settings/rules/ruby/lang/cookies/.snapshots/TestRubyLangCookies--datatype_in_signed_cookies.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/cookies/.snapshots/TestRubyLangCookies--datatype_in_signed_cookies.yml
@@ -1,18 +1,24 @@
 critical:
-    - rule_dsrid: DSR-3
-      rule_display_id: ruby_lang_cookies
-      rule_description: Sensitive data stored in a cookie detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_cookies
+    - rule:
+        cwe_ids:
+            - "315"
+            - "539"
+        id: ruby_lang_cookies
+        description: Sensitive data stored in a cookie detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_cookies
       line_number: 1
       filename: datatype_in_signed_cookies.rb
       category_groups:
         - PII
       parent_line_number: 1
       parent_content: cookies.signed[:info] = user.email
-    - rule_dsrid: DSR-3
-      rule_display_id: ruby_lang_cookies
-      rule_description: Sensitive data stored in a cookie detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_cookies
+    - rule:
+        cwe_ids:
+            - "315"
+            - "539"
+        id: ruby_lang_cookies
+        description: Sensitive data stored in a cookie detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_cookies
       line_number: 2
       filename: datatype_in_signed_cookies.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/lang/cookies/.snapshots/TestRubyLangCookies--datatype_object_in_cookie.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/cookies/.snapshots/TestRubyLangCookies--datatype_object_in_cookie.yml
@@ -1,18 +1,24 @@
 critical:
-    - rule_dsrid: DSR-3
-      rule_display_id: ruby_lang_cookies
-      rule_description: Sensitive data stored in a cookie detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_cookies
+    - rule:
+        cwe_ids:
+            - "315"
+            - "539"
+        id: ruby_lang_cookies
+        description: Sensitive data stored in a cookie detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_cookies
       line_number: 2
       filename: datatype_object_in_cookie.rb
       category_groups:
         - PII
       parent_line_number: 5
       parent_content: 'cookies[:login] = { value: user.to_json, expires: 1.hour, secure: true }'
-    - rule_dsrid: DSR-3
-      rule_display_id: ruby_lang_cookies
-      rule_description: Sensitive data stored in a cookie detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_cookies
+    - rule:
+        cwe_ids:
+            - "315"
+            - "539"
+        id: ruby_lang_cookies
+        description: Sensitive data stored in a cookie detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_cookies
       line_number: 3
       filename: datatype_object_in_cookie.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/lang/deserialization_of_user_input.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/deserialization_of_user_input.yml
@@ -52,7 +52,6 @@ metadata:
     ## Resources
     Coming soon.
     -->
-  dsr_id: DSR-? # FIXME
   cwe_id:
     - 502
   id: ruby_lang_deserialization_of_user_input

--- a/pkg/commands/process/settings/rules/ruby/lang/deserialization_of_user_input/.snapshots/TestRubyLangDeserializationOfUserInput--unsafe_event.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/deserialization_of_user_input/.snapshots/TestRubyLangDeserializationOfUserInput--unsafe_event.yml
@@ -1,66 +1,82 @@
 low:
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: User input detected in an unsafe deserialization method.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
+    - rule:
+        cwe_ids:
+            - "502"
+        id: ruby_lang_deserialization_of_user_input
+        description: User input detected in an unsafe deserialization method.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 2
       filename: unsafe_event.rb
       parent_line_number: 2
       parent_content: YAML.load(event["oops"])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: User input detected in an unsafe deserialization method.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
+    - rule:
+        cwe_ids:
+            - "502"
+        id: ruby_lang_deserialization_of_user_input
+        description: User input detected in an unsafe deserialization method.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 4
       filename: unsafe_event.rb
       parent_line_number: 4
       parent_content: Psych.load(event["oops"])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: User input detected in an unsafe deserialization method.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
+    - rule:
+        cwe_ids:
+            - "502"
+        id: ruby_lang_deserialization_of_user_input
+        description: User input detected in an unsafe deserialization method.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 6
       filename: unsafe_event.rb
       parent_line_number: 6
       parent_content: Syck.load(event["oops"])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: User input detected in an unsafe deserialization method.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
+    - rule:
+        cwe_ids:
+            - "502"
+        id: ruby_lang_deserialization_of_user_input
+        description: User input detected in an unsafe deserialization method.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 8
       filename: unsafe_event.rb
       parent_line_number: 8
       parent_content: JSON.load(event["oops"])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: User input detected in an unsafe deserialization method.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
+    - rule:
+        cwe_ids:
+            - "502"
+        id: ruby_lang_deserialization_of_user_input
+        description: User input detected in an unsafe deserialization method.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 10
       filename: unsafe_event.rb
       parent_line_number: 10
       parent_content: Oj.load(event["oops"])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: User input detected in an unsafe deserialization method.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
+    - rule:
+        cwe_ids:
+            - "502"
+        id: ruby_lang_deserialization_of_user_input
+        description: User input detected in an unsafe deserialization method.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 11
       filename: unsafe_event.rb
       parent_line_number: 11
       parent_content: |-
         Oj.object_load(event["oops"]) do |json|
           end
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: User input detected in an unsafe deserialization method.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
+    - rule:
+        cwe_ids:
+            - "502"
+        id: ruby_lang_deserialization_of_user_input
+        description: User input detected in an unsafe deserialization method.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 14
       filename: unsafe_event.rb
       parent_line_number: 14
       parent_content: Marshal.load(event["oops"])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: User input detected in an unsafe deserialization method.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
+    - rule:
+        cwe_ids:
+            - "502"
+        id: ruby_lang_deserialization_of_user_input
+        description: User input detected in an unsafe deserialization method.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 15
       filename: unsafe_event.rb
       parent_line_number: 15

--- a/pkg/commands/process/settings/rules/ruby/lang/deserialization_of_user_input/.snapshots/TestRubyLangDeserializationOfUserInput--unsafe_params.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/deserialization_of_user_input/.snapshots/TestRubyLangDeserializationOfUserInput--unsafe_params.yml
@@ -1,66 +1,82 @@
 low:
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: User input detected in an unsafe deserialization method.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
+    - rule:
+        cwe_ids:
+            - "502"
+        id: ruby_lang_deserialization_of_user_input
+        description: User input detected in an unsafe deserialization method.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 1
       filename: unsafe_params.rb
       parent_line_number: 1
       parent_content: YAML.load(params[:oops])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: User input detected in an unsafe deserialization method.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
+    - rule:
+        cwe_ids:
+            - "502"
+        id: ruby_lang_deserialization_of_user_input
+        description: User input detected in an unsafe deserialization method.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 3
       filename: unsafe_params.rb
       parent_line_number: 3
       parent_content: Psych.load(params[:oops])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: User input detected in an unsafe deserialization method.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
+    - rule:
+        cwe_ids:
+            - "502"
+        id: ruby_lang_deserialization_of_user_input
+        description: User input detected in an unsafe deserialization method.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 5
       filename: unsafe_params.rb
       parent_line_number: 5
       parent_content: Syck.load(params[:oops])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: User input detected in an unsafe deserialization method.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
+    - rule:
+        cwe_ids:
+            - "502"
+        id: ruby_lang_deserialization_of_user_input
+        description: User input detected in an unsafe deserialization method.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 7
       filename: unsafe_params.rb
       parent_line_number: 7
       parent_content: JSON.load(params[:oops])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: User input detected in an unsafe deserialization method.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
+    - rule:
+        cwe_ids:
+            - "502"
+        id: ruby_lang_deserialization_of_user_input
+        description: User input detected in an unsafe deserialization method.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 9
       filename: unsafe_params.rb
       parent_line_number: 9
       parent_content: |-
         Oj.load(params[:oops]) do |json|
         end
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: User input detected in an unsafe deserialization method.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
+    - rule:
+        cwe_ids:
+            - "502"
+        id: ruby_lang_deserialization_of_user_input
+        description: User input detected in an unsafe deserialization method.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 11
       filename: unsafe_params.rb
       parent_line_number: 11
       parent_content: Oj.object_load(params[:oops])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: User input detected in an unsafe deserialization method.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
+    - rule:
+        cwe_ids:
+            - "502"
+        id: ruby_lang_deserialization_of_user_input
+        description: User input detected in an unsafe deserialization method.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 13
       filename: unsafe_params.rb
       parent_line_number: 13
       parent_content: Marshal.load(params[:oops])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: User input detected in an unsafe deserialization method.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
+    - rule:
+        cwe_ids:
+            - "502"
+        id: ruby_lang_deserialization_of_user_input
+        description: User input detected in an unsafe deserialization method.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 14
       filename: unsafe_params.rb
       parent_line_number: 14

--- a/pkg/commands/process/settings/rules/ruby/lang/deserialization_of_user_input/.snapshots/TestRubyLangDeserializationOfUserInput--unsafe_request.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/deserialization_of_user_input/.snapshots/TestRubyLangDeserializationOfUserInput--unsafe_request.yml
@@ -1,66 +1,82 @@
 low:
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: User input detected in an unsafe deserialization method.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
+    - rule:
+        cwe_ids:
+            - "502"
+        id: ruby_lang_deserialization_of_user_input
+        description: User input detected in an unsafe deserialization method.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 1
       filename: unsafe_request.rb
       parent_line_number: 1
       parent_content: YAML.load(request.env[:oops])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: User input detected in an unsafe deserialization method.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
+    - rule:
+        cwe_ids:
+            - "502"
+        id: ruby_lang_deserialization_of_user_input
+        description: User input detected in an unsafe deserialization method.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 3
       filename: unsafe_request.rb
       parent_line_number: 3
       parent_content: Psych.load(request.env[:oops])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: User input detected in an unsafe deserialization method.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
+    - rule:
+        cwe_ids:
+            - "502"
+        id: ruby_lang_deserialization_of_user_input
+        description: User input detected in an unsafe deserialization method.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 5
       filename: unsafe_request.rb
       parent_line_number: 5
       parent_content: Syck.load(request.env[:oops])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: User input detected in an unsafe deserialization method.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
+    - rule:
+        cwe_ids:
+            - "502"
+        id: ruby_lang_deserialization_of_user_input
+        description: User input detected in an unsafe deserialization method.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 7
       filename: unsafe_request.rb
       parent_line_number: 7
       parent_content: JSON.load(request.env[:oops])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: User input detected in an unsafe deserialization method.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
+    - rule:
+        cwe_ids:
+            - "502"
+        id: ruby_lang_deserialization_of_user_input
+        description: User input detected in an unsafe deserialization method.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 9
       filename: unsafe_request.rb
       parent_line_number: 9
       parent_content: Oj.load(request.env[:oops])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: User input detected in an unsafe deserialization method.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
+    - rule:
+        cwe_ids:
+            - "502"
+        id: ruby_lang_deserialization_of_user_input
+        description: User input detected in an unsafe deserialization method.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 10
       filename: unsafe_request.rb
       parent_line_number: 10
       parent_content: |-
         Oj.object_load(request.env[:oops]) do |json|
         end
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: User input detected in an unsafe deserialization method.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
+    - rule:
+        cwe_ids:
+            - "502"
+        id: ruby_lang_deserialization_of_user_input
+        description: User input detected in an unsafe deserialization method.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 13
       filename: unsafe_request.rb
       parent_line_number: 13
       parent_content: Marshal.load(request.env[:oops])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_deserialization_of_user_input
-      rule_description: User input detected in an unsafe deserialization method.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
+    - rule:
+        cwe_ids:
+            - "502"
+        id: ruby_lang_deserialization_of_user_input
+        description: User input detected in an unsafe deserialization method.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_deserialization_of_user_input
       line_number: 14
       filename: unsafe_request.rb
       parent_line_number: 14

--- a/pkg/commands/process/settings/rules/ruby/lang/eval_using_user_input.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/eval_using_user_input.yml
@@ -56,7 +56,6 @@ metadata:
     ## Resources
     Coming soon.
     -->
-  dsr_id: DSR-? # FIXME
   cwe_id:
     - 94
   id: ruby_lang_eval_using_user_input

--- a/pkg/commands/process/settings/rules/ruby/lang/eval_using_user_input/.snapshots/TestRubyLangEvalUsingUserInput--unsafe_event.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/eval_using_user_input/.snapshots/TestRubyLangEvalUsingUserInput--unsafe_event.yml
@@ -1,72 +1,90 @@
 low:
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Potential command injection with user input detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
+    - rule:
+        cwe_ids:
+            - "94"
+        id: ruby_lang_eval_using_user_input
+        description: Potential command injection with user input detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 2
       filename: unsafe_event.rb
       parent_line_number: 2
       parent_content: RubyVM::InstructionSequence.compile(event["oops"])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Potential command injection with user input detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
+    - rule:
+        cwe_ids:
+            - "94"
+        id: ruby_lang_eval_using_user_input
+        description: Potential command injection with user input detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 4
       filename: unsafe_event.rb
       parent_line_number: 4
       parent_content: a.eval(event["oops"], "test")
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Potential command injection with user input detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
+    - rule:
+        cwe_ids:
+            - "94"
+        id: ruby_lang_eval_using_user_input
+        description: Potential command injection with user input detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 6
       filename: unsafe_event.rb
       parent_line_number: 6
       parent_content: a.instance_eval(event["oops"])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Potential command injection with user input detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
+    - rule:
+        cwe_ids:
+            - "94"
+        id: ruby_lang_eval_using_user_input
+        description: Potential command injection with user input detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 8
       filename: unsafe_event.rb
       parent_line_number: 8
       parent_content: a.class_eval(event["oops"])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Potential command injection with user input detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
+    - rule:
+        cwe_ids:
+            - "94"
+        id: ruby_lang_eval_using_user_input
+        description: Potential command injection with user input detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 10
       filename: unsafe_event.rb
       parent_line_number: 10
       parent_content: a.module_eval(event["oops"])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Potential command injection with user input detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
+    - rule:
+        cwe_ids:
+            - "94"
+        id: ruby_lang_eval_using_user_input
+        description: Potential command injection with user input detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 12
       filename: unsafe_event.rb
       parent_line_number: 12
       parent_content: eval(event["oops"])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Potential command injection with user input detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
+    - rule:
+        cwe_ids:
+            - "94"
+        id: ruby_lang_eval_using_user_input
+        description: Potential command injection with user input detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 14
       filename: unsafe_event.rb
       parent_line_number: 14
       parent_content: instance_eval(event["oops"], "test")
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Potential command injection with user input detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
+    - rule:
+        cwe_ids:
+            - "94"
+        id: ruby_lang_eval_using_user_input
+        description: Potential command injection with user input detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 16
       filename: unsafe_event.rb
       parent_line_number: 16
       parent_content: class_eval(event["oops"])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Potential command injection with user input detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
+    - rule:
+        cwe_ids:
+            - "94"
+        id: ruby_lang_eval_using_user_input
+        description: Potential command injection with user input detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 18
       filename: unsafe_event.rb
       parent_line_number: 18

--- a/pkg/commands/process/settings/rules/ruby/lang/eval_using_user_input/.snapshots/TestRubyLangEvalUsingUserInput--unsafe_params.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/eval_using_user_input/.snapshots/TestRubyLangEvalUsingUserInput--unsafe_params.yml
@@ -1,72 +1,90 @@
 low:
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Potential command injection with user input detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
+    - rule:
+        cwe_ids:
+            - "94"
+        id: ruby_lang_eval_using_user_input
+        description: Potential command injection with user input detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 1
       filename: unsafe_params.rb
       parent_line_number: 1
       parent_content: RubyVM::InstructionSequence.compile(params["oops"])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Potential command injection with user input detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
+    - rule:
+        cwe_ids:
+            - "94"
+        id: ruby_lang_eval_using_user_input
+        description: Potential command injection with user input detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 3
       filename: unsafe_params.rb
       parent_line_number: 3
       parent_content: a.eval(params["oops"], "test")
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Potential command injection with user input detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
+    - rule:
+        cwe_ids:
+            - "94"
+        id: ruby_lang_eval_using_user_input
+        description: Potential command injection with user input detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 5
       filename: unsafe_params.rb
       parent_line_number: 5
       parent_content: a.instance_eval(params["oops"])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Potential command injection with user input detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
+    - rule:
+        cwe_ids:
+            - "94"
+        id: ruby_lang_eval_using_user_input
+        description: Potential command injection with user input detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 7
       filename: unsafe_params.rb
       parent_line_number: 7
       parent_content: a.class_eval(params["oops"])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Potential command injection with user input detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
+    - rule:
+        cwe_ids:
+            - "94"
+        id: ruby_lang_eval_using_user_input
+        description: Potential command injection with user input detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 9
       filename: unsafe_params.rb
       parent_line_number: 9
       parent_content: a.module_eval(params["oops"])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Potential command injection with user input detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
+    - rule:
+        cwe_ids:
+            - "94"
+        id: ruby_lang_eval_using_user_input
+        description: Potential command injection with user input detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 11
       filename: unsafe_params.rb
       parent_line_number: 11
       parent_content: eval(params["oops"])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Potential command injection with user input detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
+    - rule:
+        cwe_ids:
+            - "94"
+        id: ruby_lang_eval_using_user_input
+        description: Potential command injection with user input detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 13
       filename: unsafe_params.rb
       parent_line_number: 13
       parent_content: instance_eval(params["oops"], "test")
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Potential command injection with user input detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
+    - rule:
+        cwe_ids:
+            - "94"
+        id: ruby_lang_eval_using_user_input
+        description: Potential command injection with user input detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 15
       filename: unsafe_params.rb
       parent_line_number: 15
       parent_content: class_eval(params["oops"])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Potential command injection with user input detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
+    - rule:
+        cwe_ids:
+            - "94"
+        id: ruby_lang_eval_using_user_input
+        description: Potential command injection with user input detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 17
       filename: unsafe_params.rb
       parent_line_number: 17

--- a/pkg/commands/process/settings/rules/ruby/lang/eval_using_user_input/.snapshots/TestRubyLangEvalUsingUserInput--unsafe_request.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/eval_using_user_input/.snapshots/TestRubyLangEvalUsingUserInput--unsafe_request.yml
@@ -1,72 +1,90 @@
 low:
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Potential command injection with user input detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
+    - rule:
+        cwe_ids:
+            - "94"
+        id: ruby_lang_eval_using_user_input
+        description: Potential command injection with user input detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 1
       filename: unsafe_request.rb
       parent_line_number: 1
       parent_content: RubyVM::InstructionSequence.compile(request.env["oops"])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Potential command injection with user input detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
+    - rule:
+        cwe_ids:
+            - "94"
+        id: ruby_lang_eval_using_user_input
+        description: Potential command injection with user input detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 3
       filename: unsafe_request.rb
       parent_line_number: 3
       parent_content: a.eval(request.env["oops"], "test")
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Potential command injection with user input detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
+    - rule:
+        cwe_ids:
+            - "94"
+        id: ruby_lang_eval_using_user_input
+        description: Potential command injection with user input detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 5
       filename: unsafe_request.rb
       parent_line_number: 5
       parent_content: a.instance_eval(request.env["oops"])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Potential command injection with user input detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
+    - rule:
+        cwe_ids:
+            - "94"
+        id: ruby_lang_eval_using_user_input
+        description: Potential command injection with user input detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 7
       filename: unsafe_request.rb
       parent_line_number: 7
       parent_content: a.class_eval(request.env["oops"])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Potential command injection with user input detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
+    - rule:
+        cwe_ids:
+            - "94"
+        id: ruby_lang_eval_using_user_input
+        description: Potential command injection with user input detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 9
       filename: unsafe_request.rb
       parent_line_number: 9
       parent_content: a.module_eval(request.env["oops"])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Potential command injection with user input detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
+    - rule:
+        cwe_ids:
+            - "94"
+        id: ruby_lang_eval_using_user_input
+        description: Potential command injection with user input detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 11
       filename: unsafe_request.rb
       parent_line_number: 11
       parent_content: eval(request.env["oops"])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Potential command injection with user input detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
+    - rule:
+        cwe_ids:
+            - "94"
+        id: ruby_lang_eval_using_user_input
+        description: Potential command injection with user input detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 13
       filename: unsafe_request.rb
       parent_line_number: 13
       parent_content: instance_eval(request.env["oops"], "test")
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Potential command injection with user input detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
+    - rule:
+        cwe_ids:
+            - "94"
+        id: ruby_lang_eval_using_user_input
+        description: Potential command injection with user input detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 15
       filename: unsafe_request.rb
       parent_line_number: 15
       parent_content: class_eval(request.env["oops"])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_eval_using_user_input
-      rule_description: Potential command injection with user input detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
+    - rule:
+        cwe_ids:
+            - "94"
+        id: ruby_lang_eval_using_user_input
+        description: Potential command injection with user input detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_eval_using_user_input
       line_number: 17
       filename: unsafe_request.rb
       parent_line_number: 17

--- a/pkg/commands/process/settings/rules/ruby/lang/exception.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/exception.yml
@@ -38,7 +38,6 @@ metadata:
     ## Resources
     Coming soon.
     -->
-  dsr_id: DSR-5
   cwe_id:
     - 210
   id: ruby_lang_exception

--- a/pkg/commands/process/settings/rules/ruby/lang/exception/.snapshots/TestRubyLangException--datatype_leak.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/exception/.snapshots/TestRubyLangException--datatype_leak.yml
@@ -1,18 +1,22 @@
 critical:
-    - rule_dsrid: DSR-5
-      rule_display_id: ruby_lang_exception
-      rule_description: Sensitive data in a exception message detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_exception
+    - rule:
+        cwe_ids:
+            - "210"
+        id: ruby_lang_exception
+        description: Sensitive data in a exception message detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_exception
       line_number: 1
       filename: datatype_leak.rb
       category_groups:
         - PII
       parent_line_number: 1
       parent_content: raise CustomException.new(user.email)
-    - rule_dsrid: DSR-5
-      rule_display_id: ruby_lang_exception
-      rule_description: Sensitive data in a exception message detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_exception
+    - rule:
+        cwe_ids:
+            - "210"
+        id: ruby_lang_exception
+        description: Sensitive data in a exception message detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_exception
       line_number: 2
       filename: datatype_leak.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/lang/file_generation.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/file_generation.yml
@@ -70,7 +70,6 @@ metadata:
     ## Resources
     Coming soon.
     -->
-  dsr_id: DSR-4
   cwe_id:
     - 532
     - 313

--- a/pkg/commands/process/settings/rules/ruby/lang/file_generation/.snapshots/TestRubyLangFileGeneration--datatype_in_csv_generate.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/file_generation/.snapshots/TestRubyLangFileGeneration--datatype_in_csv_generate.yml
@@ -1,8 +1,11 @@
 critical:
-    - rule_dsrid: DSR-4
-      rule_display_id: ruby_lang_file_generation
-      rule_description: Sensitive data detected as part of a dynamic file generation.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_file_generation
+    - rule:
+        cwe_ids:
+            - "532"
+            - "313"
+        id: ruby_lang_file_generation
+        description: Sensitive data detected as part of a dynamic file generation.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_file_generation
       line_number: 5
       filename: datatype_in_csv_generate.rb
       category_groups:
@@ -14,10 +17,13 @@ critical:
         			user.first_name,
         			user.last_name
         		]
-    - rule_dsrid: DSR-4
-      rule_display_id: ruby_lang_file_generation
-      rule_description: Sensitive data detected as part of a dynamic file generation.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_file_generation
+    - rule:
+        cwe_ids:
+            - "532"
+            - "313"
+        id: ruby_lang_file_generation
+        description: Sensitive data detected as part of a dynamic file generation.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_file_generation
       line_number: 6
       filename: datatype_in_csv_generate.rb
       category_groups:
@@ -29,10 +35,13 @@ critical:
         			user.first_name,
         			user.last_name
         		]
-    - rule_dsrid: DSR-4
-      rule_display_id: ruby_lang_file_generation
-      rule_description: Sensitive data detected as part of a dynamic file generation.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_file_generation
+    - rule:
+        cwe_ids:
+            - "532"
+            - "313"
+        id: ruby_lang_file_generation
+        description: Sensitive data detected as part of a dynamic file generation.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_file_generation
       line_number: 7
       filename: datatype_in_csv_generate.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/lang/file_generation/.snapshots/TestRubyLangFileGeneration--datatype_in_csv_open.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/file_generation/.snapshots/TestRubyLangFileGeneration--datatype_in_csv_open.yml
@@ -1,8 +1,11 @@
 critical:
-    - rule_dsrid: DSR-4
-      rule_display_id: ruby_lang_file_generation
-      rule_description: Sensitive data detected as part of a dynamic file generation.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_file_generation
+    - rule:
+        cwe_ids:
+            - "532"
+            - "313"
+        id: ruby_lang_file_generation
+        description: Sensitive data detected as part of a dynamic file generation.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_file_generation
       line_number: 5
       filename: datatype_in_csv_open.rb
       category_groups:
@@ -14,10 +17,13 @@ critical:
         			user.first_name,
         			user.last_name
         		]
-    - rule_dsrid: DSR-4
-      rule_display_id: ruby_lang_file_generation
-      rule_description: Sensitive data detected as part of a dynamic file generation.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_file_generation
+    - rule:
+        cwe_ids:
+            - "532"
+            - "313"
+        id: ruby_lang_file_generation
+        description: Sensitive data detected as part of a dynamic file generation.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_file_generation
       line_number: 6
       filename: datatype_in_csv_open.rb
       category_groups:
@@ -29,10 +35,13 @@ critical:
         			user.first_name,
         			user.last_name
         		]
-    - rule_dsrid: DSR-4
-      rule_display_id: ruby_lang_file_generation
-      rule_description: Sensitive data detected as part of a dynamic file generation.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_file_generation
+    - rule:
+        cwe_ids:
+            - "532"
+            - "313"
+        id: ruby_lang_file_generation
+        description: Sensitive data detected as part of a dynamic file generation.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_file_generation
       line_number: 7
       filename: datatype_in_csv_open.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/lang/file_generation/.snapshots/TestRubyLangFileGeneration--datatype_in_file_open.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/file_generation/.snapshots/TestRubyLangFileGeneration--datatype_in_file_open.yml
@@ -1,18 +1,24 @@
 critical:
-    - rule_dsrid: DSR-4
-      rule_display_id: ruby_lang_file_generation
-      rule_description: Sensitive data detected as part of a dynamic file generation.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_file_generation
+    - rule:
+        cwe_ids:
+            - "532"
+            - "313"
+        id: ruby_lang_file_generation
+        description: Sensitive data detected as part of a dynamic file generation.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_file_generation
       line_number: 1
       filename: datatype_in_file_open.rb
       category_groups:
         - PII
       parent_line_number: 1
       parent_content: 'f.write "#{Time.now} - User #{user.email} logged in\n"'
-    - rule_dsrid: DSR-4
-      rule_display_id: ruby_lang_file_generation
-      rule_description: Sensitive data detected as part of a dynamic file generation.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_file_generation
+    - rule:
+        cwe_ids:
+            - "532"
+            - "313"
+        id: ruby_lang_file_generation
+        description: Sensitive data detected as part of a dynamic file generation.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_file_generation
       line_number: 5
       filename: datatype_in_file_open.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/lang/file_generation/.snapshots/TestRubyLangFileGeneration--datatype_in_io_sysopen.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/file_generation/.snapshots/TestRubyLangFileGeneration--datatype_in_io_sysopen.yml
@@ -1,8 +1,11 @@
 critical:
-    - rule_dsrid: DSR-4
-      rule_display_id: ruby_lang_file_generation
-      rule_description: Sensitive data detected as part of a dynamic file generation.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_file_generation
+    - rule:
+        cwe_ids:
+            - "532"
+            - "313"
+        id: ruby_lang_file_generation
+        description: Sensitive data detected as part of a dynamic file generation.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_file_generation
       line_number: 3
       filename: datatype_in_io_sysopen.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/lang/ftp_using_user_input.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/ftp_using_user_input.yml
@@ -51,7 +51,6 @@ metadata:
     ## Resources
     Coming soon.
     -->
-  dsr_id: DSR-? # FIXME
   cwe_id:
     - 22
   id: ruby_lang_ftp_using_user_input

--- a/pkg/commands/process/settings/rules/ruby/lang/ftp_using_user_input/.snapshots/TestRubyLangFtpUsingUserInput--ok_not_unsafe.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/ftp_using_user_input/.snapshots/TestRubyLangFtpUsingUserInput--ok_not_unsafe.yml
@@ -1,16 +1,20 @@
 low:
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_lang_insecure_ftp
-      rule_description: Communication with an unsecure FTP server detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_insecure_ftp
+    - rule:
+        cwe_ids:
+            - "319"
+        id: ruby_lang_insecure_ftp
+        description: Communication with an unsecure FTP server detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_insecure_ftp
       line_number: 1
       filename: ok_not_unsafe.rb
       parent_line_number: 1
       parent_content: Net::FTP.new(x)
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_lang_insecure_ftp
-      rule_description: Communication with an unsecure FTP server detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_insecure_ftp
+    - rule:
+        cwe_ids:
+            - "319"
+        id: ruby_lang_insecure_ftp
+        description: Communication with an unsecure FTP server detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_insecure_ftp
       line_number: 3
       filename: ok_not_unsafe.rb
       parent_line_number: 3
@@ -18,10 +22,12 @@ low:
         Net::FTP.open("example.com", username: "user") do
 
         end
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_lang_insecure_ftp
-      rule_description: Communication with an unsecure FTP server detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_insecure_ftp
+    - rule:
+        cwe_ids:
+            - "319"
+        id: ruby_lang_insecure_ftp
+        description: Communication with an unsecure FTP server detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_insecure_ftp
       line_number: 8
       filename: ok_not_unsafe.rb
       parent_line_number: 8

--- a/pkg/commands/process/settings/rules/ruby/lang/ftp_using_user_input/.snapshots/TestRubyLangFtpUsingUserInput--unsafe.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/ftp_using_user_input/.snapshots/TestRubyLangFtpUsingUserInput--unsafe.yml
@@ -1,16 +1,20 @@
 low:
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_ftp_using_user_input
-      rule_description: Do not use user input to form file paths.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_ftp_using_user_input
+    - rule:
+        cwe_ids:
+            - "22"
+        id: ruby_lang_ftp_using_user_input
+        description: Do not use user input to form file paths.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_ftp_using_user_input
       line_number: 1
       filename: unsafe.rb
       parent_line_number: 1
       parent_content: Net::FTP.new(params[:oops])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_ftp_using_user_input
-      rule_description: Do not use user input to form file paths.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_ftp_using_user_input
+    - rule:
+        cwe_ids:
+            - "22"
+        id: ruby_lang_ftp_using_user_input
+        description: Do not use user input to form file paths.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_ftp_using_user_input
       line_number: 3
       filename: unsafe.rb
       parent_line_number: 3
@@ -18,26 +22,32 @@ low:
         Net::FTP.open("example.com", username: params[:user]) do
 
         end
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_ftp_using_user_input
-      rule_description: Do not use user input to form file paths.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_ftp_using_user_input
+    - rule:
+        cwe_ids:
+            - "22"
+        id: ruby_lang_ftp_using_user_input
+        description: Do not use user input to form file paths.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_ftp_using_user_input
       line_number: 9
       filename: unsafe.rb
       parent_line_number: 9
       parent_content: ftp.puttextfile("local.txt", event["filename"])
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_lang_insecure_ftp
-      rule_description: Communication with an unsecure FTP server detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_insecure_ftp
+    - rule:
+        cwe_ids:
+            - "319"
+        id: ruby_lang_insecure_ftp
+        description: Communication with an unsecure FTP server detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_insecure_ftp
       line_number: 1
       filename: unsafe.rb
       parent_line_number: 1
       parent_content: Net::FTP.new(params[:oops])
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_lang_insecure_ftp
-      rule_description: Communication with an unsecure FTP server detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_insecure_ftp
+    - rule:
+        cwe_ids:
+            - "319"
+        id: ruby_lang_insecure_ftp
+        description: Communication with an unsecure FTP server detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_insecure_ftp
       line_number: 3
       filename: unsafe.rb
       parent_line_number: 3
@@ -45,10 +55,12 @@ low:
         Net::FTP.open("example.com", username: params[:user]) do
 
         end
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_lang_insecure_ftp
-      rule_description: Communication with an unsecure FTP server detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_insecure_ftp
+    - rule:
+        cwe_ids:
+            - "319"
+        id: ruby_lang_insecure_ftp
+        description: Communication with an unsecure FTP server detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_insecure_ftp
       line_number: 8
       filename: unsafe.rb
       parent_line_number: 8

--- a/pkg/commands/process/settings/rules/ruby/lang/http_get_params.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/http_get_params.yml
@@ -77,7 +77,6 @@ metadata:
     ## Resources
     Coming soon.
     -->
-  dsr_id: DSR-2
   cwe_id:
     - 598
   id: ruby_lang_http_get_params

--- a/pkg/commands/process/settings/rules/ruby/lang/http_get_params/.snapshots/TestRubyLangHttpGetParams--datatype_in_param_hash.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/http_get_params/.snapshots/TestRubyLangHttpGetParams--datatype_in_param_hash.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_lang_http_get_params
-      rule_description: Sensitive data communicated through GET parameters detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_get_params
+    - rule:
+        cwe_ids:
+            - "598"
+        id: ruby_lang_http_get_params
+        description: Sensitive data communicated through GET parameters detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_get_params
       line_number: 1
       filename: datatype_in_param_hash.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/lang/http_get_params/.snapshots/TestRubyLangHttpGetParams--datatype_in_params.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/http_get_params/.snapshots/TestRubyLangHttpGetParams--datatype_in_params.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_lang_http_get_params
-      rule_description: Sensitive data communicated through GET parameters detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_get_params
+    - rule:
+        cwe_ids:
+            - "598"
+        id: ruby_lang_http_get_params
+        description: Sensitive data communicated through GET parameters detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_get_params
       line_number: 1
       filename: datatype_in_params.rb
       category_groups:
@@ -10,10 +12,12 @@ critical:
         - Personal Data (Sensitive)
       parent_line_number: 1
       parent_content: URI("https://my.api.com/users/search?ethnic_origin=#{user.ethnic_origin}")
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_lang_http_get_params
-      rule_description: Sensitive data communicated through GET parameters detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_get_params
+    - rule:
+        cwe_ids:
+            - "598"
+        id: ruby_lang_http_get_params
+        description: Sensitive data communicated through GET parameters detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_get_params
       line_number: 3
       filename: datatype_in_params.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/lang/http_insecure.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/http_insecure.yml
@@ -192,7 +192,6 @@ metadata:
     ## Resources
     Coming soon.
     -->
-  dsr_id: DSR-2
   cwe_id:
     - 319
   id: ruby_lang_http_insecure

--- a/pkg/commands/process/settings/rules/ruby/lang/http_insecure/.snapshots/TestRubyLangHttpInsecure--insecure_curb.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/http_insecure/.snapshots/TestRubyLangHttpInsecure--insecure_curb.yml
@@ -1,66 +1,82 @@
 low:
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_lang_http_insecure
-      rule_description: Connection through an unsecure HTTP communication detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
+    - rule:
+        cwe_ids:
+            - "319"
+        id: ruby_lang_http_insecure
+        description: Connection through an unsecure HTTP communication detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
       line_number: 3
       filename: insecure_curb.rb
       parent_line_number: 3
       parent_content: |-
         Curl.http("GET", "http://my.api.com/users/search", nil) do
         end
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_lang_http_insecure
-      rule_description: Connection through an unsecure HTTP communication detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
+    - rule:
+        cwe_ids:
+            - "319"
+        id: ruby_lang_http_insecure
+        description: Connection through an unsecure HTTP communication detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
       line_number: 6
       filename: insecure_curb.rb
       parent_line_number: 6
       parent_content: Curl.get("http://my.api.com/users/search") {}
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_lang_http_insecure
-      rule_description: Connection through an unsecure HTTP communication detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
+    - rule:
+        cwe_ids:
+            - "319"
+        id: ruby_lang_http_insecure
+        description: Connection through an unsecure HTTP communication detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
       line_number: 8
       filename: insecure_curb.rb
       parent_line_number: 8
       parent_content: Curl::Easy.perform("http://my.api.com/users/search") {}
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_lang_http_insecure
-      rule_description: Connection through an unsecure HTTP communication detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
+    - rule:
+        cwe_ids:
+            - "319"
+        id: ruby_lang_http_insecure
+        description: Connection through an unsecure HTTP communication detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
       line_number: 10
       filename: insecure_curb.rb
       parent_line_number: 10
       parent_content: Curl::Easy.new("http://my.api.com/users/search") {}
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_lang_http_insecure
-      rule_description: Connection through an unsecure HTTP communication detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
+    - rule:
+        cwe_ids:
+            - "319"
+        id: ruby_lang_http_insecure
+        description: Connection through an unsecure HTTP communication detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
       line_number: 11
       filename: insecure_curb.rb
       parent_line_number: 11
       parent_content: easy.url = "http://my.api.com/customers"
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_lang_http_insecure
-      rule_description: Connection through an unsecure HTTP communication detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
+    - rule:
+        cwe_ids:
+            - "319"
+        id: ruby_lang_http_insecure
+        description: Connection through an unsecure HTTP communication detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
       line_number: 14
       filename: insecure_curb.rb
       parent_line_number: 14
       parent_content: easy2.url = "http://my.api.com/users/search"
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_lang_http_insecure
-      rule_description: Connection through an unsecure HTTP communication detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
+    - rule:
+        cwe_ids:
+            - "319"
+        id: ruby_lang_http_insecure
+        description: Connection through an unsecure HTTP communication detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
       line_number: 16
       filename: insecure_curb.rb
       parent_line_number: 16
       parent_content: Curl::Multi.get(["https://my.api.com/secure", "http://my.api.com/users/search"], {}) {}
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_lang_http_insecure
-      rule_description: Connection through an unsecure HTTP communication detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
+    - rule:
+        cwe_ids:
+            - "319"
+        id: ruby_lang_http_insecure
+        description: Connection through an unsecure HTTP communication detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
       line_number: 18
       filename: insecure_curb.rb
       parent_line_number: 18

--- a/pkg/commands/process/settings/rules/ruby/lang/http_insecure/.snapshots/TestRubyLangHttpInsecure--insecure_excon.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/http_insecure/.snapshots/TestRubyLangHttpInsecure--insecure_excon.yml
@@ -1,16 +1,20 @@
 low:
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_lang_http_insecure
-      rule_description: Connection through an unsecure HTTP communication detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
+    - rule:
+        cwe_ids:
+            - "319"
+        id: ruby_lang_http_insecure
+        description: Connection through an unsecure HTTP communication detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
       line_number: 1
       filename: insecure_excon.rb
       parent_line_number: 1
       parent_content: 'Excon.new("http://my.api.com/insecure", foo: true)'
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_lang_http_insecure
-      rule_description: Connection through an unsecure HTTP communication detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
+    - rule:
+        cwe_ids:
+            - "319"
+        id: ruby_lang_http_insecure
+        description: Connection through an unsecure HTTP communication detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
       line_number: 3
       filename: insecure_excon.rb
       parent_line_number: 3

--- a/pkg/commands/process/settings/rules/ruby/lang/http_insecure/.snapshots/TestRubyLangHttpInsecure--insecure_get.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/http_insecure/.snapshots/TestRubyLangHttpInsecure--insecure_get.yml
@@ -1,8 +1,10 @@
 low:
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_lang_http_insecure
-      rule_description: Connection through an unsecure HTTP communication detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
+    - rule:
+        cwe_ids:
+            - "319"
+        id: ruby_lang_http_insecure
+        description: Connection through an unsecure HTTP communication detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
       line_number: 1
       filename: insecure_get.rb
       parent_line_number: 1

--- a/pkg/commands/process/settings/rules/ruby/lang/http_insecure/.snapshots/TestRubyLangHttpInsecure--insecure_net_http.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/http_insecure/.snapshots/TestRubyLangHttpInsecure--insecure_net_http.yml
@@ -1,26 +1,32 @@
 low:
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_lang_http_insecure
-      rule_description: Connection through an unsecure HTTP communication detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
+    - rule:
+        cwe_ids:
+            - "319"
+        id: ruby_lang_http_insecure
+        description: Connection through an unsecure HTTP communication detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
       line_number: 3
       filename: insecure_net_http.rb
       parent_line_number: 3
       parent_content: Net::HTTP.post_form("http://my.api.com/users/search")
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_lang_http_insecure
-      rule_description: Connection through an unsecure HTTP communication detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
+    - rule:
+        cwe_ids:
+            - "319"
+        id: ruby_lang_http_insecure
+        description: Connection through an unsecure HTTP communication detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
       line_number: 5
       filename: insecure_net_http.rb
       parent_line_number: 5
       parent_content: |-
         Net::HTTP.start("http://my.api.com/users/search") do
         end
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_lang_http_insecure
-      rule_description: Connection through an unsecure HTTP communication detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
+    - rule:
+        cwe_ids:
+            - "319"
+        id: ruby_lang_http_insecure
+        description: Connection through an unsecure HTTP communication detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
       line_number: 8
       filename: insecure_net_http.rb
       parent_line_number: 8

--- a/pkg/commands/process/settings/rules/ruby/lang/http_insecure/.snapshots/TestRubyLangHttpInsecure--insecure_post_form.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/http_insecure/.snapshots/TestRubyLangHttpInsecure--insecure_post_form.yml
@@ -6,8 +6,8 @@ low:
         description: Connection through an unsecure HTTP communication detected.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
       line_number: 1
-      filename: insecure_post.rb
+      filename: insecure_post_form.rb
       parent_line_number: 1
-      parent_content: Faraday.post("http://api.insecure.com")
+      parent_content: Net::HTTP.post_form("http://my.api.com/users/search")
 
 

--- a/pkg/commands/process/settings/rules/ruby/lang/http_insecure/.snapshots/TestRubyLangHttpInsecure--uri_encode_form.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/http_insecure/.snapshots/TestRubyLangHttpInsecure--uri_encode_form.yml
@@ -1,8 +1,10 @@
 low:
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_lang_http_insecure
-      rule_description: Connection through an unsecure HTTP communication detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
+    - rule:
+        cwe_ids:
+            - "319"
+        id: ruby_lang_http_insecure
+        description: Connection through an unsecure HTTP communication detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
       line_number: 1
       filename: uri_encode_form.rb
       parent_line_number: 1

--- a/pkg/commands/process/settings/rules/ruby/lang/http_post_insecure_with_data.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/http_post_insecure_with_data.yml
@@ -68,7 +68,6 @@ metadata:
     ## Resources
     Coming soon.
     -->
-  dsr_id: DSR-2
   cwe_id:
     - 319
   id: ruby_lang_http_post_insecure_with_data

--- a/pkg/commands/process/settings/rules/ruby/lang/http_post_insecure_with_data/.snapshots/TestRubyLangHttpPostInsecureWithData--insecure_post_form_with_datatype.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/http_post_insecure_with_data/.snapshots/TestRubyLangHttpPostInsecureWithData--insecure_post_form_with_datatype.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_lang_http_post_insecure_with_data
-      rule_description: Sensitive data sent through an an unsecure HTTP communication detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_post_insecure_with_data
+    - rule:
+        cwe_ids:
+            - "319"
+        id: ruby_lang_http_post_insecure_with_data
+        description: Sensitive data sent through an an unsecure HTTP communication detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_post_insecure_with_data
       line_number: 1
       filename: insecure_post_form_with_datatype.rb
       category_groups:
@@ -10,10 +12,12 @@ critical:
       parent_line_number: 1
       parent_content: 'Net::HTTP.post_form("http://my.api.com/users/search", email: user.email)'
 low:
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_lang_http_insecure
-      rule_description: Connection through an unsecure HTTP communication detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
+    - rule:
+        cwe_ids:
+            - "319"
+        id: ruby_lang_http_insecure
+        description: Connection through an unsecure HTTP communication detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
       line_number: 1
       filename: insecure_post_form_with_datatype.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/lang/http_post_insecure_with_data/.snapshots/TestRubyLangHttpPostInsecureWithData--insecure_post_with_datatype.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/http_post_insecure_with_data/.snapshots/TestRubyLangHttpPostInsecureWithData--insecure_post_with_datatype.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_lang_http_post_insecure_with_data
-      rule_description: Sensitive data sent through an an unsecure HTTP communication detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_post_insecure_with_data
+    - rule:
+        cwe_ids:
+            - "319"
+        id: ruby_lang_http_post_insecure_with_data
+        description: Sensitive data sent through an an unsecure HTTP communication detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_post_insecure_with_data
       line_number: 1
       filename: insecure_post_with_datatype.rb
       category_groups:
@@ -10,10 +12,12 @@ critical:
       parent_line_number: 1
       parent_content: 'HTTParty.post("http://my.api.com/users/search", body: user.email)'
 low:
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_lang_http_insecure
-      rule_description: Connection through an unsecure HTTP communication detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
+    - rule:
+        cwe_ids:
+            - "319"
+        id: ruby_lang_http_insecure
+        description: Connection through an unsecure HTTP communication detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
       line_number: 1
       filename: insecure_post_with_datatype.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/lang/http_url_using_user_input/.snapshots/TestRubyLangHttpUrlUsingUserInput--ok_not_unsafe.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/http_url_using_user_input/.snapshots/TestRubyLangHttpUrlUsingUserInput--ok_not_unsafe.yml
@@ -1,24 +1,30 @@
 low:
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_lang_http_insecure
-      rule_description: Connection through an unsecure HTTP communication detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
+    - rule:
+        cwe_ids:
+            - "319"
+        id: ruby_lang_http_insecure
+        description: Connection through an unsecure HTTP communication detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
       line_number: 20
       filename: ok_not_unsafe.rb
       parent_line_number: 20
       parent_content: 'Excon.new("http://example.com", path: x)'
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_lang_http_insecure
-      rule_description: Connection through an unsecure HTTP communication detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
+    - rule:
+        cwe_ids:
+            - "319"
+        id: ruby_lang_http_insecure
+        description: Connection through an unsecure HTTP communication detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
       line_number: 34
       filename: ok_not_unsafe.rb
       parent_line_number: 34
       parent_content: 'Excon.post("http://example.com", path: x)'
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_lang_http_insecure
-      rule_description: Connection through an unsecure HTTP communication detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
+    - rule:
+        cwe_ids:
+            - "319"
+        id: ruby_lang_http_insecure
+        description: Connection through an unsecure HTTP communication detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
       line_number: 40
       filename: ok_not_unsafe.rb
       parent_line_number: 40

--- a/pkg/commands/process/settings/rules/ruby/lang/http_url_using_user_input/.snapshots/TestRubyLangHttpUrlUsingUserInput--unsafe_curb.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/http_url_using_user_input/.snapshots/TestRubyLangHttpUrlUsingUserInput--unsafe_curb.yml
@@ -1,66 +1,82 @@
 high:
-    - rule_dsrid: ""
-      rule_display_id: ruby_lang_http_url_using_user_input
-      rule_description: HTTP communication with user-controlled destination detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
+    - rule:
+        cwe_ids:
+            - "918"
+        id: ruby_lang_http_url_using_user_input
+        description: HTTP communication with user-controlled destination detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
       line_number: 3
       filename: unsafe_curb.rb
       parent_line_number: 3
       parent_content: |-
         Curl.http("GET", params[:oops], nil) do
         end
-    - rule_dsrid: ""
-      rule_display_id: ruby_lang_http_url_using_user_input
-      rule_description: HTTP communication with user-controlled destination detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
+    - rule:
+        cwe_ids:
+            - "918"
+        id: ruby_lang_http_url_using_user_input
+        description: HTTP communication with user-controlled destination detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
       line_number: 6
       filename: unsafe_curb.rb
       parent_line_number: 6
       parent_content: Curl.get(params[:oops]) {}
-    - rule_dsrid: ""
-      rule_display_id: ruby_lang_http_url_using_user_input
-      rule_description: HTTP communication with user-controlled destination detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
+    - rule:
+        cwe_ids:
+            - "918"
+        id: ruby_lang_http_url_using_user_input
+        description: HTTP communication with user-controlled destination detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
       line_number: 8
       filename: unsafe_curb.rb
       parent_line_number: 8
       parent_content: Curl::Easy.perform(params[:oops]) {}
-    - rule_dsrid: ""
-      rule_display_id: ruby_lang_http_url_using_user_input
-      rule_description: HTTP communication with user-controlled destination detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
+    - rule:
+        cwe_ids:
+            - "918"
+        id: ruby_lang_http_url_using_user_input
+        description: HTTP communication with user-controlled destination detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
       line_number: 10
       filename: unsafe_curb.rb
       parent_line_number: 10
       parent_content: Curl::Easy.new(params[:oops]) {}
-    - rule_dsrid: ""
-      rule_display_id: ruby_lang_http_url_using_user_input
-      rule_description: HTTP communication with user-controlled destination detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
+    - rule:
+        cwe_ids:
+            - "918"
+        id: ruby_lang_http_url_using_user_input
+        description: HTTP communication with user-controlled destination detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
       line_number: 11
       filename: unsafe_curb.rb
       parent_line_number: 11
       parent_content: easy.url = params[:oops2]
-    - rule_dsrid: ""
-      rule_display_id: ruby_lang_http_url_using_user_input
-      rule_description: HTTP communication with user-controlled destination detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
+    - rule:
+        cwe_ids:
+            - "918"
+        id: ruby_lang_http_url_using_user_input
+        description: HTTP communication with user-controlled destination detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
       line_number: 14
       filename: unsafe_curb.rb
       parent_line_number: 14
       parent_content: easy2.url = params[:oops]
-    - rule_dsrid: ""
-      rule_display_id: ruby_lang_http_url_using_user_input
-      rule_description: HTTP communication with user-controlled destination detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
+    - rule:
+        cwe_ids:
+            - "918"
+        id: ruby_lang_http_url_using_user_input
+        description: HTTP communication with user-controlled destination detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
       line_number: 16
       filename: unsafe_curb.rb
       parent_line_number: 16
       parent_content: Curl::Multi.get(["https://my.api.com/secure", params[:oops]], {}) {}
-    - rule_dsrid: ""
-      rule_display_id: ruby_lang_http_url_using_user_input
-      rule_description: HTTP communication with user-controlled destination detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
+    - rule:
+        cwe_ids:
+            - "918"
+        id: ruby_lang_http_url_using_user_input
+        description: HTTP communication with user-controlled destination detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
       line_number: 18
       filename: unsafe_curb.rb
       parent_line_number: 18

--- a/pkg/commands/process/settings/rules/ruby/lang/http_url_using_user_input/.snapshots/TestRubyLangHttpUrlUsingUserInput--unsafe_excon.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/http_url_using_user_input/.snapshots/TestRubyLangHttpUrlUsingUserInput--unsafe_excon.yml
@@ -1,105 +1,131 @@
 high:
-    - rule_dsrid: ""
-      rule_display_id: ruby_lang_http_url_using_user_input
-      rule_description: HTTP communication with user-controlled destination detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
+    - rule:
+        cwe_ids:
+            - "918"
+        id: ruby_lang_http_url_using_user_input
+        description: HTTP communication with user-controlled destination detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
       line_number: 1
       filename: unsafe_excon.rb
       parent_line_number: 1
       parent_content: 'Excon.new(params[:oops], foo: true)'
-    - rule_dsrid: ""
-      rule_display_id: ruby_lang_http_url_using_user_input
-      rule_description: HTTP communication with user-controlled destination detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
+    - rule:
+        cwe_ids:
+            - "918"
+        id: ruby_lang_http_url_using_user_input
+        description: HTTP communication with user-controlled destination detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
       line_number: 2
       filename: unsafe_excon.rb
       parent_line_number: 2
       parent_content: 'Excon.new("http://example.com", path: params[:oops])'
-    - rule_dsrid: ""
-      rule_display_id: ruby_lang_http_url_using_user_input
-      rule_description: HTTP communication with user-controlled destination detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
+    - rule:
+        cwe_ids:
+            - "918"
+        id: ruby_lang_http_url_using_user_input
+        description: HTTP communication with user-controlled destination detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
       line_number: 4
       filename: unsafe_excon.rb
       parent_line_number: 4
       parent_content: 'Excon::Connection.new(host: params[:oops])'
-    - rule_dsrid: ""
-      rule_display_id: ruby_lang_http_url_using_user_input
-      rule_description: HTTP communication with user-controlled destination detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
+    - rule:
+        cwe_ids:
+            - "918"
+        id: ruby_lang_http_url_using_user_input
+        description: HTTP communication with user-controlled destination detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
       line_number: 5
       filename: unsafe_excon.rb
       parent_line_number: 5
       parent_content: 'Excon::Connection.new(hostname: params[:oops])'
-    - rule_dsrid: ""
-      rule_display_id: ruby_lang_http_url_using_user_input
-      rule_description: HTTP communication with user-controlled destination detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
+    - rule:
+        cwe_ids:
+            - "918"
+        id: ruby_lang_http_url_using_user_input
+        description: HTTP communication with user-controlled destination detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
       line_number: 6
       filename: unsafe_excon.rb
       parent_line_number: 6
       parent_content: 'Excon::Connection.new(path: params[:oops])'
-    - rule_dsrid: ""
-      rule_display_id: ruby_lang_http_url_using_user_input
-      rule_description: HTTP communication with user-controlled destination detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
+    - rule:
+        cwe_ids:
+            - "918"
+        id: ruby_lang_http_url_using_user_input
+        description: HTTP communication with user-controlled destination detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
       line_number: 7
       filename: unsafe_excon.rb
       parent_line_number: 7
       parent_content: 'Excon::Connection.new(port: params[:oops])'
-    - rule_dsrid: ""
-      rule_display_id: ruby_lang_http_url_using_user_input
-      rule_description: HTTP communication with user-controlled destination detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
+    - rule:
+        cwe_ids:
+            - "918"
+        id: ruby_lang_http_url_using_user_input
+        description: HTTP communication with user-controlled destination detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
       line_number: 9
       filename: unsafe_excon.rb
       parent_line_number: 9
       parent_content: 'connection.post(path: params[:oops])'
-    - rule_dsrid: ""
-      rule_display_id: ruby_lang_http_url_using_user_input
-      rule_description: HTTP communication with user-controlled destination detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
+    - rule:
+        cwe_ids:
+            - "918"
+        id: ruby_lang_http_url_using_user_input
+        description: HTTP communication with user-controlled destination detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
       line_number: 11
       filename: unsafe_excon.rb
       parent_line_number: 11
       parent_content: 'connection2.request(path: params[:oops])'
-    - rule_dsrid: ""
-      rule_display_id: ruby_lang_http_url_using_user_input
-      rule_description: HTTP communication with user-controlled destination detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
+    - rule:
+        cwe_ids:
+            - "918"
+        id: ruby_lang_http_url_using_user_input
+        description: HTTP communication with user-controlled destination detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
       line_number: 13
       filename: unsafe_excon.rb
       parent_line_number: 13
       parent_content: 'connection3.requests([{ :method => :get, path: params[:oops] }])'
-    - rule_dsrid: ""
-      rule_display_id: ruby_lang_http_url_using_user_input
-      rule_description: HTTP communication with user-controlled destination detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
+    - rule:
+        cwe_ids:
+            - "918"
+        id: ruby_lang_http_url_using_user_input
+        description: HTTP communication with user-controlled destination detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
       line_number: 15
       filename: unsafe_excon.rb
       parent_line_number: 15
       parent_content: Excon.get(params[:oops])
-    - rule_dsrid: ""
-      rule_display_id: ruby_lang_http_url_using_user_input
-      rule_description: HTTP communication with user-controlled destination detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
+    - rule:
+        cwe_ids:
+            - "918"
+        id: ruby_lang_http_url_using_user_input
+        description: HTTP communication with user-controlled destination detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
       line_number: 16
       filename: unsafe_excon.rb
       parent_line_number: 16
       parent_content: 'Excon.post("http://example.com", path: params[:oops])'
 low:
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_lang_http_insecure
-      rule_description: Connection through an unsecure HTTP communication detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
+    - rule:
+        cwe_ids:
+            - "319"
+        id: ruby_lang_http_insecure
+        description: Connection through an unsecure HTTP communication detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
       line_number: 2
       filename: unsafe_excon.rb
       parent_line_number: 2
       parent_content: 'Excon.new("http://example.com", path: params[:oops])'
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_lang_http_insecure
-      rule_description: Connection through an unsecure HTTP communication detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
+    - rule:
+        cwe_ids:
+            - "319"
+        id: ruby_lang_http_insecure
+        description: Connection through an unsecure HTTP communication detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
       line_number: 16
       filename: unsafe_excon.rb
       parent_line_number: 16

--- a/pkg/commands/process/settings/rules/ruby/lang/http_url_using_user_input/.snapshots/TestRubyLangHttpUrlUsingUserInput--unsafe_get.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/http_url_using_user_input/.snapshots/TestRubyLangHttpUrlUsingUserInput--unsafe_get.yml
@@ -1,8 +1,10 @@
 high:
-    - rule_dsrid: ""
-      rule_display_id: ruby_lang_http_url_using_user_input
-      rule_description: HTTP communication with user-controlled destination detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
+    - rule:
+        cwe_ids:
+            - "918"
+        id: ruby_lang_http_url_using_user_input
+        description: HTTP communication with user-controlled destination detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
       line_number: 1
       filename: unsafe_get.rb
       parent_line_number: 1

--- a/pkg/commands/process/settings/rules/ruby/lang/http_url_using_user_input/.snapshots/TestRubyLangHttpUrlUsingUserInput--unsafe_net_http.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/http_url_using_user_input/.snapshots/TestRubyLangHttpUrlUsingUserInput--unsafe_net_http.yml
@@ -1,16 +1,20 @@
 high:
-    - rule_dsrid: ""
-      rule_display_id: ruby_lang_http_url_using_user_input
-      rule_description: HTTP communication with user-controlled destination detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
+    - rule:
+        cwe_ids:
+            - "918"
+        id: ruby_lang_http_url_using_user_input
+        description: HTTP communication with user-controlled destination detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
       line_number: 3
       filename: unsafe_net_http.rb
       parent_line_number: 3
       parent_content: Net::HTTP.post_form("http://#{params[:oops]}/users/search")
-    - rule_dsrid: ""
-      rule_display_id: ruby_lang_http_url_using_user_input
-      rule_description: HTTP communication with user-controlled destination detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
+    - rule:
+        cwe_ids:
+            - "918"
+        id: ruby_lang_http_url_using_user_input
+        description: HTTP communication with user-controlled destination detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
       line_number: 5
       filename: unsafe_net_http.rb
       parent_line_number: 5
@@ -18,75 +22,93 @@ high:
         Net::HTTP.start(params[:host]) do |instance1|
           instance1.head(params[:path])
         end
-    - rule_dsrid: ""
-      rule_display_id: ruby_lang_http_url_using_user_input
-      rule_description: HTTP communication with user-controlled destination detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
+    - rule:
+        cwe_ids:
+            - "918"
+        id: ruby_lang_http_url_using_user_input
+        description: HTTP communication with user-controlled destination detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
       line_number: 6
       filename: unsafe_net_http.rb
       parent_line_number: 6
       parent_content: instance1.head(params[:path])
-    - rule_dsrid: ""
-      rule_display_id: ruby_lang_http_url_using_user_input
-      rule_description: HTTP communication with user-controlled destination detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
+    - rule:
+        cwe_ids:
+            - "918"
+        id: ruby_lang_http_url_using_user_input
+        description: HTTP communication with user-controlled destination detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
       line_number: 9
       filename: unsafe_net_http.rb
       parent_line_number: 9
       parent_content: 'Net::HTTP::Get.new(params[:oops], { "X-Test": 42 })'
-    - rule_dsrid: ""
-      rule_display_id: ruby_lang_http_url_using_user_input
-      rule_description: HTTP communication with user-controlled destination detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
+    - rule:
+        cwe_ids:
+            - "918"
+        id: ruby_lang_http_url_using_user_input
+        description: HTTP communication with user-controlled destination detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
       line_number: 11
       filename: unsafe_net_http.rb
       parent_line_number: 11
       parent_content: Net::HTTP.start(params[:oops])
-    - rule_dsrid: ""
-      rule_display_id: ruby_lang_http_url_using_user_input
-      rule_description: HTTP communication with user-controlled destination detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
+    - rule:
+        cwe_ids:
+            - "918"
+        id: ruby_lang_http_url_using_user_input
+        description: HTTP communication with user-controlled destination detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
       line_number: 12
       filename: unsafe_net_http.rb
       parent_line_number: 12
       parent_content: instance2.ipaddr = request.env[:oops]
-    - rule_dsrid: ""
-      rule_display_id: ruby_lang_http_url_using_user_input
-      rule_description: HTTP communication with user-controlled destination detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
+    - rule:
+        cwe_ids:
+            - "918"
+        id: ruby_lang_http_url_using_user_input
+        description: HTTP communication with user-controlled destination detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
       line_number: 13
       filename: unsafe_net_http.rb
       parent_line_number: 13
       parent_content: instance2.send_request("GET", params[:oops], nil)
-    - rule_dsrid: ""
-      rule_display_id: ruby_lang_http_url_using_user_input
-      rule_description: HTTP communication with user-controlled destination detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
+    - rule:
+        cwe_ids:
+            - "918"
+        id: ruby_lang_http_url_using_user_input
+        description: HTTP communication with user-controlled destination detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
       line_number: 15
       filename: unsafe_net_http.rb
       parent_line_number: 15
       parent_content: Net::HTTP.new(params[:oops])
-    - rule_dsrid: ""
-      rule_display_id: ruby_lang_http_url_using_user_input
-      rule_description: HTTP communication with user-controlled destination detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
+    - rule:
+        cwe_ids:
+            - "918"
+        id: ruby_lang_http_url_using_user_input
+        description: HTTP communication with user-controlled destination detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
       line_number: 16
       filename: unsafe_net_http.rb
       parent_line_number: 16
       parent_content: instance3.patch(params[:path])
-    - rule_dsrid: ""
-      rule_display_id: ruby_lang_http_url_using_user_input
-      rule_description: HTTP communication with user-controlled destination detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
+    - rule:
+        cwe_ids:
+            - "918"
+        id: ruby_lang_http_url_using_user_input
+        description: HTTP communication with user-controlled destination detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
       line_number: 18
       filename: unsafe_net_http.rb
       parent_line_number: 18
       parent_content: instance4.post(request.env[:oops])
 low:
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_lang_http_insecure
-      rule_description: Connection through an unsecure HTTP communication detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
+    - rule:
+        cwe_ids:
+            - "319"
+        id: ruby_lang_http_insecure
+        description: Connection through an unsecure HTTP communication detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_insecure
       line_number: 3
       filename: unsafe_net_http.rb
       parent_line_number: 3

--- a/pkg/commands/process/settings/rules/ruby/lang/http_url_using_user_input/.snapshots/TestRubyLangHttpUrlUsingUserInput--unsafe_post.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/http_url_using_user_input/.snapshots/TestRubyLangHttpUrlUsingUserInput--unsafe_post.yml
@@ -1,8 +1,10 @@
 high:
-    - rule_dsrid: ""
-      rule_display_id: ruby_lang_http_url_using_user_input
-      rule_description: HTTP communication with user-controlled destination detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
+    - rule:
+        cwe_ids:
+            - "918"
+        id: ruby_lang_http_url_using_user_input
+        description: HTTP communication with user-controlled destination detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input
       line_number: 1
       filename: unsafe_post.rb
       parent_line_number: 1

--- a/pkg/commands/process/settings/rules/ruby/lang/insecure_ftp.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/insecure_ftp.yml
@@ -38,7 +38,6 @@ metadata:
 
     ## Resources
     - [net-sftp](https://github.com/net-ssh/net-sftp)
-  dsr_id: DSR-2
   cwe_id:
     - 319
   id: ruby_lang_insecure_ftp

--- a/pkg/commands/process/settings/rules/ruby/lang/insecure_ftp/.snapshots/TestRubyLangInsecureFtp--ftp_new.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/insecure_ftp/.snapshots/TestRubyLangInsecureFtp--ftp_new.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_lang_insecure_ftp
-      rule_description: Communication with an unsecure FTP server detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_insecure_ftp
+    - rule:
+        cwe_ids:
+            - "319"
+        id: ruby_lang_insecure_ftp
+        description: Communication with an unsecure FTP server detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_insecure_ftp
       line_number: 8
       filename: ftp_new.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/lang/insecure_ftp/.snapshots/TestRubyLangInsecureFtp--ftp_open.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/insecure_ftp/.snapshots/TestRubyLangInsecureFtp--ftp_open.yml
@@ -1,8 +1,10 @@
 low:
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_lang_insecure_ftp
-      rule_description: Communication with an unsecure FTP server detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_insecure_ftp
+    - rule:
+        cwe_ids:
+            - "319"
+        id: ruby_lang_insecure_ftp
+        description: Communication with an unsecure FTP server detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_insecure_ftp
       line_number: 3
       filename: ftp_open.rb
       parent_line_number: 3

--- a/pkg/commands/process/settings/rules/ruby/lang/insecure_ftp/.snapshots/TestRubyLangInsecureFtp--ftp_open_with_datatype.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/insecure_ftp/.snapshots/TestRubyLangInsecureFtp--ftp_open_with_datatype.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_lang_insecure_ftp
-      rule_description: Communication with an unsecure FTP server detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_insecure_ftp
+    - rule:
+        cwe_ids:
+            - "319"
+        id: ruby_lang_insecure_ftp
+        description: Communication with an unsecure FTP server detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_insecure_ftp
       line_number: 3
       filename: ftp_open_with_datatype.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/lang/jwt.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/jwt.yml
@@ -38,7 +38,6 @@ metadata:
     ## Resources
     Coming soon.
     -->
-  dsr_id: DSR-3
   cwe_id:
     - 315
   id: ruby_lang_jwt

--- a/pkg/commands/process/settings/rules/ruby/lang/jwt/.snapshots/TestRubyLangJwt--datatype_in_jwt.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/jwt/.snapshots/TestRubyLangJwt--datatype_in_jwt.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-3
-      rule_display_id: ruby_lang_jwt
-      rule_description: Sensitive data in a JWT detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_jwt
+    - rule:
+        cwe_ids:
+            - "315"
+        id: ruby_lang_jwt
+        description: Sensitive data in a JWT detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_jwt
       line_number: 1
       filename: datatype_in_jwt.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/lang/jwt/.snapshots/TestRubyLangJwt--datatype_object_in_jwt.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/jwt/.snapshots/TestRubyLangJwt--datatype_object_in_jwt.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-3
-      rule_display_id: ruby_lang_jwt
-      rule_description: Sensitive data in a JWT detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_jwt
+    - rule:
+        cwe_ids:
+            - "315"
+        id: ruby_lang_jwt
+        description: Sensitive data in a JWT detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_jwt
       line_number: 3
       filename: datatype_object_in_jwt.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/lang/jwt/.snapshots/TestRubyLangJwt--datatypes_with_encrypted_jwt.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/jwt/.snapshots/TestRubyLangJwt--datatypes_with_encrypted_jwt.yml
@@ -1,28 +1,34 @@
 critical:
-    - rule_dsrid: DSR-3
-      rule_display_id: ruby_lang_jwt
-      rule_description: Sensitive data in a JWT detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_jwt
+    - rule:
+        cwe_ids:
+            - "315"
+        id: ruby_lang_jwt
+        description: Sensitive data in a JWT detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_jwt
       line_number: 2
       filename: datatypes_with_encrypted_jwt.rb
       category_groups:
         - PII
       parent_line_number: 2
       parent_content: 'JWT.encode({ user: current_user.email }, private_key, ''HS256'', {})'
-    - rule_dsrid: DSR-3
-      rule_display_id: ruby_lang_jwt
-      rule_description: Sensitive data in a JWT detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_jwt
+    - rule:
+        cwe_ids:
+            - "315"
+        id: ruby_lang_jwt
+        description: Sensitive data in a JWT detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_jwt
       line_number: 4
       filename: datatypes_with_encrypted_jwt.rb
       category_groups:
         - PII
       parent_line_number: 4
       parent_content: 'JWT.encode({ user: current_user.email }, ENV["SECRET_KEY"])'
-    - rule_dsrid: DSR-3
-      rule_display_id: ruby_lang_jwt
-      rule_description: Sensitive data in a JWT detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_jwt
+    - rule:
+        cwe_ids:
+            - "315"
+        id: ruby_lang_jwt
+        description: Sensitive data in a JWT detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_jwt
       line_number: 6
       filename: datatypes_with_encrypted_jwt.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/lang/logger.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/logger.yml
@@ -46,7 +46,6 @@ metadata:
     ## Resources
     Coming soon.
     -->
-  dsr_id: DSR-5
   cwe_id:
     - 209
     - 532

--- a/pkg/commands/process/settings/rules/ruby/lang/logger/.snapshots/TestRubyLangLogger--datatype_leak.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/logger/.snapshots/TestRubyLangLogger--datatype_leak.yml
@@ -1,8 +1,11 @@
 critical:
-    - rule_dsrid: DSR-5
-      rule_display_id: ruby_lang_logger
-      rule_description: Sensitive data in a logger message detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_logger
+    - rule:
+        cwe_ids:
+            - "209"
+            - "532"
+        id: ruby_lang_logger
+        description: Sensitive data in a logger message detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_logger
       line_number: 1
       filename: datatype_leak.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/lang/path_using_user_input.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/path_using_user_input.yml
@@ -86,7 +86,6 @@ metadata:
     ## Resources
     Coming soon.
     -->
-  dsr_id: DSR-? # FIXME
   cwe_id:
     - 22
   id: ruby_lang_path_using_user_input

--- a/pkg/commands/process/settings/rules/ruby/lang/path_using_user_input/.snapshots/TestRubyLangPathUsingUserInput--unsafe_event.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/path_using_user_input/.snapshots/TestRubyLangPathUsingUserInput--unsafe_event.yml
@@ -1,98 +1,122 @@
 low:
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_path_using_user_input
-      rule_description: Do not use user input to form file paths.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
+    - rule:
+        cwe_ids:
+            - "22"
+        id: ruby_lang_path_using_user_input
+        description: Do not use user input to form file paths.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
       line_number: 2
       filename: unsafe_event.rb
       parent_line_number: 2
       parent_content: 'Dir["foo", base: event["oops"]]'
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_path_using_user_input
-      rule_description: Do not use user input to form file paths.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
+    - rule:
+        cwe_ids:
+            - "22"
+        id: ruby_lang_path_using_user_input
+        description: Do not use user input to form file paths.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
       line_number: 4
       filename: unsafe_event.rb
       parent_line_number: 4
       parent_content: Dir.chdir("/home/#{event["oops"]}")
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_path_using_user_input
-      rule_description: Do not use user input to form file paths.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
+    - rule:
+        cwe_ids:
+            - "22"
+        id: ruby_lang_path_using_user_input
+        description: Do not use user input to form file paths.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
       line_number: 6
       filename: unsafe_event.rb
       parent_line_number: 6
       parent_content: File.exist?(event["oops"])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_path_using_user_input
-      rule_description: Do not use user input to form file paths.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
+    - rule:
+        cwe_ids:
+            - "22"
+        id: ruby_lang_path_using_user_input
+        description: Do not use user input to form file paths.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
       line_number: 8
       filename: unsafe_event.rb
       parent_line_number: 8
       parent_content: IO.readlines("/home/#{event["oops"]}")
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_path_using_user_input
-      rule_description: Do not use user input to form file paths.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
+    - rule:
+        cwe_ids:
+            - "22"
+        id: ruby_lang_path_using_user_input
+        description: Do not use user input to form file paths.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
       line_number: 10
       filename: unsafe_event.rb
       parent_line_number: 10
       parent_content: |-
         Kernel.open(event["oops"], "w+") do
           end
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_path_using_user_input
-      rule_description: Do not use user input to form file paths.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
+    - rule:
+        cwe_ids:
+            - "22"
+        id: ruby_lang_path_using_user_input
+        description: Do not use user input to form file paths.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
       line_number: 13
       filename: unsafe_event.rb
       parent_line_number: 13
       parent_content: open(event["oops"])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_path_using_user_input
-      rule_description: Do not use user input to form file paths.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
+    - rule:
+        cwe_ids:
+            - "22"
+        id: ruby_lang_path_using_user_input
+        description: Do not use user input to form file paths.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
       line_number: 15
       filename: unsafe_event.rb
       parent_line_number: 15
       parent_content: PStore.new(event["oops"])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_path_using_user_input
-      rule_description: Do not use user input to form file paths.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
+    - rule:
+        cwe_ids:
+            - "22"
+        id: ruby_lang_path_using_user_input
+        description: Do not use user input to form file paths.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
       line_number: 17
       filename: unsafe_event.rb
       parent_line_number: 17
       parent_content: Pathname.new(event["oops"])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_path_using_user_input
-      rule_description: Do not use user input to form file paths.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
+    - rule:
+        cwe_ids:
+            - "22"
+        id: ruby_lang_path_using_user_input
+        description: Do not use user input to form file paths.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
       line_number: 18
       filename: unsafe_event.rb
       parent_line_number: 18
       parent_content: path + event["two"]
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_path_using_user_input
-      rule_description: Do not use user input to form file paths.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
+    - rule:
+        cwe_ids:
+            - "22"
+        id: ruby_lang_path_using_user_input
+        description: Do not use user input to form file paths.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
       line_number: 19
       filename: unsafe_event.rb
       parent_line_number: 19
       parent_content: path / event["two"]
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_path_using_user_input
-      rule_description: Do not use user input to form file paths.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
+    - rule:
+        cwe_ids:
+            - "22"
+        id: ruby_lang_path_using_user_input
+        description: Do not use user input to form file paths.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
       line_number: 20
       filename: unsafe_event.rb
       parent_line_number: 20
       parent_content: path.join("a", event["three"])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_path_using_user_input
-      rule_description: Do not use user input to form file paths.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
+    - rule:
+        cwe_ids:
+            - "22"
+        id: ruby_lang_path_using_user_input
+        description: Do not use user input to form file paths.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
       line_number: 22
       filename: unsafe_event.rb
       parent_line_number: 22

--- a/pkg/commands/process/settings/rules/ruby/lang/path_using_user_input/.snapshots/TestRubyLangPathUsingUserInput--unsafe_params.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/path_using_user_input/.snapshots/TestRubyLangPathUsingUserInput--unsafe_params.yml
@@ -1,98 +1,122 @@
 low:
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_path_using_user_input
-      rule_description: Do not use user input to form file paths.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
+    - rule:
+        cwe_ids:
+            - "22"
+        id: ruby_lang_path_using_user_input
+        description: Do not use user input to form file paths.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
       line_number: 1
       filename: unsafe_params.rb
       parent_line_number: 1
       parent_content: 'Dir["foo", base: params[:oops]]'
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_path_using_user_input
-      rule_description: Do not use user input to form file paths.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
+    - rule:
+        cwe_ids:
+            - "22"
+        id: ruby_lang_path_using_user_input
+        description: Do not use user input to form file paths.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
       line_number: 3
       filename: unsafe_params.rb
       parent_line_number: 3
       parent_content: Dir.chdir("/home/#{params[:oops]}")
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_path_using_user_input
-      rule_description: Do not use user input to form file paths.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
+    - rule:
+        cwe_ids:
+            - "22"
+        id: ruby_lang_path_using_user_input
+        description: Do not use user input to form file paths.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
       line_number: 5
       filename: unsafe_params.rb
       parent_line_number: 5
       parent_content: File.exist?(params[:oops])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_path_using_user_input
-      rule_description: Do not use user input to form file paths.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
+    - rule:
+        cwe_ids:
+            - "22"
+        id: ruby_lang_path_using_user_input
+        description: Do not use user input to form file paths.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
       line_number: 7
       filename: unsafe_params.rb
       parent_line_number: 7
       parent_content: IO.readlines("/home/#{params[:oops]}")
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_path_using_user_input
-      rule_description: Do not use user input to form file paths.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
+    - rule:
+        cwe_ids:
+            - "22"
+        id: ruby_lang_path_using_user_input
+        description: Do not use user input to form file paths.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
       line_number: 9
       filename: unsafe_params.rb
       parent_line_number: 9
       parent_content: |-
         Kernel.open(params[:oops], "w+") do
         end
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_path_using_user_input
-      rule_description: Do not use user input to form file paths.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
+    - rule:
+        cwe_ids:
+            - "22"
+        id: ruby_lang_path_using_user_input
+        description: Do not use user input to form file paths.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
       line_number: 12
       filename: unsafe_params.rb
       parent_line_number: 12
       parent_content: open(params[:oops])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_path_using_user_input
-      rule_description: Do not use user input to form file paths.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
+    - rule:
+        cwe_ids:
+            - "22"
+        id: ruby_lang_path_using_user_input
+        description: Do not use user input to form file paths.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
       line_number: 14
       filename: unsafe_params.rb
       parent_line_number: 14
       parent_content: PStore.new(params[:oops])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_path_using_user_input
-      rule_description: Do not use user input to form file paths.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
+    - rule:
+        cwe_ids:
+            - "22"
+        id: ruby_lang_path_using_user_input
+        description: Do not use user input to form file paths.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
       line_number: 16
       filename: unsafe_params.rb
       parent_line_number: 16
       parent_content: Pathname.new(params[:oops])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_path_using_user_input
-      rule_description: Do not use user input to form file paths.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
+    - rule:
+        cwe_ids:
+            - "22"
+        id: ruby_lang_path_using_user_input
+        description: Do not use user input to form file paths.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
       line_number: 17
       filename: unsafe_params.rb
       parent_line_number: 17
       parent_content: path + params[:two]
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_path_using_user_input
-      rule_description: Do not use user input to form file paths.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
+    - rule:
+        cwe_ids:
+            - "22"
+        id: ruby_lang_path_using_user_input
+        description: Do not use user input to form file paths.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
       line_number: 18
       filename: unsafe_params.rb
       parent_line_number: 18
       parent_content: path / params[:three]
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_path_using_user_input
-      rule_description: Do not use user input to form file paths.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
+    - rule:
+        cwe_ids:
+            - "22"
+        id: ruby_lang_path_using_user_input
+        description: Do not use user input to form file paths.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
       line_number: 19
       filename: unsafe_params.rb
       parent_line_number: 19
       parent_content: path.join("a", params[:four])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_path_using_user_input
-      rule_description: Do not use user input to form file paths.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
+    - rule:
+        cwe_ids:
+            - "22"
+        id: ruby_lang_path_using_user_input
+        description: Do not use user input to form file paths.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
       line_number: 21
       filename: unsafe_params.rb
       parent_line_number: 21

--- a/pkg/commands/process/settings/rules/ruby/lang/path_using_user_input/.snapshots/TestRubyLangPathUsingUserInput--unsafe_request.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/path_using_user_input/.snapshots/TestRubyLangPathUsingUserInput--unsafe_request.yml
@@ -1,98 +1,122 @@
 low:
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_path_using_user_input
-      rule_description: Do not use user input to form file paths.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
+    - rule:
+        cwe_ids:
+            - "22"
+        id: ruby_lang_path_using_user_input
+        description: Do not use user input to form file paths.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
       line_number: 1
       filename: unsafe_request.rb
       parent_line_number: 1
       parent_content: 'Dir["foo", base: request.env[:oops]]'
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_path_using_user_input
-      rule_description: Do not use user input to form file paths.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
+    - rule:
+        cwe_ids:
+            - "22"
+        id: ruby_lang_path_using_user_input
+        description: Do not use user input to form file paths.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
       line_number: 3
       filename: unsafe_request.rb
       parent_line_number: 3
       parent_content: Dir.chdir("/home/#{request.env[:oops]}")
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_path_using_user_input
-      rule_description: Do not use user input to form file paths.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
+    - rule:
+        cwe_ids:
+            - "22"
+        id: ruby_lang_path_using_user_input
+        description: Do not use user input to form file paths.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
       line_number: 5
       filename: unsafe_request.rb
       parent_line_number: 5
       parent_content: File.exist?(request.env[:oops])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_path_using_user_input
-      rule_description: Do not use user input to form file paths.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
+    - rule:
+        cwe_ids:
+            - "22"
+        id: ruby_lang_path_using_user_input
+        description: Do not use user input to form file paths.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
       line_number: 7
       filename: unsafe_request.rb
       parent_line_number: 7
       parent_content: IO.readlines("/home/#{request.env[:oops]}")
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_path_using_user_input
-      rule_description: Do not use user input to form file paths.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
+    - rule:
+        cwe_ids:
+            - "22"
+        id: ruby_lang_path_using_user_input
+        description: Do not use user input to form file paths.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
       line_number: 9
       filename: unsafe_request.rb
       parent_line_number: 9
       parent_content: |-
         Kernel.open(request.env[:oops], "w+") do
         end
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_path_using_user_input
-      rule_description: Do not use user input to form file paths.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
+    - rule:
+        cwe_ids:
+            - "22"
+        id: ruby_lang_path_using_user_input
+        description: Do not use user input to form file paths.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
       line_number: 12
       filename: unsafe_request.rb
       parent_line_number: 12
       parent_content: open(request.env[:oops])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_path_using_user_input
-      rule_description: Do not use user input to form file paths.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
+    - rule:
+        cwe_ids:
+            - "22"
+        id: ruby_lang_path_using_user_input
+        description: Do not use user input to form file paths.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
       line_number: 14
       filename: unsafe_request.rb
       parent_line_number: 14
       parent_content: PStore.new(request.env[:oops])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_path_using_user_input
-      rule_description: Do not use user input to form file paths.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
+    - rule:
+        cwe_ids:
+            - "22"
+        id: ruby_lang_path_using_user_input
+        description: Do not use user input to form file paths.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
       line_number: 16
       filename: unsafe_request.rb
       parent_line_number: 16
       parent_content: Pathname.new(request.env[:oops])
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_path_using_user_input
-      rule_description: Do not use user input to form file paths.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
+    - rule:
+        cwe_ids:
+            - "22"
+        id: ruby_lang_path_using_user_input
+        description: Do not use user input to form file paths.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
       line_number: 17
       filename: unsafe_request.rb
       parent_line_number: 17
       parent_content: path + request.headers[:oops]
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_path_using_user_input
-      rule_description: Do not use user input to form file paths.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
+    - rule:
+        cwe_ids:
+            - "22"
+        id: ruby_lang_path_using_user_input
+        description: Do not use user input to form file paths.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
       line_number: 18
       filename: unsafe_request.rb
       parent_line_number: 18
       parent_content: path / request.query_parameters[:oops]
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_path_using_user_input
-      rule_description: Do not use user input to form file paths.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
+    - rule:
+        cwe_ids:
+            - "22"
+        id: ruby_lang_path_using_user_input
+        description: Do not use user input to form file paths.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
       line_number: 19
       filename: unsafe_request.rb
       parent_line_number: 19
       parent_content: path.join("a", request.body)
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_lang_path_using_user_input
-      rule_description: Do not use user input to form file paths.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
+    - rule:
+        cwe_ids:
+            - "22"
+        id: ruby_lang_path_using_user_input
+        description: Do not use user input to form file paths.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
       line_number: 21
       filename: unsafe_request.rb
       parent_line_number: 21

--- a/pkg/commands/process/settings/rules/ruby/lang/ssl_verification.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/ssl_verification.yml
@@ -40,7 +40,6 @@ metadata:
     ## Resources
     Coming soon.
     -->
-  dsr_id: DSR-2
   cwe_id:
     - 295
   id: ruby_lang_ssl_verification

--- a/pkg/commands/process/settings/rules/ruby/lang/ssl_verification/.snapshots/TestRubyLangSslVerification--verification_disabled.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/ssl_verification/.snapshots/TestRubyLangSslVerification--verification_disabled.yml
@@ -1,16 +1,20 @@
 low:
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_lang_ssl_verification
-      rule_description: Missing SSL certificate verification detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_ssl_verification
+    - rule:
+        cwe_ids:
+            - "295"
+        id: ruby_lang_ssl_verification
+        description: Missing SSL certificate verification detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_ssl_verification
       line_number: 1
       filename: verification_disabled.rb
       parent_line_number: 1
       parent_content: http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_lang_ssl_verification
-      rule_description: Missing SSL certificate verification detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_ssl_verification
+    - rule:
+        cwe_ids:
+            - "295"
+        id: ruby_lang_ssl_verification
+        description: Missing SSL certificate verification detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_ssl_verification
       line_number: 4
       filename: verification_disabled.rb
       parent_line_number: 4

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption.yml
@@ -120,7 +120,6 @@ metadata:
 
     ## Resources
     - [BCrypt Explained](https://dev.to/sylviapap/bcrypt-explained-4k5c)
-  dsr_id: DSR-7
   cwe_id:
     - 331
     - 326

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryption--blowfish.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryption--blowfish.yml
@@ -1,8 +1,11 @@
 low:
-    - rule_dsrid: DSR-7
-      rule_display_id: ruby_lang_weak_encryption
-      rule_description: Weak encryption library usage detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
+    - rule:
+        cwe_ids:
+            - "331"
+            - "326"
+        id: ruby_lang_weak_encryption
+        description: Weak encryption library usage detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
       line_number: 2
       filename: blowfish.rb
       parent_line_number: 2

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryption--digest_md5.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryption--digest_md5.yml
@@ -1,8 +1,11 @@
 low:
-    - rule_dsrid: DSR-7
-      rule_display_id: ruby_lang_weak_encryption
-      rule_description: Weak encryption library usage detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
+    - rule:
+        cwe_ids:
+            - "331"
+            - "326"
+        id: ruby_lang_weak_encryption
+        description: Weak encryption library usage detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
       line_number: 1
       filename: digest_md5.rb
       parent_line_number: 1

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryption--digest_sha1.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryption--digest_sha1.yml
@@ -1,8 +1,11 @@
 low:
-    - rule_dsrid: DSR-7
-      rule_display_id: ruby_lang_weak_encryption
-      rule_description: Weak encryption library usage detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
+    - rule:
+        cwe_ids:
+            - "331"
+            - "326"
+        id: ruby_lang_weak_encryption
+        description: Weak encryption library usage detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
       line_number: 1
       filename: digest_sha1.rb
       parent_line_number: 1

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryption--openssl_dsa.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryption--openssl_dsa.yml
@@ -1,16 +1,22 @@
 low:
-    - rule_dsrid: DSR-7
-      rule_display_id: ruby_lang_weak_encryption
-      rule_description: Weak encryption library usage detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
+    - rule:
+        cwe_ids:
+            - "331"
+            - "326"
+        id: ruby_lang_weak_encryption
+        description: Weak encryption library usage detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
       line_number: 3
       filename: openssl_dsa.rb
       parent_line_number: 3
       parent_content: dsa_encrypt.export(cipher, "hello world")
-    - rule_dsrid: DSR-7
-      rule_display_id: ruby_lang_weak_encryption
-      rule_description: Weak encryption library usage detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
+    - rule:
+        cwe_ids:
+            - "331"
+            - "326"
+        id: ruby_lang_weak_encryption
+        description: Weak encryption library usage detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
       line_number: 5
       filename: openssl_dsa.rb
       parent_line_number: 5

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryption--openssl_rsa.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryption--openssl_rsa.yml
@@ -1,8 +1,11 @@
 low:
-    - rule_dsrid: DSR-7
-      rule_display_id: ruby_lang_weak_encryption
-      rule_description: Weak encryption library usage detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
+    - rule:
+        cwe_ids:
+            - "331"
+            - "326"
+        id: ruby_lang_weak_encryption
+        description: Weak encryption library usage detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
       line_number: 8
       filename: openssl_rsa.rb
       parent_line_number: 8

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryption--rc4_encrypt.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption/.snapshots/TestRubyLangWeakEncryption--rc4_encrypt.yml
@@ -1,16 +1,22 @@
 low:
-    - rule_dsrid: DSR-7
-      rule_display_id: ruby_lang_weak_encryption
-      rule_description: Weak encryption library usage detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
+    - rule:
+        cwe_ids:
+            - "331"
+            - "326"
+        id: ruby_lang_weak_encryption
+        description: Weak encryption library usage detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
       line_number: 1
       filename: rc4_encrypt.rb
       parent_line_number: 1
       parent_content: RC4.new("insecure").encrypt("hello world")
-    - rule_dsrid: DSR-7
-      rule_display_id: ruby_lang_weak_encryption
-      rule_description: Weak encryption library usage detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
+    - rule:
+        cwe_ids:
+            - "331"
+            - "326"
+        id: ruby_lang_weak_encryption
+        description: Weak encryption library usage detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
       line_number: 4
       filename: rc4_encrypt.rb
       parent_line_number: 4

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data.yml
@@ -150,7 +150,6 @@ metadata:
 
     ## Resources
     - [BCrypt Explained](https://dev.to/sylviapap/bcrypt-explained-4k5c)
-  dsr_id: DSR-7
   cwe_id:
     - 326
     - 331

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithData--blowfish_data.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithData--blowfish_data.yml
@@ -1,8 +1,11 @@
 critical:
-    - rule_dsrid: DSR-7
-      rule_display_id: ruby_lang_weak_encryption_with_data
-      rule_description: Sensitive data encrypted with a weak encryption library detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption_with_data
+    - rule:
+        cwe_ids:
+            - "326"
+            - "331"
+        id: ruby_lang_weak_encryption_with_data
+        description: Sensitive data encrypted with a weak encryption library detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption_with_data
       line_number: 2
       filename: blowfish_data.rb
       category_groups:
@@ -12,10 +15,13 @@ critical:
         Crypt::Blowfish.new("insecure").encrypt_block { |user|
           user.password
         }
-    - rule_dsrid: DSR-7
-      rule_display_id: ruby_lang_weak_encryption_with_data
-      rule_description: Sensitive data encrypted with a weak encryption library detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption_with_data
+    - rule:
+        cwe_ids:
+            - "326"
+            - "331"
+        id: ruby_lang_weak_encryption_with_data
+        description: Sensitive data encrypted with a weak encryption library detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption_with_data
       line_number: 6
       filename: blowfish_data.rb
       category_groups:
@@ -25,10 +31,13 @@ critical:
         Crypt::Blowfish.new("insecure").encrypt_block do |user|
           user.password
         end
-    - rule_dsrid: DSR-7
-      rule_display_id: ruby_lang_weak_encryption_with_data
-      rule_description: Sensitive data encrypted with a weak encryption library detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption_with_data
+    - rule:
+        cwe_ids:
+            - "326"
+            - "331"
+        id: ruby_lang_weak_encryption_with_data
+        description: Sensitive data encrypted with a weak encryption library detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption_with_data
       line_number: 9
       filename: blowfish_data.rb
       category_groups:
@@ -36,10 +45,13 @@ critical:
       parent_line_number: 9
       parent_content: Crypt::Blowfish.new("your-key").encrypt_string(user.email)
 low:
-    - rule_dsrid: DSR-7
-      rule_display_id: ruby_lang_weak_encryption
-      rule_description: Weak encryption library usage detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
+    - rule:
+        cwe_ids:
+            - "331"
+            - "326"
+        id: ruby_lang_weak_encryption
+        description: Weak encryption library usage detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
       line_number: 1
       filename: blowfish_data.rb
       category_groups:
@@ -49,10 +61,13 @@ low:
         Crypt::Blowfish.new("insecure").encrypt_block { |user|
           user.password
         }
-    - rule_dsrid: DSR-7
-      rule_display_id: ruby_lang_weak_encryption
-      rule_description: Weak encryption library usage detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
+    - rule:
+        cwe_ids:
+            - "331"
+            - "326"
+        id: ruby_lang_weak_encryption
+        description: Weak encryption library usage detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
       line_number: 5
       filename: blowfish_data.rb
       category_groups:
@@ -62,10 +77,13 @@ low:
         Crypt::Blowfish.new("insecure").encrypt_block do |user|
           user.password
         end
-    - rule_dsrid: DSR-7
-      rule_display_id: ruby_lang_weak_encryption
-      rule_description: Weak encryption library usage detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
+    - rule:
+        cwe_ids:
+            - "331"
+            - "326"
+        id: ruby_lang_weak_encryption
+        description: Weak encryption library usage detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
       line_number: 9
       filename: blowfish_data.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithData--digest_md5.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithData--digest_md5.yml
@@ -1,8 +1,11 @@
 critical:
-    - rule_dsrid: DSR-7
-      rule_display_id: ruby_lang_weak_encryption_with_data
-      rule_description: Sensitive data encrypted with a weak encryption library detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption_with_data
+    - rule:
+        cwe_ids:
+            - "326"
+            - "331"
+        id: ruby_lang_weak_encryption_with_data
+        description: Sensitive data encrypted with a weak encryption library detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption_with_data
       line_number: 1
       filename: digest_md5.rb
       category_groups:
@@ -10,10 +13,13 @@ critical:
       parent_line_number: 1
       parent_content: Digest::MD5.hexdigest(user.address)
 low:
-    - rule_dsrid: DSR-7
-      rule_display_id: ruby_lang_weak_encryption
-      rule_description: Weak encryption library usage detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
+    - rule:
+        cwe_ids:
+            - "331"
+            - "326"
+        id: ruby_lang_weak_encryption
+        description: Weak encryption library usage detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
       line_number: 1
       filename: digest_md5.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithData--digest_sha1.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithData--digest_sha1.yml
@@ -1,8 +1,11 @@
 critical:
-    - rule_dsrid: DSR-7
-      rule_display_id: ruby_lang_weak_encryption_with_data
-      rule_description: Sensitive data encrypted with a weak encryption library detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption_with_data
+    - rule:
+        cwe_ids:
+            - "326"
+            - "331"
+        id: ruby_lang_weak_encryption_with_data
+        description: Sensitive data encrypted with a weak encryption library detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption_with_data
       line_number: 1
       filename: digest_sha1.rb
       category_groups:
@@ -10,10 +13,13 @@ critical:
       parent_line_number: 1
       parent_content: Digest::SHA1.hexidigest(user.first_name)
 low:
-    - rule_dsrid: DSR-7
-      rule_display_id: ruby_lang_weak_encryption
-      rule_description: Weak encryption library usage detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
+    - rule:
+        cwe_ids:
+            - "331"
+            - "326"
+        id: ruby_lang_weak_encryption
+        description: Weak encryption library usage detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
       line_number: 1
       filename: digest_sha1.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithData--openssl_dsa_data.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithData--openssl_dsa_data.yml
@@ -1,18 +1,24 @@
 critical:
-    - rule_dsrid: DSR-7
-      rule_display_id: ruby_lang_weak_encryption_with_data
-      rule_description: Sensitive data encrypted with a weak encryption library detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption_with_data
+    - rule:
+        cwe_ids:
+            - "326"
+            - "331"
+        id: ruby_lang_weak_encryption_with_data
+        description: Sensitive data encrypted with a weak encryption library detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption_with_data
       line_number: 3
       filename: openssl_dsa_data.rb
       category_groups:
         - PII
       parent_line_number: 3
       parent_content: dsa_encrypt.export(cipher, user.email)
-    - rule_dsrid: DSR-7
-      rule_display_id: ruby_lang_weak_encryption_with_data
-      rule_description: Sensitive data encrypted with a weak encryption library detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption_with_data
+    - rule:
+        cwe_ids:
+            - "326"
+            - "331"
+        id: ruby_lang_weak_encryption_with_data
+        description: Sensitive data encrypted with a weak encryption library detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption_with_data
       line_number: 5
       filename: openssl_dsa_data.rb
       category_groups:
@@ -20,20 +26,26 @@ critical:
       parent_line_number: 5
       parent_content: OpenSSL::PKey::DSA.new(2048).to_pem(cipher, user.first_name)
 low:
-    - rule_dsrid: DSR-7
-      rule_display_id: ruby_lang_weak_encryption
-      rule_description: Weak encryption library usage detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
+    - rule:
+        cwe_ids:
+            - "331"
+            - "326"
+        id: ruby_lang_weak_encryption
+        description: Weak encryption library usage detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
       line_number: 3
       filename: openssl_dsa_data.rb
       category_groups:
         - PII
       parent_line_number: 3
       parent_content: dsa_encrypt.export(cipher, user.email)
-    - rule_dsrid: DSR-7
-      rule_display_id: ruby_lang_weak_encryption
-      rule_description: Weak encryption library usage detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
+    - rule:
+        cwe_ids:
+            - "331"
+            - "326"
+        id: ruby_lang_weak_encryption
+        description: Weak encryption library usage detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
       line_number: 5
       filename: openssl_dsa_data.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithData--openssl_rsa_data.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithData--openssl_rsa_data.yml
@@ -1,18 +1,24 @@
 low:
-    - rule_dsrid: DSR-7
-      rule_display_id: ruby_lang_weak_encryption
-      rule_description: Weak encryption library usage detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
+    - rule:
+        cwe_ids:
+            - "331"
+            - "326"
+        id: ruby_lang_weak_encryption
+        description: Weak encryption library usage detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
       line_number: 5
       filename: openssl_rsa_data.rb
       category_groups:
         - PII
       parent_line_number: 5
       parent_content: rsa_encrypt.export(cipher, user.password)
-    - rule_dsrid: DSR-7
-      rule_display_id: ruby_lang_weak_encryption
-      rule_description: Weak encryption library usage detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
+    - rule:
+        cwe_ids:
+            - "331"
+            - "326"
+        id: ruby_lang_weak_encryption
+        description: Weak encryption library usage detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
       line_number: 7
       filename: openssl_rsa_data.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithData--rc4_data.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/weak_encryption_with_data/.snapshots/TestRubyLangWeakEncryptionWithData--rc4_data.yml
@@ -1,18 +1,24 @@
 critical:
-    - rule_dsrid: DSR-7
-      rule_display_id: ruby_lang_weak_encryption_with_data
-      rule_description: Sensitive data encrypted with a weak encryption library detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption_with_data
+    - rule:
+        cwe_ids:
+            - "326"
+            - "331"
+        id: ruby_lang_weak_encryption_with_data
+        description: Sensitive data encrypted with a weak encryption library detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption_with_data
       line_number: 1
       filename: rc4_data.rb
       category_groups:
         - PII
       parent_line_number: 1
       parent_content: RC4.new("insecure").encrypt(user.password)
-    - rule_dsrid: DSR-7
-      rule_display_id: ruby_lang_weak_encryption_with_data
-      rule_description: Sensitive data encrypted with a weak encryption library detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption_with_data
+    - rule:
+        cwe_ids:
+            - "326"
+            - "331"
+        id: ruby_lang_weak_encryption_with_data
+        description: Sensitive data encrypted with a weak encryption library detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption_with_data
       line_number: 4
       filename: rc4_data.rb
       category_groups:
@@ -20,20 +26,26 @@ critical:
       parent_line_number: 4
       parent_content: rc4_encrypt.encrypt!(user.password)
 low:
-    - rule_dsrid: DSR-7
-      rule_display_id: ruby_lang_weak_encryption
-      rule_description: Weak encryption library usage detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
+    - rule:
+        cwe_ids:
+            - "331"
+            - "326"
+        id: ruby_lang_weak_encryption
+        description: Weak encryption library usage detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
       line_number: 1
       filename: rc4_data.rb
       category_groups:
         - PII
       parent_line_number: 1
       parent_content: RC4.new("insecure").encrypt(user.password)
-    - rule_dsrid: DSR-7
-      rule_display_id: ruby_lang_weak_encryption
-      rule_description: Weak encryption library usage detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
+    - rule:
+        cwe_ids:
+            - "331"
+            - "326"
+        id: ruby_lang_weak_encryption
+        description: Weak encryption library usage detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption
       line_number: 4
       filename: rc4_data.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/rails/default_encryption.yml
+++ b/pkg/commands/process/settings/rules/ruby/rails/default_encryption.yml
@@ -31,7 +31,6 @@ metadata:
     ## Resources
     Coming soon.
     -->
-  dsr_id: DSR-10
   cwe_id:
     - 312
   id: ruby_rails_default_encryption

--- a/pkg/commands/process/settings/rules/ruby/rails/default_encryption/.snapshots/TestRubyRailsDefaultEncryption--application_level_encryption_missing-schema_rb-db-schema.yml
+++ b/pkg/commands/process/settings/rules/ruby/rails/default_encryption/.snapshots/TestRubyRailsDefaultEncryption--application_level_encryption_missing-schema_rb-db-schema.yml
@@ -1,8 +1,10 @@
 warning:
-    - rule_dsrid: DSR-10
-      rule_display_id: ruby_rails_default_encryption
-      rule_description: Missing application-level encryption of sensitive data detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_default_encryption
+    - rule:
+        cwe_ids:
+            - "312"
+        id: ruby_rails_default_encryption
+        description: Missing application-level encryption of sensitive data detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_default_encryption
       line_number: 3
       filename: application_level_encryption_missing/schema_rb/db/schema.rb
       category_groups:
@@ -16,10 +18,12 @@ warning:
             t.datetime "created_at", null: false
             t.datetime "updated_at", null: false
           end
-    - rule_dsrid: DSR-10
-      rule_display_id: ruby_rails_default_encryption
-      rule_description: Missing application-level encryption of sensitive data detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_default_encryption
+    - rule:
+        cwe_ids:
+            - "312"
+        id: ruby_rails_default_encryption
+        description: Missing application-level encryption of sensitive data detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_default_encryption
       line_number: 4
       filename: application_level_encryption_missing/schema_rb/db/schema.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/rails/default_encryption/.snapshots/TestRubyRailsDefaultEncryption--application_level_encryption_missing-structure_sql-db-structure.yml
+++ b/pkg/commands/process/settings/rules/ruby/rails/default_encryption/.snapshots/TestRubyRailsDefaultEncryption--application_level_encryption_missing-structure_sql-db-structure.yml
@@ -1,8 +1,10 @@
 warning:
-    - rule_dsrid: DSR-10
-      rule_display_id: ruby_rails_default_encryption
-      rule_description: Missing application-level encryption of sensitive data detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_default_encryption
+    - rule:
+        cwe_ids:
+            - "312"
+        id: ruby_rails_default_encryption
+        description: Missing application-level encryption of sensitive data detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_default_encryption
       line_number: 3
       filename: application_level_encryption_missing/structure_sql/db/structure.sql
       category_groups:
@@ -17,10 +19,12 @@ warning:
           updated_at timestamp(6) without time zone NOT NULL,
           email character varying DEFAULT ''::character varying NOT NULL
         )
-    - rule_dsrid: DSR-10
-      rule_display_id: ruby_rails_default_encryption
-      rule_description: Missing application-level encryption of sensitive data detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_default_encryption
+    - rule:
+        cwe_ids:
+            - "312"
+        id: ruby_rails_default_encryption
+        description: Missing application-level encryption of sensitive data detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_default_encryption
       line_number: 7
       filename: application_level_encryption_missing/structure_sql/db/structure.sql
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/rails/devise_password_length.yml
+++ b/pkg/commands/process/settings/rules/ruby/rails/devise_password_length.yml
@@ -48,7 +48,6 @@ metadata:
     ## Resources
     Coming soon.
     -->
-  dsr_id: DSR-8
   cwe_id:
     - 521
   id: ruby_rails_devise_password_length

--- a/pkg/commands/process/settings/rules/ruby/rails/insecure_communication.yml
+++ b/pkg/commands/process/settings/rules/ruby/rails/insecure_communication.yml
@@ -27,7 +27,6 @@ metadata:
 
     ## Resources
     - [Configuring Rails Applications - Ruby on Rails Guides](https://guides.rubyonrails.org/configuring.html#config-force-ssl)
-  dsr_id: DSR-2
   cwe_id:
     - 319
   id: ruby_rails_insecure_communication

--- a/pkg/commands/process/settings/rules/ruby/rails/insecure_communication/.snapshots/TestRubyRailsInsecureCommunication--no_datatypes.yml
+++ b/pkg/commands/process/settings/rules/ruby/rails/insecure_communication/.snapshots/TestRubyRailsInsecureCommunication--no_datatypes.yml
@@ -1,8 +1,10 @@
 low:
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_rails_insecure_communication
-      rule_description: Missing force SSL configuration for incoming communication detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_insecure_communication
+    - rule:
+        cwe_ids:
+            - "319"
+        id: ruby_rails_insecure_communication
+        description: Missing force SSL configuration for incoming communication detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_insecure_communication
       line_number: 2
       filename: no_datatypes.rb
       parent_line_number: 2

--- a/pkg/commands/process/settings/rules/ruby/rails/insecure_communication/.snapshots/TestRubyRailsInsecureCommunication--ssl_disabled.yml
+++ b/pkg/commands/process/settings/rules/ruby/rails/insecure_communication/.snapshots/TestRubyRailsInsecureCommunication--ssl_disabled.yml
@@ -1,8 +1,10 @@
 low:
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_rails_insecure_communication
-      rule_description: Missing force SSL configuration for incoming communication detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_insecure_communication
+    - rule:
+        cwe_ids:
+            - "319"
+        id: ruby_rails_insecure_communication
+        description: Missing force SSL configuration for incoming communication detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_insecure_communication
       line_number: 7
       filename: ssl_disabled.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/rails/insecure_http_password.yml
+++ b/pkg/commands/process/settings/rules/ruby/rails/insecure_http_password.yml
@@ -12,5 +12,4 @@ metadata:
   description: "Insecure HTTP Password."
   remediation_message: |
     Coming soon
-  dsr_id: DSR-2
   id: ruby_rails_insecure_http_password

--- a/pkg/commands/process/settings/rules/ruby/rails/insecure_http_password/.snapshots/TestRubyRailsInsecureHTTPPassowrd--insecure_controller.yml
+++ b/pkg/commands/process/settings/rules/ruby/rails/insecure_http_password/.snapshots/TestRubyRailsInsecureHTTPPassowrd--insecure_controller.yml
@@ -1,8 +1,9 @@
 low:
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_rails_insecure_http_password
-      rule_description: Insecure HTTP Password.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_insecure_http_password
+    - rule:
+        cwe_ids: []
+        id: ruby_rails_insecure_http_password
+        description: Insecure HTTP Password.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_insecure_http_password
       line_number: 2
       filename: insecure_controller.rb
       parent_line_number: 2

--- a/pkg/commands/process/settings/rules/ruby/rails/insecure_smtp.yml
+++ b/pkg/commands/process/settings/rules/ruby/rails/insecure_smtp.yml
@@ -39,7 +39,6 @@ metadata:
     ## Resources
     Coming soon.
     -->
-  dsr_id: DSR-2
   cwe_id:
     - 319
   id: ruby_rails_insecure_smtp

--- a/pkg/commands/process/settings/rules/ruby/rails/insecure_smtp/.snapshots/TestRubyRailsInsecureSmtp--verify_none.yml
+++ b/pkg/commands/process/settings/rules/ruby/rails/insecure_smtp/.snapshots/TestRubyRailsInsecureSmtp--verify_none.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_rails_insecure_smtp
-      rule_description: Communication with an unsecure SMTP connection detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_insecure_smtp
+    - rule:
+        cwe_ids:
+            - "319"
+        id: ruby_rails_insecure_smtp
+        description: Communication with an unsecure SMTP connection detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_insecure_smtp
       line_number: 8
       filename: verify_none.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/rails/insecure_smtp/.snapshots/TestRubyRailsInsecureSmtp--verify_none_ssl_var.yml
+++ b/pkg/commands/process/settings/rules/ruby/rails/insecure_smtp/.snapshots/TestRubyRailsInsecureSmtp--verify_none_ssl_var.yml
@@ -1,8 +1,10 @@
 low:
-    - rule_dsrid: DSR-2
-      rule_display_id: ruby_rails_insecure_smtp
-      rule_description: Communication with an unsecure SMTP connection detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_insecure_smtp
+    - rule:
+        cwe_ids:
+            - "319"
+        id: ruby_rails_insecure_smtp
+        description: Communication with an unsecure SMTP connection detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_insecure_smtp
       line_number: 3
       filename: verify_none_ssl_var.rb
       parent_line_number: 3

--- a/pkg/commands/process/settings/rules/ruby/rails/logger.yml
+++ b/pkg/commands/process/settings/rules/ruby/rails/logger.yml
@@ -44,7 +44,6 @@ metadata:
     ## Resources
     Coming soon.
     -->
-  dsr_id: DSR-5
   cwe_id:
     - 209
     - 532

--- a/pkg/commands/process/settings/rules/ruby/rails/logger/.snapshots/TestRubyRailsLogger--datatype_leak.yml
+++ b/pkg/commands/process/settings/rules/ruby/rails/logger/.snapshots/TestRubyRailsLogger--datatype_leak.yml
@@ -1,8 +1,11 @@
 critical:
-    - rule_dsrid: DSR-5
-      rule_display_id: ruby_rails_logger
-      rule_description: Sensitive data sent to Rails loggers detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_logger
+    - rule:
+        cwe_ids:
+            - "209"
+            - "532"
+        id: ruby_rails_logger
+        description: Sensitive data sent to Rails loggers detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_logger
       line_number: 1
       filename: datatype_leak.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/rails/password_length.yml
+++ b/pkg/commands/process/settings/rules/ruby/rails/password_length.yml
@@ -55,7 +55,6 @@ metadata:
     ## Resources
     Coming soon.
     -->
-  dsr_id: DSR-8
   cwe_id:
     - 521
   id: ruby_rails_password_length

--- a/pkg/commands/process/settings/rules/ruby/rails/password_length/.snapshots/TestRubyRailsPasswordLength--password_too_short.yml
+++ b/pkg/commands/process/settings/rules/ruby/rails/password_length/.snapshots/TestRubyRailsPasswordLength--password_too_short.yml
@@ -1,8 +1,10 @@
 high:
-    - rule_dsrid: DSR-8
-      rule_display_id: ruby_rails_password_length
-      rule_description: Password length (< 8) requirement is too short.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_password_length
+    - rule:
+        cwe_ids:
+            - "521"
+        id: ruby_rails_password_length
+        description: Password length (< 8) requirement is too short.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_password_length
       line_number: 3
       filename: password_too_short.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/rails/session.yml
+++ b/pkg/commands/process/settings/rules/ruby/rails/session.yml
@@ -33,7 +33,6 @@ metadata:
     ## Resources
     Coming soon.
     -->
-  dsr_id: DSR-3
   cwe_id:
     - 315
   id: ruby_rails_session

--- a/pkg/commands/process/settings/rules/ruby/rails/session/.snapshots/TestRubyRailsSession--datatype_in_session.yml
+++ b/pkg/commands/process/settings/rules/ruby/rails/session/.snapshots/TestRubyRailsSession--datatype_in_session.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-3
-      rule_display_id: ruby_rails_session
-      rule_description: Sensitive data stored in a session cookie detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_session
+    - rule:
+        cwe_ids:
+            - "315"
+        id: ruby_rails_session
+        description: Sensitive data stored in a session cookie detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_session
       line_number: 1
       filename: datatype_in_session.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/rails/session_key_using_user_input.yml
+++ b/pkg/commands/process/settings/rules/ruby/rails/session_key_using_user_input.yml
@@ -31,7 +31,6 @@ metadata:
     ## Resources
     Coming soon.
     -->
-  dsr_id: DSR-? # FIXME
   cwe_id:
     - 276
   id: ruby_rails_session_key_using_user_input

--- a/pkg/commands/process/settings/rules/ruby/rails/session_key_using_user_input/.snapshots/TestRubyRailsSessionKeyUsingUserInput--unsafe.yml
+++ b/pkg/commands/process/settings/rules/ruby/rails/session_key_using_user_input/.snapshots/TestRubyRailsSessionKeyUsingUserInput--unsafe.yml
@@ -1,24 +1,30 @@
 low:
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_rails_session_key_using_user_input
-      rule_description: User input detected in a session key.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_session_key_using_user_input
+    - rule:
+        cwe_ids:
+            - "276"
+        id: ruby_rails_session_key_using_user_input
+        description: User input detected in a session key.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_session_key_using_user_input
       line_number: 1
       filename: unsafe.rb
       parent_line_number: 1
       parent_content: session[params[:key]]
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_rails_session_key_using_user_input
-      rule_description: User input detected in a session key.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_session_key_using_user_input
+    - rule:
+        cwe_ids:
+            - "276"
+        id: ruby_rails_session_key_using_user_input
+        description: User input detected in a session key.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_session_key_using_user_input
       line_number: 3
       filename: unsafe.rb
       parent_line_number: 3
       parent_content: session[request.env[:key]]
-    - rule_dsrid: DSR-?
-      rule_display_id: ruby_rails_session_key_using_user_input
-      rule_description: User input detected in a session key.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_session_key_using_user_input
+    - rule:
+        cwe_ids:
+            - "276"
+        id: ruby_rails_session_key_using_user_input
+        description: User input detected in a session key.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_session_key_using_user_input
       line_number: 5
       filename: unsafe.rb
       parent_line_number: 5

--- a/pkg/commands/process/settings/rules/ruby/third_parties/airbrake.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/airbrake.yml
@@ -69,7 +69,6 @@ metadata:
 
     ## Resources
     - [Airbrake Docs](https://docs.airbrake.io/)
-  dsr_id: DSR-1
   cwe_id:
     - 201
   associated_recipe: Airbrake

--- a/pkg/commands/process/settings/rules/ruby/third_parties/airbrake/.snapshots/TestRubyThirdPartiesAirbrake--datatype_in_custom_notice.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/airbrake/.snapshots/TestRubyThirdPartiesAirbrake--datatype_in_custom_notice.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_airbrake
-      rule_description: Sensitive data sent to Airbrake detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_airbrake
+        description: Sensitive data sent to Airbrake detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
       line_number: 5
       filename: datatype_in_custom_notice.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/airbrake/.snapshots/TestRubyThirdPartiesAirbrake--datatype_in_extended_notify_methods.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/airbrake/.snapshots/TestRubyThirdPartiesAirbrake--datatype_in_extended_notify_methods.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_airbrake
-      rule_description: Sensitive data sent to Airbrake detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_airbrake
+        description: Sensitive data sent to Airbrake detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
       line_number: 3
       filename: datatype_in_extended_notify_methods.rb
       category_groups:
@@ -15,10 +17,12 @@ critical:
           status_code: 200,
           timing: 123.45 # ms
         )
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_airbrake
-      rule_description: Sensitive data sent to Airbrake detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_airbrake
+        description: Sensitive data sent to Airbrake detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
       line_number: 9
       filename: datatype_in_extended_notify_methods.rb
       category_groups:
@@ -31,10 +35,12 @@ critical:
           status_code: 200,
           timing: 123.45 # ms
         )
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_airbrake
-      rule_description: Sensitive data sent to Airbrake detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_airbrake
+        description: Sensitive data sent to Airbrake detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
       line_number: 17
       filename: datatype_in_extended_notify_methods.rb
       category_groups:
@@ -47,10 +53,12 @@ critical:
           },
           request_id: 123
         )
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_airbrake
-      rule_description: Sensitive data sent to Airbrake detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_airbrake
+        description: Sensitive data sent to Airbrake detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
       line_number: 23
       filename: datatype_in_extended_notify_methods.rb
       category_groups:
@@ -63,10 +71,12 @@ critical:
           },
           request_id: 123
         )
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_airbrake
-      rule_description: Sensitive data sent to Airbrake detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_airbrake
+        description: Sensitive data sent to Airbrake detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
       line_number: 31
       filename: datatype_in_extended_notify_methods.rb
       category_groups:
@@ -78,10 +88,12 @@ critical:
           route: "/users/#{user.first_name}",
           query: 'SELECT * FROM foos'
         )
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_airbrake
-      rule_description: Sensitive data sent to Airbrake detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_airbrake
+        description: Sensitive data sent to Airbrake detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
       line_number: 36
       filename: datatype_in_extended_notify_methods.rb
       category_groups:
@@ -93,10 +105,12 @@ critical:
           route: "/users/#{user.first_name}",
           query: 'SELECT * FROM foos'
         )
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_airbrake
-      rule_description: Sensitive data sent to Airbrake detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_airbrake
+        description: Sensitive data sent to Airbrake detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
       line_number: 43
       filename: datatype_in_extended_notify_methods.rb
       category_groups:
@@ -109,10 +123,12 @@ critical:
           },
           request_id: 123
         )
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_airbrake
-      rule_description: Sensitive data sent to Airbrake detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_airbrake
+        description: Sensitive data sent to Airbrake detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
       line_number: 49
       filename: datatype_in_extended_notify_methods.rb
       category_groups:
@@ -125,10 +141,12 @@ critical:
           },
           request_id: 123
         )
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_airbrake
-      rule_description: Sensitive data sent to Airbrake detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_airbrake
+        description: Sensitive data sent to Airbrake detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
       line_number: 57
       filename: datatype_in_extended_notify_methods.rb
       category_groups:
@@ -142,10 +160,12 @@ critical:
           groups: { db: 24.0, view: 0.4 }, # ms
           timing: 123.45 # ms
         )
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_airbrake
-      rule_description: Sensitive data sent to Airbrake detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_airbrake
+        description: Sensitive data sent to Airbrake detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
       line_number: 64
       filename: datatype_in_extended_notify_methods.rb
       category_groups:
@@ -159,10 +179,12 @@ critical:
           groups: { db: 24.0, view: 0.4 }, # ms
           timing: 123.45 # ms
         )
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_airbrake
-      rule_description: Sensitive data sent to Airbrake detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_airbrake
+        description: Sensitive data sent to Airbrake detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
       line_number: 73
       filename: datatype_in_extended_notify_methods.rb
       category_groups:
@@ -175,10 +197,12 @@ critical:
           },
           request_id: 123
         )
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_airbrake
-      rule_description: Sensitive data sent to Airbrake detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_airbrake
+        description: Sensitive data sent to Airbrake detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
       line_number: 79
       filename: datatype_in_extended_notify_methods.rb
       category_groups:
@@ -191,10 +215,12 @@ critical:
           },
           request_id: 123
         )
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_airbrake
-      rule_description: Sensitive data sent to Airbrake detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_airbrake
+        description: Sensitive data sent to Airbrake detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
       line_number: 101
       filename: datatype_in_extended_notify_methods.rb
       category_groups:
@@ -207,10 +233,12 @@ critical:
           },
           job_id: 123
         )
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_airbrake
-      rule_description: Sensitive data sent to Airbrake detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_airbrake
+        description: Sensitive data sent to Airbrake detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
       line_number: 107
       filename: datatype_in_extended_notify_methods.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/airbrake/.snapshots/TestRubyThirdPartiesAirbrake--datatype_in_merge_context.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/airbrake/.snapshots/TestRubyThirdPartiesAirbrake--datatype_in_merge_context.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_airbrake
-      rule_description: Sensitive data sent to Airbrake detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_airbrake
+        description: Sensitive data sent to Airbrake detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
       line_number: 1
       filename: datatype_in_merge_context.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/airbrake/.snapshots/TestRubyThirdPartiesAirbrake--datatype_in_notify.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/airbrake/.snapshots/TestRubyThirdPartiesAirbrake--datatype_in_notify.yml
@@ -1,18 +1,22 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_airbrake
-      rule_description: Sensitive data sent to Airbrake detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_airbrake
+        description: Sensitive data sent to Airbrake detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
       line_number: 1
       filename: datatype_in_notify.rb
       category_groups:
         - PII
       parent_line_number: 1
       parent_content: Airbrake.notify(user.first_name)
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_airbrake
-      rule_description: Sensitive data sent to Airbrake detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_airbrake
+        description: Sensitive data sent to Airbrake detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
       line_number: 4
       filename: datatype_in_notify.rb
       category_groups:
@@ -22,10 +26,12 @@ critical:
         Airbrake.notify('App crashed!', {
           current_user: user.email
         })
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_airbrake
-      rule_description: Sensitive data sent to Airbrake detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_airbrake
+        description: Sensitive data sent to Airbrake detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
       line_number: 8
       filename: datatype_in_notify.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/airbrake/.snapshots/TestRubyThirdPartiesAirbrake--datatype_in_rescue_block.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/airbrake/.snapshots/TestRubyThirdPartiesAirbrake--datatype_in_rescue_block.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_airbrake
-      rule_description: Sensitive data sent to Airbrake detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_airbrake
+        description: Sensitive data sent to Airbrake detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
       line_number: 4
       filename: datatype_in_rescue_block.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/algolia.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/algolia.yml
@@ -43,7 +43,6 @@ metadata:
     -->
     ## Resources
     - [Algolia docs](https://www.algolia.com/doc/)
-  dsr_id: DSR-6
   cwe_id:
     - 201
   associated_recipe: Algolia

--- a/pkg/commands/process/settings/rules/ruby/third_parties/algolia/.snapshots/TestRubyThirdPartiesAlgolia--datatype_in_save_object.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/algolia/.snapshots/TestRubyThirdPartiesAlgolia--datatype_in_save_object.yml
@@ -1,18 +1,22 @@
 critical:
-    - rule_dsrid: DSR-6
-      rule_display_id: ruby_third_parties_algolia
-      rule_description: Sensitive data sent to Algolia detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_algolia
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_algolia
+        description: Sensitive data sent to Algolia detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_algolia
       line_number: 4
       filename: datatype_in_save_object.rb
       category_groups:
         - PII
       parent_line_number: 4
       parent_content: 'index.save_object({ email: user.email }, { auto_generate_object_id_if_not_exist: true })'
-    - rule_dsrid: DSR-6
-      rule_display_id: ruby_third_parties_algolia
-      rule_description: Sensitive data sent to Algolia detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_algolia
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_algolia
+        description: Sensitive data sent to Algolia detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_algolia
       line_number: 6
       filename: datatype_in_save_object.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/bigquery.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/bigquery.yml
@@ -76,7 +76,6 @@ metadata:
     -->
     ## Resources
     - [BigQuery docs](https://cloud.google.com/ruby/docs)
-  dsr_id: DSR-6
   cwe_id:
     - 201
   associated_recipe: Google Cloud BigQuery

--- a/pkg/commands/process/settings/rules/ruby/third_parties/bigquery/.snapshots/TestRubyThirdPartiesBigQuery--datatype_in_insert.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/bigquery/.snapshots/TestRubyThirdPartiesBigQuery--datatype_in_insert.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-6
-      rule_display_id: ruby_third_parties_bigquery
-      rule_description: Sensitive data sent to BigQuery detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_bigquery
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_bigquery
+        description: Sensitive data sent to BigQuery detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_bigquery
       line_number: 4
       filename: datatype_in_insert.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/bigquery/.snapshots/TestRubyThirdPartiesBigQuery--datatype_in_insert_async.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/bigquery/.snapshots/TestRubyThirdPartiesBigQuery--datatype_in_insert_async.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-6
-      rule_display_id: ruby_third_parties_bigquery
-      rule_description: Sensitive data sent to BigQuery detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_bigquery
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_bigquery
+        description: Sensitive data sent to BigQuery detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_bigquery
       line_number: 8
       filename: datatype_in_insert_async.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/bigquery/.snapshots/TestRubyThirdPartiesBigQuery--datatype_in_table_insert.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/bigquery/.snapshots/TestRubyThirdPartiesBigQuery--datatype_in_table_insert.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-6
-      rule_display_id: ruby_third_parties_bigquery
-      rule_description: Sensitive data sent to BigQuery detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_bigquery
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_bigquery
+        description: Sensitive data sent to BigQuery detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_bigquery
       line_number: 5
       filename: datatype_in_table_insert.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/bigquery/.snapshots/TestRubyThirdPartiesBigQuery--datatype_in_table_insert_async.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/bigquery/.snapshots/TestRubyThirdPartiesBigQuery--datatype_in_table_insert_async.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-6
-      rule_display_id: ruby_third_parties_bigquery
-      rule_description: Sensitive data sent to BigQuery detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_bigquery
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_bigquery
+        description: Sensitive data sent to BigQuery detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_bigquery
       line_number: 9
       filename: datatype_in_table_insert_async.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/bugsnag.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/bugsnag.yml
@@ -46,7 +46,6 @@ metadata:
 
     ## Resources
     - [Bugsnag Docs](https://docs.bugsnag.com/platforms/ruby/rails/)
-  dsr_id: DSR-1
   cwe_id:
     - 201
   associated_recipe: Bugsnag

--- a/pkg/commands/process/settings/rules/ruby/third_parties/bugsnag/.snapshots/TestRubyThirdPartiesBugsnag--breadcrumb.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/bugsnag/.snapshots/TestRubyThirdPartiesBugsnag--breadcrumb.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_bugsnag
-      rule_description: Sensitive data sent to Bugsnag detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_bugsnag
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_bugsnag
+        description: Sensitive data sent to Bugsnag detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_bugsnag
       line_number: 2
       filename: breadcrumb.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/bugsnag/.snapshots/TestRubyThirdPartiesBugsnag--bugsnag_notify.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/bugsnag/.snapshots/TestRubyThirdPartiesBugsnag--bugsnag_notify.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-5
-      rule_display_id: ruby_lang_exception
-      rule_description: Sensitive data in a exception message detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_exception
+    - rule:
+        cwe_ids:
+            - "210"
+        id: ruby_lang_exception
+        description: Sensitive data in a exception message detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_exception
       line_number: 2
       filename: bugsnag_notify.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/clickhouse.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/clickhouse.yml
@@ -33,7 +33,6 @@ metadata:
 
     ## Resources
     - [ClickHouse docs](https://clickhouse.com/docs/en/intro/)
-  dsr_id: DSR-6
   cwe_id:
     - 201
   associated_recipe: ClickHouse

--- a/pkg/commands/process/settings/rules/ruby/third_parties/clickhouse/.snapshots/TestRubyThirdPartiesClickHouse--datatype_in_insert_rows.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/clickhouse/.snapshots/TestRubyThirdPartiesClickHouse--datatype_in_insert_rows.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-6
-      rule_display_id: ruby_third_parties_clickhouse
-      rule_description: Sensitive data sent to ClickHouse detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_clickhouse
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_clickhouse
+        description: Sensitive data sent to ClickHouse detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_clickhouse
       line_number: 6
       filename: datatype_in_insert_rows.rb
       category_groups:
@@ -15,10 +17,12 @@ critical:
               customer.email,
               customer.address
             ]
-    - rule_dsrid: DSR-6
-      rule_display_id: ruby_third_parties_clickhouse
-      rule_description: Sensitive data sent to ClickHouse detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_clickhouse
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_clickhouse
+        description: Sensitive data sent to ClickHouse detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_clickhouse
       line_number: 7
       filename: datatype_in_insert_rows.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/datadog.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/datadog.yml
@@ -50,7 +50,6 @@ metadata:
     ## Resources
     - [Datadog docs](https://docs.datadoghq.com)
     - [Scrubbing data](https://docs.datadoghq.com/tracing/configure_data_security/?tab=mongodb#scrub-sensitive-data-from-your-spans)
-  dsr_id: DSR-1
   cwe_id:
     - 201
   associated_recipe: Datadog

--- a/pkg/commands/process/settings/rules/ruby/third_parties/datadog/.snapshots/TestRubyThirdPartiesDatadog--datatype_in_tags.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/datadog/.snapshots/TestRubyThirdPartiesDatadog--datatype_in_tags.yml
@@ -1,48 +1,58 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_datadog
-      rule_description: Sensitive data sent to Datadog detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_datadog
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_datadog
+        description: Sensitive data sent to Datadog detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_datadog
       line_number: 2
       filename: datatype_in_tags.rb
       category_groups:
         - PII
       parent_line_number: 3
       parent_content: c.tags = user
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_datadog
-      rule_description: Sensitive data sent to Datadog detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_datadog
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_datadog
+        description: Sensitive data sent to Datadog detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_datadog
       line_number: 7
       filename: datatype_in_tags.rb
       category_groups:
         - PII
       parent_line_number: 7
       parent_content: span.set_tag('user.email', user.email)
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_datadog
-      rule_description: Sensitive data sent to Datadog detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_datadog
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_datadog
+        description: Sensitive data sent to Datadog detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_datadog
       line_number: 9
       filename: datatype_in_tags.rb
       category_groups:
         - PII
       parent_line_number: 9
       parent_content: Datadog::Tracing.active_span&.set_tag('customer.id', user.email)
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_datadog
-      rule_description: Sensitive data sent to Datadog detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_datadog
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_datadog
+        description: Sensitive data sent to Datadog detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_datadog
       line_number: 10
       filename: datatype_in_tags.rb
       category_groups:
         - PII
       parent_line_number: 10
       parent_content: Datadog::Tracing.active_span.set_tag('customer.id', user.email)
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_datadog
-      rule_description: Sensitive data sent to Datadog detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_datadog
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_datadog
+        description: Sensitive data sent to Datadog detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_datadog
       line_number: 12
       filename: datatype_in_tags.rb
       category_groups:
@@ -52,10 +62,12 @@ critical:
         Datadog::Tracing.trace("web.request", tags: { email: user.email }) do |span, trace|
           call
         end
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_datadog
-      rule_description: Sensitive data sent to Datadog detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_datadog
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_datadog
+        description: Sensitive data sent to Datadog detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_datadog
       line_number: 17
       filename: datatype_in_tags.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/elasticsearch.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/elasticsearch.yml
@@ -52,7 +52,6 @@ metadata:
 
     ## Resources
     - [Elasticsearch docs](https://www.elastic.co/guide/en/elasticsearch/client/ruby-api/current/index.html)
-  dsr_id: DSR-6
   cwe_id:
     - 201
   associated_recipe: Elasticsearch

--- a/pkg/commands/process/settings/rules/ruby/third_parties/elasticsearch/.snapshots/TestRubyThirdPartiesElasticsearch--datatype_in_bulk.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/elasticsearch/.snapshots/TestRubyThirdPartiesElasticsearch--datatype_in_bulk.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-6
-      rule_display_id: ruby_third_parties_elasticsearch
-      rule_description: Sensitive data sent to Elasticsearch detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_elasticsearch
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_elasticsearch
+        description: Sensitive data sent to Elasticsearch detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_elasticsearch
       line_number: 3
       filename: datatype_in_bulk.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/elasticsearch/.snapshots/TestRubyThirdPartiesElasticsearch--datatype_in_index.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/elasticsearch/.snapshots/TestRubyThirdPartiesElasticsearch--datatype_in_index.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-6
-      rule_display_id: ruby_third_parties_elasticsearch
-      rule_description: Sensitive data sent to Elasticsearch detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_elasticsearch
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_elasticsearch
+        description: Sensitive data sent to Elasticsearch detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_elasticsearch
       line_number: 3
       filename: datatype_in_index.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/elasticsearch/.snapshots/TestRubyThirdPartiesElasticsearch--datatype_in_update.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/elasticsearch/.snapshots/TestRubyThirdPartiesElasticsearch--datatype_in_update.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-6
-      rule_display_id: ruby_third_parties_elasticsearch
-      rule_description: Sensitive data sent to Elasticsearch detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_elasticsearch
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_elasticsearch
+        description: Sensitive data sent to Elasticsearch detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_elasticsearch
       line_number: 1
       filename: datatype_in_update.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/google_analytics.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/google_analytics.yml
@@ -40,7 +40,6 @@ metadata:
 
     ## Resources
     - [Google Analytics docs](https://developers.google.com/analytics/devguides/reporting/)
-  dsr_id: DSR-1
   cwe_id:
     - 201
   associated_recipe: Google Analytics

--- a/pkg/commands/process/settings/rules/ruby/third_parties/google_analytics/.snapshots/TestRubyThirdPartiesGoogleAnalytics--datatype_in_cohort.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/google_analytics/.snapshots/TestRubyThirdPartiesGoogleAnalytics--datatype_in_cohort.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_google_analytics
-      rule_description: Sensitive data sent to Google Analytics detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_analytics
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_google_analytics
+        description: Sensitive data sent to Google Analytics detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_analytics
       line_number: 1
       filename: datatype_in_cohort.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/google_analytics/.snapshots/TestRubyThirdPartiesGoogleAnalytics--datatype_in_custom_dimension.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/google_analytics/.snapshots/TestRubyThirdPartiesGoogleAnalytics--datatype_in_custom_dimension.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_google_analytics
-      rule_description: Sensitive data sent to Google Analytics detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_analytics
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_google_analytics
+        description: Sensitive data sent to Google Analytics detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_analytics
       line_number: 2
       filename: datatype_in_custom_dimension.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/google_analytics/.snapshots/TestRubyThirdPartiesGoogleAnalytics--datatype_in_event_data.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/google_analytics/.snapshots/TestRubyThirdPartiesGoogleAnalytics--datatype_in_event_data.yml
@@ -1,8 +1,10 @@
 high:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_google_analytics
-      rule_description: Sensitive data sent to Google Analytics detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_analytics
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_google_analytics
+        description: Sensitive data sent to Google Analytics detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_analytics
       line_number: 2
       filename: datatype_in_event_data.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/google_analytics/.snapshots/TestRubyThirdPartiesGoogleAnalytics--datatype_in_transaction_data.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/google_analytics/.snapshots/TestRubyThirdPartiesGoogleAnalytics--datatype_in_transaction_data.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_google_analytics
-      rule_description: Sensitive data sent to Google Analytics detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_analytics
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_google_analytics
+        description: Sensitive data sent to Google Analytics detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_analytics
       line_number: 1
       filename: datatype_in_transaction_data.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/google_analytics/.snapshots/TestRubyThirdPartiesGoogleAnalytics--datatype_in_user_classes.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/google_analytics/.snapshots/TestRubyThirdPartiesGoogleAnalytics--datatype_in_user_classes.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_google_analytics
-      rule_description: Sensitive data sent to Google Analytics detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_analytics
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_google_analytics
+        description: Sensitive data sent to Google Analytics detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_analytics
       line_number: 1
       filename: datatype_in_user_classes.rb
       category_groups:
@@ -10,10 +12,12 @@ critical:
         - Personal Data
       parent_line_number: 1
       parent_content: 'Google::Apis::AnalyticsreportingV4::User.new(user_id: user.email)'
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_google_analytics
-      rule_description: Sensitive data sent to Google Analytics detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_analytics
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_google_analytics
+        description: Sensitive data sent to Google Analytics detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_analytics
       line_number: 4
       filename: datatype_in_user_classes.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/google_dataflow.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/google_dataflow.yml
@@ -136,7 +136,6 @@ metadata:
 
     ## Resources
     - [Google Dataflow Docs](https://cloud.google.com/ruby/docs/reference/google-cloud-dataflow/latest)
-  dsr_id: DSR-1
   cwe_id:
     - 201
   id: ruby_third_parties_google_dataflow

--- a/pkg/commands/process/settings/rules/ruby/third_parties/google_dataflow/.snapshots/TestRubyThirdPartiesGoogleDataflow--datatype_in_config.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/google_dataflow/.snapshots/TestRubyThirdPartiesGoogleDataflow--datatype_in_config.yml
@@ -1,18 +1,22 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_google_dataflow
-      rule_description: Sensitive data sent to Google Dataflow detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_dataflow
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_google_dataflow
+        description: Sensitive data sent to Google Dataflow detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_dataflow
       line_number: 8
       filename: datatype_in_config.rb
       category_groups:
         - PII
       parent_line_number: 8
       parent_content: 'config.metadata = { current_user_id: current_user.email }'
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_google_dataflow
-      rule_description: Sensitive data sent to Google Dataflow detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_dataflow
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_google_dataflow
+        description: Sensitive data sent to Google Dataflow detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_dataflow
       line_number: 14
       filename: datatype_in_config.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/google_dataflow/.snapshots/TestRubyThirdPartiesGoogleDataflow--datatype_in_job_message.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/google_dataflow/.snapshots/TestRubyThirdPartiesGoogleDataflow--datatype_in_job_message.yml
@@ -1,8 +1,10 @@
 high:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_google_dataflow
-      rule_description: Sensitive data sent to Google Dataflow detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_dataflow
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_google_dataflow
+        description: Sensitive data sent to Google Dataflow detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_dataflow
       line_number: 2
       filename: datatype_in_job_message.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/google_dataflow/.snapshots/TestRubyThirdPartiesGoogleDataflow--datatype_in_metadata.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/google_dataflow/.snapshots/TestRubyThirdPartiesGoogleDataflow--datatype_in_metadata.yml
@@ -1,28 +1,34 @@
 high:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_google_dataflow
-      rule_description: Sensitive data sent to Google Dataflow detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_dataflow
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_google_dataflow
+        description: Sensitive data sent to Google Dataflow detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_dataflow
       line_number: 2
       filename: datatype_in_metadata.rb
       category_groups:
         - Personal Data
       parent_line_number: 2
       parent_content: 'custom_metadata.value = "ip: #{customer.ip_address}"'
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_google_dataflow
-      rule_description: Sensitive data sent to Google Dataflow detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_dataflow
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_google_dataflow
+        description: Sensitive data sent to Google Dataflow detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_dataflow
       line_number: 5
       filename: datatype_in_metadata.rb
       category_groups:
         - Personal Data
       parent_line_number: 5
       parent_content: 'template_metadata.description ="ip: #{customer.ip_address}"'
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_google_dataflow
-      rule_description: Sensitive data sent to Google Dataflow detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_dataflow
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_google_dataflow
+        description: Sensitive data sent to Google Dataflow detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_dataflow
       line_number: 6
       filename: datatype_in_metadata.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/google_dataflow/.snapshots/TestRubyThirdPartiesGoogleDataflow--datatype_in_params_entry.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/google_dataflow/.snapshots/TestRubyThirdPartiesGoogleDataflow--datatype_in_params_entry.yml
@@ -1,8 +1,10 @@
 high:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_google_dataflow
-      rule_description: Sensitive data sent to Google Dataflow detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_dataflow
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_google_dataflow
+        description: Sensitive data sent to Google Dataflow detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_dataflow
       line_number: 2
       filename: datatype_in_params_entry.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/google_dataflow/.snapshots/TestRubyThirdPartiesGoogleDataflow--datatype_in_snapshot_job_request.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/google_dataflow/.snapshots/TestRubyThirdPartiesGoogleDataflow--datatype_in_snapshot_job_request.yml
@@ -1,8 +1,10 @@
 high:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_google_dataflow
-      rule_description: Sensitive data sent to Google Dataflow detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_dataflow
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_google_dataflow
+        description: Sensitive data sent to Google Dataflow detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_dataflow
       line_number: 2
       filename: datatype_in_snapshot_job_request.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/google_dataflow/.snapshots/TestRubyThirdPartiesGoogleDataflow--datatype_in_snapshot_setter.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/google_dataflow/.snapshots/TestRubyThirdPartiesGoogleDataflow--datatype_in_snapshot_setter.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_google_dataflow
-      rule_description: Sensitive data sent to Google Dataflow detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_dataflow
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_google_dataflow
+        description: Sensitive data sent to Google Dataflow detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_dataflow
       line_number: 9
       filename: datatype_in_snapshot_setter.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/google_dataflow/.snapshots/TestRubyThirdPartiesGoogleDataflow--datatype_in_structured_message.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/google_dataflow/.snapshots/TestRubyThirdPartiesGoogleDataflow--datatype_in_structured_message.yml
@@ -1,8 +1,10 @@
 high:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_google_dataflow
-      rule_description: Sensitive data sent to Google Dataflow detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_dataflow
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_google_dataflow
+        description: Sensitive data sent to Google Dataflow detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_dataflow
       line_number: 4
       filename: datatype_in_structured_message.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/google_dataflow/.snapshots/TestRubyThirdPartiesGoogleDataflow--datatype_in_structured_message_param.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/google_dataflow/.snapshots/TestRubyThirdPartiesGoogleDataflow--datatype_in_structured_message_param.yml
@@ -1,8 +1,10 @@
 high:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_google_dataflow
-      rule_description: Sensitive data sent to Google Dataflow detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_dataflow
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_google_dataflow
+        description: Sensitive data sent to Google Dataflow detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_dataflow
       line_number: 2
       filename: datatype_in_structured_message_param.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/google_dataflow/.snapshots/TestRubyThirdPartiesGoogleDataflow--datatype_in_template_job_creation.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/google_dataflow/.snapshots/TestRubyThirdPartiesGoogleDataflow--datatype_in_template_job_creation.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_google_dataflow
-      rule_description: Sensitive data sent to Google Dataflow detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_dataflow
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_google_dataflow
+        description: Sensitive data sent to Google Dataflow detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_dataflow
       line_number: 5
       filename: datatype_in_template_job_creation.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/google_dataflow/.snapshots/TestRubyThirdPartiesGoogleDataflow--fail_with_different_version.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/google_dataflow/.snapshots/TestRubyThirdPartiesGoogleDataflow--fail_with_different_version.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_google_dataflow
-      rule_description: Sensitive data sent to Google Dataflow detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_dataflow
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_google_dataflow
+        description: Sensitive data sent to Google Dataflow detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_dataflow
       line_number: 5
       filename: fail_with_different_version.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/honeybadger.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/honeybadger.yml
@@ -43,7 +43,6 @@ metadata:
 
     ## Resources
     - [Honeybadger Docs](https://docs.honeybadger.io/lib/ruby/integration-guides/rails-exception-tracking/)
-  dsr_id: DSR-1
   cwe_id:
     - 201
   associated_recipe: Honeybadger

--- a/pkg/commands/process/settings/rules/ruby/third_parties/honeybadger/.snapshots/TestRubyThirdPartiesHoneybadger--honeybadger_breadcrumb.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/honeybadger/.snapshots/TestRubyThirdPartiesHoneybadger--honeybadger_breadcrumb.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_honeybadger
-      rule_description: Sensitive data sent to Honeybadger detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_honeybadger
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_honeybadger
+        description: Sensitive data sent to Honeybadger detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_honeybadger
       line_number: 1
       filename: honeybadger_breadcrumb.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/honeybadger/.snapshots/TestRubyThirdPartiesHoneybadger--honeybadger_context.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/honeybadger/.snapshots/TestRubyThirdPartiesHoneybadger--honeybadger_context.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_honeybadger
-      rule_description: Sensitive data sent to Honeybadger detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_honeybadger
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_honeybadger
+        description: Sensitive data sent to Honeybadger detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_honeybadger
       line_number: 1
       filename: honeybadger_context.rb
       category_groups:
@@ -12,10 +14,12 @@ critical:
         Honeybadger.context({
           tags: tags
         })
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_honeybadger
-      rule_description: Sensitive data sent to Honeybadger detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_honeybadger
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_honeybadger
+        description: Sensitive data sent to Honeybadger detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_honeybadger
       line_number: 8
       filename: honeybadger_context.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/honeybadger/.snapshots/TestRubyThirdPartiesHoneybadger--honeybadger_methods.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/honeybadger/.snapshots/TestRubyThirdPartiesHoneybadger--honeybadger_methods.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_honeybadger
-      rule_description: Sensitive data sent to Honeybadger detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_honeybadger
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_honeybadger
+        description: Sensitive data sent to Honeybadger detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_honeybadger
       line_number: 3
       filename: honeybadger_methods.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/honeybadger/.snapshots/TestRubyThirdPartiesHoneybadger--honeybadger_notify.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/honeybadger/.snapshots/TestRubyThirdPartiesHoneybadger--honeybadger_notify.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_honeybadger
-      rule_description: Sensitive data sent to Honeybadger detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_honeybadger
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_honeybadger
+        description: Sensitive data sent to Honeybadger detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_honeybadger
       line_number: 2
       filename: honeybadger_notify.rb
       category_groups:
@@ -17,10 +19,12 @@ critical:
           context: context,
           parameters: parameters,
         )
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_honeybadger
-      rule_description: Sensitive data sent to Honeybadger detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_honeybadger
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_honeybadger
+        description: Sensitive data sent to Honeybadger detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_honeybadger
       line_number: 9
       filename: honeybadger_notify.rb
       category_groups:
@@ -35,10 +39,12 @@ critical:
           context: context,
           parameters: parameters,
         )
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_honeybadger
-      rule_description: Sensitive data sent to Honeybadger detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_honeybadger
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_honeybadger
+        description: Sensitive data sent to Honeybadger detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_honeybadger
       line_number: 13
       filename: honeybadger_notify.rb
       category_groups:
@@ -53,10 +59,12 @@ critical:
           context: context,
           parameters: parameters,
         )
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_honeybadger
-      rule_description: Sensitive data sent to Honeybadger detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_honeybadger
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_honeybadger
+        description: Sensitive data sent to Honeybadger detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_honeybadger
       line_number: 14
       filename: honeybadger_notify.rb
       category_groups:
@@ -71,10 +79,12 @@ critical:
           context: context,
           parameters: parameters,
         )
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_honeybadger
-      rule_description: Sensitive data sent to Honeybadger detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_honeybadger
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_honeybadger
+        description: Sensitive data sent to Honeybadger detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_honeybadger
       line_number: 22
       filename: honeybadger_notify.rb
       category_groups:
@@ -89,10 +99,12 @@ critical:
           context: context,
           parameters: parameters,
         )
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_honeybadger
-      rule_description: Sensitive data sent to Honeybadger detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_honeybadger
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_honeybadger
+        description: Sensitive data sent to Honeybadger detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_honeybadger
       line_number: 29
       filename: honeybadger_notify.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/new_relic.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/new_relic.yml
@@ -37,7 +37,6 @@ metadata:
     ## Resources
     - [New Relic Docs](https://docs.newrelic.com/)
     - [Log obfuscation](https://docs.newrelic.com/docs/logs/ui-data/obfuscation-ui/)
-  dsr_id: DSR-1
   cwe_id:
     - 201
   associated_recipe: New Relic

--- a/pkg/commands/process/settings/rules/ruby/third_parties/new_relic/.snapshots/TestRubyThirdPartiesNewRelic--datatype_in_add_custom_attributes.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/new_relic/.snapshots/TestRubyThirdPartiesNewRelic--datatype_in_add_custom_attributes.yml
@@ -1,18 +1,22 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_new_relic
-      rule_description: Sensitive data sent to New Relic detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_new_relic
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_new_relic
+        description: Sensitive data sent to New Relic detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_new_relic
       line_number: 1
       filename: datatype_in_add_custom_attributes.rb
       category_groups:
         - PII
       parent_line_number: 2
       parent_content: NewRelic::Agent.add_custom_attributes(user)
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_new_relic
-      rule_description: Sensitive data sent to New Relic detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_new_relic
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_new_relic
+        description: Sensitive data sent to New Relic detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_new_relic
       line_number: 3
       filename: datatype_in_add_custom_attributes.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/new_relic/.snapshots/TestRubyThirdPartiesNewRelic--datatype_in_add_custom_parameters.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/new_relic/.snapshots/TestRubyThirdPartiesNewRelic--datatype_in_add_custom_parameters.yml
@@ -1,18 +1,22 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_new_relic
-      rule_description: Sensitive data sent to New Relic detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_new_relic
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_new_relic
+        description: Sensitive data sent to New Relic detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_new_relic
       line_number: 1
       filename: datatype_in_add_custom_parameters.rb
       category_groups:
         - PII
       parent_line_number: 2
       parent_content: NewRelic::Agent.add_custom_parameters(user)
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_new_relic
-      rule_description: Sensitive data sent to New Relic detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_new_relic
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_new_relic
+        description: Sensitive data sent to New Relic detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_new_relic
       line_number: 3
       filename: datatype_in_add_custom_parameters.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/new_relic/.snapshots/TestRubyThirdPartiesNewRelic--datatype_in_notice_error.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/new_relic/.snapshots/TestRubyThirdPartiesNewRelic--datatype_in_notice_error.yml
@@ -1,18 +1,22 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_new_relic
-      rule_description: Sensitive data sent to New Relic detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_new_relic
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_new_relic
+        description: Sensitive data sent to New Relic detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_new_relic
       line_number: 1
       filename: datatype_in_notice_error.rb
       category_groups:
         - PII
       parent_line_number: 2
       parent_content: 'NewRelic::Agent.notice_error(exception, { custom_params: user })'
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_new_relic
-      rule_description: Sensitive data sent to New Relic detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_new_relic
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_new_relic
+        description: Sensitive data sent to New Relic detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_new_relic
       line_number: 3
       filename: datatype_in_notice_error.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry.yml
@@ -53,7 +53,6 @@ metadata:
 
     ## Resources
     - [Open Telemetry Docs](https://opentelemetry.io/docs/)
-  dsr_id: DSR-1
   cwe_id:
     - 201
   id: ruby_third_parties_open_telemetry

--- a/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/.snapshots/TestRubyThirdPartiesOpenTelemetry--datatype_in_record_exception.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/.snapshots/TestRubyThirdPartiesOpenTelemetry--datatype_in_record_exception.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_open_telemetry
-      rule_description: Sensitive data sent to Open Telemetry detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_open_telemetry
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_open_telemetry
+        description: Sensitive data sent to Open Telemetry detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_open_telemetry
       line_number: 7
       filename: datatype_in_record_exception.rb
       category_groups:
@@ -10,10 +12,12 @@ critical:
         - Personal Data
       parent_line_number: 7
       parent_content: 'current_span.status = OpenTelemetry::Trace::Status.error("error for user #{current_user.email}")'
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_open_telemetry
-      rule_description: Sensitive data sent to Open Telemetry detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_open_telemetry
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_open_telemetry
+        description: Sensitive data sent to Open Telemetry detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_open_telemetry
       line_number: 17
       filename: datatype_in_record_exception.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/.snapshots/TestRubyThirdPartiesOpenTelemetry--datatype_in_span_attributes.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/.snapshots/TestRubyThirdPartiesOpenTelemetry--datatype_in_span_attributes.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_open_telemetry
-      rule_description: Sensitive data sent to Open Telemetry detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_open_telemetry
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_open_telemetry
+        description: Sensitive data sent to Open Telemetry detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_open_telemetry
       line_number: 7
       filename: datatype_in_span_attributes.rb
       category_groups:
@@ -13,10 +15,12 @@ critical:
             "user.id" => user.id,
             "user.first_name" => user.first_name
           })
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_open_telemetry
-      rule_description: Sensitive data sent to Open Telemetry detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_open_telemetry
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_open_telemetry
+        description: Sensitive data sent to Open Telemetry detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_open_telemetry
       line_number: 13
       filename: datatype_in_span_attributes.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/.snapshots/TestRubyThirdPartiesOpenTelemetry--datatype_in_span_event.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/.snapshots/TestRubyThirdPartiesOpenTelemetry--datatype_in_span_event.yml
@@ -1,18 +1,22 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_open_telemetry
-      rule_description: Sensitive data sent to Open Telemetry detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_open_telemetry
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_open_telemetry
+        description: Sensitive data sent to Open Telemetry detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_open_telemetry
       line_number: 2
       filename: datatype_in_span_event.rb
       category_groups:
         - PII
       parent_line_number: 2
       parent_content: 'span.add_event("Schedule job for user: #{current_user.email}")'
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_open_telemetry
-      rule_description: Sensitive data sent to Open Telemetry detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_open_telemetry
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_open_telemetry
+        description: Sensitive data sent to Open Telemetry detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_open_telemetry
       line_number: 4
       filename: datatype_in_span_event.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/.snapshots/TestRubyThirdPartiesOpenTelemetry--datatypes_in_span_init_block.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/open_telemetry/.snapshots/TestRubyThirdPartiesOpenTelemetry--datatypes_in_span_init_block.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_open_telemetry
-      rule_description: Sensitive data sent to Open Telemetry detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_open_telemetry
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_open_telemetry
+        description: Sensitive data sent to Open Telemetry detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_open_telemetry
       line_number: 2
       filename: datatypes_in_span_init_block.rb
       category_groups:
@@ -12,10 +14,12 @@ critical:
         Tracer.in_span("data leaking", attributes: { "current_user" => user.email, "date" => DateTime.now }) do |span|
           puts "in the span block"
         end
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_open_telemetry
-      rule_description: Sensitive data sent to Open Telemetry detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_open_telemetry
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_open_telemetry
+        description: Sensitive data sent to Open Telemetry detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_open_telemetry
       line_number: 6
       filename: datatypes_in_span_init_block.rb
       category_groups:
@@ -25,20 +29,24 @@ critical:
         SomeOtherTracer.in_span("data leaking", attributes: { "current_user" => user.email, "date" => DateTime.now }) do |span|
           span.add_attributes(user.email)
         end
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_open_telemetry
-      rule_description: Sensitive data sent to Open Telemetry detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_open_telemetry
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_open_telemetry
+        description: Sensitive data sent to Open Telemetry detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_open_telemetry
       line_number: 7
       filename: datatypes_in_span_init_block.rb
       category_groups:
         - PII
       parent_line_number: 7
       parent_content: span.add_attributes(user.email)
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_open_telemetry
-      rule_description: Sensitive data sent to Open Telemetry detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_open_telemetry
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_open_telemetry
+        description: Sensitive data sent to Open Telemetry detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_open_telemetry
       line_number: 11
       filename: datatypes_in_span_init_block.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/rollbar.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/rollbar.yml
@@ -63,7 +63,6 @@ metadata:
     ## Resources
     - [Rollbar docs](https://docs.rollbar.com/docs/ruby)
     - [Scrubbing items](https://docs.rollbar.com/docs/ruby#section-scrubbing-items)
-  dsr_id: DSR-1
   cwe_id:
     - 201
   associated_recipe: Rollbar

--- a/pkg/commands/process/settings/rules/ruby/third_parties/rollbar/.snapshots/TestRubyThirdPartiesRollbar--datatype_in_context.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/rollbar/.snapshots/TestRubyThirdPartiesRollbar--datatype_in_context.yml
@@ -1,8 +1,10 @@
 low:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_rollbar
-      rule_description: Sensitive data sent to Rollbar detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_rollbar
+        description: Sensitive data sent to Rollbar detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
       line_number: 1
       filename: datatype_in_context.rb
       parent_line_number: 1

--- a/pkg/commands/process/settings/rules/ruby/third_parties/rollbar/.snapshots/TestRubyThirdPartiesRollbar--datatype_in_log.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/rollbar/.snapshots/TestRubyThirdPartiesRollbar--datatype_in_log.yml
@@ -1,28 +1,34 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_rollbar
-      rule_description: Sensitive data sent to Rollbar detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_rollbar
+        description: Sensitive data sent to Rollbar detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
       line_number: 1
       filename: datatype_in_log.rb
       category_groups:
         - PII
       parent_line_number: 1
       parent_content: 'Rollbar.log("error", "oops #{user.email}")'
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_rollbar
-      rule_description: Sensitive data sent to Rollbar detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_rollbar
+        description: Sensitive data sent to Rollbar detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
       line_number: 2
       filename: datatype_in_log.rb
       category_groups:
         - PII
       parent_line_number: 2
       parent_content: 'Rollbar.log("error", "oops", user: { email: "someone@example.com" })'
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_rollbar
-      rule_description: Sensitive data sent to Rollbar detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_rollbar
+        description: Sensitive data sent to Rollbar detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
       line_number: 3
       filename: datatype_in_log.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/rollbar/.snapshots/TestRubyThirdPartiesRollbar--datatype_in_log_helper.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/rollbar/.snapshots/TestRubyThirdPartiesRollbar--datatype_in_log_helper.yml
@@ -1,78 +1,94 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_rollbar
-      rule_description: Sensitive data sent to Rollbar detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_rollbar
+        description: Sensitive data sent to Rollbar detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
       line_number: 1
       filename: datatype_in_log_helper.rb
       category_groups:
         - PII
       parent_line_number: 1
       parent_content: 'Rollbar.critical("oops #{user.email}")'
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_rollbar
-      rule_description: Sensitive data sent to Rollbar detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_rollbar
+        description: Sensitive data sent to Rollbar detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
       line_number: 2
       filename: datatype_in_log_helper.rb
       category_groups:
         - PII
       parent_line_number: 2
       parent_content: 'Rollbar.critical(e, "oops #{user.email}")'
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_rollbar
-      rule_description: Sensitive data sent to Rollbar detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_rollbar
+        description: Sensitive data sent to Rollbar detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
       line_number: 3
       filename: datatype_in_log_helper.rb
       category_groups:
         - PII
       parent_line_number: 3
       parent_content: 'Rollbar.critical(e, user: { email: "someone@example.com" })'
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_rollbar
-      rule_description: Sensitive data sent to Rollbar detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_rollbar
+        description: Sensitive data sent to Rollbar detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
       line_number: 4
       filename: datatype_in_log_helper.rb
       category_groups:
         - PII
       parent_line_number: 4
       parent_content: 'Rollbar.critical(e, { user: { first_name: "someone" } })'
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_rollbar
-      rule_description: Sensitive data sent to Rollbar detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_rollbar
+        description: Sensitive data sent to Rollbar detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
       line_number: 6
       filename: datatype_in_log_helper.rb
       category_groups:
         - PII
       parent_line_number: 6
       parent_content: 'Rollbar.error("oops #{user.email}")'
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_rollbar
-      rule_description: Sensitive data sent to Rollbar detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_rollbar
+        description: Sensitive data sent to Rollbar detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
       line_number: 8
       filename: datatype_in_log_helper.rb
       category_groups:
         - PII
       parent_line_number: 8
       parent_content: 'Rollbar.debug("oops #{user.email}")'
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_rollbar
-      rule_description: Sensitive data sent to Rollbar detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_rollbar
+        description: Sensitive data sent to Rollbar detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
       line_number: 10
       filename: datatype_in_log_helper.rb
       category_groups:
         - PII
       parent_line_number: 10
       parent_content: 'Rollbar.info("oops #{user.email}")'
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_rollbar
-      rule_description: Sensitive data sent to Rollbar detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_rollbar
+        description: Sensitive data sent to Rollbar detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
       line_number: 12
       filename: datatype_in_log_helper.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/rollbar/.snapshots/TestRubyThirdPartiesRollbar--datatype_in_scope.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/rollbar/.snapshots/TestRubyThirdPartiesRollbar--datatype_in_scope.yml
@@ -1,28 +1,34 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_rollbar
-      rule_description: Sensitive data sent to Rollbar detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_rollbar
+        description: Sensitive data sent to Rollbar detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
       line_number: 1
       filename: datatype_in_scope.rb
       category_groups:
         - PII
       parent_line_number: 1
       parent_content: 'Rollbar.scope!({ user: { email: "someone@example.com" }})'
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_rollbar
-      rule_description: Sensitive data sent to Rollbar detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_rollbar
+        description: Sensitive data sent to Rollbar detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
       line_number: 3
       filename: datatype_in_scope.rb
       category_groups:
         - PII
       parent_line_number: 5
       parent_content: Rollbar.scope(user)
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_rollbar
-      rule_description: Sensitive data sent to Rollbar detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_rollbar
+        description: Sensitive data sent to Rollbar detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
       line_number: 7
       filename: datatype_in_scope.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/rollbar/.snapshots/TestRubyThirdPartiesRollbar--datatype_in_scoped.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/rollbar/.snapshots/TestRubyThirdPartiesRollbar--datatype_in_scoped.yml
@@ -1,8 +1,10 @@
 low:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_rollbar
-      rule_description: Sensitive data sent to Rollbar detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_rollbar
+        description: Sensitive data sent to Rollbar detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
       line_number: 1
       filename: datatype_in_scoped.rb
       parent_line_number: 3

--- a/pkg/commands/process/settings/rules/ruby/third_parties/scout_apm.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/scout_apm.yml
@@ -31,7 +31,6 @@ metadata:
 
     ## Resources
     - [Scout APM docs](https://scoutapm.com/docs/ruby)
-  dsr_id: DSR-1
   cwe_id:
     - 201
   associated_recipe: Scout APM

--- a/pkg/commands/process/settings/rules/ruby/third_parties/scout_apm/.snapshots/TestRubyThirdPartiesScoutAPM--datatype_in_add.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/scout_apm/.snapshots/TestRubyThirdPartiesScoutAPM--datatype_in_add.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_scout_apm
-      rule_description: Sensitive data sent to Scout APM detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_scout_apm
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_scout_apm
+        description: Sensitive data sent to Scout APM detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_scout_apm
       line_number: 1
       filename: datatype_in_add.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/scout_apm/.snapshots/TestRubyThirdPartiesScoutAPM--datatype_in_add_user.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/scout_apm/.snapshots/TestRubyThirdPartiesScoutAPM--datatype_in_add_user.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_scout_apm
-      rule_description: Sensitive data sent to Scout APM detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_scout_apm
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_scout_apm
+        description: Sensitive data sent to Scout APM detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_scout_apm
       line_number: 1
       filename: datatype_in_add_user.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/segment.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/segment.yml
@@ -40,7 +40,6 @@ metadata:
 
     ## Resources
     - [Segment docs](https://segment.com/docs/connections/sources/catalog/libraries/server/ruby/)
-  dsr_id: DSR-1
   cwe_id:
     - 201
   associated_recipe: Segment

--- a/pkg/commands/process/settings/rules/ruby/third_parties/segment/.snapshots/TestRubyThirdPartiesSegment--datatype_as_user_id.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/segment/.snapshots/TestRubyThirdPartiesSegment--datatype_as_user_id.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_segment
-      rule_description: Sensitive data sent to Segment detected..
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_segment
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_segment
+        description: Sensitive data sent to Segment detected..
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_segment
       line_number: 2
       filename: datatype_as_user_id.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/segment/.snapshots/TestRubyThirdPartiesSegment--datatype_in_nested_attribute.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/segment/.snapshots/TestRubyThirdPartiesSegment--datatype_in_nested_attribute.yml
@@ -1,8 +1,10 @@
 high:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_segment
-      rule_description: Sensitive data sent to Segment detected..
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_segment
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_segment
+        description: Sensitive data sent to Segment detected..
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_segment
       line_number: 2
       filename: datatype_in_nested_attribute.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/sentry.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/sentry.yml
@@ -144,7 +144,6 @@ metadata:
 
     ## Resources
     - [Sentry Docs](https://docs.sentry.io/)
-  dsr_id: DSR-1
   cwe_id:
     - 201
   associated_recipe: Sentry

--- a/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentry--datatype_in_breadcrumb.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentry--datatype_in_breadcrumb.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_sentry
-      rule_description: Sensitive data sent to Sentry detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_sentry
+        description: Sensitive data sent to Sentry detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
       line_number: 3
       filename: datatype_in_breadcrumb.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentry--datatype_in_capture_message.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentry--datatype_in_capture_message.yml
@@ -1,38 +1,46 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_sentry
-      rule_description: Sensitive data sent to Sentry detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_sentry
+        description: Sensitive data sent to Sentry detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
       line_number: 1
       filename: datatype_in_capture_message.rb
       category_groups:
         - PII
       parent_line_number: 1
       parent_content: 'Sentry.capture_message("test: #{user.email}")'
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_sentry
-      rule_description: Sensitive data sent to Sentry detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_sentry
+        description: Sensitive data sent to Sentry detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
       line_number: 2
       filename: datatype_in_capture_message.rb
       category_groups:
         - PII
       parent_line_number: 2
       parent_content: 'Sentry.capture_message("test", extra: { email: user.email })'
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_sentry
-      rule_description: Sensitive data sent to Sentry detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_sentry
+        description: Sensitive data sent to Sentry detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
       line_number: 3
       filename: datatype_in_capture_message.rb
       category_groups:
         - PII
       parent_line_number: 3
       parent_content: 'Sentry.capture_message("test", tags: { email: user.email })'
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_sentry
-      rule_description: Sensitive data sent to Sentry detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_sentry
+        description: Sensitive data sent to Sentry detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
       line_number: 4
       filename: datatype_in_capture_message.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentry--datatype_in_init.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentry--datatype_in_init.yml
@@ -1,8 +1,10 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_sentry
-      rule_description: Sensitive data sent to Sentry detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_sentry
+        description: Sensitive data sent to Sentry detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
       line_number: 3
       filename: datatype_in_init.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentry--datatype_in_set_context.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentry--datatype_in_set_context.yml
@@ -1,28 +1,34 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_sentry
-      rule_description: Sensitive data sent to Sentry detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_sentry
+        description: Sensitive data sent to Sentry detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
       line_number: 1
       filename: datatype_in_set_context.rb
       category_groups:
         - PII
       parent_line_number: 1
       parent_content: 'Sentry.set_context(''email'', { email: user.email })'
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_sentry
-      rule_description: Sensitive data sent to Sentry detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_sentry
+        description: Sensitive data sent to Sentry detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
       line_number: 4
       filename: datatype_in_set_context.rb
       category_groups:
         - PII
       parent_line_number: 4
       parent_content: 'scope.set_context(''email'', { email: user.email })'
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_sentry
-      rule_description: Sensitive data sent to Sentry detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_sentry
+        description: Sensitive data sent to Sentry detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
       line_number: 8
       filename: datatype_in_set_context.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentry--datatype_in_set_extra.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentry--datatype_in_set_extra.yml
@@ -1,18 +1,22 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_sentry
-      rule_description: Sensitive data sent to Sentry detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_sentry
+        description: Sensitive data sent to Sentry detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
       line_number: 2
       filename: datatype_in_set_extra.rb
       category_groups:
         - PII
       parent_line_number: 2
       parent_content: scope.set_extra(:email, user.email)
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_sentry
-      rule_description: Sensitive data sent to Sentry detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_sentry
+        description: Sensitive data sent to Sentry detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
       line_number: 6
       filename: datatype_in_set_extra.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentry--datatype_in_set_extras.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentry--datatype_in_set_extras.yml
@@ -1,28 +1,34 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_sentry
-      rule_description: Sensitive data sent to Sentry detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_sentry
+        description: Sensitive data sent to Sentry detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
       line_number: 1
       filename: datatype_in_set_extras.rb
       category_groups:
         - PII
       parent_line_number: 1
       parent_content: 'Sentry.set_extras(email: user.email)'
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_sentry
-      rule_description: Sensitive data sent to Sentry detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_sentry
+        description: Sensitive data sent to Sentry detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
       line_number: 4
       filename: datatype_in_set_extras.rb
       category_groups:
         - PII
       parent_line_number: 4
       parent_content: 'scope.set_extras(email: user.email)'
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_sentry
-      rule_description: Sensitive data sent to Sentry detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_sentry
+        description: Sensitive data sent to Sentry detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
       line_number: 8
       filename: datatype_in_set_extras.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentry--datatype_in_set_tag.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentry--datatype_in_set_tag.yml
@@ -1,18 +1,22 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_sentry
-      rule_description: Sensitive data sent to Sentry detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_sentry
+        description: Sensitive data sent to Sentry detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
       line_number: 2
       filename: datatype_in_set_tag.rb
       category_groups:
         - PII
       parent_line_number: 2
       parent_content: scope.set_tag(:email, user.email)
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_sentry
-      rule_description: Sensitive data sent to Sentry detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_sentry
+        description: Sensitive data sent to Sentry detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
       line_number: 6
       filename: datatype_in_set_tag.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentry--datatype_in_set_tags.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentry--datatype_in_set_tags.yml
@@ -1,28 +1,34 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_sentry
-      rule_description: Sensitive data sent to Sentry detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_sentry
+        description: Sensitive data sent to Sentry detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
       line_number: 1
       filename: datatype_in_set_tags.rb
       category_groups:
         - PII
       parent_line_number: 1
       parent_content: 'Sentry.set_tags(email: user.email)'
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_sentry
-      rule_description: Sensitive data sent to Sentry detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_sentry
+        description: Sensitive data sent to Sentry detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
       line_number: 4
       filename: datatype_in_set_tags.rb
       category_groups:
         - PII
       parent_line_number: 4
       parent_content: 'scope.set_tags(email: user.email)'
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_sentry
-      rule_description: Sensitive data sent to Sentry detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_sentry
+        description: Sensitive data sent to Sentry detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
       line_number: 8
       filename: datatype_in_set_tags.rb
       category_groups:

--- a/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentry--datatype_in_set_user.yml
+++ b/pkg/commands/process/settings/rules/ruby/third_parties/sentry/.snapshots/TestRubyThirdPartiesSentry--datatype_in_set_user.yml
@@ -1,28 +1,34 @@
 critical:
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_sentry
-      rule_description: Sensitive data sent to Sentry detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_sentry
+        description: Sensitive data sent to Sentry detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
       line_number: 3
       filename: datatype_in_set_user.rb
       category_groups:
         - PII
       parent_line_number: 3
       parent_content: 'Sentry.set_user(email: user.email)'
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_sentry
-      rule_description: Sensitive data sent to Sentry detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_sentry
+        description: Sensitive data sent to Sentry detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
       line_number: 6
       filename: datatype_in_set_user.rb
       category_groups:
         - PII
       parent_line_number: 6
       parent_content: 'scope.set_user(email: user.email)'
-    - rule_dsrid: DSR-1
-      rule_display_id: ruby_third_parties_sentry
-      rule_description: Sensitive data sent to Sentry detected.
-      rule_documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_sentry
+        description: Sensitive data sent to Sentry detected.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
       line_number: 10
       filename: datatype_in_set_user.rb
       category_groups:

--- a/pkg/commands/process/settings/settings.go
+++ b/pkg/commands/process/settings/settings.go
@@ -63,12 +63,12 @@ type PolicyModule struct {
 }
 
 type RuleMetadata struct {
-	Description        string `mapstructure:"description" json:"description" yaml:"description"`
-	RemediationMessage string `mapstructure:"remediation_message" json:"remediation_messafe" yaml:"remediation_messafe"`
-	DSRID              string `mapstructure:"dsr_id" json:"dsr_id" yaml:"dsr_id"`
-	AssociatedRecipe   string `mapstructure:"associated_recipe" json:"associated_recipe" yaml:"associated_recipe"`
-	ID                 string `mapstructure:"id" json:"id" yaml:"id"`
-	DocumentationUrl   string `mapstructure:"documentation_url" json:"documentation_url" yaml:"documentation_url"`
+	Description        string   `mapstructure:"description" json:"description" yaml:"description"`
+	RemediationMessage string   `mapstructure:"remediation_message" json:"remediation_messafe" yaml:"remediation_messafe"`
+	CWEIDs             []string `mapstructure:"cwe_id" json:"cwe_id" yaml:"cwe_id"`
+	AssociatedRecipe   string   `mapstructure:"associated_recipe" json:"associated_recipe" yaml:"associated_recipe"`
+	ID                 string   `mapstructure:"id" json:"id" yaml:"id"`
+	DocumentationUrl   string   `mapstructure:"documentation_url" json:"documentation_url" yaml:"documentation_url"`
 }
 
 type RuleDefinition struct {
@@ -128,7 +128,7 @@ type Rule struct {
 	Severity           map[string]string `mapstructure:"severity" json:"severity,omitempty" yaml:"severity,omitempty"`
 	Description        string            `mapstructure:"description" json:"description" yaml:"description"`
 	RemediationMessage string            `mapstructure:"remediation_message" json:"remediation_messafe" yaml:"remediation_messafe"`
-	DSRID              string            `mapstructure:"dsr_id" json:"dsr_id" yaml:"dsr_id"`
+	CWEIDs             []string          `mapstructure:"cwe_ids" json:"cwe_ids" yaml:"cwe_ids"`
 	Languages          []string          `mapstructure:"languages" json:"languages" yaml:"languages"`
 	Patterns           []RulePattern     `mapstructure:"patterns" json:"patterns" yaml:"patterns"`
 	DocumentationUrl   string            `mapstructure:"documentation_url" json:"documentation_url" yaml:"documentation_url"`

--- a/pkg/report/output/summary/.snapshots/TestBuildReportString
+++ b/pkg/report/output/summary/.snapshots/TestBuildReportString
@@ -3,14 +3,12 @@
 Summary Report
 
 =====================================
-Checks: 
 
-- Its a test! (custom_test_rule)
-- Missing SSL certificate verification detected. (ruby_lang_ssl_verification) [DSR-2]
-- Sensitive data sent to Rails loggers detected. (ruby_rails_logger) [DSR-5]
+Rules: 
+ - 2 default rules applied (https://docs.bearer.com/reference/rules)
+ - 1 custom rules applied
 
-
-CRITICAL: Sensitive data sent to Rails loggers detected. [DSR-5]
+CRITICAL: Sensitive data sent to Rails loggers detected. [CWE-209, CWE-532]
 https://docs.bearer.com/reference/rules/ruby_rails_logger
 To skip this rule, use the flag --skip-rule=ruby_rails_logger
 
@@ -18,7 +16,7 @@ File: pkg/datatype_leak.rb:1
 
 
 
-LOW: Missing SSL certificate verification detected. [DSR-2]
+LOW: Missing SSL certificate verification detected. [CWE-295]
 https://docs.bearer.com/reference/rules/ruby_lang_ssl_verification
 To skip this rule, use the flag --skip-rule=ruby_lang_ssl_verification
 
@@ -29,10 +27,10 @@ File: config/application.rb:2
 
 3 checks, 2 failures, 0 warnings
 
-CRITICAL: 1 (DSR-5)
+CRITICAL: 1 (CWE-209, CWE-532)
 HIGH: 0
 MEDIUM: 0
-LOW: 1 (DSR-2)
+LOW: 1 (CWE-295)
 WARNING: 0
 
 Need help or want to discuss the output? Join the Community https://discord.gg/eaHZBJUXRF

--- a/pkg/report/output/summary/.snapshots/TestGetOutput
+++ b/pkg/report/output/summary/.snapshots/TestGetOutput
@@ -1,10 +1,15 @@
 (map[string][]summary.Result) (len=2) {
   (string) (len=8) "critical": ([]summary.Result) (len=1) {
     (summary.Result) {
-      RuleDSRID: (string) (len=5) "DSR-5",
-      RuleDisplayId: (string) (len=17) "ruby_rails_logger",
-      RuleDescription: (string) (len=46) "Sensitive data sent to Rails loggers detected.",
-      RuleDocumentationUrl: (string) (len=57) "https://docs.bearer.com/reference/rules/ruby_rails_logger",
+      Rule: (*summary.RuleResultSummary)({
+        CWEIDs: ([]string) (len=2) {
+          (string) (len=3) "209",
+          (string) (len=3) "532"
+        },
+        Id: (string) (len=17) "ruby_rails_logger",
+        Description: (string) (len=46) "Sensitive data sent to Rails loggers detected.",
+        DocumentationUrl: (string) (len=57) "https://docs.bearer.com/reference/rules/ruby_rails_logger"
+      }),
       LineNumber: (int) 1,
       Filename: (string) (len=20) "pkg/datatype_leak.rb",
       CategoryGroups: ([]string) (len=1) {
@@ -12,16 +17,19 @@
       },
       ParentLineNumber: (int) 1,
       ParentContent: (string) (len=29) "Rails.logger.info(user.email)",
-      OmitParent: (bool) false,
       DetailedContext: (string) ""
     }
   },
   (string) (len=3) "low": ([]summary.Result) (len=1) {
     (summary.Result) {
-      RuleDSRID: (string) (len=5) "DSR-2",
-      RuleDisplayId: (string) (len=26) "ruby_lang_ssl_verification",
-      RuleDescription: (string) (len=46) "Missing SSL certificate verification detected.",
-      RuleDocumentationUrl: (string) (len=66) "https://docs.bearer.com/reference/rules/ruby_lang_ssl_verification",
+      Rule: (*summary.RuleResultSummary)({
+        CWEIDs: ([]string) (len=1) {
+          (string) (len=3) "295"
+        },
+        Id: (string) (len=26) "ruby_lang_ssl_verification",
+        Description: (string) (len=46) "Missing SSL certificate verification detected.",
+        DocumentationUrl: (string) (len=66) "https://docs.bearer.com/reference/rules/ruby_lang_ssl_verification"
+      }),
       LineNumber: (int) 2,
       Filename: (string) (len=21) "config/application.rb",
       CategoryGroups: ([]string) (len=1) {
@@ -29,7 +37,6 @@
       },
       ParentLineNumber: (int) 2,
       ParentContent: (string) (len=44) "http.verify_mode = OpenSSL::SSL::VERIFY_NONE",
-      OmitParent: (bool) false,
       DetailedContext: (string) ""
     }
   }

--- a/pkg/report/output/summary/.snapshots/TestTestGetOutputWithSeverity
+++ b/pkg/report/output/summary/.snapshots/TestTestGetOutputWithSeverity
@@ -1,10 +1,15 @@
 (map[string][]summary.Result) (len=1) {
   (string) (len=8) "critical": ([]summary.Result) (len=1) {
     (summary.Result) {
-      RuleDSRID: (string) (len=5) "DSR-5",
-      RuleDisplayId: (string) (len=17) "ruby_rails_logger",
-      RuleDescription: (string) (len=46) "Sensitive data sent to Rails loggers detected.",
-      RuleDocumentationUrl: (string) (len=57) "https://docs.bearer.com/reference/rules/ruby_rails_logger",
+      Rule: (*summary.RuleResultSummary)({
+        CWEIDs: ([]string) (len=2) {
+          (string) (len=3) "209",
+          (string) (len=3) "532"
+        },
+        Id: (string) (len=17) "ruby_rails_logger",
+        Description: (string) (len=46) "Sensitive data sent to Rails loggers detected.",
+        DocumentationUrl: (string) (len=57) "https://docs.bearer.com/reference/rules/ruby_rails_logger"
+      }),
       LineNumber: (int) 1,
       Filename: (string) (len=20) "pkg/datatype_leak.rb",
       CategoryGroups: ([]string) (len=1) {
@@ -12,7 +17,6 @@
       },
       ParentLineNumber: (int) 1,
       ParentContent: (string) (len=29) "Rails.logger.info(user.email)",
-      OmitParent: (bool) false,
       DetailedContext: (string) ""
     }
   }

--- a/pkg/report/output/summary/summary.go
+++ b/pkg/report/output/summary/summary.go
@@ -123,14 +123,14 @@ func GetOutput(dataflow *dataflow.DataFlow, config settings.Config) (map[string]
 			}
 
 			for _, output := range results["policy_failure"] {
-				ruleSummay := &RuleResultSummary{
+				ruleSummary := &RuleResultSummary{
 					Description:      rule.Description,
 					Id:               rule.Id,
 					CWEIDs:           rule.CWEIDs,
 					DocumentationUrl: rule.DocumentationUrl,
 				}
 				result := Result{
-					Rule:             ruleSummay,
+					Rule:             ruleSummary,
 					Filename:         output.Filename,
 					LineNumber:       output.LineNumber,
 					CategoryGroups:   output.CategoryGroups,

--- a/pkg/report/output/summary/summary_test.go
+++ b/pkg/report/output/summary/summary_test.go
@@ -29,7 +29,7 @@ func TestBuildReportString(t *testing.T) {
 	customRule := &settings.Rule{
 		Id:          "custom_test_rule",
 		Description: "Its a test!",
-		DSRID:       "",
+		CWEIDs:      []string{},
 		Type:        "risk",
 		Severity:    map[string]string{"default": "low"},
 	}


### PR DESCRIPTION
## Description
Improve overall output from summary report now we have lots of rules


- Now just display summary of rules run to reduce output 
<img width="615" alt="Screenshot 2023-02-22 at 17 24 25" src="https://user-images.githubusercontent.com/699436/220710414-38fe0b1d-0ffa-483e-b94f-8ee2fcb52fc6.png">

- Show CWE instead of old DSR

<img width="758" alt="Screenshot 2023-02-22 at 17 24 18" src="https://user-images.githubusercontent.com/699436/220710484-60fbb204-1a3b-4214-acc7-7c82de909efe.png">

- update items for summary json output to scope rule info under a rule key
```json
{
      "rule": {
        "cwe_ids": [
          "201"
        ],
        "id": "ruby_third_parties_sentry",
        "description": "Sensitive data sent to Sentry detected.",
        "documentation_url": "https://docs.bearer.com/reference/rules/ruby_third_parties_sentry"
      },
      "line_number": 39,
      "filename": "/Users/phil/development/bearer/bear-publishing/app/controllers/application_controller.rb",
      "category_groups": [
        "PII"
      ],
      "parent_line_number": 39,
      "parent_content": "Sentry.set_user(email: current_user.email)"
    }
```




## Related

- Close #605


## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
