### PR TITLE
feat: add string regex filter

### DIFF
--- a/docs/guides/custom-rule.md
+++ b/docs/guides/custom-rule.md
@@ -134,11 +134,12 @@ patterns:
 - Comparison keys: Use these on their own with or nested inside `either`.
   - `values`: Provide an array of values to match a variable against. Useful for specific method names and known options.
   - `length_less_than`: Compare the length of the (string) variable to the number provided with a **less than** statement.
+  - `string_regex`: Applies a regular expression test against the string value of the linked variable. This uses the [RE2 syntax](https://github.com/google/re2/wiki/Syntax).
   - `less_than`: Compare the variable to the number provided with a **less than** statement.
   - `less_than_or_equal`: Compare the variable to the number provided with a *less than or equal* statement.
   - `greater_than`: Compare the variable to the number provided with a *greater than* statement.
   - `greater_than_or_equal`: Compare the variable to the number provided with a *greater than or equal* statement.
-  - `regex`: Applies a regular expression test against the linked variable. This uses the [RE2 syntax](https://github.com/google/re2/wiki/Syntax).
+  - `regex`: Applies a regular expression test against the code content of the linked variable. This uses the [RE2 syntax](https://github.com/google/re2/wiki/Syntax).
 - `not`: Inverts the results of another filter. Can be used with a single comparison key by nesting the key below `not`, or with an `either` block by nesting the block below `not`.
 - `either`: Allows for multiple conditional checks. It behaves like an OR condition. You can nest any filter inside of `either`, such as `values`, `detection`, etc.
 - `detection`: Detection filters rely on existing filter types, so they handle much of the logic for you.

--- a/pkg/commands/process/settings/settings.go
+++ b/pkg/commands/process/settings/settings.go
@@ -184,6 +184,7 @@ type PatternFilter struct {
 	LessThanOrEqual    *int            `mapstructure:"less_than_or_equal" json:"less_than_or_equal" yaml:"less_than_or_equal"`
 	GreaterThan        *int            `mapstructure:"greater_than" json:"greater_than" yaml:"greater_than"`
 	GreaterThanOrEqual *int            `mapstructure:"greater_than_or_equal" json:"greater_than_or_equal" yaml:"greater_than_or_equal"`
+	StringRegex        *Regexp         `mapstructure:"string_regex" json:"string_regex" yaml:"string_regex"`
 }
 
 type RulePattern struct {


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Adds a new filter `string_regex` that matches a regular expression against the string value of a node.

This will allow us to match against strings, taking into account concatenation, interpolation, etc. The first use case will be a rule to match manually constructed HTML strings containing user input.

### Future work 

It might be possible to remove the built-in `insecure_url` detector and use this new filter in the rules that currently use it.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [x] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
