### PR TITLE
feat(JS rules): Extend expressjs insecure cookie rule

### DIFF
--- a/pkg/commands/process/settings/rules/javascript/express/insecure_cookie.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/insecure_cookie.yml
@@ -11,8 +11,71 @@ patterns:
           $<!>httpOnly: true
         }
       }
+  - pattern: |
+      {
+        cookie: $<!>$<HASH_CONTENT>
+      }
+    filters:
+      - not:
+          variable: HASH_CONTENT
+          detection: express_insecure_cookie_name_attribute
+  - pattern: |
+      {
+        cookie: $<!>$<HASH_CONTENT>
+      }
+    filters:
+      - not:
+          variable: HASH_CONTENT
+          detection: express_insecure_cookie_expiry_attribute
+  - pattern: |
+      {
+        cookie: $<!>$<HASH_CONTENT>
+      }
+    filters:
+      - not:
+          variable: HASH_CONTENT
+          detection: express_insecure_cookie_path_attribute
+  - pattern: |
+      {
+        cookie: $<!>$<HASH_CONTENT>
+      }
+    filters:
+      - not:
+          variable: HASH_CONTENT
+          detection: express_insecure_cookie_domain_attribute
+  - pattern: |
+      {
+        cookie: $<!>$<HASH_CONTENT>
+      }
+    filters:
+      - not:
+          variable: HASH_CONTENT
+          detection: express_insecure_cookie_secure_attribute
 languages:
   - javascript
+auxiliary:
+  - id: express_insecure_cookie_name_attribute
+    patterns:
+    - |
+      { $<...>name: $<_>$<...> }
+  - id: express_insecure_cookie_expiry_attribute
+    patterns:
+    - |
+      { $<...>maxAge: $<_>$<...> }
+    - |
+      { $<...>expires: $<_>$<...> }
+  - id: express_insecure_cookie_path_attribute
+    patterns:
+    - |
+      { $<...>path: $<_>$<...> }
+  - id: express_insecure_cookie_domain_attribute
+    patterns:
+    - |
+      { $<...>domain: $<_>$<...> }
+  - id: express_insecure_cookie_secure_attribute
+    patterns:
+    - |
+      { $<...>secure: $<_>$<...> }
 trigger: presence
 severity:
   default: "low"
@@ -38,4 +101,5 @@ metadata:
     - 1004
     - 614
     - 523
+    - 522
   id: "express_insecure_cookie"

--- a/pkg/commands/process/settings/rules/javascript/express/insecure_cookie/.snapshots/TestExpressSecureCookie--http_only.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/insecure_cookie/.snapshots/TestExpressSecureCookie--http_only.yml
@@ -4,6 +4,7 @@ low:
             - "1004"
             - "614"
             - "523"
+            - "522"
         id: express_insecure_cookie
         description: Missing secure options for cookie detected.
         documentation_url: https://docs.bearer.com/reference/rules/express_insecure_cookie

--- a/pkg/commands/process/settings/rules/javascript/express/insecure_cookie/.snapshots/TestExpressSecureCookie--insecure_cookie.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/insecure_cookie/.snapshots/TestExpressSecureCookie--insecure_cookie.yml
@@ -4,6 +4,7 @@ low:
             - "1004"
             - "614"
             - "523"
+            - "522"
         id: express_insecure_cookie
         description: Missing secure options for cookie detected.
         documentation_url: https://docs.bearer.com/reference/rules/express_insecure_cookie
@@ -11,5 +12,36 @@ low:
       filename: insecure_cookie.js
       parent_line_number: 9
       parent_content: 'secure: false'
+    - rule:
+        cwe_ids:
+            - "1004"
+            - "614"
+            - "523"
+            - "522"
+        id: express_insecure_cookie
+        description: Missing secure options for cookie detected.
+        documentation_url: https://docs.bearer.com/reference/rules/express_insecure_cookie
+      line_number: 23
+      filename: insecure_cookie.js
+      parent_line_number: 23
+      parent_content: 'httpOnly: true'
+    - rule:
+        cwe_ids:
+            - "1004"
+            - "614"
+            - "523"
+            - "522"
+        id: express_insecure_cookie
+        description: Missing secure options for cookie detected.
+        documentation_url: https://docs.bearer.com/reference/rules/express_insecure_cookie
+      line_number: 33
+      filename: insecure_cookie.js
+      parent_line_number: 33
+      parent_content: |-
+        {
+        			domain: "example.com",
+        			secure: true,
+        			httpOnly: false
+        		}
 
 

--- a/pkg/commands/process/settings/rules/javascript/express/insecure_cookie/testdata/http_only.js
+++ b/pkg/commands/process/settings/rules/javascript/express/insecure_cookie/testdata/http_only.js
@@ -7,6 +7,10 @@ app.use(
 		cookie: {
 			domain: "example.com",
 			httpOnly: true,
+			secure: true,
+			name: "my-custom-cookie-name",
+			maxAge: 24 * 60 * 60 * 1000,
+			path: "/some-path"
 		},
 	})
 );

--- a/pkg/commands/process/settings/rules/javascript/express/insecure_cookie/testdata/insecure_cookie.js
+++ b/pkg/commands/process/settings/rules/javascript/express/insecure_cookie/testdata/insecure_cookie.js
@@ -7,6 +7,33 @@ app.use(
 		cookie: {
 			domain: "example.com",
 			secure: false, // Ensures the browser only sends the cookie over HTTPS.
+			httpOnly: false,
+			name: "my-custom-cookie-name",
+			maxAge: 24 * 60 * 60 * 1000,
+			path: "/some-path"
+		},
+	})
+);
+
+app.use(
+	session({
+		cookie: {
+			domain: "example.com",
+			secure: true,
+			httpOnly: true,
+			name: "my-custom-cookie-name",
+			maxAge: 24 * 60 * 60 * 1000,
+			path: "/some-path"
+		},
+	})
+);
+
+app.use(
+	session({
+		cookie: {
+			domain: "example.com",
+			secure: true,
+			httpOnly: false
 		},
 	})
 );


### PR DESCRIPTION
## Description
Extend insecure cookie rule to catch on absence of best practices attributes like name, domain, maxAge or expires, etc. 

Relates to #606 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [x] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
