### PR TITLE
fix(JS rules): make express eval rule stricter

### DIFF
--- a/pkg/commands/process/settings/rules/javascript/express/eval_user_input.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/eval_user_input.yml
@@ -1,21 +1,21 @@
 patterns:
   - pattern: |
-      eval($<...>$<USER_INPUT>$<...>)
+      eval($<USER_INPUT>)
     filters:
       - variable: USER_INPUT
         detection: javascript_express_eval_user_input_user_input
   - pattern: |
-      new Function($<...>$<USER_INPUT>$<...>)
+      new Function($<USER_INPUT>)
     filters:
       - variable: USER_INPUT
         detection: javascript_express_eval_user_input_user_input
   - pattern: |
-      setTimeout($<...>$<USER_INPUT>$<...>)
+      setTimeout($<USER_INPUT>)
     filters:
       - variable: USER_INPUT
         detection: javascript_express_eval_user_input_user_input
   - pattern: |
-      setInterval($<...>$<USER_INPUT>$<...>)
+      setInterval($<USER_INPUT>)
     filters:
       - variable: USER_INPUT
         detection: javascript_express_eval_user_input_user_input


### PR DESCRIPTION
## Description
From battletesting, we see express eval rule matching on code snippets like the following, which may be false positives:

```javascript
            setTimeout(function() {
                if (location.href.indexOf("mish_bearer") != -1) {
                    // some code
                }
            }, 3000);
``` 

We remove the any matches from the eval pattern. The test snapshots still pass so this may be a change required after the bug fixes here: https://github.com/Bearer/bearer/pull/622

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
