### PR TITLE
feat(kpi): add bearer and bearer rules version to client meta

### DIFF
--- a/pkg/commands/process/settings/rules.go
+++ b/pkg/commands/process/settings/rules.go
@@ -18,10 +18,10 @@ var (
 )
 
 func RefreshRules(config Config, externalRuleDirs []string, options flag.RuleOptions, foundLanguages []string) (err error) {
-	builtInRules, rules, _, bearerRulesVersion, err := loadRules(externalRuleDirs, options, foundLanguages, true)
-	config.BuiltInRules = builtInRules
-	config.Rules = rules
-	config.BearerRulesVersion = bearerRulesVersion
+	result, err := loadRules(externalRuleDirs, options, foundLanguages, true)
+	config.BuiltInRules = result.BuiltInRules
+	config.Rules = result.Rules
+	config.BearerRulesVersion = result.BearerRulesVersion
 
 	return
 }
@@ -31,22 +31,17 @@ func loadRules(
 	options flag.RuleOptions,
 	foundLanguages []string,
 	force bool) (
-	map[string]*Rule,
-	map[string]*Rule,
-	bool,
-	string,
-	error,
+	result LoadRulesResult,
+	err error,
 ) {
 	definitions := make(map[string]RuleDefinition)
 	builtInDefinitions := make(map[string]RuleDefinition)
 	ruleLanguages := make(map[string]bool)
 
-	var bearerRulesVersion string
-	cacheUsed := false
 	if !options.DisableDefaultRules {
 		bearerRulesDir := bearerRulesDir()
 		if !force && cachedRulesExist(bearerRulesDir) {
-			cacheUsed = true
+			result.CacheUsed = true
 			err := filepath.WalkDir(bearerRulesDir, func(filePath string, d fs.DirEntry, err error) error {
 				if !d.IsDir() {
 					file, err := os.Open(filepath.Join(bearerRulesDir, d.Name()))
@@ -61,28 +56,28 @@ func loadRules(
 			})
 
 			if err != nil {
-				return nil, nil, cacheUsed, bearerRulesVersion, fmt.Errorf("error loading rules from cache: %s", err)
+				return result, fmt.Errorf("error loading rules from cache: %s", err)
 			}
 
 			for _, foundLang := range foundLanguages {
 				if !ruleLanguages[foundLang] {
 					definitions = make(map[string]RuleDefinition)
-					cacheUsed = false // re-cache rules
+					result.CacheUsed = false // re-cache rules
 				}
 			}
 		}
 
-		if !cacheUsed {
+		if !result.CacheUsed {
 			if err := cleanupRuleDirFiles(bearerRulesDir); err != nil {
-				return nil, nil, cacheUsed, bearerRulesVersion, fmt.Errorf("error cleaning rules cache: %s", err)
+				return result, fmt.Errorf("error cleaning rules cache: %s", err)
 			}
 
 			tagVersion, err := LoadRuleDefinitionsFromGitHub(definitions, foundLanguages)
 			if err != nil {
-				return nil, nil, cacheUsed, bearerRulesVersion, fmt.Errorf("error loading rules: %s", err)
+				return result, fmt.Errorf("error loading rules: %s", err)
 			}
 
-			bearerRulesVersion = tagVersion
+			result.BearerRulesVersion = tagVersion
 		}
 
 		// add default documentation urls for default rules
@@ -94,7 +89,7 @@ func loadRules(
 	}
 
 	if err := loadRuleDefinitionsFromDir(builtInDefinitions, buildInRulesFs); err != nil {
-		return nil, nil, cacheUsed, bearerRulesVersion, fmt.Errorf("error loading built-in rules: %w", err)
+		return result, fmt.Errorf("error loading built-in rules: %w", err)
 	}
 
 	for _, dir := range externalRuleDirs {
@@ -104,18 +99,21 @@ func loadRules(
 		}
 		log.Debug().Msgf("loading external rules from: %s", dir)
 		if err := loadRuleDefinitionsFromDir(definitions, os.DirFS(dir)); err != nil {
-			return nil, nil, cacheUsed, bearerRulesVersion, fmt.Errorf("error loading external rules from %s: %w", dir, err)
+			return result, fmt.Errorf("error loading external rules from %s: %w", dir, err)
 		}
 	}
 
 	if err := validateRuleOptionIDs(options, definitions, builtInDefinitions); err != nil {
-		return nil, nil, cacheUsed, bearerRulesVersion, err
+		return result, err
 	}
 
 	enabledRules := getEnabledRules(options, definitions, nil)
 	builtInRules := getEnabledRules(options, builtInDefinitions, enabledRules)
 
-	return buildRules(builtInDefinitions, builtInRules), buildRules(definitions, enabledRules), cacheUsed, bearerRulesVersion, nil
+	result.Rules = buildRules(definitions, enabledRules)
+	result.BuiltInRules = buildRules(builtInDefinitions, builtInRules)
+
+	return result, nil
 }
 
 func loadRuleDefinitionsFromDir(definitions map[string]RuleDefinition, dir fs.FS) error {

--- a/pkg/commands/process/settings/settings.go
+++ b/pkg/commands/process/settings/settings.go
@@ -74,6 +74,13 @@ const (
 	STORED_DATA_TYPES MatchOn = "stored_data_types"
 )
 
+type LoadRulesResult struct {
+	BuiltInRules       map[string]*Rule
+	Rules              map[string]*Rule
+	CacheUsed          bool
+	BearerRulesVersion string
+}
+
 type RuleTrigger struct {
 	MatchOn           MatchOn `mapstructure:"match_on" json:"match_on" yaml:"match_on"`
 	DataTypesRequired bool    `mapstructure:"data_types_required" json:"data_types_required" yaml:"data_types_required"`
@@ -245,7 +252,7 @@ func defaultWorkerOptions() WorkerOptions {
 func FromOptions(opts flag.Options, foundLanguages []string) (Config, error) {
 	policies := DefaultPolicies()
 	workerOptions := defaultWorkerOptions()
-	builtInRules, rules, cacheUsed, bearerRulesVersion, err := loadRules(
+	result, err := loadRules(
 		opts.ExternalRuleDir,
 		opts.RuleOptions,
 		foundLanguages,
@@ -275,10 +282,10 @@ func FromOptions(opts flag.Options, foundLanguages []string) (Config, error) {
 		Scan:               opts.ScanOptions,
 		Report:             opts.ReportOptions,
 		Policies:           policies,
-		Rules:              rules,
-		BuiltInRules:       builtInRules,
-		CacheUsed:          cacheUsed,
-		BearerRulesVersion: bearerRulesVersion,
+		Rules:              result.Rules,
+		BuiltInRules:       result.BuiltInRules,
+		CacheUsed:          result.CacheUsed,
+		BearerRulesVersion: result.BearerRulesVersion,
 	}
 
 	return config, nil

--- a/pkg/commands/process/settings/settings.go
+++ b/pkg/commands/process/settings/settings.go
@@ -40,15 +40,16 @@ type WorkerOptions struct {
 }
 
 type Config struct {
-	Client       *api.API
-	Worker       WorkerOptions      `mapstructure:"worker" json:"worker" yaml:"worker"`
-	Scan         flag.ScanOptions   `mapstructure:"scan" json:"scan" yaml:"scan"`
-	Report       flag.ReportOptions `mapstructure:"report" json:"report" yaml:"report"`
-	Policies     map[string]*Policy `mapstructure:"policies" json:"policies" yaml:"policies"`
-	Target       string             `mapstructure:"target" json:"target" yaml:"target"`
-	Rules        map[string]*Rule   `mapstructure:"rules" json:"rules" yaml:"rules"`
-	BuiltInRules map[string]*Rule   `mapstructure:"built_in_rules" json:"built_in_rules" yaml:"built_in_rules"`
-	CacheUsed    bool               `mapstructure:"cache_used" json:"cache_used" yaml:"cache_used"`
+	Client             *api.API
+	Worker             WorkerOptions      `mapstructure:"worker" json:"worker" yaml:"worker"`
+	Scan               flag.ScanOptions   `mapstructure:"scan" json:"scan" yaml:"scan"`
+	Report             flag.ReportOptions `mapstructure:"report" json:"report" yaml:"report"`
+	Policies           map[string]*Policy `mapstructure:"policies" json:"policies" yaml:"policies"`
+	Target             string             `mapstructure:"target" json:"target" yaml:"target"`
+	Rules              map[string]*Rule   `mapstructure:"rules" json:"rules" yaml:"rules"`
+	BuiltInRules       map[string]*Rule   `mapstructure:"built_in_rules" json:"built_in_rules" yaml:"built_in_rules"`
+	CacheUsed          bool               `mapstructure:"cache_used" json:"cache_used" yaml:"cache_used"`
+	BearerRulesVersion string             `mapstructure:"bearer_rules_version" json:"bearer_rules_version" yaml:"bearer_rules_version"`
 }
 
 type Modules []*PolicyModule
@@ -244,7 +245,7 @@ func defaultWorkerOptions() WorkerOptions {
 func FromOptions(opts flag.Options, foundLanguages []string) (Config, error) {
 	policies := DefaultPolicies()
 	workerOptions := defaultWorkerOptions()
-	builtInRules, rules, cacheUsed, err := loadRules(
+	builtInRules, rules, cacheUsed, bearerRulesVersion, err := loadRules(
 		opts.ExternalRuleDir,
 		opts.RuleOptions,
 		foundLanguages,
@@ -269,14 +270,15 @@ func FromOptions(opts flag.Options, foundLanguages []string) (Config, error) {
 	}
 
 	config := Config{
-		Client:       opts.Client,
-		Worker:       workerOptions,
-		Scan:         opts.ScanOptions,
-		Report:       opts.ReportOptions,
-		Policies:     policies,
-		Rules:        rules,
-		BuiltInRules: builtInRules,
-		CacheUsed:    cacheUsed,
+		Client:             opts.Client,
+		Worker:             workerOptions,
+		Scan:               opts.ScanOptions,
+		Report:             opts.ReportOptions,
+		Policies:           policies,
+		Rules:              rules,
+		BuiltInRules:       builtInRules,
+		CacheUsed:          cacheUsed,
+		BearerRulesVersion: bearerRulesVersion,
 	}
 
 	return config, nil

--- a/pkg/report/output/output.go
+++ b/pkg/report/output/output.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/bearer/bearer/api"
 	"github.com/bearer/bearer/api/s3"
+	"github.com/bearer/bearer/cmd/bearer/build"
 	"github.com/bearer/bearer/pkg/commands/process/balancer/filelist"
 	"github.com/bearer/bearer/pkg/commands/process/settings"
 	"github.com/bearer/bearer/pkg/flag"
@@ -282,31 +283,35 @@ func getMeta(config settings.Config) (*Meta, error) {
 	}
 
 	return &Meta{
-		ID:            info.ID,
-		Host:          string(info.Host),
-		Username:      info.Username,
-		Name:          info.Name,
-		FullName:      info.FullName,
-		URL:           info.Raw,
-		Target:        config.Scan.Target,
-		SHA:           strings.TrimSuffix(string(sha), "\n"),
-		CurrentBranch: strings.TrimSuffix(string(currentBranch), "\n"),
-		DefaultBranch: strings.TrimPrefix(strings.TrimSuffix(string(defaultBranch), "\n"), "origin/"),
+		ID:                 info.ID,
+		Host:               string(info.Host),
+		Username:           info.Username,
+		Name:               info.Name,
+		FullName:           info.FullName,
+		URL:                info.Raw,
+		Target:             config.Scan.Target,
+		SHA:                strings.TrimSuffix(string(sha), "\n"),
+		CurrentBranch:      strings.TrimSuffix(string(currentBranch), "\n"),
+		DefaultBranch:      strings.TrimPrefix(strings.TrimSuffix(string(defaultBranch), "\n"), "origin/"),
+		BearerRulesVersion: config.BearerRulesVersion,
+		BearerVersion:      build.Version,
 	}, nil
 }
 
 type Meta struct {
-	ID            string `json:"id" yaml:"id"`
-	Host          string `json:"host" yaml:"host"`
-	Username      string `json:"username" yaml:"username"`
-	Name          string `json:"name" yaml:"name"`
-	URL           string `json:"url" yaml:"url"`
-	FullName      string `json:"full_name" yaml:"full_name"`
-	Target        string `json:"target" yaml:"target"`
-	SHA           string `json:"sha" yaml:"sha"`
-	CurrentBranch string `json:"current_branch" yaml:"current_branch"`
-	DefaultBranch string `json:"default_branch" yaml:"default_branch"`
-	SignedID      string `json:"signed_id,omitempty" yaml:"signed_id,omitempty"`
+	ID                 string `json:"id" yaml:"id"`
+	Host               string `json:"host" yaml:"host"`
+	Username           string `json:"username" yaml:"username"`
+	Name               string `json:"name" yaml:"name"`
+	URL                string `json:"url" yaml:"url"`
+	FullName           string `json:"full_name" yaml:"full_name"`
+	Target             string `json:"target" yaml:"target"`
+	SHA                string `json:"sha" yaml:"sha"`
+	CurrentBranch      string `json:"current_branch" yaml:"current_branch"`
+	DefaultBranch      string `json:"default_branch" yaml:"default_branch"`
+	SignedID           string `json:"signed_id,omitempty" yaml:"signed_id,omitempty"`
+	BearerRulesVersion string `json:"bearer_rules_version,omitempty" yaml:"bearer_rules_version,omitempty"`
+	BearerVersion      string `json:"bearer_version,omitempty" yaml:"bearer_version,omitempty"`
 }
 
 type BearerReport struct {


### PR DESCRIPTION
## Description
Add Bearer version and Bearer Rules version to meta we send to Client
This will be used to allow us to select specific Bearer and Bearer Rules versions for the KPI reports

Relates to #895

<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
