### PR TITLE
build: use ubuntu as base of docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
-FROM alpine:latest
+FROM ubuntu:23.04
 
-RUN apk update
-RUN apk upgrade
-RUN apk add --no-cache git libc6-compat libgcc libstdc++
+RUN apt-get update && \
+    apt-get install -y git && \
+    \
+    git config --global --add safe.directory '*' && \
+    \
+    adduser --system --group runuser
 
 COPY bearer /usr/local/bin/
 
-RUN addgroup -S rungroup && adduser -S runuser -G rungroup
 USER runuser
-
-RUN git config --global --add safe.directory '*'
 
 ENTRYPOINT ["bearer"]


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Use Ubuntu instead of Alpine for the base of the docker image. 

Now we're dynamically linking against libc, the current Alpine image no longer works. I tried all three compatibility libraries mentioned [here](https://stackoverflow.com/a/73359981) and I couldn't get it to work. 

The docker image is 90mb after this change, whereas it was 23mb previously (3.6 times bigger). In the future, we could try building against musl (Alpine's libc) and move back to Alpine. But we had problems compiling against that in previous projects so it might not be straightforward.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
