### PR TITLE
fix(JS Express rules): tighten path traversal rule

### DIFF
--- a/pkg/commands/process/settings/rules/javascript/express/path_traversal.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/path_traversal.yml
@@ -8,6 +8,9 @@ patterns:
           - resolve
       - variable: USER_INPUT
         detection: javascript_express_path_traversal_request_obj
+      - not:
+          variable: USER_INPUT
+          detection: javascript_express_path_traversal_sanitized_user_input
 auxiliary:
   - id: javascript_express_path_traversal_request_obj
     patterns:
@@ -16,6 +19,10 @@ auxiliary:
       - req.body
       - req.cookies
       - req.headers
+  - id: javascript_express_path_traversal_sanitized_user_input
+    patterns:
+      - $<_>.replace($<_>, "")
+      - $<_>.replace($<_>, '')
 languages:
   - javascript
 trigger: presence

--- a/pkg/commands/process/settings/rules/javascript/express/path_traversal.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/path_traversal.yml
@@ -32,12 +32,36 @@ metadata:
   remediation_message: |
     ## Description
     Allowing unsanitized user input in path resolution methods means an attacker could gain access to files and folders outside of the intended scope.
-    <!--
+
     ## Remediations
-    Coming soon.
+    ❌ Avoid wherever possible
+
+    ✅ Sanitize user input when resolving paths, for example:
+    - Use `replace()` to mitigate against unwanted patterns in the path (such as `\..\..`)
+    - Actively guard against paths that end in "%00" (poison NULL byte attacks)
+    - Use path concatenation to ensure the intended scope is respected
+
+    ```javascript
+    const path = require("path");
+
+    app.get("/", (req, res) => {
+      if (req.params.path.indexOf('\0')) !== -1 {
+        // prevent access
+      }
+
+      var folder = req.params.path.replace(/^(\.\.(\/|\\|$))+/, '')
+
+      var pathname = path.join("/public/", folder)
+      if pathname.indexOf("/public/") !== 0 {
+        // prevent access
+      }
+
+      path.resolve(pathname)
+    })
+    ```
+
     ## Resources
-    Coming soon.
-    -->
+    - [OWASP path traversal](https://owasp.org/www-community/attacks/Path_Traversal)
   cwe_id:
     - 22
   id: "javascript_express_path_traversal"

--- a/pkg/commands/process/settings/rules/javascript/express/path_traversal/.snapshots/TestJavascriptExpressPathTraversal--path_traversal_vulnerability.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/path_traversal/.snapshots/TestJavascriptExpressPathTraversal--path_traversal_vulnerability.yml
@@ -8,7 +8,7 @@ high:
       line_number: 9
       filename: path_traversal_vulnerability.js
       parent_line_number: 9
-      parent_content: path.join("/public/" + req.query.path)
+      parent_content: path.join("/public/", req.query.path)
     - rule:
         cwe_ids:
             - "22"

--- a/pkg/commands/process/settings/rules/javascript/express/path_traversal/testdata/ok_no_path_traversal_vulnerability.js
+++ b/pkg/commands/process/settings/rules/javascript/express/path_traversal/testdata/ok_no_path_traversal_vulnerability.js
@@ -6,6 +6,9 @@ app.use(helmet())
 app.use(helmet.hidePoweredBy())
 
 app.get("/ok", (_req, _res) => {
-  path.join("public" + "/user/1")
+  path.join("public", "/user/1")
   path.resolve("public/tmp/images")
+
+  var folder = req.params.path.replace(/^(\.\.(\/|\\|$))+/ )
+  path.resolve("public/" + folder)
 })

--- a/pkg/commands/process/settings/rules/javascript/express/path_traversal/testdata/ok_no_path_traversal_vulnerability.js
+++ b/pkg/commands/process/settings/rules/javascript/express/path_traversal/testdata/ok_no_path_traversal_vulnerability.js
@@ -9,6 +9,6 @@ app.get("/ok", (_req, _res) => {
   path.join("public", "/user/1")
   path.resolve("public/tmp/images")
 
-  var folder = req.params.path.replace(/^(\.\.(\/|\\|$))+/ )
+  var folder = req.params.path.replace(/^(\.\.(\/|\\|$))+/, "")
   path.resolve("public/" + folder)
 })

--- a/pkg/commands/process/settings/rules/javascript/express/path_traversal/testdata/path_traversal_vulnerability.js
+++ b/pkg/commands/process/settings/rules/javascript/express/path_traversal/testdata/path_traversal_vulnerability.js
@@ -6,6 +6,6 @@ app.use(helmet())
 app.use(helmet.hidePoweredBy())
 
 app.get("/bad", (req, _res) => {
-  path.join("/public/" + req.query.path)
+  path.join("/public/", req.query.path)
   path.resolve(req.query.path)
 })


### PR DESCRIPTION
## Description
A "fix" for path traversal is to replace dangerous characters like `.../.../` with empty strings.
We tighten the JS Express rule around path traversal to exclude cases where we are calling replace on the user input.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [x] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
