### PR TITLE
docs: add ci/cd guide

### DIFF
--- a/docs/_data/nav.js
+++ b/docs/_data/nav.js
@@ -9,6 +9,10 @@ module.exports = [
       { name: "Configure the scan", url: "/guides/configure-scan/" },
       { name: "Using the GitHub action", url: "/guides/github-action/" },
       {
+        name: "Set up CI/CD",
+        url: "/guides/ci-setup/",
+      },
+      {
         name: "Create a custom rule",
         url: "/guides/custom-rule/",
       },

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -36,6 +36,7 @@ Guides help you make the most of Bearer CLI so you can get up and running quickl
 
 - [Configure the scan command](/guides/configure-scan/)
 - [GitHub action integration](/guides/github-action/)
+- [Set up CI/CD](/guides/ci-setup/)
 - [Create custom rule](/guides/custom-rule/)
 
 ## Explanations

--- a/docs/guides/ci-setup.md
+++ b/docs/guides/ci-setup.md
@@ -1,0 +1,30 @@
+---
+title: Set up CI/CD
+---
+
+# Set up CI/CD for Bearer CLI
+
+Using Bearer CLI in your CI/CD pipeline works similarly to most other integrations. If you're using GitHub, the easiest method is with the [GitHub Action](/guides/github-action/). If you rely on another setup, see the guides below.
+
+## GitLab
+
+To integrate Bearer CLI with GitLab CI/CD, we recommend using the docker entrypoint method. Edit your existing `.gitlab-ci.yml` file or add one to your repository root, then add the following lines:
+
+```yml
+image: 
+  name: bearer/bearer
+  entrypoint: [ "" ]
+
+bearer:
+  script: bearer scan .
+```
+
+This tells GitLab to use the `bearer/bearer` docker image. You can adjust the `script` key to [customize the scan](/guides/configure-scan/) with flags the same way as a local installation. An example of this file is available in [our example GitLab repo](https://gitlab.com/cfabianski/bear-publishing/-/tree/main).
+
+GitLab's guide on [Running CI/CD jobs in Docker containers](https://docs.gitlab.com/ee/ci/docker/using_docker_images.html) provides additional context on configuring the CI in this way.
+
+## Universal setup
+
+For other services, we recommend selecting the [installation method](/reference/installation/) that best fits the platform.
+
+Do you have a CI/CD workflow that you'd like to see added to this guide? [Open an issue]({{meta.links.issues}}) or let us know on [discord]({{meta.links.discord}}).

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -8,4 +8,5 @@ Guides help you make the most of Bearer CLI so you can get up and running quickl
 
 - [Configure the scan command](/guides/configure-scan/)
 - [Using the GitHub action](/guides/github-action/)
+- [Set up CI/CD](/guides/ci-setup/)
 - [Create a custom rule](/guides/custom-rule/)


### PR DESCRIPTION
## Description
Adds a guide describing the setup/usage process for GitLab CI/CD. Additional services should be added as needed in the future.


## Related
- close #893
## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
