### PR TITLE
docs: fix incorrect recipe link

### DIFF
--- a/docs/reference/recipes.njk
+++ b/docs/reference/recipes.njk
@@ -6,7 +6,7 @@ layout: layouts/doc.njk
 {% renderTemplate "liquid,md",
 recipes %}
 # Recipes
-Bearer CLI uses recipes to make connections between your code and other sources. These are things like data stores, APIs, and internal services. For information on contributing to the recipes database, see the [contribute new recipes](/contributing/recipe/) doc.
+Bearer CLI uses recipes to make connections between your code and other sources. These are things like data stores, APIs, and internal services. For information on contributing to the recipes database, see the [contribute new recipes](/contributing/recipes/) doc.
 {% endrenderTemplate %}
 
 <form action="" id="recipe-search">


### PR DESCRIPTION
## Description
Fixes an incorrect link to the recipes contributing page from the recipes reference page.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
