### PR TITLE
ci: kpi scan workflow

### DIFF
--- a/.github/workflows/kpi_scans.yml
+++ b/.github/workflows/kpi_scans.yml
@@ -1,0 +1,42 @@
+name: KPI Scans
+on:
+  schedule:
+    - cron: '0 6 * * *'
+
+jobs:
+  build:
+    name: Run KPI scans
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        repository_url:
+          - https://github.com/juice-shop/juice-shop
+          - https://github.com/OWASP/railsgoat
+          - https://github.com/OWASP/NodeGoat
+          - https://github.com/WebGoat/WebGoat
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: github-action-battle-test
+          aws-region: eu-west-1
+          role-skip-session-tagging: true
+          role-duration-seconds: 3600
+
+      - name: Run task
+        run: |
+          aws ecs run-task \
+              --cluster ${{ secrets.CLUSTER }} \
+              --count 1 \
+              --tags key=service,value=${TASK_DEFINITION} \
+              --network-configuration "awsvpcConfiguration={subnets=['${{ secrets.SUBNET }}'],securityGroups=['${{ secrets.SECURITY_GROUP }}'],assignPublicIp=ENABLED}" \
+              --launch-type FARGATE \
+              --region eu-west-1 \
+              --task-definition ${TASK_DEFINITION} \
+              --overrides '{ "containerOverrides": [ { "name": "kpi-scan", "environment": [ { "name": "REPOSITORY_URL", "value": "${{ matrix.repository_url }}" }, { "name": "API_KEY", "value": "${{ secrets.KPI_SCAN_API_KEY }}" } ] } ] }'
+        env:
+          TASK_DEFINITION: kpi-scan:1

--- a/kpi_scan/Dockerfile
+++ b/kpi_scan/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu
+
+RUN apt-get update && apt-get install -y curl git jq
+
+RUN mkdir /app
+ADD run.sh /app/
+WORKDIR /app
+
+CMD ["/app/run.sh"]

--- a/kpi_scan/README.md
+++ b/kpi_scan/README.md
@@ -1,0 +1,13 @@
+# KPI Scan docker image
+
+This docker image is ubuntu with a script to download the latest Bearer CLI
+and run it for a given REPOSITORY_URL and API_KEY.
+
+## Building
+
+The image must be built and deployed manually. For MacOS:
+
+```sh
+$ docker buildx build --platform=linux/amd64 -t bearersh/kpi-scan .
+$ docker push bearersh/kpi-scan:latest
+```

--- a/kpi_scan/run.sh
+++ b/kpi_scan/run.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -eu
+
+echo "Finding latest Bearer version"
+curl -H "Accept: application/vnd.github.v3+json" \
+     https://api.github.com/repos/bearer/bearer/releases/latest > /tmp/bearer-release.json
+
+BEARER_URL=$(jq -r '.assets[] | select(.name | test("bearer_.*_linux_amd64.tar.gz")).browser_download_url' /tmp/bearer-release.json)
+if [[ -z "$BEARER_URL" ]]; then
+  echo "Can't find bearer URL"
+  exit 1
+fi
+
+echo
+echo "Downloading Bearer from $BEARER_URL"
+curl --location --output /tmp/bearer.tar.gz "$BEARER_URL"
+tar --extract --gunzip --file /tmp/bearer.tar.gz --directory /tmp/
+
+echo
+echo "Cloning $REPOSITORY_URL"
+git clone "$REPOSITORY_URL" /tmp/repository
+
+echo
+echo "Scanning"
+/tmp/bearer scan --host=my.staging.bearer.sh --api-key "$API_KEY" /tmp/repository


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Adds a workflow that is triggered every day at 6am to scan the following repositories:

- https://github.com/juice-shop/juice-shop
- https://github.com/OWASP/railsgoat
- https://github.com/OWASP/NodeGoat
- https://github.com/WebGoat/WebGoat
          
This is done by invoking a Fargate task that uses the docker image in `kpi_scan/`. The docker image downloads the latest Bearer CLI, clones the target repository and then sends the report to the staging backend.

A secret `KPI_SCAN_API_KEY` is added to this repository to specify the staging account for reporting scan results.

## Related
- https://github.com/Bearer/bearer/issues/895

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
