### PR TITLE
build: fix linux performance regression

### DIFF
--- a/.goreleaser/common.yaml
+++ b/.goreleaser/common.yaml
@@ -50,7 +50,6 @@ builds:
     binary: bearer
     env:
       - CGO_ENABLED=1
-      - CGO_CFLAGS=-std=c99 -D_GNU_SOURCE
     goos:
       - linux
     goarch:


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Remove C flags that are causing a performance regression for linux builds. These were added to build on an earlier version of Ubuntu, but that didn't end up being feasible anyway. They aren't needed for Ubuntu 18.04 (used for the build).

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
