### PR TITLE
docs: external rules logic

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 _site/
+_tmp/
 .cache/

--- a/docs/_data/rules.js
+++ b/docs/_data/rules.js
@@ -2,12 +2,23 @@ const { readFile, readdir } = require("node:fs/promises");
 const { statSync } = require("fs");
 const path = require("path");
 const yaml = require("js-yaml");
-const rulesPath = "../pkg/commands/process/settings/rules/";
 const cweList = require("./cweList.json");
+const gitly = require("gitly");
+const source = "bearer/bearer-rules";
+const rulesPath = "_tmp/rules-data";
 
 function isDirectory(dir) {
   const result = statSync(dir);
   return result.isDirectory();
+}
+
+async function fetchRelease() {
+  try {
+    let src = await gitly.download(source);
+    await gitly.extract(src, rulesPath);
+  } catch (e) {
+    throw console.error(e);
+  }
 }
 
 async function fetchData(location) {
@@ -79,5 +90,6 @@ async function fetchFile(location) {
 }
 
 module.exports = async function () {
-  return await fetchData("../pkg/commands/process/settings/rules/");
+  await fetchRelease();
+  return await fetchData(rulesPath);
 };

--- a/docs/_data/rules.js
+++ b/docs/_data/rules.js
@@ -7,7 +7,7 @@ const cweList = require("./cweList.json");
 const gitly = require("gitly");
 const source = "bearer/bearer-rules";
 const rulesPath = "_tmp/rules-data";
-const languageDirectories = ["ruby", "javascript"];
+const excludeDirectories = [".github", "scripts"];
 
 function isDirectory(dir) {
   const result = statSync(dir);
@@ -42,7 +42,7 @@ async function fetchData(location) {
     // ex: looping through rules [ruby, gitleaks, sql]
     dirs.forEach(async (dir) => {
       const dirPath = path.join(rulesPath, dir);
-      if (isDirectory(dirPath) && languageDirectories.includes(dir)) {
+      if (isDirectory(dirPath) && !excludeDirectories.includes(dir)) {
         const subDirs = await readdir(dirPath);
         // ex. looping through rules/ruby [lang, rails]
         subDirs.forEach(async (subDir) => {

--- a/docs/_data/rules.js
+++ b/docs/_data/rules.js
@@ -1,6 +1,6 @@
 const { readFile, readdir } = require("node:fs/promises");
 const { statSync } = require("fs");
-const fetch = require("node-fetch");
+const EleventyFetch = require("@11ty/eleventy-fetch");
 const path = require("path");
 const yaml = require("js-yaml");
 const cweList = require("./cweList.json");
@@ -15,15 +15,20 @@ function isDirectory(dir) {
 }
 
 async function fetchRelease() {
-  const latest = await fetch(
-    `https://api.github.com/repos/${source}/releases/latest`
-  )
-    .then((res) => res.json())
-    .then((data) => {
-      return data.tag_name;
-    });
+  let latest = {};
   try {
-    let src = await gitly.download(`${source}#${latest}`);
+    latest = await EleventyFetch(
+      `https://api.github.com/repos/${source}/releases/latest`,
+      {
+        duration: "60m",
+        type: "json",
+      }
+    );
+  } catch (e) {
+    console.error(e);
+  }
+  try {
+    let src = await gitly.download(`${source}#${latest.tag_name}`);
     await gitly.extract(src, rulesPath);
   } catch (e) {
     throw console.error(e);
@@ -32,30 +37,26 @@ async function fetchRelease() {
 
 async function fetchData(location) {
   let rules = [];
-  let groupedRules = [];
   try {
     const dirs = await readdir(location);
     // ex: looping through rules [ruby, gitleaks, sql]
     dirs.forEach(async (dir) => {
       const dirPath = path.join(rulesPath, dir);
       if (isDirectory(dirPath) && languageDirectories.includes(dir)) {
-        const dirData = {
-          name: dir,
-          children: [],
-        };
-
         const subDirs = await readdir(dirPath);
         // ex. looping through rules/ruby [lang, rails]
         subDirs.forEach(async (subDir) => {
           const subDirPath = path.join(dirPath, subDir);
           if (isDirectory(subDirPath)) {
             const files = await readdir(subDirPath);
-            const children = await fetchAllFiles(subDirPath, files);
-            dirData.children.push(...children);
+            const children = await fetchAllFiles(
+              subDirPath,
+              path.join(dir, subDir),
+              files
+            );
             rules.push(...children);
           }
         });
-        groupedRules.push(dirData);
       }
     });
     return rules;
@@ -64,12 +65,12 @@ async function fetchData(location) {
   }
 }
 
-async function fetchAllFiles(directory, files) {
+async function fetchAllFiles(directory, breadcrumb, files) {
   let result = await Promise.all(
     files.reduce((all, file) => {
       const location = path.join(directory, file);
       if (path.extname(location) === ".yml") {
-        return [...all, fetchFile(path.join(directory, file))];
+        return [...all, fetchFile(path.join(directory, file), breadcrumb)];
       } else {
         return all;
       }
@@ -78,7 +79,7 @@ async function fetchAllFiles(directory, files) {
   return result;
 }
 
-async function fetchFile(location) {
+async function fetchFile(location, breadcrumb) {
   return readFile(location, { encoding: "utf8" }).then((file) => {
     let out = yaml.load(file);
     let owasps = new Set();
@@ -91,7 +92,7 @@ async function fetchFile(location) {
     }
     return {
       name: path.basename(location, ".yml"),
-      location: location.substring(2),
+      location: path.join(breadcrumb, path.basename(location, ".yml")),
       owasp_ids: [...owasps].sort(),
       ...out,
     };

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -14,6 +14,7 @@
         "@11ty/eleventy-plugin-syntaxhighlight": "^4.1.0",
         "@tailwindcss/typography": "^0.5.7",
         "eleventy-plugin-toc": "^1.1.5",
+        "gitly": "^2.4.1",
         "js-yaml": "^4.1.0",
         "markdown-it": "^13.0.1",
         "markdown-it-anchor": "^8.6.5",
@@ -473,6 +474,23 @@
       "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
       "dev": true
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
+    },
+    "node_modules/axios": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
+      "integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/babel-walk": {
       "version": "3.0.0-canary-5",
       "resolved": "https://registry.npmjs.org/babel-walk/-/babel-walk-3.0.0-canary-5.tgz",
@@ -824,6 +842,15 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -841,6 +868,18 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/commander": {
       "version": "5.1.0",
@@ -951,6 +990,15 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/dependency-graph": {
@@ -1307,6 +1355,52 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dev": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1345,6 +1439,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gitly": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/gitly/-/gitly-2.4.1.tgz",
+      "integrity": "sha512-RDGzR94EjKfj+blA2PBf28yZ8erY9GBUv6YAgynID/BRVFcQHPCNMcfWsE22Kbz6ajkgwifk05AnX0wlmD03jA==",
+      "dev": true,
+      "dependencies": {
+        "axios": "^1.3.4",
+        "tar": "^6.1.13"
       }
     },
     "node_modules/glob": {
@@ -2016,6 +2120,27 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -2047,6 +2172,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dev": true,
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/mkdirp": {
@@ -2606,6 +2744,12 @@
         "any-promise": "^0.1.0"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
+    },
     "node_modules/prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -3081,6 +3225,44 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/tar": {
+      "version": "6.1.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.13.tgz",
+      "integrity": "sha512-jdIBIN6LTIe2jqzay/2vtYLlBHa3JF42ot3h1dW8Q0PaAG4v8rm0cvpVePtau5C6OKXGGcgO9q2AMNSWxiLqKw==",
+      "dev": true,
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^4.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tar/node_modules/minipass": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.5.tgz",
+      "integrity": "sha512-+yQl7SX3bIT83Lhb4BVorMAHVuqsskxRdlmO9kTpyukp8vsm2Sn/fUOV9xlnG8/a5JsypJzap21lz/y3FBMJ8Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/to-fast-properties": {
@@ -3614,6 +3796,23 @@
       "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
       "dev": true
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
+    },
+    "axios": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
+      "integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "babel-walk": {
       "version": "3.0.0-canary-5",
       "resolved": "https://registry.npmjs.org/babel-walk/-/babel-walk-3.0.0-canary-5.tgz",
@@ -3870,6 +4069,12 @@
         "readdirp": "~3.6.0"
       }
     },
+    "chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "dev": true
+    },
     "color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3884,6 +4089,15 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
     },
     "commander": {
       "version": "5.1.0",
@@ -3962,6 +4176,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.1.tgz",
       "integrity": "sha512-hsBd2qSVCRE+5PmNdHt1uzyrFu5d3RwmFDKzyNZMFq/EwDNJF7Ee5+D5oEKF0hU6LhtoUF1macFvOe4AskQC1Q==",
+      "dev": true
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "dev": true
     },
     "dependency-graph": {
@@ -4239,6 +4459,32 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
     },
+    "follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "dev": true
+    },
+    "form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dev": true,
+      "requires": {
+        "minipass": "^3.0.0"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -4267,6 +4513,16 @@
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.3"
+      }
+    },
+    "gitly": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/gitly/-/gitly-2.4.1.tgz",
+      "integrity": "sha512-RDGzR94EjKfj+blA2PBf28yZ8erY9GBUv6YAgynID/BRVFcQHPCNMcfWsE22Kbz6ajkgwifk05AnX0wlmD03jA==",
+      "dev": true,
+      "requires": {
+        "axios": "^1.3.4",
+        "tar": "^6.1.13"
       }
     },
     "glob": {
@@ -4779,6 +5035,21 @@
       "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
       "dev": true
     },
+    "mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.52.0"
+      }
+    },
     "minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -4800,6 +5071,16 @@
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
       "dev": true,
       "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
+    "minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dev": true,
+      "requires": {
+        "minipass": "^3.0.0",
         "yallist": "^4.0.0"
       }
     },
@@ -5182,6 +5463,12 @@
         "any-promise": "^0.1.0"
       }
     },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
+    },
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -5549,6 +5836,34 @@
           "requires": {
             "is-glob": "^4.0.3"
           }
+        }
+      }
+    },
+    "tar": {
+      "version": "6.1.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.13.tgz",
+      "integrity": "sha512-jdIBIN6LTIe2jqzay/2vtYLlBHa3JF42ot3h1dW8Q0PaAG4v8rm0cvpVePtau5C6OKXGGcgO9q2AMNSWxiLqKw==",
+      "dev": true,
+      "requires": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^4.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "minipass": {
+          "version": "4.2.5",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.5.tgz",
+          "integrity": "sha512-+yQl7SX3bIT83Lhb4BVorMAHVuqsskxRdlmO9kTpyukp8vsm2Sn/fUOV9xlnG8/a5JsypJzap21lz/y3FBMJ8Q==",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
         }
       }
     },

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -19,6 +19,7 @@
         "markdown-it": "^13.0.1",
         "markdown-it-anchor": "^8.6.5",
         "markdown-it-emoji": "^2.0.2",
+        "node-fetch": "^2.6.9",
         "tailwindcss": "^3.1.8"
       }
     },

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -19,7 +19,6 @@
         "markdown-it": "^13.0.1",
         "markdown-it-anchor": "^8.6.5",
         "markdown-it-emoji": "^2.0.2",
-        "node-fetch": "^2.6.9",
         "tailwindcss": "^3.1.8"
       }
     },

--- a/docs/package.json
+++ b/docs/package.json
@@ -24,6 +24,7 @@
     "markdown-it": "^13.0.1",
     "markdown-it-anchor": "^8.6.5",
     "markdown-it-emoji": "^2.0.2",
+    "node-fetch": "^2.6.9",
     "tailwindcss": "^3.1.8"
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -24,7 +24,6 @@
     "markdown-it": "^13.0.1",
     "markdown-it-anchor": "^8.6.5",
     "markdown-it-emoji": "^2.0.2",
-    "node-fetch": "^2.6.9",
     "tailwindcss": "^3.1.8"
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -7,7 +7,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "eleventy --serve --watch --incremental & npx tailwindcss -i _src/styles/tailwind.css -c _src/styles/tailwind.config.js -o _site/style.css --watch",
     "debug": "DEBUG=Eleventy* eleventy --serve & npx tailwindcss -i _src/styles/tailwind.css -c _src/styles/tailwind.config.js -o _site/style.css --watch",
-    "build": "ELEVENTY_PRODUCTION=true eleventy && NODE_ENV=production npx tailwindcss -i _src/styles/tailwind.css -c _src/styles/tailwind.config.js -o _site/style.css --minify"
+    "build": "ELEVENTY_PRODUCTION=true eleventy && NODE_ENV=production npx tailwindcss -i _src/styles/tailwind.css -c _src/styles/tailwind.config.js -o _site/style.css --minify",
+    "clean": "rm -rf _site _tmp"
   },
   "keywords": [],
   "author": "",
@@ -18,6 +19,7 @@
     "@11ty/eleventy-plugin-syntaxhighlight": "^4.1.0",
     "@tailwindcss/typography": "^0.5.7",
     "eleventy-plugin-toc": "^1.1.5",
+    "gitly": "^2.4.1",
     "js-yaml": "^4.1.0",
     "markdown-it": "^13.0.1",
     "markdown-it-anchor": "^8.6.5",

--- a/docs/reference/rule-pages.njk
+++ b/docs/reference/rule-pages.njk
@@ -26,7 +26,7 @@ eleventyComputed:
   {% endif %}
   <li>
     <strong>Source:</strong>
-    <a class=" text-main dark:text-main-300 hover:underline" href="{{meta.sourcePath}}/blob/main/{{rule.location}}">{{rule.name}}.yml</a>
+    <a class="text-main dark:text-main-300 hover:underline" href="https://github.com/bearer/bearer-rules/blob/main/{{rule.location}}.yml">{{rule.name}}.yml</a>
   </li>
 </ul>
 {% renderTemplate 'liquid,md',

--- a/docs/reference/rules.njk
+++ b/docs/reference/rules.njk
@@ -5,9 +5,9 @@ title: Rules
 {% renderTemplate "liquid,md" %}
 # Rules
 
-Rules are ways to detect security risks and vulnerabilities across your codebase and enforce best practices. Bearer's summary report allows you to quickly identify rule violations in your code.
+Rules are ways to detect security risks and vulnerabilities across your codebase and enforce best practices. Bearer's [security report](/explanations/reports/#security-report) allows you to quickly identify rule violations in your code.
 
-Bearer's built-in rules aim to keep you protected from the most cirtical security risks and vulnerabilities of web applcations and include corresponding [Common Weakness Enumeration](https://cwe.mitre.org/data/index.html) (CWE) and [OWASP](https://owasp.org/Top10) links to help you identify them. 
+The built-in rules aim to keep you protected from the most cirtical security risks and vulnerabilities of web applcations and include corresponding [Common Weakness Enumeration](https://cwe.mitre.org/data/index.html) (CWE) and [OWASP](https://owasp.org/Top10) links to help you identify them. 
 
 {% endrenderTemplate %}
 


### PR DESCRIPTION
## Description
Updates rules documentation to handle the move to an external rules repo. Specific caveats:
- Relies on hard-coded language support to confirm contents are rules. Docs will require updates when new languages are added, so shouldn't be a problem in the near term.
- Expects `bearer/bearer-rules` as the external rules repo for both processing data and linking to rule source.
- Always pulls the latest release. This means a doc rebuild will always pull the latest rules release.
- Somewhat messy caching in docs dev environment. Watch for temp dirs when changing branches until the included gitignore is everywhere. Won't affect production.

Not yet included:
- Messaging related to external rules repo.
- UI for rules version in the `reference/rules` page. Decisions on how to handle this TBD.

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
