### PR TITLE
feat: ignore local 'insecure' URLs

### DIFF
--- a/new/detector/implementation/generic/.snapshots/TestInsecureUrlDetector-insecure_url
+++ b/new/detector/implementation/generic/.snapshots/TestInsecureUrlDetector-insecure_url
@@ -1,0 +1,7 @@
+- position: "2:1"
+  content: '"http://api.insecure.com"'
+  data: null
+- position: "2:2"
+  content: http://api.insecure.com
+  data: null
+

--- a/new/detector/implementation/generic/generic_test.go
+++ b/new/detector/implementation/generic/generic_test.go
@@ -11,6 +11,10 @@ func TestDatatypeDetector(t *testing.T) {
 	runTest(t, "datatype", "datatype", "testdata/datatype.rb")
 }
 
+func TestInsecureUrlDetector(t *testing.T) {
+	runTest(t, "insecure_url", "insecure_url", "testdata/insecureurl.rb")
+}
+
 func runTest(t *testing.T, name string, detectorType, fileName string) {
 	testhelper.RunTest(t, name, ruby.New, detectorType, fileName)
 }

--- a/new/detector/implementation/generic/insecureurl/insecureurl.go
+++ b/new/detector/implementation/generic/insecureurl/insecureurl.go
@@ -15,6 +15,7 @@ type insecureURLDetector struct {
 }
 
 var insecureUrlPattern = regexp.MustCompile(`^http:`)
+var localhostInsecureUrlPattern = regexp.MustCompile(`^http://(localhost|127.0.0.1)`)
 
 func New(lang languagetypes.Language) (types.Detector, error) {
 	return &insecureURLDetector{}, nil
@@ -35,8 +36,12 @@ func (detector *insecureURLDetector) DetectAt(
 
 	for _, detection := range detections {
 		value := detection.Data.(generictypes.String).Value
-
 		if insecureUrlPattern.MatchString(value) {
+			if localhostInsecureUrlPattern.MatchString(value) {
+				// ignore insecure local URLs
+				continue
+			}
+
 			return []interface{}{nil}, nil
 		}
 	}

--- a/new/detector/implementation/generic/testdata/insecureurl.rb
+++ b/new/detector/implementation/generic/testdata/insecureurl.rb
@@ -1,0 +1,6 @@
+# match
+"http://api.insecure.com"
+# not match
+"https://api.secure.com"
+"http://localhost:3000/admin"
+"http://127.0.0.1/admin"


### PR DESCRIPTION
## Description

In the insecure URL detector, disregard URLs that start with `http://localhost` and `http://127.0.0.1` 
These are insecure URLs but we do not want to flag them because they are for local development

Closes #867 

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
