### PR TITLE
fix: clean up superfluous YAML attributes in rules

### DIFF
--- a/pkg/commands/process/settings/rules/javascript/express/insecure_cookie.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/insecure_cookie.yml
@@ -22,8 +22,6 @@ patterns:
 languages:
   - javascript
 trigger: presence
-skip_data_types:
-  - "Unique Identifier"
 metadata:
   description: "Missing secure options for cookie detected."
   remediation_message: |

--- a/pkg/commands/process/settings/rules/javascript/express/insecure_template_rendering.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/insecure_template_rendering.yml
@@ -82,8 +82,6 @@ auxiliary:
     patterns:
       - new Liquid()
 trigger: presence
-skip_data_types:
-  - "Unique Identifier"
 metadata:
   description: "Insecure template rendering detected."
   remediation_message: |


### PR DESCRIPTION
## Description
* Remove superfluous YAML attribute - since trigger is presence, we don't care about data types and we don't care about skipping them either

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
