### PR TITLE
feat: add length_less_than filter

### DIFF
--- a/docs/guides/custom-rule.md
+++ b/docs/guides/custom-rule.md
@@ -133,6 +133,7 @@ patterns:
 - `variable`: The name of the variable. This is required, even in patterns that contain a single variable. (Required)
 - Comparison keys: Use these on their own with or nested inside `either`.
   - `values`: Provide an array of values to match a variable against. Useful for specific method names and known options.
+  - `length_less_than`: Compare the length of the (string) variable to the number provided with a **less than** statement.
   - `less_than`: Compare the variable to the number provided with a **less than** statement.
   - `less_than_or_equal`: Compare the variable to the number provided with a *less than or equal* statement.
   - `greater_than`: Compare the variable to the number provided with a *greater than* statement.

--- a/new/detector/implementation/custom/filter.go
+++ b/new/detector/implementation/custom/filter.go
@@ -5,6 +5,7 @@ import (
 
 	"golang.org/x/exp/slices"
 
+	"github.com/bearer/bearer/new/detector/implementation/generic"
 	"github.com/bearer/bearer/new/detector/types"
 	"github.com/bearer/bearer/new/language/tree"
 	languagetypes "github.com/bearer/bearer/new/language/types"
@@ -46,7 +47,7 @@ func matchFilter(
 		)
 	}
 
-	return matchContentFilter(filter, node.Content()), nil, nil
+	return matchContentFilter(filter, evaluator, node), nil, nil
 }
 
 func matchAllFilters(
@@ -166,7 +167,9 @@ func matchDetectionFilter(
 	return boolPointer(foundDetection), datatypeDetections, err
 }
 
-func matchContentFilter(filter settings.PatternFilter, content string) *bool {
+func matchContentFilter(filter settings.PatternFilter, evaluator types.Evaluator, node *tree.Node) *bool {
+	content := node.Content()
+
 	if len(filter.Values) != 0 && !slices.Contains(filter.Values, content) {
 		return boolPointer(false)
 	}
@@ -176,7 +179,12 @@ func matchContentFilter(filter settings.PatternFilter, content string) *bool {
 	}
 
 	if filter.LengthLessThan != nil {
-		if len(content) >= *filter.LengthLessThan {
+		strValue, _, err := generic.GetStringValue(node, evaluator)
+		if err != nil || strValue == "" {
+			return nil
+		}
+
+		if len(strValue) >= *filter.LengthLessThan {
 			return boolPointer(false)
 		}
 	}

--- a/new/detector/implementation/custom/filter.go
+++ b/new/detector/implementation/custom/filter.go
@@ -175,6 +175,12 @@ func matchContentFilter(filter settings.PatternFilter, content string) *bool {
 		return boolPointer(filter.Regex.MatchString(content))
 	}
 
+	if filter.LengthLessThan != nil {
+		if len(content) >= *filter.LengthLessThan {
+			return boolPointer(false)
+		}
+	}
+
 	if filter.LessThan != nil {
 		value, err := strconv.Atoi(content)
 		if err != nil {

--- a/new/detector/implementation/generic/generic.go
+++ b/new/detector/implementation/generic/generic.go
@@ -1,6 +1,8 @@
 package generic
 
 import (
+	"fmt"
+
 	generictypes "github.com/bearer/bearer/new/detector/implementation/generic/types"
 	"github.com/bearer/bearer/new/detector/types"
 	"github.com/bearer/bearer/new/language/tree"
@@ -79,4 +81,22 @@ func ProjectObject(
 	}
 
 	return result, nil
+}
+
+func GetStringValue(node *tree.Node, evaluator types.Evaluator) (string, bool, error) {
+	detections, err := evaluator.ForNode(node, "string", true)
+	if err != nil {
+		return "", false, err
+	}
+
+	switch len(detections) {
+	case 0:
+		return "", false, nil
+	case 1:
+		childString := detections[0].Data.(generictypes.String)
+
+		return childString.Value, childString.IsLiteral, nil
+	default:
+		return "", false, fmt.Errorf("expected single string detection but got %d", len(detections))
+	}
 }

--- a/new/detector/implementation/javascript/string/string.go
+++ b/new/detector/implementation/javascript/string/string.go
@@ -58,7 +58,7 @@ func concatenateChildren(node *tree.Node, evaluator types.Evaluator) ([]interfac
 			return nil, err
 		}
 
-		if childValue == "" {
+		if childValue == "" && !childIsLiteral {
 			childValue = "*"
 		}
 

--- a/new/detector/implementation/javascript/string/string.go
+++ b/new/detector/implementation/javascript/string/string.go
@@ -88,7 +88,7 @@ func handleTemplateString(node *tree.Node, evaluator types.Evaluator) ([]interfa
 			return err
 		}
 
-		if childValue == "" {
+		if childValue == "" && !childIsLiteral {
 			childValue = "*"
 		}
 

--- a/pkg/commands/process/settings/settings.go
+++ b/pkg/commands/process/settings/settings.go
@@ -179,6 +179,7 @@ type PatternFilter struct {
 	Contains           *bool           `mapstructure:"contains" json:"contains" yaml:"contains"`
 	Regex              *Regexp         `mapstructure:"regex" json:"regex" yaml:"regex"`
 	Values             []string        `mapstructure:"values" json:"values" yaml:"values"`
+	LengthLessThan     *int            `mapstructure:"length_less_than" json:"length_less_than" yaml:"length_less_than"`
 	LessThan           *int            `mapstructure:"less_than" json:"less_than" yaml:"less_than"`
 	LessThanOrEqual    *int            `mapstructure:"less_than_or_equal" json:"less_than_or_equal" yaml:"less_than_or_equal"`
 	GreaterThan        *int            `mapstructure:"greater_than" json:"greater_than" yaml:"greater_than"`


### PR DESCRIPTION
## Description

Context: current less than / greater than filters work on integer values only. 

Add length less than filter to support string values here. 

Relates to https://github.com/Bearer/bearer-rules/pull/34

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [x] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
