### PR TITLE
feat: match types in javascript patterns

### DIFF
--- a/new/language/implementation/javascript/javascript.go
+++ b/new/language/implementation/javascript/javascript.go
@@ -201,7 +201,7 @@ func (javascriptImplementation *javascriptImplementation) ShouldSkipNode(node *t
 func (*javascriptImplementation) PatternLeafContentTypes() []string {
 	return []string{
 		// identifiers
-		"identifier", "property_identifier", "shorthand_property_identifier",
+		"identifier", "property_identifier", "shorthand_property_identifier", "type_identifier",
 		// datatypes/literals
 		"template_string", "string_fragment", "number", "null", "true", "false",
 	}


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Adds type identifiers to the list of node types that match on content. 

This allows typescript type names to be used in Javascript patterns.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
