### PR TITLE
docs: add java filtering to rule search

### DIFF
--- a/docs/guides/custom-rule.md
+++ b/docs/guides/custom-rule.md
@@ -17,7 +17,7 @@ Each rule is a unique `yml` file. Custom rules share the same format as internal
 To better understand the structure of a rule file, let’s look at each key:
 
 - `patterns`: See the section below for the Pattern Syntax.
-- `languages`: An array of the languages the rule applies to. Available values are: `ruby`, `javascript`
+- `languages`: An array of the languages the rule applies to. Available values are: `ruby`, `javascript`, `java`
 - `trigger`: Defines under which conditions the rule should raise a result. Optional.
   - `match_on`: Refers to the rule's pattern matches.
     - `presence`: Triggers if the rule's pattern is detected. (Default)

--- a/docs/reference/rules.njk
+++ b/docs/reference/rules.njk
@@ -20,10 +20,13 @@ The built-in rules aim to keep you protected from the most cirtical security ris
       <input type="checkbox" name="lang-ruby" id="lang-ruby" class='filter-toggle' value="ruby">
       <label for="lang-ruby" class="toggle-label">Ruby</label>
     </div>
-
     <div>
       <input type="checkbox" name="lang-jsts" id="lang-jsts" class='filter-toggle' value="javascript">
       <label for="lang-jsts" class="toggle-label">JS / TS</label>
+    </div>
+    <div>
+      <input type="checkbox" name="lang-java" id="lang-java" class='filter-toggle' value="java_">
+      <label for="lang-java" class="toggle-label">Java</label>
     </div>
   </div>
 </form>


### PR DESCRIPTION
## Description
Adds java filter to rules search + adds it to list of available languages in custom rules.

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
