### PR TITLE
fix(Ruby rules): tighten ruby hardcoded secret rule pattern

### DIFF
--- a/pkg/commands/process/settings/rules/ruby/lang/hardcoded_secret.yml
+++ b/pkg/commands/process/settings/rules/ruby/lang/hardcoded_secret.yml
@@ -3,7 +3,7 @@ patterns:
       $<NAME> = $<STRING_LITERAL>
     filters:
       - variable: NAME
-        regex: (?i)password|api_?key|secret
+        regex: (?i)(password|api_?key|secret)\b
       - variable: STRING_LITERAL
         detection: string_literal
         contains: false
@@ -11,7 +11,7 @@ patterns:
       $<_>($<!>$<NAME>: $<STRING_LITERAL>)
     filters:
       - variable: NAME
-        regex: (?i)password|api_?key|secret
+        regex: (?i)(password|api_?key|secret)\b
       - variable: STRING_LITERAL
         detection: string_literal
         contains: false
@@ -27,7 +27,7 @@ patterns:
       { $<!>$<NAME>: $<STRING_LITERAL> }
     filters:
       - variable: NAME
-        regex: (?i)password|api_?key|secret
+        regex: (?i)(password|api_?key|secret)\b
       - variable: STRING_LITERAL
         detection: string_literal
         contains: false

--- a/pkg/commands/process/settings/rules/ruby/lang/hardcoded_secret/testdata/ok.rb
+++ b/pkg/commands/process/settings/rules/ruby/lang/hardcoded_secret/testdata/ok.rb
@@ -8,3 +8,5 @@ call("secret" => x)
 { API_KEY: "a #{x}" }
 
 { "secret" => x }
+
+Passwordless.default_from_address = "some_address@bear.com"


### PR DESCRIPTION
## Description
Add an end word boundary to exclude Passwordless case

Closes #760 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
