### PR TITLE
docs: fix "report type" dead link in scanners.md

### DIFF
--- a/docs/explanations/scanners.md
+++ b/docs/explanations/scanners.md
@@ -9,7 +9,7 @@ Bearer comes with two types of security scanners, SAST (default) and Secrets.
 ## SAST Scanner
 
 The SAST scanner is the default one if you don't specify any.
-This scanner uses the [built-in rules](/explanations/rules) to detect various security risks and vulnerabilities in your code.
+This scanner uses the [built-in rules](/reference/rules) to detect various security risks and vulnerabilities in your code.
 
 The output of the SAST scanner depends on the [report type](/explanations/reports) used, by default the security report will be selected and display the list of rules violations in your terminal.
 

--- a/docs/explanations/scanners.md
+++ b/docs/explanations/scanners.md
@@ -9,9 +9,9 @@ Bearer comes with two types of security scanners, SAST (default) and Secrets.
 ## SAST Scanner
 
 The SAST scanner is the default one if you don't specify any.
-This scanner uses the [built-in rules](/reference/rules) to detect various security risks and vulnerabilities in your code.
+This scanner uses the [built-in rules](/explanations/rules) to detect various security risks and vulnerabilities in your code.
 
-The output of the SAST scanner depends on the [report type](/reference/reports) used, by default the security report will be selected and display the list of rules violations in your terminal.
+The output of the SAST scanner depends on the [report type](/explanations/reports) used, by default the security report will be selected and display the list of rules violations in your terminal.
 
 ```txt
 $ bearer scan . --scanner=sast


### PR DESCRIPTION
## Description

The "report type" link on https://docs.bearer.com/explanations/scanners/ 404s because it uses /reference instead of /explanations.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
