### PR TITLE
fix: improve error messaging for custom detector failures

### DIFF
--- a/pkg/commands/process/balancer/process.go
+++ b/pkg/commands/process/balancer/process.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"runtime/debug"
 	"strconv"
+	"strings"
 	"time"
 
 	config "github.com/bearer/bearer/pkg/commands/process/settings"
@@ -85,7 +86,15 @@ func (process *Process) StartProcess(task *workertype.ProcessRequest) error {
 
 	err = process.WaitForOnline(task)
 	if err != nil {
-		log.Fatal().Msgf("Failed to start bearer, error with your configuration %s", err)
+		var result = strings.Split(err.Error(), "failed to create detector customDetector:")
+		if len(result) > 1 {
+			// custom detector issue ; assume custom rule parse issue
+			var ruleName = strings.Split(result[1], ":")[0]
+			log.Fatal().Msgf("could not parse rule %s. Is this a custom rule? See documentation on rule patterns and format https://docs.bearer.com/guides/custom-rule/", ruleName)
+		} else {
+			log.Fatal().Msgf("failed to start bearer, error with your configuration %s", err)
+		}
+
 		return err
 	}
 


### PR DESCRIPTION
## Description
* Assume a custom detector failure is an external rule and improve error messaging appropriately
* Retain original error message as a debug message

Before
```
{"level":"fatal","time":"2023-03-14T18:17:58+02:00","message":"Failed to start bearer, error with your configuration classifier error: failed to instantiate composition ruby:failed to create detector customDetector:my_rule: error compiling pattern: failed to build: error parsing pattern at 1:5: $4"}
```

After

```
{"level":"fatal","time":"2023-03-14T17:59:12+02:00","message":"could not parse rule my_rule. Is this a custom rule? See documentation on rule patterns and format https://docs.bearer.com/guides/custom-rule/"}
```

Partially addresses #545

The more sophisticated solution to the above, however, would be a YAML validator and a rule pattern validator, so that we can catch any issues when loading the rules, rather than during the scan itself. 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
