### PR TITLE
docs: add scan configuration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,9 +193,9 @@ WARNING: 6
 
 The security report is just one [report type](https://docs.bearer.com/explanations/reports) available in Bearer.
 
-Additional options for using and configuring the `scan` command can be found in the [scan documentation](https://docs.bearer.com/reference/commands/#scan). 
+Ready for the next step? Additional options for using and configuring the `scan` command can be found in [configuring the scan command](https://docs.bearer.com/guides/configure-scan/).
 
-For additional guides and usage tips, [view the docs](https://docs.bearer.com/).
+For more guides and usage tips, [view the docs](https://docs.bearer.com/).
 
 ## :question: FAQs
 

--- a/docs/_data/nav.js
+++ b/docs/_data/nav.js
@@ -6,6 +6,7 @@ module.exports = [
   {
     name: "Guides",
     items: [
+      { name: "Configure the scan", url: "/guides/configure-scan/" },
       { name: "Using the GitHub action", url: "/guides/github-action/" },
       {
         name: "Create a custom rule",
@@ -27,7 +28,7 @@ module.exports = [
       {
         name: "Sensitive data flow",
         url: "/explanations/discovery-and-classification/",
-      }
+      },
     ],
   },
   {
@@ -38,7 +39,7 @@ module.exports = [
       { name: "Commands", url: "/reference/commands/" },
       { name: "Rules", url: "/reference/rules/" },
       { name: "Data Types", url: "/reference/datatypes/" },
-      { name: "Supported Languages", url: "/reference/supported-languages/" }
+      { name: "Supported Languages", url: "/reference/supported-languages/" },
     ],
   },
   {

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -31,6 +31,7 @@ Ready to dive in? Bearer's [scanners](/explanations/scanners/) and [reports](/ex
 
 Guides help you make the most of Bearer so you can get up and running quickly.
 
+- [Configure the scan command](/guides/configure-scan/)
 - [GitHub action integration](/guides/github-action/)
 - [Create custom rule](/guides/custom-rule/)
 

--- a/docs/guides/configure-scan.md
+++ b/docs/guides/configure-scan.md
@@ -1,0 +1,120 @@
+---
+title: Configure the scan command
+---
+
+# Configure the scan to meet your needs
+
+Bearer offers a variety of ways to configure the core `scan` command to best meet your needs. Here are some common situations. For a full list of options, see the [commands reference](/reference/commands/). For many of the command flags listed below, you can also define them in your `bearer.yml` [config file](/reference/config/).
+
+## Select a report type
+
+There are a variety of [report types](/explanations/reports/) to choose from. Bearer defaults to the Security report, but you can select any other type with the `--report` flag.
+
+```bash
+bearer scan . --report privacy
+```
+
+## Select a scanner type
+
+Did you know that Bearer can also detect hard-coded secrets in your code? In addition to the default SAST scanner, there's a built-in secrets scanner. Use the `--scanner` flag to change [scanner types](/explanations/scanners/).
+
+```bash
+bearer scan . --scanner secrets
+```
+
+## Skip or ignore specific rules
+
+Sometimes you want to ignore one or more rules, either for the entire scan or for individual blocks of code. Rules are identified by their id, for example: `ruby_lang_exception`.
+
+### Skip rules for the entire scan
+
+To ignore rules for the entire scan you can use the `--skip-rule` flag with the `scan` command.
+
+Using `--skip-rule`:
+
+```bash
+# skip a single rule
+bearer scan . --skip-rule ruby_lang_exception
+
+# skip multiple rules
+bearer scan . --skip-rule ruby_lang_exception,ruby_lang_cookies
+```
+
+Using `bearer.yml`
+
+```yaml
+rule:
+  skip-rule: [ruby_lang_exception, ruby_lang_cookies]
+```
+
+### Skip rules for individual code blocks
+
+Bearer supports comment-based rule skipping using the `bearer:disable` comment. To ignore a block of code, place the comment immediately before the block.
+
+In ruby:
+
+```ruby
+# bearer:disable ruby_lang_logger, ruby_lang_http_insecure
+Net::HTTP.start("http://my.api.com/users/search) do
+  logger.warn("Searching for #{current_user.email}")
+  ...
+end
+```
+
+In javascript:
+
+```javascript
+// bearer:disable javascript_lang_logger
+function logUser(user) {
+  log.info(user.name)
+}
+```
+
+To ignore an individual line of code, place the comment immediately before the line.
+
+```ruby
+def my_func
+ # bearer:disable ruby_rails_logger
+  Rails.logger(current_user.email)
+end
+```
+
+```javascript
+function logUser(user) {
+  log.info(user.name)
+  // bearer:disable javascript_lang_logger
+  log.info(user.uuid)
+}
+```
+
+## Run only specified rules
+
+Similar to how you can skip rules, you can also tell the scan to only run specific rules. To do so, specify the rule IDs with the `--only-rule` flag.
+
+```bash
+bearer scan . --only-rule ruby_lang_cookies
+```
+
+## Change the output format
+
+Each [report type](/explanations/reports/) has a default output format, but in general you're able to also select between `json` and `yaml` with the `--format` flag.
+
+```bash
+bearer scan . --format yaml
+```
+
+## Output to a file
+
+Sometimes you'll want to hand off the report, and while you could pipe the results to another command, we've included the `--output` flag to make it easier. Specify the path to the output file.
+
+```bash
+bearer scan . --report dataflow --output dataflow.json
+```
+
+## Limit severity levels
+
+Depending on how you're using Bearer, you may want to limit the severity levels that show up in the report. This can be useful for triaging only the most critical issues. Use the `--severity` flag to define which levels to include from the list of critical, high, medium, low, and warning.
+
+```bash
+bearer scan . --severity critical,high
+```

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -6,5 +6,6 @@ title: Guides
 
 Guides help you make the most of Bearer so you can get up and running quickly. Have a request for a new guide? Open an [issue on GitHub]({{meta.links.issues}}).
 
+- [Configure the scan command](/guides/configure-scan/)
 - [Using the GitHub action](/guides/github-action/)
 - [Create a custom rule](/guides/custom-rule/)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -79,8 +79,6 @@ WARNING: 6
 
 ```
 
-The security report is just one [report type](/explanations/reports) available in Bearer.
+The security report is just one [report type](/explanations/reports/) available in Bearer.
 
-Additional options for using and configuring the `scan` command can be found in the [scan documentation](/reference/commands/#scan). 
-
-For additional guides and usage tips, [view the docs](/).
+Ready for the next step? Additional options for using and configuring the `scan` command can be found in [configuring the scan command](/guides/configure-scan/).


### PR DESCRIPTION
## Description
Adds a guide on configuring the scan command. The guide includes common configuration use cases, rather than relying only on the command reference.

Links across docs and readme have been updated to reflect the new guide.

## Related
- close #796 
- wraps up the pending documentation from #788 

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [x] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
