### PR TITLE
fix(ruby rules): set correct match node in hard coded secret rule

### DIFF
--- a/pkg/commands/process/settings/rules/ruby/lang/hardcoded_secret.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/hardcoded_secret.yml
@@ -8,7 +8,7 @@ patterns:
         detection: string_literal
         contains: false
   - pattern: |
-      $<_>($<NAME>: $<STRING_LITERAL>)
+      $<_>($<!>$<NAME>: $<STRING_LITERAL>)
     filters:
       - variable: NAME
         regex: (?i)password|api_?key|secret
@@ -16,7 +16,7 @@ patterns:
         detection: string_literal
         contains: false
   - pattern: |
-      $<_>($<NAME> => $<STRING_LITERAL>)
+      $<_>($<!>$<NAME> => $<STRING_LITERAL>)
     filters:
       - variable: NAME
         regex: (?i)['"](password|api_?key|secret)['"]
@@ -24,7 +24,7 @@ patterns:
         detection: string_literal
         contains: false
   - pattern: |
-      { $<NAME>: $<STRING_LITERAL> }
+      { $<!>$<NAME>: $<STRING_LITERAL> }
     filters:
       - variable: NAME
         regex: (?i)password|api_?key|secret
@@ -32,7 +32,7 @@ patterns:
         detection: string_literal
         contains: false
   - pattern: |
-      { $<NAME> => $<STRING_LITERAL> }
+      { $<!>$<NAME> => $<STRING_LITERAL> }
     filters:
       - variable: NAME
         regex: (?i)['"](password|api_?key|secret)['"]

--- a/pkg/commands/process/settings/rules/ruby/lang/hardcoded_secret/.snapshots/TestRubyLangHardcodedSecret--bad.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/hardcoded_secret/.snapshots/TestRubyLangHardcodedSecret--bad.yml
@@ -18,7 +18,7 @@ medium:
       line_number: 4
       filename: bad.rb
       parent_line_number: 4
-      parent_content: 'call(api_key: "oops")'
+      parent_content: 'api_key: "oops"'
     - rule:
         cwe_ids:
             - "798"
@@ -28,7 +28,7 @@ medium:
       line_number: 6
       filename: bad.rb
       parent_line_number: 6
-      parent_content: call("secret" => "oops")
+      parent_content: '"secret" => "oops"'
     - rule:
         cwe_ids:
             - "798"
@@ -38,7 +38,7 @@ medium:
       line_number: 8
       filename: bad.rb
       parent_line_number: 8
-      parent_content: '{ API_KEY: "oops" }'
+      parent_content: 'API_KEY: "oops"'
     - rule:
         cwe_ids:
             - "798"
@@ -48,6 +48,6 @@ medium:
       line_number: 10
       filename: bad.rb
       parent_line_number: 10
-      parent_content: '{ "secret" => "oops" }'
+      parent_content: '"secret" => "oops"'
 
 

--- a/pkg/commands/process/settings/rules/ruby/rails/insecure_http_password/.snapshots/TestRubyRailsInsecureHTTPPassowrd--insecure_controller.yml
+++ b/pkg/commands/process/settings/rules/ruby/rails/insecure_http_password/.snapshots/TestRubyRailsInsecureHTTPPassowrd--insecure_controller.yml
@@ -18,6 +18,6 @@ medium:
       line_number: 2
       filename: insecure_controller.rb
       parent_line_number: 2
-      parent_content: 'http_basic_authenticate_with name: "foo", password: "my-secret-password"'
+      parent_content: 'password: "my-secret-password"'
 
 


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

For the Ruby hardcoded secret rule: ensure we report the match for hashes/keyword arguments at the position of the key-value pair, rather than the overall hash/function call.

Currently matches don't reference the correct line for multi-line calls/hashes.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [x] I've added test coverage that shows my fix or feature works as expected.
- [x] I've updated or added documentation if required.
- [x] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
