### PR TITLE
fix: produce a single property for java classes

### DIFF
--- a/new/detector/implementation/java/.snapshots/TestJavaObjects-object_class
+++ b/new/detector/implementation/java/.snapshots/TestJavaObjects-object_class
@@ -12,7 +12,7 @@
   data:
     properties:
         - name: User
-          node: {}
+          node: null
           object:
             detectortype: object
             matchnode: {}
@@ -20,24 +20,10 @@
                 properties:
                     - name: name
                       node: {}
-                      object:
-                        detectortype: object
-                        matchnode: {}
-                        data: null
-                isvirtual: false
-        - name: User
-          node: {}
-          object:
-            detectortype: object
-            matchnode: {}
-            data:
-                properties:
+                      object: null
                     - name: LowercaseName
                       node: {}
-                      object:
-                        detectortype: object
-                        matchnode: {}
-                        data: null
+                      object: null
                 isvirtual: false
     isvirtual: false
 

--- a/new/detector/implementation/java/object/object.go
+++ b/new/detector/implementation/java/object/object.go
@@ -15,8 +15,7 @@ import (
 type objectDetector struct {
 	types.DetectorBase
 	// Base
-	classNameQuery     *tree.Query
-	classPropertyQuery *tree.Query
+	classQuery *tree.Query
 	// Naming
 	assignmentQuery *tree.Query
 	// Projection
@@ -31,29 +30,20 @@ func New(lang languagetypes.Language) (types.Detector, error) {
 	}
 
 	// class User {
-	//
-	// }
-	classNameQuery, err := lang.CompileQuery(`
-		(class_declaration name: (identifier) @class_name
-			(class_body) @class_body
-		) @root`)
-	if err != nil {
-		return nil, fmt.Errorf("error compiling class name query: %s", err)
-	}
-
-	// class User {
 	//    String name
 	//	  String getLevel(){}
 	// }
-	classPropertyQuery, err := lang.CompileQuery(
-		`(class_body
-			[
-			  (field_declaration (variable_declarator name: (identifier) @name))
-			  (method_declaration name: (identifier) @name)
-			]
-		)@root`)
+	classQuery, err := lang.CompileQuery(`
+		(class_declaration name: (identifier) @class_name
+			(class_body
+				[
+					(field_declaration (variable_declarator name: (identifier) @name))
+					(method_declaration name: (identifier) @name)
+				]
+			)
+		) @root`)
 	if err != nil {
-		return nil, fmt.Errorf("error compiling class property query: %s", err)
+		return nil, fmt.Errorf("error compiling class query: %s", err)
 	}
 
 	// user.name
@@ -63,10 +53,9 @@ func New(lang languagetypes.Language) (types.Detector, error) {
 	}
 
 	return &objectDetector{
-		assignmentQuery:    assignmentQuery,
-		classNameQuery:     classNameQuery,
-		classPropertyQuery: classPropertyQuery,
-		fieldAccessQuery:   fieldAccessQuery,
+		assignmentQuery:  assignmentQuery,
+		classQuery:       classQuery,
+		fieldAccessQuery: fieldAccessQuery,
 	}, nil
 }
 
@@ -89,12 +78,7 @@ func (detector *objectDetector) DetectAt(
 		return detections, err
 	}
 
-	detections, err = detector.getClassName(node, evaluator)
-	if len(detections) != 0 || err != nil {
-		return detections, err
-	}
-
-	detections, err = detector.getClassProperties(node, evaluator)
+	detections, err = detector.getClass(node, evaluator)
 	if len(detections) != 0 || err != nil {
 		return detections, err
 	}
@@ -131,66 +115,40 @@ func (detector *objectDetector) getAssignment(
 	return objects, nil
 }
 
-func (detector *objectDetector) getClassName(node *tree.Node, evaluator types.Evaluator) ([]interface{}, error) {
-	result, err := detector.classNameQuery.MatchOnceAt(node)
-	if result == nil || err != nil {
-		return nil, err
-	}
-
-	className := result["class_name"].Content()
-
-	properties, err := generic.GetNonVirtualObjects(evaluator, result["class_body"])
-	if err != nil {
-		return nil, err
-	}
-
-	if len(properties) == 0 {
-		return nil, nil
-	}
-
-	object := generictypes.Object{
-		IsVirtual: false,
-	}
-
-	for _, property := range properties {
-		object.Properties = append(object.Properties, generictypes.Property{
-			Name:   className,
-			Node:   node,
-			Object: property,
-		})
-	}
-
-	return []interface{}{object}, nil
-}
-
-func (detector *objectDetector) getClassProperties(node *tree.Node, evaluator types.Evaluator) ([]interface{}, error) {
-	results, err := detector.classPropertyQuery.MatchAt(node)
+func (detector *objectDetector) getClass(node *tree.Node, evaluator types.Evaluator) ([]interface{}, error) {
+	results, err := detector.classQuery.MatchAt(node)
 	if len(results) == 0 || err != nil {
 		return nil, err
 	}
 
-	var objects []interface{}
+	className := results[0]["class_name"].Content()
 
+	var properties []generictypes.Property
 	for _, result := range results {
-		objects = append(objects, generictypes.Object{
-			IsVirtual: false,
-			Properties: []generictypes.Property{{
-				Name: result["name"].Content(),
-				Node: node,
-				Object: &types.Detection{
-					DetectorType: "object",
-					MatchNode:    result["name"],
-				},
-			}},
+		nameNode := result["name"]
+
+		properties = append(properties, generictypes.Property{
+			Name: nameNode.Content(),
+			Node: nameNode,
 		})
 	}
 
-	return objects, nil
+	return []interface{}{generictypes.Object{
+		Properties: []generictypes.Property{{
+			Name: className,
+			Object: &types.Detection{
+				DetectorType: "object",
+				MatchNode:    node,
+				Data: generictypes.Object{
+					Properties: properties,
+				},
+			},
+		}},
+	}}, nil
 }
 
 func (detector *objectDetector) Close() {
-	detector.classNameQuery.Close()
-	detector.classPropertyQuery.Close()
+	detector.classQuery.Close()
 	detector.assignmentQuery.Close()
 	detector.fieldAccessQuery.Close()
 }


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Changes the Java object detector so we only produce a single property for the class. Previously a class like:

```java
    public class User
    {
        public String name;

        public String LowercaseName()
        {
            return name.toLowerCase();
        }
    }
```

would produce an object: `{ User: { name }, User: { LowercaseName } }`
when it should be: `{ User: { name, LowercaseName } }`.

We also remove the separate object detections for methods and fields as they're not needed.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [x] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
