### PR TITLE
feat(load rules externally): add disable default rules flag

### DIFF
--- a/docs/_data/bearer_scan.yaml
+++ b/docs/_data/bearer_scan.yaml
@@ -13,6 +13,9 @@ options:
     - name: debug
       default_value: "false"
       usage: Enable debug logs
+    - name: disable-default-rules
+      default_value: "false"
+      usage: Disables all default and built-in rules.
     - name: disable-domain-resolution
       default_value: "true"
       usage: |

--- a/e2e/flags/.snapshots/TestInitCommand
+++ b/e2e/flags/.snapshots/TestInitCommand
@@ -4,6 +4,7 @@ report:
     report: security
     severity: critical,high,medium,low,warning
 rule:
+    disable-default-rules: false
     only-rule: []
     skip-rule: []
 scan:

--- a/e2e/flags/.snapshots/TestMetadataFlags-help-scan
+++ b/e2e/flags/.snapshots/TestMetadataFlags-help-scan
@@ -16,8 +16,9 @@ Report Flags
       --severity string   Specify which severities are included in the report. (default "critical,high,medium,low,warning")
 
 Rule Flags
-      --only-rule strings   Specify the comma-separated ids of the rules you would like to run. Skips all other rules.
-      --skip-rule strings   Specify the comma-separated ids of the rules you would like to skip. Runs all other rules.
+      --disable-default-rules   Disables all default and built-in rules.
+      --only-rule strings       Specify the comma-separated ids of the rules you would like to run. Skips all other rules.
+      --skip-rule strings       Specify the comma-separated ids of the rules you would like to skip. Runs all other rules.
 
 Scan Flags
       --context string                       Expand context of schema classification e.g., --context=health, to include data types particular to health

--- a/e2e/flags/.snapshots/TestMetadataFlags-scan-help
+++ b/e2e/flags/.snapshots/TestMetadataFlags-scan-help
@@ -16,8 +16,9 @@ Report Flags
       --severity string   Specify which severities are included in the report. (default "critical,high,medium,low,warning")
 
 Rule Flags
-      --only-rule strings   Specify the comma-separated ids of the rules you would like to run. Skips all other rules.
-      --skip-rule strings   Specify the comma-separated ids of the rules you would like to skip. Runs all other rules.
+      --disable-default-rules   Disables all default and built-in rules.
+      --only-rule strings       Specify the comma-separated ids of the rules you would like to run. Skips all other rules.
+      --skip-rule strings       Specify the comma-separated ids of the rules you would like to skip. Runs all other rules.
 
 Scan Flags
       --context string                       Expand context of schema classification e.g., --context=health, to include data types particular to health

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-context-flag
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-context-flag
@@ -17,8 +17,9 @@ Report Flags
       --severity string   Specify which severities are included in the report. (default "critical,high,medium,low,warning")
 
 Rule Flags
-      --only-rule strings   Specify the comma-separated ids of the rules you would like to run. Skips all other rules.
-      --skip-rule strings   Specify the comma-separated ids of the rules you would like to skip. Runs all other rules.
+      --disable-default-rules   Disables all default and built-in rules.
+      --only-rule strings       Specify the comma-separated ids of the rules you would like to run. Skips all other rules.
+      --skip-rule strings       Specify the comma-separated ids of the rules you would like to skip. Runs all other rules.
 
 Scan Flags
       --context string                       Expand context of schema classification e.g., --context=health, to include data types particular to health

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag
@@ -17,8 +17,9 @@ Report Flags
       --severity string   Specify which severities are included in the report. (default "critical,high,medium,low,warning")
 
 Rule Flags
-      --only-rule strings   Specify the comma-separated ids of the rules you would like to run. Skips all other rules.
-      --skip-rule strings   Specify the comma-separated ids of the rules you would like to skip. Runs all other rules.
+      --disable-default-rules   Disables all default and built-in rules.
+      --only-rule strings       Specify the comma-separated ids of the rules you would like to run. Skips all other rules.
+      --skip-rule strings       Specify the comma-separated ids of the rules you would like to skip. Runs all other rules.
 
 Scan Flags
       --context string                       Expand context of schema classification e.g., --context=health, to include data types particular to health

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-report-flag
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-report-flag
@@ -17,8 +17,9 @@ Report Flags
       --severity string   Specify which severities are included in the report. (default "critical,high,medium,low,warning")
 
 Rule Flags
-      --only-rule strings   Specify the comma-separated ids of the rules you would like to run. Skips all other rules.
-      --skip-rule strings   Specify the comma-separated ids of the rules you would like to skip. Runs all other rules.
+      --disable-default-rules   Disables all default and built-in rules.
+      --only-rule strings       Specify the comma-separated ids of the rules you would like to run. Skips all other rules.
+      --skip-rule strings       Specify the comma-separated ids of the rules you would like to skip. Runs all other rules.
 
 Scan Flags
       --context string                       Expand context of schema classification e.g., --context=health, to include data types particular to health

--- a/pkg/commands/process/settings/rules.go
+++ b/pkg/commands/process/settings/rules.go
@@ -21,18 +21,20 @@ func loadRules(externalRuleDirs []string, options flag.RuleOptions) (map[string]
 	definitions := make(map[string]RuleDefinition)
 	builtInDefinitions := make(map[string]RuleDefinition)
 
-	if err := loadRuleDefinitions(definitions, rulesFs); err != nil {
-		return nil, nil, fmt.Errorf("error loading default rules: %s", err)
-	}
-	// add default documentation urls for default rules
-	for id, definition := range definitions {
-		if definition.Metadata.DocumentationUrl == "" {
-			definitions[id].Metadata.DocumentationUrl = "https://docs.bearer.com/reference/rules/" + id
+	if !options.DisableDefaultRules {
+		if err := loadRuleDefinitions(definitions, rulesFs); err != nil {
+			return nil, nil, fmt.Errorf("error loading default rules: %s", err)
 		}
-	}
+		// add default documentation urls for default rules
+		for id, definition := range definitions {
+			if definition.Metadata.DocumentationUrl == "" {
+				definitions[id].Metadata.DocumentationUrl = "https://docs.bearer.com/reference/rules/" + id
+			}
+		}
 
-	if err := loadRuleDefinitions(builtInDefinitions, builtInRulesFs); err != nil {
-		return nil, nil, fmt.Errorf("error loading default built-in rules: %s", err)
+		if err := loadRuleDefinitions(builtInDefinitions, builtInRulesFs); err != nil {
+			return nil, nil, fmt.Errorf("error loading default built-in rules: %s", err)
+		}
 	}
 
 	for _, dir := range externalRuleDirs {

--- a/pkg/flag/rule_flags.go
+++ b/pkg/flag/rule_flags.go
@@ -1,6 +1,12 @@
 package flag
 
 var (
+	DisableDefaultRulesFlag = Flag{
+		Name:       "disable-default-rules",
+		ConfigName: "rule.disable-default-rules",
+		Value:      false,
+		Usage:      "Disables all default and built-in rules.",
+	}
 	SkipRuleFlag = Flag{
 		Name:       "skip-rule",
 		ConfigName: "rule.skip-rule",
@@ -16,19 +22,22 @@ var (
 )
 
 type RuleFlagGroup struct {
-	SkipRuleFlag *Flag
-	OnlyRuleFlag *Flag
+	DisableDefaultRulesFlag *Flag
+	SkipRuleFlag            *Flag
+	OnlyRuleFlag            *Flag
 }
 
 type RuleOptions struct {
-	SkipRule map[string]bool `mapstructure:"skip-rule" json:"skip-rule" yaml:"skip-rule"`
-	OnlyRule map[string]bool `mapstructure:"only-rule" json:"only-rule" yaml:"only-rule"`
+	DisableDefaultRules bool            `mapstructure:"disable-default-rules" json:"disable-default-rules" yaml:"disable-default-rules"`
+	SkipRule            map[string]bool `mapstructure:"skip-rule" json:"skip-rule" yaml:"skip-rule"`
+	OnlyRule            map[string]bool `mapstructure:"only-rule" json:"only-rule" yaml:"only-rule"`
 }
 
 func NewRuleFlagGroup() *RuleFlagGroup {
 	return &RuleFlagGroup{
-		SkipRuleFlag: &SkipRuleFlag,
-		OnlyRuleFlag: &OnlyRuleFlag,
+		DisableDefaultRulesFlag: &DisableDefaultRulesFlag,
+		SkipRuleFlag:            &SkipRuleFlag,
+		OnlyRuleFlag:            &OnlyRuleFlag,
 	}
 }
 
@@ -38,6 +47,7 @@ func (f *RuleFlagGroup) Name() string {
 
 func (f *RuleFlagGroup) Flags() []*Flag {
 	return []*Flag{
+		f.DisableDefaultRulesFlag,
 		f.SkipRuleFlag,
 		f.OnlyRuleFlag,
 	}
@@ -45,7 +55,8 @@ func (f *RuleFlagGroup) Flags() []*Flag {
 
 func (f *RuleFlagGroup) ToOptions(args []string) RuleOptions {
 	return RuleOptions{
-		SkipRule: argsToMap(f.SkipRuleFlag),
-		OnlyRule: argsToMap(f.OnlyRuleFlag),
+		DisableDefaultRules: getBool(f.DisableDefaultRulesFlag),
+		SkipRule:            argsToMap(f.SkipRuleFlag),
+		OnlyRule:            argsToMap(f.OnlyRuleFlag),
 	}
 }


### PR DESCRIPTION
## Description

Adds a new rules flag to disable default rules

This will be used by the CI on the upcoming bearer-rules repository. This change does two things:
* improves CI performance (because we can avoid downloading rules from GH from the binary)
* makes it more straight-forward to test unreleased rules (because we can load them as external rules without worrying about rule ID conflicts)

Relates to #799

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [x] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
