### PR TITLE
docs: add update link to outdated version message

### DIFF
--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -226,7 +226,7 @@ func Run(ctx context.Context, opts flag.Options, targetKind TargetKind) (err err
 	} else {
 		version := strings.TrimPrefix(*release.Name, "v")
 		if version != build.Version && build.Version != "dev" && !opts.Quiet {
-			outputhandler.StdErrLogger().Msgf("You are running an outdated version of bearer, %s is now available. You can find update instructions at https://docs.bearer.com/reference/installation/#updating-bearer", *release.Name)
+			outputhandler.StdErrLogger().Msgf("You are running an outdated version of Bearer CLI, %s is now available. You can find update instructions at https://docs.bearer.com/reference/installation/#updating-bearer", *release.Name)
 		}
 	}
 

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -226,7 +226,7 @@ func Run(ctx context.Context, opts flag.Options, targetKind TargetKind) (err err
 	} else {
 		version := strings.TrimPrefix(*release.Name, "v")
 		if version != build.Version && build.Version != "dev" && !opts.Quiet {
-			outputhandler.StdErrLogger().Msgf("You are running an outdated version of bearer, %s is now available.", *release.Name)
+			outputhandler.StdErrLogger().Msgf("You are running an outdated version of bearer, %s is now available. You can find update instructions at https://docs.bearer.com/reference/installation/#updating-bearer", *release.Name)
 		}
 	}
 


### PR DESCRIPTION
## Description
Adds a link to the update installation documentation in the "outdated version" cli message .

## Related
- As discussed in #861 

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
