### PR TITLE
fix: broken privacy rego

### DIFF
--- a/pkg/commands/process/settings/policies/risk_policy.rego
+++ b/pkg/commands/process/settings/policies/risk_policy.rego
@@ -145,11 +145,12 @@ local_rule_failure contains item if {
 	some detector in presence_failures
 	some location in detector.locations
 	some data_type in location.data_types
+	some schema in data_type.schemas
 
 	item := {
 		"name": data_type.name,
 		"category_groups": data.bearer.common.groups_for_datatype(data_type),
-		"subject_name": location.subject_name,
+		"subject_name": schema.subject_name,
 		"line_number": location.line_number,
 		"rule_id": input.rule.id,
 		"third_party": input.rule.associated_recipe,

--- a/pkg/report/output/privacy/.snapshots/TestBuildCsvString
+++ b/pkg/report/output/privacy/.snapshots/TestBuildCsvString
@@ -1,0 +1,7 @@
+
+Subject,Data Types,Detection Count,Critical Risk Failure,High Risk Failure,Medium Risk Failure,Low Risk Failure,Rules Passed
+User,Email Address,1,0,1,0,0,0
+
+Third Party,Subject,Data Types,Critical Risk Failure,High Risk Failure,Medium Risk Failure,Low Risk Failure,Rules Passed
+Sentry,User,"Email Address",0,1,0,0,0
+

--- a/pkg/report/output/privacy/.snapshots/TestGetOutput
+++ b/pkg/report/output/privacy/.snapshots/TestGetOutput
@@ -1,0 +1,28 @@
+(*privacy.Report)({
+  Subjects: ([]privacy.Subject) (len=1) {
+    (privacy.Subject) {
+      DataSubject: (string) (len=4) "User",
+      DataType: (string) (len=13) "Email Address",
+      DetectionCount: (int) 1,
+      CriticalRiskFailureCount: (int) 0,
+      HighRiskFailureCount: (int) 1,
+      MediumRiskFailureCount: (int) 0,
+      LowRiskFailureCount: (int) 0,
+      RulesPassedCount: (int) 0
+    }
+  },
+  ThirdParty: ([]privacy.ThirdParty) (len=1) {
+    (privacy.ThirdParty) {
+      ThirdParty: (string) (len=6) "Sentry",
+      DataSubject: (string) (len=4) "User",
+      DataTypes: ([]string) (len=1) {
+        (string) (len=13) "Email Address"
+      },
+      CriticalRiskFailureCount: (int) 0,
+      HighRiskFailureCount: (int) 1,
+      MediumRiskFailureCount: (int) 0,
+      LowRiskFailureCount: (int) 0,
+      RulesPassedCount: (int) 0
+    }
+  }
+})

--- a/pkg/report/output/privacy/privacy.go
+++ b/pkg/report/output/privacy/privacy.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/bearer/bearer/pkg/classification/db"
 	"github.com/bearer/bearer/pkg/commands/process/settings"
+	"github.com/bearer/bearer/pkg/types"
 	"github.com/bearer/bearer/pkg/util/output"
 	"github.com/bearer/bearer/pkg/util/progressbar"
 	"github.com/bearer/bearer/pkg/util/rego"
@@ -212,15 +213,16 @@ func GetOutput(dataflow *dataflow.DataFlow, config settings.Config) (*Report, *d
 						TriggeredRules:           make(map[string]bool),
 					}
 				}
+
 				// count severity
 				switch ruleSeverity {
-				case "critical":
+				case types.LevelCritical:
 					subjectRuleFailure.CriticalRiskFailureCount += 1
-				case "high":
+				case types.LevelHigh:
 					subjectRuleFailure.HighRiskFailureCount += 1
-				case "medium":
+				case types.LevelMedium:
 					subjectRuleFailure.MediumRiskFailureCount += 1
-				case "low":
+				case types.LevelLow:
 					subjectRuleFailure.LowRiskFailureCount += 1
 				}
 
@@ -254,13 +256,13 @@ func GetOutput(dataflow *dataflow.DataFlow, config settings.Config) (*Report, *d
 
 				// count severity
 				switch ruleSeverity {
-				case "critical":
+				case types.LevelCritical:
 					thirdPartyDataSubject.CriticalRiskFailureCount += 1
-				case "high":
+				case types.LevelHigh:
 					thirdPartyDataSubject.HighRiskFailureCount += 1
-				case "medium":
+				case types.LevelMedium:
 					thirdPartyDataSubject.MediumRiskFailureCount += 1
-				case "low":
+				case types.LevelLow:
 					thirdPartyDataSubject.LowRiskFailureCount += 1
 				}
 

--- a/pkg/report/output/privacy/privacy_test.go
+++ b/pkg/report/output/privacy/privacy_test.go
@@ -1,0 +1,134 @@
+package privacy_test
+
+import (
+	"testing"
+
+	"github.com/bearer/bearer/pkg/commands/process/settings"
+	"github.com/bearer/bearer/pkg/flag"
+	"github.com/bearer/bearer/pkg/report/output/dataflow"
+	"github.com/bearer/bearer/pkg/report/output/dataflow/types"
+	"github.com/bearer/bearer/pkg/report/output/privacy"
+	"github.com/bearer/bearer/pkg/report/schema"
+	"github.com/bradleyjkemp/cupaloy"
+)
+
+func TestBuildCsvString(t *testing.T) {
+	config, err := generateConfig(flag.ReportOptions{Report: "privacy"})
+	config.Rules = map[string]*settings.Rule{
+		"ruby_third_parties_sentry": config.Rules["ruby_third_parties_sentry"],
+	}
+
+	if err != nil {
+		t.Fatalf("failed to generate config:%s", err)
+	}
+
+	dataflow := dummyDataflow()
+
+	stringBuilder, _ := privacy.BuildCsvString(&dataflow, config)
+	cupaloy.SnapshotT(t, stringBuilder.String())
+}
+
+func TestGetOutput(t *testing.T) {
+	config, err := generateConfig(flag.ReportOptions{Report: "privacy"})
+	config.Rules = map[string]*settings.Rule{
+		"ruby_third_parties_sentry": config.Rules["ruby_third_parties_sentry"],
+	}
+
+	if err != nil {
+		t.Fatalf("failed to generate config:%s", err)
+	}
+
+	dataflow := dummyDataflow()
+	results, _, err := privacy.GetOutput(&dataflow, config)
+	if err != nil {
+		t.Fatalf("failed to generate privacy output err:%s", err)
+	}
+
+	cupaloy.SnapshotT(t, results)
+}
+
+func generateConfig(reportOptions flag.ReportOptions) (settings.Config, error) {
+	opts := flag.Options{
+		ScanOptions: flag.ScanOptions{
+			Scanner: []string{"sast"},
+		},
+		RuleOptions:    flag.RuleOptions{},
+		RepoOptions:    flag.RepoOptions{},
+		ReportOptions:  reportOptions,
+		GeneralOptions: flag.GeneralOptions{},
+	}
+
+	return settings.FromOptions(opts, []string{"ruby"})
+}
+
+func dummyDataflow() dataflow.DataFlow {
+	subject := "User"
+	thirdPartyRisk := types.RiskDetector{
+		DetectorID: "ruby_third_parties_sentry",
+		Locations: []types.RiskLocation{
+			{
+				Filename:   "/app/controllers/application_controller.rb",
+				LineNumber: 39,
+				Parent: &schema.Parent{
+					LineNumber: 38,
+					Content:    "Sentry.set_user(email: current_user.email)",
+				},
+				DataTypes: []types.RiskDatatype{
+					{
+						Name:         "Email Address",
+						CategoryUUID: "cef587dd-76db-430b-9e18-7b031e1a193b",
+						Schemas: []types.RiskSchema{
+							{
+								FieldName:   "email",
+								ObjectName:  "current_user",
+								SubjectName: &subject,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// build risk []interface
+	risks := make([]types.RiskDetector, 1)
+	risks[0] = thirdPartyRisk
+
+	return dataflow.DataFlow{
+		Datatypes: []types.Datatype{
+			{
+				Name:         "Email Address",
+				CategoryName: "Contact",
+				Detectors: []types.DatatypeDetector{
+					{
+						Name: "ruby",
+						Locations: []types.DatatypeLocation{
+							{
+								Filename:    "/app/controllers/application_controller.rb",
+								LineNumber:  39,
+								FieldName:   "email",
+								ObjectName:  "current_user",
+								SubjectName: &subject,
+							},
+						},
+					},
+				},
+			},
+		},
+		Risks: risks,
+		Components: []types.Component{
+			{
+				Name:    "Sentry",
+				Type:    "external_service",
+				SubType: "third_party",
+				Locations: []types.ComponentLocation{
+					{
+						Detector:   "gemfile-lock",
+						Filename:   "/Users/elsapet/Bearer/bear-publishing/Gemfile.lock",
+						LineNumber: 204,
+					},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
## Description
Update local rule failure rego item following changes to dataflow structure
Add minimal test coverage for privacy report to protect against such cases going forward

Impact: 
- privacy report was not counting rule failures by severity
- privacy report was not connecting datatypes with associated third parties (where possible; sometimes it is not possible)

Privacy report before (run on bear publishing)

```
Subject,Data Types,Detection Count,Critical Risk Failure,High Risk Failure,Medium Risk Failure,Low Risk Failure,Rules Passed
User,Fullname,4,0,0,0,0,48
User,Email Address,9,0,0,0,0,48
User,Telephone Number,1,0,0,0,0,48

Third Party,Subject,Data Types,Critical Risk Failure,High Risk Failure,Medium Risk Failure,Low Risk Failure,Rules Passed
Segment,Unknown,"Unknown",0,0,0,0,0
Sentry,Unknown,"Unknown",0,0,0,0,0
```

Privacy report after 

```
Subject,Data Types,Detection Count,Critical Risk Failure,High Risk Failure,Medium Risk Failure,Low Risk Failure,Rules Passed
User,Telephone Number,1,0,0,0,0,48
User,Fullname,4,0,1,0,0,47
User,Email Address,9,0,6,0,0,42

Third Party,Subject,Data Types,Critical Risk Failure,High Risk Failure,Medium Risk Failure,Low Risk Failure,Rules Passed
Segment,Unknown,"Unknown",0,0,0,0,0
Sentry,User,"Email Address",0,1,0,0,1
```

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [x] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
