### PR TITLE
fix: refactor logging message

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -78,7 +78,7 @@ func (api *API) makeRequest(route string, httpMethod string, data interface{}) (
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("fail reading response body %e %s", err, fullURL)
+		return nil, fmt.Errorf("fail reading response body %s %s", err, fullURL)
 	}
 
 	if resp.StatusCode == http.StatusUnauthorized {

--- a/pkg/commands/process/balancer/worker.go
+++ b/pkg/commands/process/balancer/worker.go
@@ -18,6 +18,7 @@ import (
 	"github.com/bearer/bearer/pkg/report/detections"
 	"github.com/bearer/bearer/pkg/util/jsonlines"
 	"github.com/bearer/bearer/pkg/util/output"
+	"github.com/bearer/bearer/pkg/util/progressbar"
 	"github.com/bearer/bearer/pkg/util/tmpfile"
 )
 
@@ -89,7 +90,7 @@ func (worker *Worker) Start() {
 	if !worker.config.Scan.Quiet {
 		output.StdErrLogger().Msgf("Scanning target %s", worker.config.Scan.Target)
 	}
-	bar := output.GetProgressBar(len(worker.FileList), worker.config, "files")
+	bar := progressbar.GetProgressBar(len(worker.FileList), worker.config, "files")
 
 	reportFile, err := os.Create(worker.task.Definition.ReportPath)
 	if err != nil {

--- a/pkg/commands/processing_worker.go
+++ b/pkg/commands/processing_worker.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bearer/bearer/pkg/util/output"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 func NewProcessingWorkerCommand() *cobra.Command {
@@ -24,12 +25,10 @@ func NewProcessingWorkerCommand() *cobra.Command {
 				return fmt.Errorf("flag bind error: %w", err)
 			}
 
-			generalOptions, err := flags.ToOptions(args)
-			if err != nil {
-				return fmt.Errorf("options binding error: %w", err)
-			}
-
-			output.Setup(cmd, generalOptions)
+			output.Setup(cmd, output.SetupRequest{
+				Debug: viper.GetBool(flag.DebugFlag.ConfigName),
+				Quiet: viper.GetBool(flag.QuietFlag.ConfigName),
+			})
 
 			processOptions, err := flags.ProcessFlagGroup.ToOptions()
 			if err != nil {

--- a/pkg/commands/scan.go
+++ b/pkg/commands/scan.go
@@ -7,6 +7,7 @@ import (
 	"github.com/bearer/bearer/pkg/flag"
 	"github.com/bearer/bearer/pkg/util/file"
 	"github.com/bearer/bearer/pkg/util/output"
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"golang.org/x/xerrors"
@@ -54,6 +55,11 @@ func NewScanCommand() *cobra.Command {
 				return xerrors.Errorf("flag bind error: %w", err)
 			}
 
+			output.Setup(cmd, output.SetupRequest{
+				Debug: viper.GetBool(flag.DebugFlag.ConfigName),
+				Quiet: viper.GetBool(flag.QuietFlag.ConfigName),
+			})
+
 			configPath := viper.GetString(flag.ConfigFileFlag.ConfigName)
 			var defaultConfigPath = ""
 			if len(args) == 1 {
@@ -76,11 +82,7 @@ func NewScanCommand() *cobra.Command {
 				return xerrors.Errorf("flag error: %w", err)
 			}
 
-			if !options.Quiet {
-				output.StdErrLogger().Msgf(loadFileMessage)
-			}
-
-			output.Setup(cmd, options)
+			log.Debug().Msgf(loadFileMessage)
 
 			if options.Target == "" {
 				return cmd.Help()

--- a/pkg/flag/general_flags.go
+++ b/pkg/flag/general_flags.go
@@ -74,7 +74,7 @@ func (f *GeneralFlagGroup) ToOptions() GeneralOptions {
 
 		_, err := client.Hello()
 		if err != nil {
-			log.Error().Msgf("couldn't initialize client -> %s", err.Error())
+			log.Debug().Msgf("couldn't initialize client -> %s", err.Error())
 		} else {
 			log.Debug().Msgf("Initialized client for report")
 			return GeneralOptions{

--- a/pkg/report/output/privacy/privacy.go
+++ b/pkg/report/output/privacy/privacy.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bearer/bearer/pkg/classification/db"
 	"github.com/bearer/bearer/pkg/commands/process/settings"
 	"github.com/bearer/bearer/pkg/util/output"
+	"github.com/bearer/bearer/pkg/util/progressbar"
 	"github.com/bearer/bearer/pkg/util/rego"
 	"github.com/hhatto/gocloc"
 	"golang.org/x/exp/maps"
@@ -133,7 +134,7 @@ func GetOutput(dataflow *dataflow.DataFlow, lineOfCodeOutput *gocloc.Result, con
 		output.StdErrLogger().Msgf("Evaluating rules")
 	}
 
-	bar := output.GetProgressBar(len(config.Rules), config, "rules")
+	bar := progressbar.GetProgressBar(len(config.Rules), config, "rules")
 
 	subjectRuleFailures := make(map[string]RuleFailureSummary)
 	thirdPartyRuleFailures := make(map[string]map[string]RuleFailureSummary)

--- a/pkg/report/output/security/security.go
+++ b/pkg/report/output/security/security.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bearer/bearer/pkg/util/file"
 	"github.com/bearer/bearer/pkg/util/maputil"
 	"github.com/bearer/bearer/pkg/util/output"
+	bearerprogressbar "github.com/bearer/bearer/pkg/util/progressbar"
 	"github.com/bearer/bearer/pkg/util/rego"
 	"github.com/fatih/color"
 	"github.com/hhatto/gocloc"
@@ -106,7 +107,7 @@ func evaluateRules(
 ) error {
 	var bar *progressbar.ProgressBar
 	if !builtIn {
-		bar = output.GetProgressBar(len(rules), config, "rules")
+		bar = bearerprogressbar.GetProgressBar(len(rules), config, "rules")
 	}
 
 	for _, rule := range maputil.ToSortedSlice(rules) {

--- a/pkg/util/output/output.go
+++ b/pkg/util/output/output.go
@@ -4,7 +4,6 @@ import (
 	"io"
 	"os"
 
-	"github.com/bearer/bearer/pkg/flag"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
@@ -12,8 +11,13 @@ import (
 
 var (
 	outputWriter io.Writer = os.Stdout
-	errorWriter  io.Writer = os.Stderr
+	ErrorWriter  io.Writer = os.Stderr
 )
+
+type SetupRequest struct {
+	Quiet bool
+	Debug bool
+}
 
 // DefaultLogger returns default output logger
 func StdOutLogger() *zerolog.Event {
@@ -21,7 +25,7 @@ func StdOutLogger() *zerolog.Event {
 }
 
 func StdErrLogger() *zerolog.Event {
-	return PlainLogger(errorWriter)
+	return PlainLogger(ErrorWriter)
 }
 
 func PlainLogger(out io.Writer) *zerolog.Event {
@@ -39,9 +43,9 @@ func PlainLogger(out io.Writer) *zerolog.Event {
 	return logger.Info()
 }
 
-func Setup(cmd *cobra.Command, options flag.Options) {
+func Setup(cmd *cobra.Command, options SetupRequest) {
 	outputWriter = cmd.OutOrStdout()
-	errorWriter = cmd.ErrOrStderr()
+	ErrorWriter = cmd.ErrOrStderr()
 
 	if options.Debug {
 		zerolog.SetGlobalLevel(zerolog.DebugLevel)

--- a/pkg/util/progressbar/progressbar.go
+++ b/pkg/util/progressbar/progressbar.go
@@ -1,7 +1,8 @@
-package output
+package progressbar
 
 import (
 	"github.com/bearer/bearer/pkg/commands/process/settings"
+	"github.com/bearer/bearer/pkg/util/output"
 	"github.com/schollz/progressbar/v3"
 )
 
@@ -9,13 +10,13 @@ func GetProgressBar(filesLength int, config settings.Config, display_type string
 	hideProgress := config.Scan.Quiet || config.Scan.Debug
 	return progressbar.NewOptions(filesLength,
 		progressbar.OptionSetVisibility(!hideProgress),
-		progressbar.OptionSetWriter(errorWriter),
+		progressbar.OptionSetWriter(output.ErrorWriter),
 		progressbar.OptionShowCount(),
 		progressbar.OptionSetWidth(15),
 		progressbar.OptionEnableColorCodes(false),
 		progressbar.OptionShowElapsedTimeOnFinish(),
 		progressbar.OptionOnCompletion(func() {
-			errorWriter.Write([]byte("\n")) //nolint:all,errcheck
+			output.ErrorWriter.Write([]byte("\n")) //nolint:all,errcheck
 		}),
 		progressbar.OptionShowIts(),
 		progressbar.OptionSetItsString(display_type),


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

closes #830 #840 

We were not initializing the output log which led to messages getting send when they shouldn't have been
This should now make it safer and solve the issues raised

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
