### PR TITLE
ci: add github docker auth to linux build image

### DIFF
--- a/.github/actions/linux-build/entrypoint.sh
+++ b/.github/actions/linux-build/entrypoint.sh
@@ -4,6 +4,10 @@ set -eu -o pipefail
 
 echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
 
+if [[ ! -z "${GITHUB_USER-}"]]; then
+  echo "$GITHUB_TOKEN" | docker login ghcr.io --username "$GITHUB_USER" --password-stdin
+fi
+
 git config --global --add safe.directory '*'
 
 exec goreleaser "$@"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,7 @@ jobs:
           args: release --clean --split
         env:
           GOOS: linux
+          GITHUB_USER: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           DOCKER_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Authenticate to Github's docker registry in the linux build image. 

For release containers we push to Github as well as Docker Hub. This was broken as we're not authenticated.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
