### PR TITLE
ci: only clone default branch for KPI projects

### DIFF
--- a/.github/workflows/kpi_scans.yml
+++ b/.github/workflows/kpi_scans.yml
@@ -59,4 +59,4 @@ jobs:
               --task-definition ${TASK_DEFINITION} \
               --overrides '{ "containerOverrides": [ { "name": "kpi-scan", "environment": [ { "name": "REPOSITORY_URL", "value": "${{ matrix.repository_url }}" }, { "name": "API_KEY", "value": "${{ secrets.KPI_SCAN_API_KEY }}" }, { "name": "API_HOST", "value": "${{ secrets.KPI_SCAN_HOST }}" } ] } ] }'
         env:
-          TASK_DEFINITION: kpi-scan:1
+          TASK_DEFINITION: kpi-scan:3

--- a/.github/workflows/kpi_scans.yml
+++ b/.github/workflows/kpi_scans.yml
@@ -3,6 +3,21 @@ on:
   schedule:
     - cron: '0 6 * * *'
 jobs:
+  build_and_push_docker_image:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          tags: bearersh/kpi-scan:latest
+          file: ./kpi_scan/Dockerfile
   load_repo_list:
     name: Load KPI repo list
     runs-on: ubuntu-latest
@@ -15,7 +30,7 @@ jobs:
           content=$(cat ./kpi_scan/kpi_repo_list.json | jq -c)
           echo "matrix=$content" >> $GITHUB_OUTPUT
   build:
-    needs: load_repo_list
+    needs: [build_and_push_docker_image, load_repo_list]
     name: Run KPI scans
     runs-on: ubuntu-latest
     strategy:

--- a/kpi_scan/Dockerfile
+++ b/kpi_scan/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu
 RUN apt-get update && apt-get install -y curl git jq
 
 RUN mkdir /app
-ADD run.sh /app/
+ADD ./kpi_scan/run.sh /app/
 WORKDIR /app
 
 CMD ["/app/run.sh"]

--- a/kpi_scan/run.sh
+++ b/kpi_scan/run.sh
@@ -19,7 +19,7 @@ tar --extract --gunzip --file /tmp/bearer.tar.gz --directory /tmp/
 
 echo
 echo "Cloning $REPOSITORY_URL"
-git clone --depth=1 "$REPOSITORY_URL" /tmp/repository
+git clone --depth=1 --single-branch "$REPOSITORY_URL" /tmp/repository
 cd /tmp/repository
 
 echo


### PR DESCRIPTION
## Description

Several things happening here: 

* Only clone default branch for KPI projects. We were still getting a fatal error when cloning into GitLab during the KPI action. GitLab currently has 14.5K branches so we limit ourselves to the default branch.
* Rebuild the docker image during the KPI GitHub action, otherwise we risk running things on a stale image.
* Update the task definition from kpi-scan:1 to kpi-scan:3. We've increased the memory and CPU of the task definition to address the `worker ABC failed to close reportfile` errors we were seeing for larger repositories


<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
