### PR TITLE
docs: add typescript support note

### DIFF
--- a/docs/reference/rules.njk
+++ b/docs/reference/rules.njk
@@ -23,7 +23,7 @@ Bearer's built-in rules aim to keep you protected from the most cirtical securit
 
     <div>
       <input type="checkbox" name="lang-jsts" id="lang-jsts" class='filter-toggle' value="javascript">
-      <label for="lang-jsts" class="toggle-label">Javascript</label>
+      <label for="lang-jsts" class="toggle-label">JS / TS</label>
     </div>
   </div>
 </form>

--- a/docs/reference/supported-languages.md
+++ b/docs/reference/supported-languages.md
@@ -7,11 +7,10 @@ layout: layouts/doc.njk
 
 Bearer currently supports Ruby and JavaScript codebase.
 
-| Languages       | Supported |
-| --------------- | --------------  |
-| Ruby            | ✅              | 
-| JavaScript      | ✅              |
-| TypeScript      | *Coming soon*   |
+| Languages               | Supported |
+| ----------------------- | --------- |
+| Ruby                    | ✅         |
+| JavaScript / Typescript | ✅         |
 
 We are working on adding more languages in the coming months, especially PHP, Java, C#, Go, and Python.
 

--- a/docs/reference/supported-languages.md
+++ b/docs/reference/supported-languages.md
@@ -10,7 +10,7 @@ Bearer currently supports Ruby and JavaScript codebase.
 | Languages               | Supported |
 | ----------------------- | --------- |
 | Ruby                    | ✅         |
-| JavaScript / Typescript | ✅         |
+| JavaScript / TypeScript | ✅         |
 
 We are working on adding more languages in the coming months, especially PHP, Java, C#, Go, and Python.
 


### PR DESCRIPTION
## Description
Updates the docs to note that typescript is supported alongside JS.

## Related
- close #831 

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
