### PR TITLE
docs: add overview video to readme and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@
 ## Code security scanner that natively filters and prioritizes security risks using sensitive data flow analysis.
 <hr/>
 
-<iframe style="display:block; width: 100%; aspect-ratio: 16 / 9;" src="https://www.youtube.com/embed/WeyPmYyP5Nc" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-
+https://user-images.githubusercontent.com/1649672/230208878-9fefaa19-8e88-46fb-82a2-5236c310c91f.mp4
 
 Bearer provides built-in rules against a common set of security risks and vulnerabilities, known as [OWASP Top 10](https://owasp.org/www-project-top-ten/). Here are some practical examples of what those rules look for:
 * Non-filtered user input.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 ## Code security scanner that natively filters and prioritizes security risks using sensitive data flow analysis.
 <hr/>
 
-https://user-images.githubusercontent.com/1649672/230208878-9fefaa19-8e88-46fb-82a2-5236c310c91f.mp4
+https://user-images.githubusercontent.com/1649672/230438696-9bb0fd35-2aa9-4273-9970-733189d01ff1.mp4
 
 Bearer provides built-in rules against a common set of security risks and vulnerabilities, known as [OWASP Top 10](https://owasp.org/www-project-top-ten/). Here are some practical examples of what those rules look for:
 * Non-filtered user input.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 ## Code security scanner that natively filters and prioritizes security risks using sensitive data flow analysis.
 <hr/>
 
-https://user-images.githubusercontent.com/380564/221234857-4d449804-fe20-4ca4-8d4d-145b7997c379.mov
+<iframe style="display:block; width: 100%; aspect-ratio: 16 / 9;" src="https://www.youtube.com/embed/WeyPmYyP5Nc" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
 
 Bearer provides built-in rules against a common set of security risks and vulnerabilities, known as [OWASP Top 10](https://owasp.org/www-project-top-ten/). Here are some practical examples of what those rules look for:

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -19,7 +19,9 @@ And [many more](/reference/rules).
 
 Bearer currently supports **JavaScript** and **Ruby** stacks, more will follow.
 
-![bearer security scanner gif](/assets/img/Bearer-security-OSS.gif)
+Want a quick rundown? Here's a minute and a half of what you can expect from Bearer CLI:
+
+<iframe class="w-full aspect-video" src="https://www.youtube.com/embed/WeyPmYyP5Nc" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
 ## Getting started
 

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -8,7 +8,8 @@ permalink: "/"
 
 Welcome to the Bearer documentation. Bearer is a static application security testing (SAST) tool that scans your source code and analyzes your [data flows](/explanations/discovery-and-classification) to discover, filter and prioritize security risks and vulnerabilities leading to [sensitive data](/reference/datatypes/) exposures (PII, PHI, PD).
 
-We provides [built-in rules](/reference/rules) against a common set of security risks and vulnerabilities, known as [OWASP Top 10](https://owasp.org/www-project-top-ten/). Here are some practical examples of what those rules look for:
+The CLI provides [built-in rules](/reference/rules) that check against a common set of security risks and vulnerabilities, known as [OWASP Top 10](https://owasp.org/www-project-top-ten/). Here are some practical examples of what those rules look for:
+
 - Leakage of sensitive data through cookies, internal loggers, third-party logging services, and into analytics environments.
 - Usage of weak encryption libraries or misusage of encryption algorithms.
 - Unencrypted incoming and outgoing communication (HTTP, FTP, SMTP) of sensitive information.
@@ -17,7 +18,7 @@ We provides [built-in rules](/reference/rules) against a common set of security 
 
 And [many more](/reference/rules).
 
-Bearer currently supports **JavaScript** and **Ruby** stacks, more will follow.
+Bearer currently supports **JavaScript / TypeScript** and **Ruby** stacks, and more will follow.
 
 Want a quick rundown? Here's a minute and a half of what you can expect from Bearer CLI:
 


### PR DESCRIPTION
## Description
Updates the main docs page and readme with a walkthrough of the CLI and docs.
- The docs version uses a youtube embed, with optional subtitles/cc.
- The readme uses github's native embed, since github won't parse iframes in md files. Unfortunately, github doesn't offer the addition of closed captioning for video files, so that version has subtitles burned in.
- Also handles a few small grammar fixes on the main docs page.

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
