### PR TITLE
fix(docs): update command to update using homebrew to `brew upgrade`

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ curl -sfL https://raw.githubusercontent.com/Bearer/bearer/main/contrib/install.s
   Update an existing installation with the following:
 
   ```bash
-  brew update && brew update bearer/tap/bearer
+  brew update && brew upgrade bearer/tap/bearer
   ```
 
 </details>


### PR DESCRIPTION
## Description
when trying to upgrade bearer through homebrew, I got following error:
![Screenshot 2023-05-03 at 13 47 23](https://user-images.githubusercontent.com/36336875/235907925-0143cda2-d622-48d3-97ec-eff898e852b1.png)


## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [x] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
