### PR TITLE
feat: support spread element in JS/TS

### DIFF
--- a/new/detector/composition/javascript/.snapshots/TestFlow-assigment-expression.json
+++ b/new/detector/composition/javascript/.snapshots/TestFlow-assigment-expression.json
@@ -84,7 +84,10 @@
 						]
 					}
 				}
-			]
+			],
+			"VariableNodes": {
+				"DATA_TYPE": {}
+			}
 		}
 	}
 ]

--- a/new/detector/composition/javascript/.snapshots/TestFlow-variable-declarator.json
+++ b/new/detector/composition/javascript/.snapshots/TestFlow-variable-declarator.json
@@ -84,7 +84,10 @@
 						]
 					}
 				}
-			]
+			],
+			"VariableNodes": {
+				"DATA_TYPE": {}
+			}
 		}
 	}
 ]

--- a/new/detector/composition/javascript/.snapshots/TestObjectDeconstructing-deconstructing.json
+++ b/new/detector/composition/javascript/.snapshots/TestObjectDeconstructing-deconstructing.json
@@ -4,7 +4,8 @@
 		"MatchNode": {},
 		"Data": {
 			"Pattern": "const { $\u003c!\u003e$\u003c_\u003e } = req.params\n",
-			"Datatypes": null
+			"Datatypes": null,
+			"VariableNodes": {}
 		}
 	}
 ]

--- a/new/detector/composition/javascript/.snapshots/TestObjectDeconstructing-multiple_objects.json
+++ b/new/detector/composition/javascript/.snapshots/TestObjectDeconstructing-multiple_objects.json
@@ -4,7 +4,8 @@
 		"MatchNode": {},
 		"Data": {
 			"Pattern": "const { $\u003c!\u003e$\u003c_\u003e } = req.params\n",
-			"Datatypes": null
+			"Datatypes": null,
+			"VariableNodes": {}
 		}
 	},
 	{
@@ -12,7 +13,8 @@
 		"MatchNode": {},
 		"Data": {
 			"Pattern": "const { $\u003c!\u003e$\u003c_\u003e } = req.params\n",
-			"Datatypes": null
+			"Datatypes": null,
+			"VariableNodes": {}
 		}
 	}
 ]

--- a/new/detector/composition/javascript/.snapshots/TestString-concatanation.json
+++ b/new/detector/composition/javascript/.snapshots/TestString-concatanation.json
@@ -64,7 +64,11 @@
 						]
 					}
 				}
-			]
+			],
+			"VariableNodes": {
+				"DATA_TYPE": {},
+				"INSECURE_URL": {}
+			}
 		}
 	}
 ]

--- a/new/detector/composition/javascript/.snapshots/TestString-simple.json
+++ b/new/detector/composition/javascript/.snapshots/TestString-simple.json
@@ -64,7 +64,11 @@
 						]
 					}
 				}
-			]
+			],
+			"VariableNodes": {
+				"DATA_TYPE": {},
+				"INSECURE_URL": {}
+			}
 		}
 	}
 ]

--- a/new/detector/composition/javascript/.snapshots/TestString-single-quotes.json
+++ b/new/detector/composition/javascript/.snapshots/TestString-single-quotes.json
@@ -64,7 +64,11 @@
 						]
 					}
 				}
-			]
+			],
+			"VariableNodes": {
+				"DATA_TYPE": {},
+				"INSECURE_URL": {}
+			}
 		}
 	}
 ]

--- a/new/detector/composition/javascript/.snapshots/TestString-template-variable-reconciliation.json
+++ b/new/detector/composition/javascript/.snapshots/TestString-template-variable-reconciliation.json
@@ -64,7 +64,11 @@
 						]
 					}
 				}
-			]
+			],
+			"VariableNodes": {
+				"DATA_TYPE": {},
+				"INSECURE_URL": {}
+			}
 		}
 	}
 ]

--- a/new/detector/composition/javascript/.snapshots/TestString-template.json
+++ b/new/detector/composition/javascript/.snapshots/TestString-template.json
@@ -64,7 +64,11 @@
 						]
 					}
 				}
-			]
+			],
+			"VariableNodes": {
+				"DATA_TYPE": {},
+				"INSECURE_URL": {}
+			}
 		}
 	}
 ]

--- a/new/detector/composition/ruby/.snapshots/TestRuby-call.json
+++ b/new/detector/composition/ruby/.snapshots/TestRuby-call.json
@@ -64,7 +64,10 @@
 						]
 					}
 				}
-			]
+			],
+			"VariableNodes": {
+				"DATA_TYPE": {}
+			}
 		}
 	}
 ]

--- a/new/detector/composition/ruby/.snapshots/TestRuby-object-variable-reconciliation.json
+++ b/new/detector/composition/ruby/.snapshots/TestRuby-object-variable-reconciliation.json
@@ -84,7 +84,10 @@
 						]
 					}
 				}
-			]
+			],
+			"VariableNodes": {
+				"DATA_TYPE": {}
+			}
 		}
 	}
 ]

--- a/new/detector/composition/ruby/.snapshots/TestRuby-object.json
+++ b/new/detector/composition/ruby/.snapshots/TestRuby-object.json
@@ -25,7 +25,10 @@
 						]
 					}
 				}
-			]
+			],
+			"VariableNodes": {
+				"DATA_TYPE": {}
+			}
 		}
 	}
 ]

--- a/new/detector/implementation/javascript/.snapshots/TestJavascriptObjectDetector-object_spread
+++ b/new/detector/implementation/javascript/.snapshots/TestJavascriptObjectDetector-object_spread
@@ -1,0 +1,133 @@
+- position: "1:5"
+  content: 'user = { a: 123 }'
+  data:
+    properties:
+        - name: user
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: a
+                      node: {}
+                      object: null
+                isvirtual: false
+    isvirtual: true
+- position: "2:5"
+  content: 'nested = { ...user, b: 456 }'
+  data:
+    properties:
+        - name: nested
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: user
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: a
+                                  node: {}
+                                  object: null
+                            isvirtual: false
+                    - name: a
+                      node: {}
+                      object: null
+                    - name: b
+                      node: {}
+                      object: null
+                isvirtual: false
+    isvirtual: true
+- position: "4:6"
+  content: |-
+    {
+      x: { n: nested },
+      y: { c: 4 },
+    }
+  data:
+    properties:
+        - name: x
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: "n"
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: nested
+                                  node: {}
+                                  object:
+                                    detectortype: object
+                                    matchnode: {}
+                                    data:
+                                        properties:
+                                            - name: user
+                                              node: {}
+                                              object:
+                                                detectortype: object
+                                                matchnode: {}
+                                                data:
+                                                    properties:
+                                                        - name: a
+                                                          node: {}
+                                                          object: null
+                                                    isvirtual: false
+                                            - name: a
+                                              node: {}
+                                              object: null
+                                            - name: b
+                                              node: {}
+                                              object: null
+                                        isvirtual: false
+                            isvirtual: true
+                    - name: "n"
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: user
+                                  node: {}
+                                  object:
+                                    detectortype: object
+                                    matchnode: {}
+                                    data:
+                                        properties:
+                                            - name: a
+                                              node: {}
+                                              object: null
+                                        isvirtual: false
+                                - name: a
+                                  node: {}
+                                  object: null
+                                - name: b
+                                  node: {}
+                                  object: null
+                            isvirtual: false
+                isvirtual: false
+        - name: "y"
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: c
+                      node: {}
+                      object: null
+                isvirtual: false
+    isvirtual: false
+

--- a/new/detector/implementation/javascript/javascript_test.go
+++ b/new/detector/implementation/javascript/javascript_test.go
@@ -10,6 +10,7 @@ import (
 func TestJavascriptObjectDetector(t *testing.T) {
 	runTest(t, "object_class", "object", "testdata/object_class.js")
 	runTest(t, "object_object", "object", "testdata/object_object.js")
+	runTest(t, "object_spread", "object", "testdata/object_spread.js")
 	runTest(t, "object_projection", "object", "testdata/object_projection.js")
 }
 

--- a/new/detector/implementation/javascript/testdata/object_spread.js
+++ b/new/detector/implementation/javascript/testdata/object_spread.js
@@ -1,0 +1,7 @@
+let user = { a: 123 }
+let nested = { ...user, b: 456 }
+
+call({
+  x: { n: nested },
+  y: { c: 4 },
+})

--- a/new/language/implementation/javascript/javascript.go
+++ b/new/language/implementation/javascript/javascript.go
@@ -24,6 +24,7 @@ var (
 		"binary_expression",
 		"template_substitution",
 		"array",
+		"spread_element",
 	}
 
 	anonymousPatternNodeParentTypes = []string{}
@@ -134,7 +135,6 @@ func (*javascriptImplementation) AnalyzeFlow(rootNode *tree.Node) error {
 	})
 }
 
-// TODO: See if anything needs to be added here
 func (implementation *javascriptImplementation) ExtractPatternVariables(input string) (string, []patternquerytypes.Variable, error) {
 	nameIndex := patternQueryVariableRegex.SubexpIndex("name")
 	typesIndex := patternQueryVariableRegex.SubexpIndex("types")
@@ -178,17 +178,14 @@ func produceDummyValue(i int, nodeType string) string {
 	return "CurioVar" + fmt.Sprint(i)
 }
 
-// TODO: See if anything needs to be added here
 func (implementation *javascriptImplementation) AnonymousPatternNodeParentTypes() []string {
 	return anonymousPatternNodeParentTypes
 }
 
-// TODO: See if anything needs to be added here
 func (implementation *javascriptImplementation) FindPatternMatchNode(input []byte) [][]int {
 	return matchNodeRegex.FindAllIndex(input, -1)
 }
 
-// TODO: See if anything needs to be added here
 func (implementation *javascriptImplementation) FindPatternUnanchoredPoints(input []byte) [][]int {
 	return ellipsisRegex.FindAllIndex(input, -1)
 }


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Add support for `spread_element` so that data type nested within spread_element could be found

e.g. 

```javascript
const sensitiveInfo = { firstName: "John", lastName: "Doe" }
const user = { ...sensitiveInfo, foo: "Bar" }
logger.info(user)
```

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
