### PR TITLE
feat(JS rules): add CWE to JS insecure cookie

### DIFF
--- a/pkg/commands/process/settings/rules/javascript/express/insecure_cookie.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/insecure_cookie.yml
@@ -37,4 +37,5 @@ metadata:
   cwe_id:
     - 1004
     - 614
+    - 523
   id: "express_insecure_cookie"

--- a/pkg/commands/process/settings/rules/javascript/express/insecure_cookie/.snapshots/TestExpressSecureCookie--http_only.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/insecure_cookie/.snapshots/TestExpressSecureCookie--http_only.yml
@@ -3,6 +3,7 @@ low:
         cwe_ids:
             - "1004"
             - "614"
+            - "523"
         id: express_insecure_cookie
         description: Missing secure options for cookie detected.
         documentation_url: https://docs.bearer.com/reference/rules/express_insecure_cookie

--- a/pkg/commands/process/settings/rules/javascript/express/insecure_cookie/.snapshots/TestExpressSecureCookie--insecure_cookie.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/insecure_cookie/.snapshots/TestExpressSecureCookie--insecure_cookie.yml
@@ -3,6 +3,7 @@ low:
         cwe_ids:
             - "1004"
             - "614"
+            - "523"
         id: express_insecure_cookie
         description: Missing secure options for cookie detected.
         documentation_url: https://docs.bearer.com/reference/rules/express_insecure_cookie


### PR DESCRIPTION
## Description

Add CWE-523 (Unprotected Transport of Credentials) to existing Expressjs insecure cookie rule. 
As a note, CWE-523 here refers to `httpOnly: true` setting for cookies.

Relates to #606 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
