### PR TITLE
fix: secrets rules

### DIFF
--- a/e2e/rules/.snapshots/TestSecrets-secrets
+++ b/e2e/rules/.snapshots/TestSecrets-secrets
@@ -1,0 +1,28 @@
+high:
+    - rule:
+        cwe_ids:
+            - "798"
+        id: gitleaks
+        title: Hard-coded secret detected.
+        description: |
+            ## Description
+
+            Hard-coding secrets in a project opens them up to leakage. This rule checks for common secret types such as keys, tokens, and passwords using the popular Gitleaks library and ensures they aren't hard-coded.
+
+            ## Remediations
+
+            Do not hard-code secrets in committed code. Instead, use environment variables and a secret management system.
+
+            ## Resources
+            - [Gitleaks](https://gitleaks.io/)
+        documentation_url: ""
+      line_number: 3
+      filename: e2e/rules/testdata/data/secrets/leaked.rb
+      parent_line_number: 3
+      snippet: '    @private_key ||= ''-----BEGIN PGP PRIVATE KEY BLOCK-----asdf-----END PGP PRIVATE KEY BLOCK-----'''
+      fingerprint: 47146043fab58ba5fc86fd0c716b20d8_0
+      detailed_context: PGP private key
+
+
+--
+

--- a/e2e/rules/rules_test.go
+++ b/e2e/rules/rules_test.go
@@ -1,8 +1,32 @@
 package rules_test
 
 import (
+	"path/filepath"
 	"testing"
+
+	"github.com/bearer/bearer/e2e/internal/testhelper"
 )
+
+func TestSecrets(t *testing.T) {
+	t.Parallel()
+
+	testCases := []testhelper.TestCase{
+		testhelper.NewTestCase(
+			"secrets",
+			[]string{
+				"scan",
+				filepath.Join("e2e", "rules", "testdata/data/secrets"),
+				"--scanner=secrets",
+				"--only-rule=gitleaks",
+				"--format=yaml",
+				"--disable-default-rules",
+			},
+			testhelper.TestCaseOptions{},
+		),
+	}
+
+	testhelper.RunTestsWithSnapshotSubdirectory(t, testCases, ".snapshots")
+}
 
 func TestAuxilary(t *testing.T) {
 	t.Parallel()

--- a/e2e/rules/testdata/data/secrets/leaked.rb
+++ b/e2e/rules/testdata/data/secrets/leaked.rb
@@ -1,0 +1,5 @@
+class User
+  def private_key
+    @private_key ||= '-----BEGIN PGP PRIVATE KEY BLOCK-----asdf-----END PGP PRIVATE KEY BLOCK-----'
+  end
+end

--- a/pkg/commands/process/settings/built_in_rules/third_party/gitleaks/secret_detection.yml
+++ b/pkg/commands/process/settings/built_in_rules/third_party/gitleaks/secret_detection.yml
@@ -1,6 +1,6 @@
 type: risk
 severity: high
-omit_parent_content: true
+has_detailed_context: true
 metadata:
   description: "Hard-coded secret detected."
   remediation_message: |

--- a/pkg/commands/process/settings/policies/common.rego
+++ b/pkg/commands/process/settings/policies/common.rego
@@ -4,12 +4,13 @@ import future.keywords
 
 build_item(location) := {
 	"filename": location.filename,
-	"parent_line_number": location.line_number,
+	"parent_line_number": location.parent.line_number,
+	"parent_content": location.parent.content,
 	"line_number": location.line_number,
-	"detailed_context": location.content,
+	"detailed_context": location.presence_matches[0].name,
 } if {
 	# FIXME: This is only for secret detections. Should be more explicit
-	input.rule.omit_parent_content == true
+	input.rule.has_detailed_context == true
 }
 
 cat_groups := data.bearer.common.groups_for_datatypes(input.dataflow.data_types) if {
@@ -29,7 +30,7 @@ build_local_item(location, data_type) := {
 	"parent_content": location.parent.content,
 	"datatype_name": data_type.name
 } if {
-	not input.rule.omit_parent_content == true
+	not input.rule.has_detailed_context == true
 }
 
 build_item(location) := {
@@ -39,7 +40,7 @@ build_item(location) := {
 	"parent_line_number": location.parent.line_number,
 	"parent_content": location.parent.content,
 } if {
-	not input.rule.omit_parent_content == true
+	not input.rule.has_detailed_context == true
 }
 
 global_data_types contains data_type if {

--- a/pkg/commands/process/settings/rules.go
+++ b/pkg/commands/process/settings/rules.go
@@ -300,7 +300,7 @@ func BuildRules(definitions map[string]RuleDefinition, enabledRules map[string]s
 			ParamParenting:     definition.ParamParenting,
 			Patterns:           definition.Patterns,
 			DocumentationUrl:   definition.Metadata.DocumentationUrl,
-			OmitParentContent:  definition.OmitParentContent,
+			HasDetailedContext: definition.HasDetailedContext,
 		}
 
 		for _, auxiliaryDefinition := range definition.Auxiliary {

--- a/pkg/commands/process/settings/settings.go
+++ b/pkg/commands/process/settings/settings.go
@@ -103,23 +103,23 @@ type RuleMetadata struct {
 }
 
 type RuleDefinition struct {
-	Disabled          bool                   `mapstructure:"disabled" json:"disabled" yaml:"disabled"`
-	Type              string                 `mapstructure:"type" json:"type" yaml:"type"`
-	Languages         []string               `mapstructure:"languages" json:"languages" yaml:"languages"`
-	ParamParenting    bool                   `mapstructure:"param_parenting" json:"param_parenting" yaml:"param_parenting"`
-	Patterns          []RulePattern          `mapstructure:"patterns" json:"patterns" yaml:"patterns"`
-	Stored            bool                   `mapstructure:"stored" json:"stored" yaml:"stored"`
-	Detectors         []string               `mapstructure:"detectors" json:"detectors,omitempty" yaml:"detectors,omitempty"`
-	Processors        []string               `mapstructure:"processors" json:"processors,omitempty" yaml:"processors,omitempty"`
-	AutoEncrytPrefix  string                 `mapstructure:"auto_encrypt_prefix" json:"auto_encrypt_prefix,omitempty" yaml:"auto_encrypt_prefix,omitempty"`
-	DetectPresence    bool                   `mapstructure:"detect_presence" json:"detect_presence" yaml:"detect_presence"`
-	Trigger           *RuleDefinitionTrigger `mapstructure:"trigger" json:"trigger" yaml:"trigger"` // TODO: use enum value
-	Severity          string                 `mapstructure:"severity" json:"severity,omitempty" yaml:"severity,omitempty"`
-	SkipDataTypes     []string               `mapstructure:"skip_data_types" json:"skip_data_types,omitempty" yaml:"skip_data_types,omitempty"`
-	OnlyDataTypes     []string               `mapstructure:"only_data_types" json:"only_data_types,omitempty" yaml:"only_data_types,omitempty"`
-	OmitParentContent bool                   `mapstructure:"omit_parent_content" json:"omit_parent_content,omitempty" yaml:"omit_parent_content,omitempty"`
-	Metadata          *RuleMetadata          `mapstructure:"metadata" json:"metadata" yaml:"metadata"`
-	Auxiliary         []Auxiliary            `mapstructure:"auxiliary" json:"auxiliary" yaml:"auxiliary"`
+	Disabled           bool                   `mapstructure:"disabled" json:"disabled" yaml:"disabled"`
+	Type               string                 `mapstructure:"type" json:"type" yaml:"type"`
+	Languages          []string               `mapstructure:"languages" json:"languages" yaml:"languages"`
+	ParamParenting     bool                   `mapstructure:"param_parenting" json:"param_parenting" yaml:"param_parenting"`
+	Patterns           []RulePattern          `mapstructure:"patterns" json:"patterns" yaml:"patterns"`
+	Stored             bool                   `mapstructure:"stored" json:"stored" yaml:"stored"`
+	Detectors          []string               `mapstructure:"detectors" json:"detectors,omitempty" yaml:"detectors,omitempty"`
+	Processors         []string               `mapstructure:"processors" json:"processors,omitempty" yaml:"processors,omitempty"`
+	AutoEncrytPrefix   string                 `mapstructure:"auto_encrypt_prefix" json:"auto_encrypt_prefix,omitempty" yaml:"auto_encrypt_prefix,omitempty"`
+	DetectPresence     bool                   `mapstructure:"detect_presence" json:"detect_presence" yaml:"detect_presence"`
+	Trigger            *RuleDefinitionTrigger `mapstructure:"trigger" json:"trigger" yaml:"trigger"` // TODO: use enum value
+	Severity           string                 `mapstructure:"severity" json:"severity,omitempty" yaml:"severity,omitempty"`
+	SkipDataTypes      []string               `mapstructure:"skip_data_types" json:"skip_data_types,omitempty" yaml:"skip_data_types,omitempty"`
+	OnlyDataTypes      []string               `mapstructure:"only_data_types" json:"only_data_types,omitempty" yaml:"only_data_types,omitempty"`
+	HasDetailedContext bool                   `mapstructure:"has_detailed_context" json:"has_detailed_context,omitempty" yaml:"has_detailed_context,omitempty"`
+	Metadata           *RuleMetadata          `mapstructure:"metadata" json:"metadata" yaml:"metadata"`
+	Auxiliary          []Auxiliary            `mapstructure:"auxiliary" json:"auxiliary" yaml:"auxiliary"`
 }
 
 type Auxiliary struct {
@@ -152,7 +152,7 @@ type Rule struct {
 	Processors         []string      `mapstructure:"processors" json:"processors,omitempty" yaml:"processors,omitempty"`
 	Stored             bool          `mapstructure:"stored" json:"stored,omitempty" yaml:"stored,omitempty"`
 	AutoEncrytPrefix   string        `mapstructure:"auto_encrypt_prefix" json:"auto_encrypt_prefix,omitempty" yaml:"auto_encrypt_prefix,omitempty"`
-	OmitParentContent  bool          `mapstructure:"omit_parent_content" json:"omit_parent_content,omitempty" yaml:"omit_parent_content,omitempty"`
+	HasDetailedContext bool          `mapstructure:"has_detailed_context" json:"has_detailed_context,omitempty" yaml:"has_detailed_context,omitempty"`
 	SkipDataTypes      []string      `mapstructure:"skip_data_types" json:"skip_data_types,omitempty" yaml:"skip_data_types,omitempty"`
 	OnlyDataTypes      []string      `mapstructure:"only_data_types" json:"only_data_types,omitempty" yaml:"only_data_types,omitempty"`
 	Severity           string        `mapstructure:"severity" json:"severity,omitempty" yaml:"severity,omitempty"`

--- a/pkg/detectors/gitleaks/.snapshots/TestSecretLeaks
+++ b/pkg/detectors/gitleaks/.snapshots/TestSecretLeaks
@@ -9,7 +9,7 @@
       LanguageType: (string) "",
       LineNumber: (*int)(1),
       ColumnNumber: (*int)(15),
-      Text: (*string)(<nil>)
+      Text: (*string)((len=36) "const test = \"AKIASWPMONFAAAFHB223\";")
     },
     Value: (secret.Secret) {
       Description: (string) (len=16) "AWS Access Token"
@@ -25,7 +25,7 @@
       LanguageType: (string) "",
       LineNumber: (*int)(1),
       ColumnNumber: (*int)(15),
-      Text: (*string)(<nil>)
+      Text: (*string)((len=36) "const test = \"AKIASWPMONFAAAFHB223\";")
     },
     Value: (secret.Secret) {
       Description: (string) (len=16) "AWS Access Token"

--- a/pkg/detectors/gitleaks/gitleaks.go
+++ b/pkg/detectors/gitleaks/gitleaks.go
@@ -57,6 +57,7 @@ func (detector *detector) ProcessFile(file *file.FileInfo, dir *file.Path, repor
 			Filename:     file.Path.RelativePath,
 			LineNumber:   &finding.StartLine,
 			ColumnNumber: &finding.StartColumn,
+			Text:         &finding.Line,
 		})
 	}
 

--- a/pkg/detectors/gitleaks/gitleaks.go
+++ b/pkg/detectors/gitleaks/gitleaks.go
@@ -3,6 +3,7 @@ package gitleaks
 import (
 	_ "embed"
 	"log"
+	"strings"
 
 	"github.com/bearer/bearer/pkg/detectors/types"
 	"github.com/bearer/bearer/pkg/parser/nodeid"
@@ -51,13 +52,14 @@ func (detector *detector) ProcessFile(file *file.FileInfo, dir *file.Path, repor
 	}
 
 	for _, finding := range findings {
+		text := strings.TrimPrefix(finding.Line, "\n")
 		report.AddSecretLeak(secret.Secret{
 			Description: finding.Description,
 		}, source.Source{
 			Filename:     file.Path.RelativePath,
 			LineNumber:   &finding.StartLine,
 			ColumnNumber: &finding.StartColumn,
-			Text:         &finding.Line,
+			Text:         &text,
 		})
 	}
 

--- a/pkg/report/output/dataflow/risks/risks.go
+++ b/pkg/report/output/dataflow/risks/risks.go
@@ -71,14 +71,20 @@ func (holder *Holder) AddRiskPresence(detection detections.Detection) {
 	ruleName := string(detection.DetectorType)
 	fileName := detection.Source.Filename
 	lineNumber := *detection.Source.LineNumber
-	// can be nil
-	parent := extractCustomRiskParent(detection.Value)
+
+	var parent *schema.Parent
 	var content string
 
 	if detection.DetectorType == detectors.DetectorGitleaks {
 		value := detection.Value.(map[string]interface{})["description"]
 		content = value.(string)
+		parent = &schema.Parent{
+			LineNumber: *detection.Source.LineNumber,
+			Content:    *detection.Source.Text,
+		}
 	} else {
+		// parent can be nil
+		parent = extractCustomRiskParent(detection.Value)
 		content = *detection.Source.Text
 	}
 

--- a/pkg/report/output/security/security.go
+++ b/pkg/report/output/security/security.go
@@ -474,7 +474,7 @@ func writeFailureToString(reportStr *strings.Builder, result Result, severity st
 	reportStr.WriteString(color.HiBlackString("To skip this rule, use the flag --skip-rule=" + result.Id + "\n"))
 	reportStr.WriteString("\n")
 	if result.DetailedContext != "" {
-		reportStr.WriteString("Detected: " + result.DetailedContext + "\n")
+		reportStr.WriteString("Detected: " + result.DetailedContext + "\n\n")
 	}
 	reportStr.WriteString(color.HiBlueString("File: " + underline(result.Filename+":"+fmt.Sprint(result.LineNumber)) + "\n"))
 

--- a/pkg/report/output/security/security.go
+++ b/pkg/report/output/security/security.go
@@ -478,10 +478,8 @@ func writeFailureToString(reportStr *strings.Builder, result Result, severity st
 	}
 	reportStr.WriteString(color.HiBlueString("File: " + underline(result.Filename+":"+fmt.Sprint(result.LineNumber)) + "\n"))
 
-	if result.DetailedContext == "" {
-		reportStr.WriteString("\n")
-		reportStr.WriteString(highlightCodeExtract(result.Filename, result.LineNumber, result.ParentLineNumber, result.ParentContent))
-	}
+	reportStr.WriteString("\n")
+	reportStr.WriteString(highlightCodeExtract(result.Filename, result.LineNumber, result.ParentLineNumber, result.ParentContent))
 }
 
 func formatSeverity(severity string) string {


### PR DESCRIPTION
## Description

Secrets detection was not working as expected, following earlier refactoring work. 

We add parent content to Gitleaks detections and adjust report display to handle this.

Before

No secrets detected

<img width="734" alt="Screenshot 2023-05-04 at 15 45 34" src="https://user-images.githubusercontent.com/4560746/236225036-625572f4-ea8a-46f6-8e36-25c0889b4a41.png">

After

<img width="576" alt="Screenshot 2023-05-04 at 15 43 29" src="https://user-images.githubusercontent.com/4560746/236224759-fc19c177-f11e-428b-a403-620617efb37f.png">


<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
