### PR TITLE
fix(JS Express rules): improve default cookie rule

### DIFF
--- a/new/language/implementation/javascript/javascript.go
+++ b/new/language/implementation/javascript/javascript.go
@@ -239,7 +239,7 @@ func (implementation *javascriptImplementation) IsRootOfRuleQuery(node *tree.Nod
 }
 
 func (implementation *javascriptImplementation) PatternNodeTypes(node *tree.Node) []string {
-	if node.Type() == "statement_block" && node.Parent().Type() == "program" {
+	if node.Type() == "statement_block" && node.Parent().Type() == "program" && node.NamedChildCount() == 0 {
 		return []string{"object"}
 	}
 

--- a/new/language/implementation/javascript/javascript.go
+++ b/new/language/implementation/javascript/javascript.go
@@ -239,6 +239,10 @@ func (implementation *javascriptImplementation) IsRootOfRuleQuery(node *tree.Nod
 }
 
 func (implementation *javascriptImplementation) PatternNodeTypes(node *tree.Node) []string {
+	if node.Type() == "statement_block" && node.Parent().Type() == "program" {
+		return []string{"object"}
+	}
+
 	return []string{node.Type()}
 }
 

--- a/pkg/commands/process/settings/rules/javascript/express/default_cookie_config.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/default_cookie_config.yml
@@ -4,6 +4,8 @@ patterns:
         cookie: $<!>$<HASH_CONTENT>
       }
     filters:
+      - variable: HASH_CONTENT
+        detection: express_default_cookie_config_hash_val
       - either:
         - not:
             variable: HASH_CONTENT
@@ -23,6 +25,8 @@ patterns:
   - pattern: |
       cookieSession($<!>$<HASH_CONTENT>)
     filters:
+      - variable: HASH_CONTENT
+        detection: express_default_cookie_config_hash_val
       - either:
         - not:
             variable: HASH_CONTENT
@@ -42,6 +46,10 @@ patterns:
 languages:
   - javascript
 auxiliary:
+  - id: express_default_cookie_config_hash_val
+    patterns:
+    - |
+      {}
   - id: express_default_cookie_config_name_attribute
     patterns:
     - |

--- a/pkg/commands/process/settings/rules/javascript/express/default_cookie_config/.snapshots/TestExpressDefaultCookieConfig--default_express_session_cookie_config.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/default_cookie_config/.snapshots/TestExpressDefaultCookieConfig--default_express_session_cookie_config.yml
@@ -9,6 +9,17 @@ medium:
       line_number: 11
       filename: default_express_session_cookie_config.js
       parent_line_number: 11
+      parent_content: '{}'
+    - rule:
+        cwe_ids:
+            - "523"
+            - "522"
+        id: express_default_cookie_config
+        description: Cookie with default config detected.
+        documentation_url: https://docs.bearer.com/reference/rules/express_default_cookie_config
+      line_number: 17
+      filename: default_express_session_cookie_config.js
+      parent_line_number: 17
       parent_content: |-
         {
               domain: "example.com",
@@ -24,9 +35,9 @@ medium:
         id: express_default_cookie_config
         description: Cookie with default config detected.
         documentation_url: https://docs.bearer.com/reference/rules/express_default_cookie_config
-      line_number: 23
+      line_number: 29
       filename: default_express_session_cookie_config.js
-      parent_line_number: 23
+      parent_line_number: 29
       parent_content: |-
         {
               domain: "example.com",
@@ -44,6 +55,20 @@ medium:
       line_number: 10
       filename: default_express_session_cookie_config.js
       parent_line_number: 10
+      parent_content: |-
+        {
+            cookie: {},
+          }
+    - rule:
+        cwe_ids:
+            - "523"
+            - "522"
+        id: express_default_session_config
+        description: Session cookie with default config detected.
+        documentation_url: https://docs.bearer.com/reference/rules/express_default_session_config
+      line_number: 16
+      filename: default_express_session_cookie_config.js
+      parent_line_number: 16
       parent_content: |-
         {
             cookie: {

--- a/pkg/commands/process/settings/rules/javascript/express/default_cookie_config/testdata/default_express_session_cookie_config.js
+++ b/pkg/commands/process/settings/rules/javascript/express/default_cookie_config/testdata/default_express_session_cookie_config.js
@@ -8,6 +8,12 @@ app.use(helmet.hidePoweredBy())
 
 app.use(
   session({
+    cookie: {},
+  })
+)
+
+app.use(
+  session({
     cookie: {
       domain: "example.com",
       secure: true,

--- a/pkg/commands/process/settings/rules/javascript/express/default_cookie_config/testdata/ok_cookie_configured.js
+++ b/pkg/commands/process/settings/rules/javascript/express/default_cookie_config/testdata/ok_cookie_configured.js
@@ -18,3 +18,9 @@ app.use(
     },
   })
 )
+
+// some other non-express cookie usage
+var config = {
+  hello: "world",
+  cookie: "some-encrypted-string"
+}


### PR DESCRIPTION
## Description
* Only trigger default cookie rule if there's a hash present

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [x] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
