### PR TITLE
fix(JS rules): fix insert HTML rule

### DIFF
--- a/pkg/commands/process/settings/rules/javascript/lang/dangerous_insert_html.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/dangerous_insert_html.yml
@@ -20,8 +20,12 @@ patterns:
           variable: DATA
           detection: javascript_dangerous_insert_html_sanitzed_input
   - pattern: |
-      $<_>.$<METHOD>($<...>$<DATA>$<...>)
+      $<SOURCE>.$<METHOD>($<...>$<DATA>$<...>)
     filters:
+      - not:
+          variable: SOURCE
+          values:
+            - React
       - variable: METHOD
         values:
           - setHTML
@@ -41,6 +45,11 @@ auxiliary:
           - variable: STRING_LITERAL
             detection: string_literal
             contains: false
+      - pattern: |
+          $<EMPTY_STRING>
+        filters:
+          - variable: EMPTY_STRING
+            regex: (""|'')
       - $<_>.sanitize()
       - $<_>.sanitizeHTML()
   - id: javascript_dangerous_insert_html_unsanitzed_input

--- a/pkg/commands/process/settings/rules/javascript/lang/dangerous_insert_html.yml
+++ b/pkg/commands/process/settings/rules/javascript/lang/dangerous_insert_html.yml
@@ -49,7 +49,7 @@ auxiliary:
           $<EMPTY_STRING>
         filters:
           - variable: EMPTY_STRING
-            regex: (""|'')
+            regex: (""|''|``)
       - $<_>.sanitize()
       - $<_>.sanitizeHTML()
   - id: javascript_dangerous_insert_html_unsanitzed_input

--- a/pkg/commands/process/settings/rules/javascript/lang/dangerous_insert_html/testdata/secure.js
+++ b/pkg/commands/process/settings/rules/javascript/lang/dangerous_insert_html/testdata/secure.js
@@ -1,3 +1,10 @@
 function renderListItem(input) {
 	this.ref.insertAdjacentHTML("beforebegin", `<li>fixed list item</li>`);
+	this.ref.insertAdjacentHTML("beforebegin", `<li>fixed list item</li>`);
+	this.ref.innerHTML = "";
+	React.createElement(CssPropTringle, {
+		s: 100,
+		x: 0,
+		y: 0,
+	})
 }


### PR DESCRIPTION
## Description
* Update `not` filter that uses `string_literal` detector, following bug fix to `string_literal` detector
* Exclude `React` as source for certain methods e.g. `createElement`

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
