### PR TITLE
feat(JS rules): rule for express session for static assets

### DIFF
--- a/integration/rules/javascript_test.go
+++ b/integration/rules/javascript_test.go
@@ -151,6 +151,11 @@ func TestJavascriptExpressInsecureTemplateRendering(t *testing.T) {
 	getRunner(t).runTest(t, javascriptRulesPath+"express/insecure_template_rendering")
 }
 
+func TestJavascriptExpressStaticAssetWithSession(t *testing.T) {
+	t.Parallel()
+	getRunner(t).runTest(t, javascriptRulesPath+"express/static_asset_with_session")
+}
+
 func TestJavascriptExpressUiRedress(t *testing.T) {
 	t.Parallel()
 	getRunner(t).runTest(t, javascriptRulesPath+"express/ui_redress")

--- a/new/language/implementation/javascript/javascript.go
+++ b/new/language/implementation/javascript/javascript.go
@@ -219,6 +219,10 @@ func (*javascriptImplementation) PatternLeafContentTypes() []string {
 }
 
 func (implementation *javascriptImplementation) PatternIsAnchored(node *tree.Node) (bool, bool) {
+	if node.Type() == "pair" {
+		return false, false
+	}
+
 	parent := node.Parent()
 	if parent == nil {
 		return true, true
@@ -227,10 +231,10 @@ func (implementation *javascriptImplementation) PatternIsAnchored(node *tree.Nod
 	// Class body class_body
 	// arrow functions statement_block
 	// function statement_block
-	// method statement_blocks
-	unAnchored := []string{"statement_blocks", "class_body", "pair"}
+	// method statement_block
+	unAnchored := []string{"statement_block", "class_body"}
 
-	isUnanchored := !slices.Contains(unAnchored, node.Type())
+	isUnanchored := !slices.Contains(unAnchored, parent.Type())
 	return isUnanchored, isUnanchored
 }
 
@@ -239,8 +243,12 @@ func (implementation *javascriptImplementation) IsRootOfRuleQuery(node *tree.Nod
 }
 
 func (implementation *javascriptImplementation) PatternNodeTypes(node *tree.Node) []string {
-	if node.Type() == "statement_block" && node.Parent().Type() == "program" && node.NamedChildCount() == 0 {
-		return []string{"object"}
+	if node.Type() == "statement_block" && node.Parent().Type() == "program" {
+		if node.NamedChildCount() == 0 {
+			return []string{"object"}
+		} else {
+			return []string{node.Type(), "program"}
+		}
 	}
 
 	return []string{node.Type()}

--- a/pkg/commands/process/settings/rules/javascript/express/static_asset_with_session.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/static_asset_with_session.yml
@@ -1,0 +1,55 @@
+patterns:
+  - pattern: |
+      {
+        $<SESSION>
+        $<!>$<STATIC>
+      }
+    filters:
+      - variable: SESSION
+        detection: javascript_express_static_asset_with_session_session
+      - variable: STATIC
+        detection: javascript_express_static_asset_with_session_static
+auxiliary:
+  - id: javascript_express_static_asset_with_session_session
+    patterns:
+      - pattern: app.use($<MIDDLEWARE>)
+        filters:
+          - variable: MIDDLEWARE
+            detection: javascript_express_static_asset_with_session_session_init
+  - id: javascript_express_static_asset_with_session_session_init
+    patterns:
+      - session()
+  - id: javascript_express_static_asset_with_session_static
+    patterns:
+      - pattern: app.use($<MIDDLEWARE>)
+        filters:
+          - variable: MIDDLEWARE
+            detection: javascript_express_static_asset_with_session_static_init
+  - id: javascript_express_static_asset_with_session_static_init
+    patterns:
+      - express.static()
+languages:
+  - javascript
+trigger: presence
+metadata:
+  description: Static asset with active session detected.
+  remediation_message: |
+    ## Description
+    Static assets are often cached by services in front of the application
+    (eg. CDNs). Serving static assets with sessions enabled may lead to
+    Cross-Site Request Forgery (CSRF) attacks that can hijack a user's session.
+
+    ## Remediations
+
+    ✅ Ensure static resources are handled prior to session initialization:
+
+    ```javascript
+      // static middleware should be added before session middleware
+      app.use(express.static(__dirname + "/public"))
+
+      app.use(session())
+    ```
+  cwe_id:
+    - 352
+    - 668
+  id: javascript_express_static_asset_with_session

--- a/pkg/commands/process/settings/rules/javascript/express/static_asset_with_session/.snapshots/TestJavascriptExpressStaticAssetWithSession--ok.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/static_asset_with_session/.snapshots/TestJavascriptExpressStaticAssetWithSession--ok.yml
@@ -1,0 +1,14 @@
+medium:
+    - rule:
+        cwe_ids:
+            - "523"
+            - "522"
+        id: express_default_session_config
+        description: Session cookie with default config detected.
+        documentation_url: https://docs.bearer.com/reference/rules/express_default_session_config
+      line_number: 2
+      filename: ok.js
+      parent_line_number: 2
+      parent_content: '{}'
+
+

--- a/pkg/commands/process/settings/rules/javascript/express/static_asset_with_session/.snapshots/TestJavascriptExpressStaticAssetWithSession--unsafe.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/static_asset_with_session/.snapshots/TestJavascriptExpressStaticAssetWithSession--unsafe.yml
@@ -1,0 +1,26 @@
+low:
+    - rule:
+        cwe_ids:
+            - "352"
+            - "668"
+        id: javascript_express_static_asset_with_session
+        description: Static asset with active session detected.
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_express_static_asset_with_session
+      line_number: 3
+      filename: unsafe.js
+      parent_line_number: 3
+      parent_content: app.use(express.static(__dirname + "/public"))
+medium:
+    - rule:
+        cwe_ids:
+            - "523"
+            - "522"
+        id: express_default_session_config
+        description: Session cookie with default config detected.
+        documentation_url: https://docs.bearer.com/reference/rules/express_default_session_config
+      line_number: 1
+      filename: unsafe.js
+      parent_line_number: 1
+      parent_content: '{}'
+
+

--- a/pkg/commands/process/settings/rules/javascript/express/static_asset_with_session/testdata/ok.js
+++ b/pkg/commands/process/settings/rules/javascript/express/static_asset_with_session/testdata/ok.js
@@ -1,0 +1,2 @@
+app.use(express.static(__dirname + "/public"))
+app.use(session({}))

--- a/pkg/commands/process/settings/rules/javascript/express/static_asset_with_session/testdata/unsafe.js
+++ b/pkg/commands/process/settings/rules/javascript/express/static_asset_with_session/testdata/unsafe.js
@@ -1,0 +1,3 @@
+app.use(session({}))
+app.use(other())
+app.use(express.static(__dirname + "/public"))


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Adds a rule for Express that matches session middleware being initialized prior to static asset middleware, ie. when sessions are active for the static middleware.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [x] I've added test coverage that shows my fix or feature works as expected.
- [x] I've updated or added documentation if required.
- [x] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
