### PR TITLE
fix: load bearer.yml file automatically

### DIFF
--- a/e2e/flags/.snapshots/TestMetadataFlags-help-scan
+++ b/e2e/flags/.snapshots/TestMetadataFlags-help-scan
@@ -33,7 +33,7 @@ Scan Flags
       --skip-path strings                    Specify the comma separated files and directories to skip. Supports * syntax, e.g. --skip-path users/*.go,users/admin.sql
 
 General Flags
-      --config-file string   Load configuration from the specified path.
+      --config-file string   Load configuration from the specified path. (default "bearer.yml")
 
 
 --

--- a/e2e/flags/.snapshots/TestMetadataFlags-scan-help
+++ b/e2e/flags/.snapshots/TestMetadataFlags-scan-help
@@ -33,7 +33,7 @@ Scan Flags
       --skip-path strings                    Specify the comma separated files and directories to skip. Supports * syntax, e.g. --skip-path users/*.go,users/admin.sql
 
 General Flags
-      --config-file string   Load configuration from the specified path.
+      --config-file string   Load configuration from the specified path. (default "bearer.yml")
 
 
 --

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-context-flag
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-context-flag
@@ -34,7 +34,7 @@ Scan Flags
       --skip-path strings                    Specify the comma separated files and directories to skip. Supports * syntax, e.g. --skip-path users/*.go,users/admin.sql
 
 General Flags
-      --config-file string   Load configuration from the specified path.
+      --config-file string   Load configuration from the specified path. (default "bearer.yml")
 
 
 flag error: scan flag error: invalid context argument; supported values: health

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag
@@ -34,7 +34,7 @@ Scan Flags
       --skip-path strings                    Specify the comma separated files and directories to skip. Supports * syntax, e.g. --skip-path users/*.go,users/admin.sql
 
 General Flags
-      --config-file string   Load configuration from the specified path.
+      --config-file string   Load configuration from the specified path. (default "bearer.yml")
 
 
 flag error: report flags error: invalid format argument; supported values: json, yaml

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-report-flag
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-report-flag
@@ -34,7 +34,7 @@ Scan Flags
       --skip-path strings                    Specify the comma separated files and directories to skip. Supports * syntax, e.g. --skip-path users/*.go,users/admin.sql
 
 General Flags
-      --config-file string   Load configuration from the specified path.
+      --config-file string   Load configuration from the specified path. (default "bearer.yml")
 
 
 flag error: report flags error: invalid report argument; supported values: security, privacy

--- a/pkg/commands/process/balancer/process.go
+++ b/pkg/commands/process/balancer/process.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"runtime/debug"
 	"strconv"
 	"strings"
 	"time"
@@ -226,7 +225,7 @@ func (process *Process) doTask(task *Task) {
 func (process *Process) monitorMemory(pid int) {
 	recovery := func() {
 		if r := recover(); r != nil {
-			log.Debug().Msgf("error recovered %s %s", r, debug.Stack())
+			log.Debug().Msgf("error recovered %s", r)
 		}
 	}
 	defer recovery()

--- a/pkg/commands/scan.go
+++ b/pkg/commands/scan.go
@@ -7,7 +7,6 @@ import (
 	"github.com/bearer/bearer/pkg/flag"
 	"github.com/bearer/bearer/pkg/util/file"
 	"github.com/bearer/bearer/pkg/util/output"
-	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"golang.org/x/xerrors"
@@ -58,17 +57,15 @@ func NewScanCommand() *cobra.Command {
 			configPath := viper.GetString(flag.ConfigFileFlag.ConfigName)
 			defaultConfigPath := file.GetFullFilename(args[0], configPath)
 
-			loadedFile := false
+			var loadFileMessage string
 			if err := readConfig(configPath); err != nil {
 				if err := readConfig(defaultConfigPath); err != nil {
-					log.Debug().Msgf("Couldn't find config file %s or %s", configPath, defaultConfigPath)
+					loadFileMessage = fmt.Sprintf("Couldn't find config file %s or %s", configPath, defaultConfigPath)
 				} else {
-					log.Debug().Msgf("Loading default config file %s", defaultConfigPath)
-					loadedFile = true
+					loadFileMessage = fmt.Sprintf("Loading default config file %s", defaultConfigPath)
 				}
 			} else {
-				log.Debug().Msgf("Loading config file %s", configPath)
-				loadedFile = true
+				loadFileMessage = fmt.Sprintf("Loading config file %s", configPath)
 			}
 
 			options, err := ScanFlags.ToOptions(args)
@@ -76,8 +73,8 @@ func NewScanCommand() *cobra.Command {
 				return xerrors.Errorf("flag error: %w", err)
 			}
 
-			if !options.Quiet && loadedFile {
-				output.StdErrLogger().Msgf("Loaded configuration file")
+			if !options.Quiet {
+				output.StdErrLogger().Msgf(loadFileMessage)
 			}
 
 			output.Setup(cmd, options)

--- a/pkg/detectors/detectors.go
+++ b/pkg/detectors/detectors.go
@@ -3,7 +3,6 @@ package detectors
 import (
 	"fmt"
 	"path/filepath"
-	"runtime/debug"
 
 	"github.com/bearer/bearer/new/scanner"
 	"github.com/bearer/bearer/pkg/commands/process/settings"
@@ -176,8 +175,8 @@ func ExtractWithDetectors(
 		func(file *file.FileInfo) error {
 			recovery := func() {
 				if r := recover(); r != nil {
-					log.Printf("error recovered %s %s", r, debug.Stack())
-					report.AddError(file.Path.RelativePath, fmt.Errorf("skipping file: due to panic %s, %s", r, string(debug.Stack())))
+					log.Printf("file %s -> error recovered %s", file.AbsolutePath, r)
+					report.AddError(file.Path.RelativePath, fmt.Errorf("skipping file: due to panic %s", r))
 				}
 			}
 			defer recovery()

--- a/pkg/flag/general_flags.go
+++ b/pkg/flag/general_flags.go
@@ -25,7 +25,7 @@ var (
 	ConfigFileFlag = Flag{
 		Name:            "config-file",
 		ConfigName:      "config-file",
-		Value:           "",
+		Value:           "bearer.yml",
 		Usage:           "Load configuration from the specified path.",
 		DisableInConfig: true,
 	}

--- a/pkg/report/output/dataflow/dataflow.go
+++ b/pkg/report/output/dataflow/dataflow.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/bearer/bearer/pkg/commands/process/settings"
 	"github.com/bearer/bearer/pkg/report/customdetectors"
@@ -14,6 +13,7 @@ import (
 	"github.com/bearer/bearer/pkg/report/output/dataflow/datatypes"
 	"github.com/bearer/bearer/pkg/report/output/dataflow/detectiondecoder"
 	"github.com/bearer/bearer/pkg/report/output/dataflow/risks"
+	"github.com/bearer/bearer/pkg/util/file"
 	"github.com/bearer/bearer/pkg/util/output"
 	"github.com/hhatto/gocloc"
 
@@ -95,7 +95,7 @@ func GetOutput(input []interface{}, config settings.Config, isInternal bool) (*D
 		}
 
 		// add full path to filename
-		fullFilename := GetFullFilename(config.Target, castDetection.Source.Filename)
+		fullFilename := file.GetFullFilename(config.Target, castDetection.Source.Filename)
 		castDetection.Source.Filename = fullFilename
 
 		switch detectionType {
@@ -186,19 +186,4 @@ func GetOutput(input []interface{}, config settings.Config, isInternal bool) (*D
 		Components: componentsHolder.ToDataFlow(),
 	}
 	return dataflow, nil, nil, nil
-}
-
-func GetFullFilename(path string, filename string) string {
-	path = strings.TrimSuffix(path, "/")
-	filename = strings.TrimPrefix(filename, "/")
-
-	if filename == "." {
-		return path
-	}
-
-	if path == "" || path == "." {
-		return filename
-	}
-
-	return path + "/" + filename
 }

--- a/pkg/report/output/output.go
+++ b/pkg/report/output/output.go
@@ -15,9 +15,9 @@ import (
 	"github.com/bearer/bearer/pkg/commands/process/settings"
 	"github.com/bearer/bearer/pkg/flag"
 	"github.com/bearer/bearer/pkg/report/output/dataflow"
-	dataflowoutput "github.com/bearer/bearer/pkg/report/output/dataflow"
 	"github.com/bearer/bearer/pkg/report/output/privacy"
 	"github.com/bearer/bearer/pkg/report/output/security"
+	"github.com/bearer/bearer/pkg/util/file"
 	"github.com/gitsight/go-vcsurl"
 	"github.com/google/uuid"
 
@@ -89,7 +89,7 @@ func getDiscoveredFiles(config settings.Config) []string {
 	filesDiscovered, _ := filelist.Discover(config.Scan.Target, config)
 	files := []string{}
 	for _, fileDiscovered := range filesDiscovered {
-		files = append(files, dataflowoutput.GetFullFilename(config.Scan.Target, fileDiscovered.FilePath))
+		files = append(files, file.GetFullFilename(config.Scan.Target, fileDiscovered.FilePath))
 	}
 
 	return files

--- a/pkg/util/file/file.go
+++ b/pkg/util/file/file.go
@@ -326,3 +326,18 @@ func ReadFileSingleLine(filePath string, lineNumber int) (string, error) {
 
 	return "", nil
 }
+
+func GetFullFilename(path string, filename string) string {
+	path = strings.TrimSuffix(path, "/")
+	filename = strings.TrimPrefix(filename, "/")
+
+	if filename == "." {
+		return path
+	}
+
+	if path == "" || path == "." {
+		return filename
+	}
+
+	return path + "/" + filename
+}


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

closes #812 

Load config-file from specified location using `--config-file` 
If we can't find it, we try to load it from the default location
> if at the root of the target we have `bearer.yml`, we will load it

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
