### PR TITLE
feat: add filename filter

### DIFF
--- a/docs/guides/custom-rule.md
+++ b/docs/guides/custom-rule.md
@@ -132,6 +132,7 @@ patterns:
 
 - `variable`: The name of the variable. This is required, even in patterns that contain a single variable. (Required)
 - Comparison keys: Use these on their own with or nested inside `either`.
+  - `filename_regex`: Applies a regular expression test against the filename. This uses the [RE2 syntax](https://github.com/google/re2/wiki/Syntax).
   - `values`: Provide an array of values to match a variable against. Useful for specific method names and known options.
   - `length_less_than`: Compare the length of the (string) variable to the number provided with a **less than** statement.
   - `string_regex`: Applies a regular expression test against the string value of the linked variable. This uses the [RE2 syntax](https://github.com/google/re2/wiki/Syntax).

--- a/new/detector/implementation/custom/filter.go
+++ b/new/detector/implementation/custom/filter.go
@@ -30,6 +30,10 @@ func matchFilter(
 		return matchEitherFilters(result, evaluator, variableNodes, filter.Either)
 	}
 
+	if filter.FilenameRegex != nil {
+		return boolPointer(filter.FilenameRegex.MatchString(evaluator.FileName())), nil, nil
+	}
+
 	node, ok := result.Variables[filter.Variable]
 	// shouldn't happen if filters are validated against pattern
 	if !ok {

--- a/pkg/commands/process/settings/settings.go
+++ b/pkg/commands/process/settings/settings.go
@@ -185,6 +185,7 @@ type PatternFilter struct {
 	GreaterThan        *int            `mapstructure:"greater_than" json:"greater_than" yaml:"greater_than"`
 	GreaterThanOrEqual *int            `mapstructure:"greater_than_or_equal" json:"greater_than_or_equal" yaml:"greater_than_or_equal"`
 	StringRegex        *Regexp         `mapstructure:"string_regex" json:"string_regex" yaml:"string_regex"`
+	FilenameRegex      *Regexp         `mapstructure:"filename_regex" json:"filename_regex" yaml:"filename_regex"`
 }
 
 type RulePattern struct {


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Add a new type of filter for filenames. The first use case will be a rule that matches Rails configuration, but ignoring test/development config files.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [x] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
