### PR TITLE
feat(ruby rules): add rails send_file to path rule

### DIFF
--- a/pkg/commands/process/settings/rules/ruby/lang/path_using_user_input.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/path_using_user_input.yml
@@ -167,6 +167,11 @@ patterns:
           - template
       - variable: USER_INPUT
         detection: ruby_lang_path_using_user_input_user_input
+  - pattern: |
+      send_file($<USER_INPUT>$<...>)
+    filters:
+      - variable: USER_INPUT
+        detection: ruby_lang_path_using_user_input_user_input
 auxiliary:
   - id: ruby_lang_path_using_user_input_user_input
     patterns:
@@ -235,4 +240,5 @@ metadata:
     -->
   cwe_id:
     - 22
+    - 73
   id: ruby_lang_path_using_user_input

--- a/pkg/commands/process/settings/rules/ruby/lang/path_using_user_input/.snapshots/TestRubyLangPathUsingUserInput--unsafe_event.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/path_using_user_input/.snapshots/TestRubyLangPathUsingUserInput--unsafe_event.yml
@@ -2,6 +2,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
@@ -12,6 +13,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
@@ -22,6 +24,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
@@ -32,6 +35,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
@@ -42,6 +46,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
@@ -54,6 +59,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
@@ -64,6 +70,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
@@ -74,6 +81,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
@@ -84,6 +92,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
@@ -94,6 +103,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
@@ -104,6 +114,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input

--- a/pkg/commands/process/settings/rules/ruby/lang/path_using_user_input/.snapshots/TestRubyLangPathUsingUserInput--unsafe_params.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/path_using_user_input/.snapshots/TestRubyLangPathUsingUserInput--unsafe_params.yml
@@ -2,6 +2,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
@@ -12,6 +13,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
@@ -22,6 +24,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
@@ -32,6 +35,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
@@ -42,6 +46,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
@@ -54,6 +59,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
@@ -64,6 +70,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
@@ -74,6 +81,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
@@ -84,6 +92,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
@@ -94,6 +103,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
@@ -104,6 +114,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
@@ -114,6 +125,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
@@ -124,6 +136,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input

--- a/pkg/commands/process/settings/rules/ruby/lang/path_using_user_input/.snapshots/TestRubyLangPathUsingUserInput--unsafe_rails.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/path_using_user_input/.snapshots/TestRubyLangPathUsingUserInput--unsafe_rails.yml
@@ -2,6 +2,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
@@ -12,6 +13,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
@@ -22,6 +24,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
@@ -29,5 +32,16 @@ low:
       filename: unsafe_rails.rb
       parent_line_number: 4
       parent_content: 'render_to_string({ file: "/templates/#{params[:oops]}" })'
+    - rule:
+        cwe_ids:
+            - "22"
+            - "73"
+        id: ruby_lang_path_using_user_input
+        description: Do not use user input to form file paths.
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
+      line_number: 6
+      filename: unsafe_rails.rb
+      parent_line_number: 6
+      parent_content: 'send_file params[:oops], type: "text/html"'
 
 

--- a/pkg/commands/process/settings/rules/ruby/lang/path_using_user_input/.snapshots/TestRubyLangPathUsingUserInput--unsafe_request.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/path_using_user_input/.snapshots/TestRubyLangPathUsingUserInput--unsafe_request.yml
@@ -2,6 +2,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
@@ -12,6 +13,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
@@ -22,6 +24,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
@@ -32,6 +35,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
@@ -42,6 +46,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
@@ -54,6 +59,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
@@ -64,6 +70,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
@@ -74,6 +81,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
@@ -84,6 +92,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
@@ -94,6 +103,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
@@ -104,6 +114,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input

--- a/pkg/commands/process/settings/rules/ruby/lang/path_using_user_input/.snapshots/TestRubyLangPathUsingUserInput--unsafe_shell.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/path_using_user_input/.snapshots/TestRubyLangPathUsingUserInput--unsafe_shell.yml
@@ -2,6 +2,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
@@ -12,6 +13,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
@@ -22,6 +24,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
@@ -32,6 +35,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
@@ -42,6 +46,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
@@ -52,6 +57,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
@@ -62,6 +68,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
@@ -72,6 +79,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input
@@ -82,6 +90,7 @@ low:
     - rule:
         cwe_ids:
             - "22"
+            - "73"
         id: ruby_lang_path_using_user_input
         description: Do not use user input to form file paths.
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_path_using_user_input

--- a/pkg/commands/process/settings/rules/ruby/lang/path_using_user_input/testdata/ok_not_unsafe.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/path_using_user_input/testdata/ok_not_unsafe.rb
@@ -46,3 +46,5 @@ end
 
 render(partial: x, locals: { z: params[:ok] })
 render_to_string({ file: "/templates/#{x}", locals: { z: params[:ok] } })
+
+send_file x, type: "text/html"

--- a/pkg/commands/process/settings/rules/ruby/lang/path_using_user_input/testdata/unsafe_rails.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/path_using_user_input/testdata/unsafe_rails.rb
@@ -2,3 +2,5 @@ Rails.root.join(params[:oops])
 
 render(partial: params[:oops])
 render_to_string({ file: "/templates/#{params[:oops]}" })
+
+send_file params[:oops], type: "text/html"


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Adds the Rails `send_file` method to the Ruby "path using user input" rule.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [x] I've added test coverage that shows my fix or feature works as expected.
- [x] I've updated or added documentation if required.
- [x] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
