### PR TITLE
fix: list all detected data types in privacy report

### DIFF
--- a/pkg/commands/process/settings/policies/privacy_report.rego
+++ b/pkg/commands/process/settings/policies/privacy_report.rego
@@ -42,7 +42,7 @@ items contains item if {
 
   item := {
     "name": data_type.name,
-    "subject_name": "n/a",
+    "subject_name": "",
     "line_number": location.line_number
   }
 }

--- a/pkg/commands/process/settings/policies/privacy_report.rego
+++ b/pkg/commands/process/settings/policies/privacy_report.rego
@@ -4,14 +4,45 @@ import data.bearer.common
 
 import future.keywords
 
+contains(arr, elem) if {
+	arr[_] = elem
+}
+
+data_types_with_subject contains item if {
+  some data_type in input.dataflow.data_types
+  some detector in data_type.detectors
+  some location in detector.locations
+
+  location.subject_name
+
+  item = data_type.name
+}
+
 items contains item if {
   some data_type in input.dataflow.data_types
   some detector in data_type.detectors
   some location in detector.locations
 
+  location.subject_name
+
   item := {
     "name": data_type.name,
     "subject_name": location.subject_name,
+    "line_number": location.line_number
+  }
+}
+
+items contains item if {
+  some data_type in input.dataflow.data_types
+  some detector in data_type.detectors
+  some location in detector.locations
+
+  not location.subject_name
+  not contains(data_types_with_subject, data_type.name)
+
+  item := {
+    "name": data_type.name,
+    "subject_name": "n/a",
     "line_number": location.line_number
   }
 }

--- a/pkg/report/output/privacy/.snapshots/TestBuildCsvString
+++ b/pkg/report/output/privacy/.snapshots/TestBuildCsvString
@@ -1,7 +1,7 @@
 
 Subject,Data Types,Detection Count,Critical Risk Finding,High Risk Finding,Medium Risk Finding,Low Risk Finding,Rules Passed
 User,Email Address,1,0,1,0,0,0
-n/a,Country,1,0,0,0,0,1
+Unknown,Country,1,0,0,0,0,1
 
 Third Party,Subject,Data Types,Critical Risk Finding,High Risk Finding,Medium Risk Finding,Low Risk Finding,Rules Passed
 Sentry,User,"Email Address",0,1,0,0,0

--- a/pkg/report/output/privacy/.snapshots/TestBuildCsvString
+++ b/pkg/report/output/privacy/.snapshots/TestBuildCsvString
@@ -1,6 +1,7 @@
 
 Subject,Data Types,Detection Count,Critical Risk Finding,High Risk Finding,Medium Risk Finding,Low Risk Finding,Rules Passed
 User,Email Address,1,0,1,0,0,0
+n/a,Country,1,0,0,0,0,1
 
 Third Party,Subject,Data Types,Critical Risk Finding,High Risk Finding,Medium Risk Finding,Low Risk Finding,Rules Passed
 Sentry,User,"Email Address",0,1,0,0,0

--- a/pkg/report/output/privacy/.snapshots/TestGetOutput
+++ b/pkg/report/output/privacy/.snapshots/TestGetOutput
@@ -11,7 +11,7 @@
       RulesPassedCount: (int) 0
     },
     (privacy.Subject) {
-      DataSubject: (string) (len=3) "n/a",
+      DataSubject: (string) (len=7) "Unknown",
       DataType: (string) (len=7) "Country",
       DetectionCount: (int) 1,
       CriticalRiskFindingCount: (int) 0,

--- a/pkg/report/output/privacy/.snapshots/TestGetOutput
+++ b/pkg/report/output/privacy/.snapshots/TestGetOutput
@@ -1,5 +1,5 @@
 (*privacy.Report)({
-  Subjects: ([]privacy.Subject) (len=1) {
+  Subjects: ([]privacy.Subject) (len=2) {
     (privacy.Subject) {
       DataSubject: (string) (len=4) "User",
       DataType: (string) (len=13) "Email Address",
@@ -9,6 +9,16 @@
       MediumRiskFindingCount: (int) 0,
       LowRiskFindingCount: (int) 0,
       RulesPassedCount: (int) 0
+    },
+    (privacy.Subject) {
+      DataSubject: (string) (len=3) "n/a",
+      DataType: (string) (len=7) "Country",
+      DetectionCount: (int) 1,
+      CriticalRiskFindingCount: (int) 0,
+      HighRiskFindingCount: (int) 0,
+      MediumRiskFindingCount: (int) 0,
+      LowRiskFindingCount: (int) 0,
+      RulesPassedCount: (int) 1
     }
   },
   ThirdParty: ([]privacy.ThirdParty) (len=1) {

--- a/pkg/report/output/privacy/privacy_test.go
+++ b/pkg/report/output/privacy/privacy_test.go
@@ -114,6 +114,23 @@ func dummyDataflow() dataflow.DataFlow {
 					},
 				},
 			},
+			{
+				Name:         "Country",
+				CategoryName: "Location",
+				Detectors: []types.DatatypeDetector{
+					{
+						Name: "ruby",
+						Locations: []types.DatatypeLocation{
+							{
+								Filename:   "/app/models/location.rb",
+								LineNumber: 112,
+								FieldName:  "country",
+								ObjectName: "Address",
+							},
+						},
+					},
+				},
+			},
 		},
 		Risks: risks,
 		Components: []types.Component{


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->
Includes in privacy report all data types, even those without an associated data subject

Closes #903

Juice shop repo results: 

## Before

```
Subject,Data Types,Detection Count,Critical Risk Finding,High Risk Finding,Medium Risk Finding,Low Risk Finding,Rules Passed
User,Unique Identifier,1,0,0,0,0,21
User,Physical Address,1,0,0,0,0,21
User,Passwords,4,0,0,0,0,21
User,Username,2,0,0,0,0,21
User,Email Address,2,0,1,0,0,20

Third Party,Subject,Data Types,Critical Risk Finding,High Risk Finding,Medium Risk Finding,Low Risk Finding,Rules Passed
Amazon AWS APIs,Unknown,"Unknown",0,0,0,0,0
```

## After

```
Subject,Data Types,Detection Count,Critical Risk Finding,High Risk Finding,Medium Risk Finding,Low Risk Finding,Rules Passed
User,Email Address,2,0,1,0,0,20
User,Passwords,4,0,0,0,0,21
User,Physical Address,1,0,0,0,0,21
User,Unique Identifier,1,0,0,0,0,21
User,Username,2,0,0,0,0,21
Unknown,Country,2,0,0,0,0,21
Unknown,Fullname,4,0,0,0,0,21
Unknown,Interactions,1,0,0,0,0,21
Unknown,Telephone Number,2,0,0,0,0,21

Third Party,Subject,Data Types,Critical Risk Finding,High Risk Finding,Medium Risk Finding,Low Risk Finding,Rules Passed
Amazon AWS APIs,Unknown,"Unknown",0,0,0,0,0
```

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [x] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
