### PR TITLE
fix: fix remediation message indentation

### DIFF
--- a/pkg/commands/process/settings/rules/javascript/aws_lambda/code_injection.yml
+++ b/pkg/commands/process/settings/rules/javascript/aws_lambda/code_injection.yml
@@ -52,37 +52,37 @@ metadata:
     Running code that contains unsanitized data, such as user input or request data, makes your application vulnerable to injection attacks.
 
     ## Remediations
-        Think twice if user input is really needed there.
+    Think twice if user input is really needed there.
 
-        It might be possible to use dynamic hardcoded values:
+    It might be possible to use dynamic hardcoded values:
 
-        ```javascript
-          exports.handler = async (event) => {
-              let myFunc = "(a, b) => a + b"
+    ```javascript
+      exports.handler = async (event) => {
+          let myFunc = "(a, b) => a + b"
 
-              if event["singleMember"] {
-                myFunc = "(a) => a"
-              }
+          if event["singleMember"] {
+            myFunc = "(a) => a"
+          }
 
-              vm.compileFunction(myFunc);
-          };
-        ```
+          vm.compileFunction(myFunc);
+      };
+    ```
 
-        or pass user input to a compiled function, instead of compiling it with user input.
+    or pass user input to a compiled function, instead of compiling it with user input.
 
-        ```javascript
-          exports.handler = async (event) => {
-              let myFunc = "(a, b) => a + b"
+    ```javascript
+      exports.handler = async (event) => {
+          let myFunc = "(a, b) => a + b"
 
-              if event["singleMember"] {
-                myFunc = "(a) => a"
-              }
+          if event["singleMember"] {
+            myFunc = "(a) => a"
+          }
 
-              let compiledFunction = vm.compileFunction(myFunc);
+          let compiledFunction = vm.compileFunction(myFunc);
 
-              compiledFunction(event)
-          };
-        ```
+          compiledFunction(event)
+      };
+    ```
 
     ## Resources
     - [OWASP sql injection explained](https://owasp.org/www-community/attacks/Code_Injection)


### PR DESCRIPTION
## Description
Fix indentation for JS AWS Lambda remediation message so that code snippet is rendered correctly. 

Don't think this has made it onto main docs site yet; just on Staging (see screenshot): 

<img width="612" alt="Screenshot 2023-03-10 at 14 39 23" src="https://user-images.githubusercontent.com/4560746/224318290-263b0943-193c-4418-89b7-9bd209f2c049.png">


<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
