### PR TITLE
ci: don't run code workflows when PR is edited

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -7,7 +7,6 @@ on:
     types:
       - opened
       - synchronize
-      - edited
       - reopened
 permissions:
   contents: read

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -7,7 +7,6 @@ on:
     types:
       - opened
       - synchronize
-      - edited
       - reopened
 permissions:
   contents: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,6 @@ on:
     types:
       - opened
       - synchronize
-      - edited
       - reopened
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,6 @@ on:
     types:
       - opened
       - synchronize
-      - edited
       - reopened
 permissions:
   contents: read


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Remove `edited` from the PR triggers for the lint/test workflows. We don't need to run these when a PR title/body is edited.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
