### PR TITLE
fix: don't report nested datatype detections

### DIFF
--- a/new/detector/implementation/generic/datatype/datatype.go
+++ b/new/detector/implementation/generic/datatype/datatype.go
@@ -53,6 +53,10 @@ func (detector *datatypeDetector) Name() string {
 	return "datatype"
 }
 
+func (detector *datatypeDetector) NestedDetections() bool {
+	return false
+}
+
 func (detector *datatypeDetector) DetectAt(
 	node *tree.Node,
 	evaluator types.Evaluator,


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

We don't keep descending down the tree for object detections once one is found, but we currently do for datatype detections (which are just classified objects).

This change makes the behaviour consistent and prevents us finding datatypes from a parent object when . ie.

```javascript
let user = { email: "", other: "" }

user.other // this expression would include "email" prior to this change and will just be "other" now
```

## Related
<!-- Closes some existing issue
- Close https://github.com/Bearer/bearer/issues/674
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
