### PR TITLE
feat(ruby rule): add rails render to path rule

### DIFF
--- a/pkg/commands/process/settings/rules/ruby/lang/path_using_user_input.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/path_using_user_input.yml
@@ -51,6 +51,36 @@ patterns:
         detection: ruby_lang_path_using_user_input_pathname
       - variable: USER_INPUT
         detection: ruby_lang_path_using_user_input_user_input
+  - pattern: |
+      $<METHOD>($<ARGUMENT>: $<USER_INPUT>)
+    filters:
+      - variable: METHOD
+        values:
+          - render
+          - render_to_string
+      - variable: ARGUMENT
+        values:
+          - action
+          - file
+          - partial
+          - template
+      - variable: USER_INPUT
+        detection: ruby_lang_path_using_user_input_user_input
+  - pattern: |
+      $<METHOD>({ $<ARGUMENT>: $<USER_INPUT> })
+    filters:
+      - variable: METHOD
+        values:
+          - render
+          - render_to_string
+      - variable: ARGUMENT
+        values:
+          - action
+          - file
+          - partial
+          - template
+      - variable: USER_INPUT
+        detection: ruby_lang_path_using_user_input_user_input
 auxiliary:
   - id: ruby_lang_path_using_user_input_user_input
     patterns:

--- a/pkg/commands/process/settings/rules/ruby/lang/path_using_user_input/.snapshots/TestRubyLangPathUsingUserInput--unsafe_event.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/path_using_user_input/.snapshots/TestRubyLangPathUsingUserInput--unsafe_event.yml
@@ -111,15 +111,5 @@ low:
       filename: unsafe_event.rb
       parent_line_number: 20
       parent_content: path.join("a", event["three"])
-    - rule:
-        cwe_ids:
-            - "22"
-        id: ruby_lang_path_using_user_input
-        description: Do not use user input to form file paths.
-        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
-      line_number: 22
-      filename: unsafe_event.rb
-      parent_line_number: 22
-      parent_content: Rails.root.join(event["oops"])
 
 

--- a/pkg/commands/process/settings/rules/ruby/lang/path_using_user_input/.snapshots/TestRubyLangPathUsingUserInput--unsafe_params.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/path_using_user_input/.snapshots/TestRubyLangPathUsingUserInput--unsafe_params.yml
@@ -111,15 +111,5 @@ low:
       filename: unsafe_params.rb
       parent_line_number: 19
       parent_content: path.join("a", params[:four])
-    - rule:
-        cwe_ids:
-            - "22"
-        id: ruby_lang_path_using_user_input
-        description: Do not use user input to form file paths.
-        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
-      line_number: 21
-      filename: unsafe_params.rb
-      parent_line_number: 21
-      parent_content: Rails.root.join(params[:oops])
 
 

--- a/pkg/commands/process/settings/rules/ruby/lang/path_using_user_input/.snapshots/TestRubyLangPathUsingUserInput--unsafe_rails.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/path_using_user_input/.snapshots/TestRubyLangPathUsingUserInput--unsafe_rails.yml
@@ -1,0 +1,33 @@
+low:
+    - rule:
+        cwe_ids:
+            - "22"
+        id: ruby_lang_path_using_user_input
+        description: Do not use user input to form file paths.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
+      line_number: 1
+      filename: unsafe_rails.rb
+      parent_line_number: 1
+      parent_content: Rails.root.join(params[:oops])
+    - rule:
+        cwe_ids:
+            - "22"
+        id: ruby_lang_path_using_user_input
+        description: Do not use user input to form file paths.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
+      line_number: 3
+      filename: unsafe_rails.rb
+      parent_line_number: 3
+      parent_content: 'render(partial: params[:oops])'
+    - rule:
+        cwe_ids:
+            - "22"
+        id: ruby_lang_path_using_user_input
+        description: Do not use user input to form file paths.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
+      line_number: 4
+      filename: unsafe_rails.rb
+      parent_line_number: 4
+      parent_content: 'render_to_string({ file: "/templates/#{params[:oops]}" })'
+
+

--- a/pkg/commands/process/settings/rules/ruby/lang/path_using_user_input/.snapshots/TestRubyLangPathUsingUserInput--unsafe_request.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/path_using_user_input/.snapshots/TestRubyLangPathUsingUserInput--unsafe_request.yml
@@ -111,15 +111,5 @@ low:
       filename: unsafe_request.rb
       parent_line_number: 19
       parent_content: path.join("a", request.body)
-    - rule:
-        cwe_ids:
-            - "22"
-        id: ruby_lang_path_using_user_input
-        description: Do not use user input to form file paths.
-        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
-      line_number: 21
-      filename: unsafe_request.rb
-      parent_line_number: 21
-      parent_content: Rails.root.join(request.env[:oops])
 
 

--- a/pkg/commands/process/settings/rules/ruby/lang/path_using_user_input/testdata/ok_not_unsafe.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/path_using_user_input/testdata/ok_not_unsafe.rb
@@ -19,4 +19,8 @@ path + x
 path / x
 path.join("a", x)
 
+
 Rails.root.join(x)
+
+render(partial: x, locals: { z: params[:ok] })
+render_to_string({ file: "/templates/#{x}", locals: { z: params[:ok] } })

--- a/pkg/commands/process/settings/rules/ruby/lang/path_using_user_input/testdata/unsafe_event.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/path_using_user_input/testdata/unsafe_event.rb
@@ -18,6 +18,4 @@ def my_handler(event:, context:)
   path + event["two"]
   path / event["two"]
   path.join("a", event["three"])
-
-  Rails.root.join(event["oops"])
 end

--- a/pkg/commands/process/settings/rules/ruby/lang/path_using_user_input/testdata/unsafe_params.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/path_using_user_input/testdata/unsafe_params.rb
@@ -17,5 +17,3 @@ path = Pathname.new(params[:oops])
 path + params[:two]
 path / params[:three]
 path.join("a", params[:four])
-
-Rails.root.join(params[:oops])

--- a/pkg/commands/process/settings/rules/ruby/lang/path_using_user_input/testdata/unsafe_rails.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/path_using_user_input/testdata/unsafe_rails.rb
@@ -1,0 +1,4 @@
+Rails.root.join(params[:oops])
+
+render(partial: params[:oops])
+render_to_string({ file: "/templates/#{params[:oops]}" })

--- a/pkg/commands/process/settings/rules/ruby/lang/path_using_user_input/testdata/unsafe_request.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/path_using_user_input/testdata/unsafe_request.rb
@@ -17,5 +17,3 @@ path = Pathname.new(request.env[:oops])
 path + request.headers[:oops]
 path / request.query_parameters[:oops]
 path.join("a", request.body)
-
-Rails.root.join(request.env[:oops])

--- a/pkg/commands/process/settings/rules/ruby/rails/open_redirect.yml
+++ b/pkg/commands/process/settings/rules/ruby/rails/open_redirect.yml
@@ -3,11 +3,11 @@ patterns:
       redirect_to($<USER_INPUT>)
     filters:
       - variable: USER_INPUT
-        detection: rails_redirect_to_user_input
+        detection: ruby_rails_redirect_to_user_input
 languages:
   - ruby
 auxiliary:
-  - id: rails_redirect_to_user_input
+  - id: ruby_rails_redirect_to_user_input
     patterns:
       - params
       - request
@@ -22,4 +22,4 @@ metadata:
     A web application accepts a user-controlled input that specifies a link to an external site, and uses that link in a Redirect. This simplifies phishing attacks.
   cwe_id:
     - 601
-  id: "rails_redirect_to"
+  id: ruby_rails_redirect_to

--- a/pkg/commands/process/settings/rules/ruby/rails/open_redirect/.snapshots/TestRubyRailsOpenRedirect--unsecure.yml
+++ b/pkg/commands/process/settings/rules/ruby/rails/open_redirect/.snapshots/TestRubyRailsOpenRedirect--unsecure.yml
@@ -2,9 +2,9 @@ low:
     - rule:
         cwe_ids:
             - "601"
-        id: rails_redirect_to
+        id: ruby_rails_redirect_to
         description: Open redirect detected
-        documentation_url: https://docs.bearer.com/reference/rules/rails_redirect_to
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_redirect_to
       line_number: 3
       filename: unsecure.rb
       parent_line_number: 3


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Adds support for Rails `render` methods to the Ruby "path using user input" rule.

Also fixes the id of the Rails redirect to rule.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [x] I've added test coverage that shows my fix or feature works as expected.
- [x] I've updated or added documentation if required.
- [x] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
