### PR TITLE
fix: incorrect classifications

### DIFF
--- a/pkg/classification/db/data_type_classification_patterns/100_telephone_number.json
+++ b/pkg/classification/db/data_type_classification_patterns/100_telephone_number.json
@@ -6,7 +6,7 @@
   "exclude_types": ["boolean"],
   "friendly_name": "Telephone Number",
   "health_context_data_type_uuid": null,
-  "include_regexp": "\\b((sender)?(tele|mobile|contact|phone|(billing\\s?phone))\\s?(number)?)|(primary\\s?phone\\s?(number)?)\\b",
+  "include_regexp": "\\b((sender)?(telephone|mobile|contact|phone|(billing\\s?phone))\\s?(number)?)|(primary\\s?phone\\s?(number)?)\\b",
   "match_column": true,
   "match_object": false,
   "object_type": ["known", "unknown_extended"]

--- a/pkg/classification/db/data_type_classification_patterns/2_email_address.json
+++ b/pkg/classification/db/data_type_classification_patterns/2_email_address.json
@@ -6,7 +6,7 @@
   "exclude_types": ["boolean", "date", "number"],
   "friendly_name": "Email Address",
   "health_context_data_type_uuid": null,
-  "include_regexp": "\\b(.*email\\s?(address)?)\\b",
+  "include_regexp": "\\b.*email(\\s?address)?\\z",
   "match_column": true,
   "match_object": false,
   "object_type": ["unknown"]

--- a/pkg/classification/db/data_type_classification_patterns/72_interactions.json
+++ b/pkg/classification/db/data_type_classification_patterns/72_interactions.json
@@ -6,7 +6,7 @@
   "exclude_types": ["boolean"],
   "friendly_name": "Interactions",
   "health_context_data_type_uuid": null,
-  "include_regexp": "\\b(interactions?)\\b",
+  "include_regexp": "\\b(interactions?)\\z",
   "match_column": true,
   "match_object": false,
   "object_type": ["known", "unknown_extended"]

--- a/pkg/classification/db/known_person_object_patterns/authentication.json
+++ b/pkg/classification/db/known_person_object_patterns/authentication.json
@@ -1,8 +1,0 @@
-{
-  "metadata": { "version": "1.0" },
-  "id": 8,
-  "act_as_identifier": false,
-  "category": "Authentication",
-  "exclude_regexp": "\\b(.|_)?author(.|_)?\\b",
-  "include_regexp": "\\b.*authentication.*|.*oauth.*|.*auth.*\\b"
-}

--- a/pkg/classification/db/known_person_object_patterns/client.json
+++ b/pkg/classification/db/known_person_object_patterns/client.json
@@ -4,5 +4,5 @@
   "act_as_identifier": true,
   "category": "Client",
   "include_regexp": "\\b.*client.*\\b",
-  "exclude_regexp": "\\bconfig\\b"
+  "exclude_regexp": "\\b(config|auth(entication)?)\\b"
 }

--- a/pkg/classification/schema/.snapshots/TestCSharp
+++ b/pkg/classification/schema/.snapshots/TestCSharp
@@ -1,4 +1,4 @@
-([]testhelper.ClassificationResult) (len=64) {
+([]testhelper.ClassificationResult) (len=63) {
   (testhelper.ClassificationResult) {
     Name: (string) (len=18) "EditForumPostModel",
     Decision: (classify.ClassificationDecision) {
@@ -1494,7 +1494,7 @@
         Name: (string) (len=10) "EmailMatch",
         Decision: (classify.ClassificationDecision) {
           State: (classify.ValidationState) (len=5) "valid",
-          Reason: (string) (len=21) "valid_unknown_pattern"
+          Reason: (string) (len=22) "valid_extended_pattern"
         },
         Properties: (map[string]testhelper.ClassificationResult) <nil>
       },
@@ -2778,7 +2778,7 @@
     Name: (string) (len=27) "AssociatedExternalAuthModel",
     Decision: (classify.ClassificationDecision) {
       State: (classify.ValidationState) (len=5) "valid",
-      Reason: (string) (len=34) "valid_object_with_valid_properties"
+      Reason: (string) (len=36) "invalid_object_with_valid_properties"
     },
     Properties: (map[string]testhelper.ClassificationResult) (len=3) {
       (string) (len=14) "AuthMethodName": (testhelper.ClassificationResult) {
@@ -2793,7 +2793,7 @@
         Name: (string) (len=5) "Email",
         Decision: (classify.ClassificationDecision) {
           State: (classify.ValidationState) (len=5) "valid",
-          Reason: (string) (len=13) "known_pattern"
+          Reason: (string) (len=21) "valid_unknown_pattern"
         },
         Properties: (map[string]testhelper.ClassificationResult) <nil>
       },
@@ -5134,8 +5134,8 @@
       (string) (len=20) "Home2TelephoneNumber": (testhelper.ClassificationResult) {
         Name: (string) (len=20) "Home2TelephoneNumber",
         Decision: (classify.ClassificationDecision) {
-          State: (classify.ValidationState) (len=7) "invalid",
-          Reason: (string) (len=16) "invalid_property"
+          State: (classify.ValidationState) (len=5) "valid",
+          Reason: (string) (len=13) "known_pattern"
         },
         Properties: (map[string]testhelper.ClassificationResult) <nil>
       },
@@ -5966,8 +5966,8 @@
       (string) (len=11) "TelexNumber": (testhelper.ClassificationResult) {
         Name: (string) (len=11) "TelexNumber",
         Decision: (classify.ClassificationDecision) {
-          State: (classify.ValidationState) (len=5) "valid",
-          Reason: (string) (len=13) "known_pattern"
+          State: (classify.ValidationState) (len=7) "invalid",
+          Reason: (string) (len=16) "invalid_property"
         },
         Properties: (map[string]testhelper.ClassificationResult) <nil>
       },
@@ -6371,47 +6371,6 @@
         Decision: (classify.ClassificationDecision) {
           State: (classify.ValidationState) (len=5) "valid",
           Reason: (string) (len=25) "known_database_identifier"
-        },
-        Properties: (map[string]testhelper.ClassificationResult) <nil>
-      }
-    }
-  },
-  (testhelper.ClassificationResult) {
-    Name: (string) (len=25) "WeiboAuthorizationRequest",
-    Decision: (classify.ClassificationDecision) {
-      State: (classify.ValidationState) (len=5) "valid",
-      Reason: (string) (len=34) "valid_object_with_valid_properties"
-    },
-    Properties: (map[string]testhelper.ClassificationResult) (len=4) {
-      (string) (len=7) "Display": (testhelper.ClassificationResult) {
-        Name: (string) (len=7) "Display",
-        Decision: (classify.ClassificationDecision) {
-          State: (classify.ValidationState) (len=7) "invalid",
-          Reason: (string) (len=16) "invalid_property"
-        },
-        Properties: (map[string]testhelper.ClassificationResult) <nil>
-      },
-      (string) (len=10) "Forcelogin": (testhelper.ClassificationResult) {
-        Name: (string) (len=10) "Forcelogin",
-        Decision: (classify.ClassificationDecision) {
-          State: (classify.ValidationState) (len=7) "invalid",
-          Reason: (string) (len=16) "invalid_property"
-        },
-        Properties: (map[string]testhelper.ClassificationResult) <nil>
-      },
-      (string) (len=8) "Language": (testhelper.ClassificationResult) {
-        Name: (string) (len=8) "Language",
-        Decision: (classify.ClassificationDecision) {
-          State: (classify.ValidationState) (len=5) "valid",
-          Reason: (string) (len=13) "known_pattern"
-        },
-        Properties: (map[string]testhelper.ClassificationResult) <nil>
-      },
-      (string) (len=5) "Scope": (testhelper.ClassificationResult) {
-        Name: (string) (len=5) "Scope",
-        Decision: (classify.ClassificationDecision) {
-          State: (classify.ValidationState) (len=7) "invalid",
-          Reason: (string) (len=16) "invalid_property"
         },
         Properties: (map[string]testhelper.ClassificationResult) <nil>
       }
@@ -9054,7 +9013,7 @@
         Name: (string) (len=13) "emailNotExist",
         Decision: (classify.ClassificationDecision) {
           State: (classify.ValidationState) (len=5) "valid",
-          Reason: (string) (len=21) "valid_unknown_pattern"
+          Reason: (string) (len=22) "valid_extended_pattern"
         },
         Properties: (map[string]testhelper.ClassificationResult) <nil>
       },
@@ -13246,7 +13205,7 @@
         Name: (string) (len=19) "userWithEmailExists",
         Decision: (classify.ClassificationDecision) {
           State: (classify.ValidationState) (len=5) "valid",
-          Reason: (string) (len=21) "valid_unknown_pattern"
+          Reason: (string) (len=22) "valid_extended_pattern"
         },
         Properties: (map[string]testhelper.ClassificationResult) <nil>
       },
@@ -13927,8 +13886,8 @@
       (string) (len=24) "InteractionStartDateTime": (testhelper.ClassificationResult) {
         Name: (string) (len=24) "InteractionStartDateTime",
         Decision: (classify.ClassificationDecision) {
-          State: (classify.ValidationState) (len=5) "valid",
-          Reason: (string) (len=22) "valid_extended_pattern"
+          State: (classify.ValidationState) (len=7) "invalid",
+          Reason: (string) (len=16) "invalid_property"
         },
         Properties: (map[string]testhelper.ClassificationResult) <nil>
       },

--- a/pkg/classification/schema/.snapshots/TestCSharpKPI
+++ b/pkg/classification/schema/.snapshots/TestCSharpKPI
@@ -1,11 +1,11 @@
 (testhelper.KPI) {
   DetectionsCount: (int) 3346,
-  ValidDetectionsCount: (int) 376,
-  ValidObjectDetectionsCount: (int) 57,
-  ValidFieldDetectionsCount: (int) 319,
-  ExpectedValidDetectionsCount: (int) 381,
+  ValidDetectionsCount: (int) 373,
+  ValidObjectDetectionsCount: (int) 56,
+  ValidFieldDetectionsCount: (int) 317,
+  ExpectedValidDetectionsCount: (int) 380,
   ExpectedValidObjectDetectionsCount: (int) 58,
-  ExpectedValidFieldDetectionsCount: (int) 323,
-  ExpectedTruePositivesCount: (int) 379,
+  ExpectedValidFieldDetectionsCount: (int) 322,
+  ExpectedTruePositivesCount: (int) 378,
   ExpectedFalsePositivesCount: (int) 2
 }

--- a/pkg/classification/schema/.snapshots/TestTypescriptKPI
+++ b/pkg/classification/schema/.snapshots/TestTypescriptKPI
@@ -1,5 +1,5 @@
 (testhelper.KPI) {
-  DetectionsCount: (int) 35,
+  DetectionsCount: (int) 41,
   ValidDetectionsCount: (int) 19,
   ValidObjectDetectionsCount: (int) 1,
   ValidFieldDetectionsCount: (int) 18,

--- a/pkg/classification/schema/fixtures/csharp.json
+++ b/pkg/classification/schema/fixtures/csharp.json
@@ -10071,11 +10071,7 @@
       },
       {
         "name": "Language",
-        "type": "string",
-        "data_type_info": "Spoken Languages",
-        "state": "valid",
-        "reason": "known_pattern",
-        "false_positive": false
+        "type": "string"
       }
     ],
     "state": "valid"

--- a/pkg/classification/schema/fixtures/typescript.json
+++ b/pkg/classification/schema/fixtures/typescript.json
@@ -214,5 +214,38 @@
       }
     ],
     "state": "valid"
+  },
+  {
+    "name": "BrowserAuthError",
+    "filename": "lib/msal-react/src/hooks/useMsalAuthentication.ts",
+    "detector_type": "JavaScript",
+    "properties": [
+      {
+        "name": "createInteractionInProgressError",
+        "type": "unknown"
+      }
+    ]
+  },
+  {
+    "name": "GitEmailPolicy",
+    "filename": "lib/msal-react/src/hooks/useMsalAuthentication.ts",
+    "detector_type": "JavaScript",
+    "properties": [
+      {
+        "name": "getEmailExampleLines",
+        "type": "unknown"
+      }
+    ]
+  },
+  {
+    "name": "ClientConfigurationError",
+    "filename": "lib/msal-core/src/UserAgentApplication.ts",
+    "detector_type": "JavaScript",
+    "properties": [
+      {
+        "name": "createTelemetryConfigError",
+        "type": "unknown"
+      }
+    ]
   }
 ]

--- a/pkg/util/normalize_key/normalize_key.go
+++ b/pkg/util/normalize_key/normalize_key.go
@@ -7,7 +7,7 @@ import (
 
 var (
 	normalizeCaseRegexp      = regexp.MustCompile(`[A-Z][A-Z][a-z]|[a-z][A-Z]`) // Matches "AP(INa)me" or "firs(tN)ame"
-	normalizeSeparatorRegexp = regexp.MustCompile(`[_\-.,\s:]+`)
+	normalizeSeparatorRegexp = regexp.MustCompile(`[_\-.,\s:0-9]+`)
 )
 
 func Normalize(key string) string {


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Fixes some false positive classifications found when scanning https://github.com/AzureAD/microsoft-authentication-library-for-js.

Fixes:

- Strip numbers before classification
- Remove "authentication" as a known person.
- Improvements to regex patterns

## Related
- Close https://github.com/Bearer/bearer/issues/859
<!-- References some existing PR
- #CCC
-->

## Checklist

- [x] I've added test coverage that shows my fix or feature works as expected.
- [x] I've updated or added documentation if required.
- [x] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
