### PR TITLE
fix: false +ves in js open redirect rule

### DIFF
--- a/pkg/commands/process/settings/rules/javascript/express/open_redirect.yml
+++ b/pkg/commands/process/settings/rules/javascript/express/open_redirect.yml
@@ -1,27 +1,50 @@
 patterns:
   - pattern: |
-      res.redirect($<USER_INPUT>$<...>)
+      res.redirect($<DATA>$<...>)
     filters:
-      - variable: USER_INPUT
-        detection: javascript_express_open_redirect_req_object
+      - variable: DATA
+        detection: javascript_express_open_redirect_data
+        contains: false
 auxiliary:
-  - id: javascript_express_open_redirect_req_object
+  - id: javascript_express_open_redirect_data
     patterns:
-      - pattern: $<DATA>
+      - pattern: $<USER_INPUT>
         filters:
-          - variable: DATA
+          - variable: USER_INPUT
             detection: javascript_express_open_redirect_user_input
-      - pattern: const { $<!>$<_> } = $<DATA>
+          - not:
+              variable: USER_INPUT
+              detection: javascript_express_open_redirect_sanitized
+      - pattern: const { $<!>$<_> } = $<USER_INPUT>
         filters:
-          - variable: DATA
+          - variable: USER_INPUT
             detection: javascript_express_open_redirect_user_input
-  - id: javascript_express_open_redirect_user_input
+          - not:
+              variable: USER_INPUT
+              detection: javascript_express_open_redirect_sanitized
+  - id: javascript_express_open_redirect_user_input_source
     patterns:
       - req.params
       - req.query
       - req.body
       - req.cookies
       - req.headers
+  - id: javascript_express_open_redirect_sanitized
+    patterns:
+      - pattern: |
+          !$<SANITIZED>
+        filters:
+          - variable: SANITIZED
+            detection: javascript_express_open_redirect_user_input
+  # MATCHED_USER_INPUT ensures that the main rule and the sanitized rule refer
+  # to the same input source node
+  - id: javascript_express_open_redirect_user_input
+    patterns:
+      - pattern: $<MATCHED_USER_INPUT>
+        filters:
+          - variable: MATCHED_USER_INPUT
+            detection: javascript_express_open_redirect_user_input_source
+            contains: false
 languages:
   - javascript
 severity: medium

--- a/pkg/commands/process/settings/rules/javascript/express/open_redirect/testdata/ok_no_open_redirect.js
+++ b/pkg/commands/process/settings/rules/javascript/express/open_redirect/testdata/ok_no_open_redirect.js
@@ -1,3 +1,4 @@
 module.exports.foo = function (_req, res) {
   res.redirect("https://google.com")
+  res.redirect(!!req.query.google ? "https://google.com" : "https://bing.com")
 }

--- a/pkg/commands/process/settings/rules/ruby/rails/sql_injection.yml
+++ b/pkg/commands/process/settings/rules/ruby/rails/sql_injection.yml
@@ -116,9 +116,9 @@ auxiliary:
         filters:
           - variable: SANITIZED
             detection: ruby_rails_sql_injection_user_input
-      - pattern: $<METHOD>($<SANITIZED>)
+      - pattern: $<SANITIZE_METHOD>($<SANITIZED>)
         filters:
-          - variable: METHOD
+          - variable: SANITIZE_METHOD
             values:
               - sanitize_sql
               - sanitize_sql_for_assignment


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Fixes some false +ves for the JS Express open redirect rule.

Also fixes a non-unique variable name in the Ruby SQL injection rule.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [x] I've added test coverage that shows my fix or feature works as expected.
- [x] I've updated or added documentation if required.
- [x] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
