### PR TITLE
ci: make kpi host configurable

### DIFF
--- a/.github/workflows/kpi_scans.yml
+++ b/.github/workflows/kpi_scans.yml
@@ -37,6 +37,6 @@ jobs:
               --launch-type FARGATE \
               --region eu-west-1 \
               --task-definition ${TASK_DEFINITION} \
-              --overrides '{ "containerOverrides": [ { "name": "kpi-scan", "environment": [ { "name": "REPOSITORY_URL", "value": "${{ matrix.repository_url }}" }, { "name": "API_KEY", "value": "${{ secrets.KPI_SCAN_API_KEY }}" } ] } ] }'
+              --overrides '{ "containerOverrides": [ { "name": "kpi-scan", "environment": [ { "name": "REPOSITORY_URL", "value": "${{ matrix.repository_url }}" }, { "name": "API_KEY", "value": "${{ secrets.KPI_SCAN_API_KEY }}" }, { "name": "API_HOST", "value": "${{ secrets.KPI_SCAN_HOST }}" } ] } ] }'
         env:
           TASK_DEFINITION: kpi-scan:1

--- a/kpi_scan/run.sh
+++ b/kpi_scan/run.sh
@@ -23,4 +23,4 @@ git clone "$REPOSITORY_URL" /tmp/repository
 
 echo
 echo "Scanning"
-/tmp/bearer scan --host=my.staging.bearer.sh --api-key "$API_KEY" /tmp/repository
+/tmp/bearer scan "--host=$API_HOST" --api-key "$API_KEY" /tmp/repository


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Makes the backend host configurable for the KPI scanning process. 

The host is set in the `KPI_SCAN_HOST` repository secret.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
