### PR TITLE
ci: fix typo in linux build entrypoint

### DIFF
--- a/.github/actions/linux-build/entrypoint.sh
+++ b/.github/actions/linux-build/entrypoint.sh
@@ -4,7 +4,7 @@ set -eu -o pipefail
 
 echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
 
-if [[ ! -z "${GITHUB_USER-}"]]; then
+if [[ ! -z "${GITHUB_USER-}" ]]; then
   echo "$GITHUB_TOKEN" | docker login ghcr.io --username "$GITHUB_USER" --password-stdin
 fi
 


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Fix typo when checking for github user in linux build image entrypoint.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
