### PR TITLE
ci: use apt-get instead of binary dl

### DIFF
--- a/kpi_scan/Dockerfile
+++ b/kpi_scan/Dockerfile
@@ -1,6 +1,11 @@
 FROM ubuntu
 
-RUN apt-get update && apt-get install -y curl git jq
+RUN apt-get update && apt-get install -y curl git jq ca-certificates
+RUN update-ca-certificates
+RUN apt-get install apt-transport-https
+
+RUN echo "deb [trusted=yes] https://apt.fury.io/bearer/ /" > /etc/apt/sources.list.d/fury.list
+RUN apt-get update && apt-get install -y bearer
 
 RUN mkdir /app
 ADD ./kpi_scan/run.sh /app/

--- a/kpi_scan/run.sh
+++ b/kpi_scan/run.sh
@@ -2,21 +2,6 @@
 
 set -eu
 
-echo "Finding latest Bearer version"
-curl -H "Accept: application/vnd.github.v3+json" \
-     https://api.github.com/repos/bearer/bearer/releases/latest > /tmp/bearer-release.json
-
-BEARER_URL=$(jq -r '.assets[] | select(.name | test("bearer_.*_linux_amd64.tar.gz")).browser_download_url' /tmp/bearer-release.json)
-if [[ -z "$BEARER_URL" ]]; then
-  echo "Can't find bearer URL"
-  exit 1
-fi
-
-echo
-echo "Downloading Bearer from $BEARER_URL"
-curl --location --output /tmp/bearer.tar.gz "$BEARER_URL"
-tar --extract --gunzip --file /tmp/bearer.tar.gz --directory /tmp/
-
 echo
 echo "Cloning $REPOSITORY_URL"
 git clone --depth=1 --single-branch "$REPOSITORY_URL" /tmp/repository
@@ -24,4 +9,4 @@ cd /tmp/repository
 
 echo
 echo "Scanning"
-/tmp/bearer scan . "--host=$API_HOST" --api-key "$API_KEY"
+bearer scan . "--host=$API_HOST" --api-key "$API_KEY"


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

We don't really need to dl the latest binary since we use Ubuntu we can use the installation steps to install it instead

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
