### PR TITLE
docs: update action guide with dynamic data

### DIFF
--- a/docs/_data/bearerAction.js
+++ b/docs/_data/bearerAction.js
@@ -1,0 +1,20 @@
+const EleventyFetch = require("@11ty/eleventy-fetch");
+const yaml = require("js-yaml");
+module.exports = async function () {
+  let action;
+  try {
+    const response = await EleventyFetch(
+      "https://raw.githubusercontent.com/Bearer/bearer-action/main/action.yml",
+      {
+        duration: "60m",
+        type: "text",
+      }
+    );
+    action = yaml.load(response);
+  } catch (err) {
+    console.log("Could not fetch release");
+  }
+  return {
+    ...action,
+  };
+};

--- a/docs/guides/github-action.njk
+++ b/docs/guides/github-action.njk
@@ -1,7 +1,7 @@
 ---
 title: Using the GitHub Action
 ---
-
+{% renderTemplate "md" %}
 # Using the GitHub Action
 
 Running Bearer from the CLI is great, but if you want it integrated directly with your Git workflow there's nothing easier than a GitHub action. If you're unfamiliar with GitHub actions, here's a [primer available from GitHub](https://github.com/features/actions). You can also see how the action works directly on our [Bear Publishing example app](https://github.com/Bearer/bear-publishing/actions/workflows/bearer.yml).
@@ -62,41 +62,37 @@ steps:
 ```
 
 The following are a list of available inputs and outputs:
+{% endrenderTemplate %}
 
-### Inputs
+<h3>Inputs</h3>
 
-#### `scanner`
+{% for key, value in bearerAction.inputs %}
+  <h4>
+    <code class="language-">{{key}}</code>
+  </h4>
+  <p>{{value.description}}
+    {% if not value.required %}
+      <strong>(Optional)</strong>
+    {% endif %}
+  </p>
+{% endfor %}
 
- **Optional** Specify the comma-separated scanner to use e.g. `sast,secrets`
+<h3>Outputs</h3>
+{% for key, value in bearerAction.outputs %}
+  <h4>
+    <code class="language-">{{key}}</code>
+  </h4>
+  <p>{{value.description}}
+    {% if not value.required %}
+      <strong>(Optional)</strong>
+    {% endif %}
+  </p>
+{% endfor %}
 
-#### `config-file`
-
-**Optional** Bearer configuration file path
-
-#### `only-rule`
-
-**Optional** Specify the comma-separated IDs of the rules to run; skips all other rules.
-
-#### `skip-rule`
-
-**Optional** Specify the comma-separated IDs of the rules to skip; runs all other rules.
-
-#### `skip-path`
-
-**Optional** Specify the comma-separated paths to skip. Supports wildcard syntax, e.g. `users/*.go,users/admin.sql`
-
-### Outputs
-
-#### `rule_breaches`
-
-Details of any rule breaches that occur. This is URL encoded to work round GitHub issues with multiline outputs.
-
-#### `exit_code`
-
-Exit code of the bearer binary, 0 indicates a pass
-
+{% renderTemplate "md" %}
 ## Make the most of Bearer
 
 For more ways to use Bearer, check out the different [report types](/explanations/reports/), [available rules](/reference/rules/), [supported data types](/reference/datatypes/).
 
 Have a question or need help? Join our [Discord community]({{meta.links.discord}}) or [open an issue on GitHub]({{meta.links.issues}}).
+{% endrenderTemplate %}


### PR DESCRIPTION
## Description
Updates the GitHub action guide to use the action's `action.yml` to display input/output keys and descriptions rather than manually duplicating them in the docs.

Key changes:
- This introduces a new bearerAction datafile that reads `action.yml` from bearer/bearer-action/main.
- The action markdown file is now an njk file mixing markdown and njk templating.

## Related
- close #940 
- close https://github.com/Bearer/bearer-action/issues/22

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
