### PR TITLE
docs(fix): resolve empty owasp rule page bug

### DIFF
--- a/docs/_data/owaspURLs.json
+++ b/docs/_data/owaspURLs.json
@@ -1,12 +1,42 @@
 {
-  "A01:2021": "https://owasp.org/Top10/A01_2021-Broken_Access_Control/",
-  "A02:2021": "https://owasp.org/Top10/A02_2021-Cryptographic_Failures/",
-  "A03:2021": "https://owasp.org/Top10/A03_2021-Injection/",
-  "A04:2021": "https://owasp.org/Top10/A04_2021-Insecure_Design/",
-  "A05:2021": "https://owasp.org/Top10/A05_2021-Security_Misconfiguration/",
-  "A06:2021": "https://owasp.org/Top10/A06_2021-Vulnerable_and_Outdated_Components/",
-  "A07:2021": "https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/",
-  "A08:2021": "https://owasp.org/Top10/A08_2021-Software_and_Data_Integrity_Failures/",
-  "A09:2021": "https://owasp.org/Top10/A09_2021-Security_Logging_and_Monitoring_Failures/",
-  "A10:2021": "https://owasp.org/Top10/A10_2021-Server-Side_Request_Forgery_%28SSRF%29/"
+  "A01:2021": {
+    "url": "https://owasp.org/Top10/A01_2021-Broken_Access_Control/",
+    "name": "Broken Access Control"
+  },
+  "A02:2021": {
+    "url": "https://owasp.org/Top10/A02_2021-Cryptographic_Failures/",
+    "name": "Cryptographic Failures"
+  },
+  "A03:2021": {
+    "url": "https://owasp.org/Top10/A03_2021-Injection/",
+    "name": "Injection"
+  },
+  "A04:2021": {
+    "url": "https://owasp.org/Top10/A04_2021-Insecure_Design/",
+    "name": "Insecure Design"
+  },
+  "A05:2021": {
+    "url": "https://owasp.org/Top10/A05_2021-Security_Misconfiguration/",
+    "name": "Security Misconfiguration"
+  },
+  "A06:2021": {
+    "url": "https://owasp.org/Top10/A06_2021-Vulnerable_and_Outdated_Components/",
+    "name": "Vulnerable and Outdated Components"
+  },
+  "A07:2021": {
+    "url": "https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/",
+    "name": "Identification and Authentication Failures"
+  },
+  "A08:2021": {
+    "url": "https://owasp.org/Top10/A08_2021-Software_and_Data_Integrity_Failures/",
+    "name": "Software and Data Integrity Failures"
+  },
+  "A09:2021": {
+    "url": "https://owasp.org/Top10/A09_2021-Security_Logging_and_Monitoring_Failures/",
+    "name": "Security Logging and Monitoring Failures"
+  },
+  "A10:2021": {
+    "url": "https://owasp.org/Top10/A10_2021-Server-Side_Request_Forgery_%28SSRF%29/",
+    "name": "Server-side Request Forgery (SSRF)"
+  }
 }

--- a/docs/_data/rules.js
+++ b/docs/_data/rules.js
@@ -3,6 +3,7 @@ const { statSync } = require("fs");
 const path = require("path");
 const yaml = require("js-yaml");
 const rulesPath = "../pkg/commands/process/settings/rules/";
+const cweList = require("./cweList.json");
 
 function isDirectory(dir) {
   const result = statSync(dir);
@@ -60,10 +61,18 @@ async function fetchAllFiles(directory, files) {
 async function fetchFile(location) {
   return readFile(location, { encoding: "utf8" }).then((file) => {
     let out = yaml.load(file);
-
+    let owasps = new Set();
+    if (out.metadata.cwe_id) {
+      out.metadata.cwe_id.forEach((i) => {
+        if (cweList[i].owasp) {
+          owasps.add(cweList[i].owasp.id);
+        }
+      });
+    }
     return {
       name: path.basename(location, ".yml"),
       location: location.substring(2),
+      owasp_ids: [...owasps].sort(),
       ...out,
     };
   });

--- a/docs/reference/rule-pages.njk
+++ b/docs/reference/rule-pages.njk
@@ -37,7 +37,6 @@ rule.metadata %}
 {% endrenderTemplate %}
 
 {% if rule.metadata.cwe_id %}
-  {% set owaspList = [] %}
   <h2 id="associated-cwe">Associated CWE</h2>
   <ul>
     {% for id in rule.metadata.cwe_id %}
@@ -46,18 +45,15 @@ rule.metadata %}
     CWE-{{id}}: {{cweList[id].name}}
         </a>
       </li>
-      {% if cweList[id].owasp %}
-        {% set owaspList = (owaspList.push(cweList[id].owasp), owaspList) %}
-      {% endif %}
       {% endfor%}
     </ul>
-    {% if owaspList %}
+    {% if rule.owasp_ids %}
       <h2 id="owasp-top10">OWASP Top 10</h2>
       <ul>
-        {% for value in owaspList | deduplicate %}
+        {% for value in rule.owasp_ids %}
           <li>
-            <a href="{{owaspURLs[value.id]}}">
-              {{value.id}} - {{value.name}}
+            <a href="{{owaspURLs[value].url}}">
+              {{value}} - {{owaspURLs[value].name}}
             </a>
           </li>
         {% endfor %}

--- a/docs/reference/rule-pages.njk
+++ b/docs/reference/rule-pages.njk
@@ -36,7 +36,7 @@ rule.metadata %}
 
 {% endrenderTemplate %}
 
-{% if rule.metadata.cwe_id %}
+{% if rule.metadata.cwe_id | length %}
   <h2 id="associated-cwe">Associated CWE</h2>
   <ul>
     {% for id in rule.metadata.cwe_id %}
@@ -47,7 +47,7 @@ rule.metadata %}
       </li>
       {% endfor%}
     </ul>
-    {% if rule.owasp_ids %}
+    {% if rule.owasp_ids | length %}
       <h2 id="owasp-top10">OWASP Top 10</h2>
       <ul>
         {% for value in rule.owasp_ids %}

--- a/docs/reference/rules.njk
+++ b/docs/reference/rules.njk
@@ -45,6 +45,9 @@ Bearer's built-in rules aim to keep you protected from the most cirtical securit
           {% for id in rule.metadata.cwe_id %}
             <li class=" text-xs py-2 px-4 rounded-full bg-neutral-200 dark:bg-code">CWE-{{id}}</li>
           {% endfor %}
+          {% for id in rule.owasp_ids %}
+            <li class=" text-xs py-2 px-4 rounded-full bg-neutral-200 dark:bg-code">{{id}}</li>
+          {% endfor %}
         </ul>
       </div>
     </li>


### PR DESCRIPTION
## Description
Fixes a bug where rules with a CWE that doesn't have a corresponding OWASP top 10 item would still display the OWASP heading on the rule detail page.

In addition:
- restructures the way OWASP data is connected to CWE data to make it easier to use in the future.
- adds OWASP tags to main rules search so you can now search and browse by OWASP ID in addition to CWE ID


## Related
- close #846 

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
