### PR TITLE
ci: shallow clone KPI projects

### DIFF
--- a/kpi_scan/run.sh
+++ b/kpi_scan/run.sh
@@ -19,7 +19,7 @@ tar --extract --gunzip --file /tmp/bearer.tar.gz --directory /tmp/
 
 echo
 echo "Cloning $REPOSITORY_URL"
-git clone "$REPOSITORY_URL" /tmp/repository
+git clone --depth=1 "$REPOSITORY_URL" /tmp/repository
 cd /tmp/repository
 
 echo


### PR DESCRIPTION
## Description

Use shallow clone for KPI projects

This is to address the error we are seeing in AWS ECS when cloning into larger projects (namely, GitLab): 

```
fatal: fetch-pack: invalid index-pack output
```

Shallow clone for the KPI purpose should be adequate. See this [GitHub blog](https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone)

> `git clone --depth=1 <url>` creates a shallow clone. These clones truncate the commit history to reduce the clone size.[...] They are helpful for some build environments where the repository will be deleted after a single build.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
