### PR TITLE
docs(fix): 918 owasp id updated

### DIFF
--- a/docs/_data/cweList.json
+++ b/docs/_data/cweList.json
@@ -4248,7 +4248,7 @@
     "id": "918",
     "description": "The web server receives a URL or similar request from an upstream component and retrieves the contents of this URL, but it does not sufficiently ensure that the request is being sent to the expected destination.",
     "owasp": {
-      "id": "A010:2021",
+      "id": "A10:2021",
       "name": "Server-Side Request Forgery (SSRF)"
     }
   },


### PR DESCRIPTION
## Description
Fixes an error in the cwelist where CWE-918 was referencing an invalid OWASP id, and causing the owasp linked in https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input to lead nowhere.

## Related

- Close #823 


## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
