### PR TITLE
fix: ignore invalid rules

### DIFF
--- a/pkg/commands/process/settings/rules.go
+++ b/pkg/commands/process/settings/rules.go
@@ -86,6 +86,11 @@ func loadRuleDefinitions(definitions map[string]RuleDefinition, dir fs.FS) error
 			return fmt.Errorf("failed to unmarshal rule %s: %w", path, err)
 		}
 
+		if ruleDefinition.Metadata == nil {
+			log.Debug().Msgf("Rule file has invalid metadata %s", path)
+			return nil
+		}
+
 		id := ruleDefinition.Metadata.ID
 
 		if _, exists := definitions[id]; exists {


### PR DESCRIPTION
## Description
Allow loading rules directories that are not 'clean' of other yaml files. 

Previosuly if you tired to do this a valid yaml file that did not contain metadata would segfault.

This way you can do the following if you have checked out `bearer-rules` repo and want to alter things then test:

```
bearer scan my_project --disable-default-rules=true --external-rule-dir bearer-rules
```

## Related
- #799
- #429

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
