### PR TITLE
feat: sanitizer rules

### DIFF
--- a/new/detector/composition/java/java.go
+++ b/new/detector/composition/java/java.go
@@ -112,6 +112,7 @@ func New(rules map[string]*settings.Rule, classifier *classification.Classifier)
 
 	for ruleName, rule := range jsRules {
 		patterns := rule.Patterns
+		sanitizerRuleID := rule.SanitizerRuleID
 		localRuleName := ruleName
 
 		if !rule.IsAuxilary || presenceRules[ruleName] {
@@ -123,6 +124,7 @@ func New(rules map[string]*settings.Rule, classifier *classification.Classifier)
 				lang,
 				localRuleName,
 				patterns,
+				sanitizerRuleID,
 			)
 
 			receiver <- types.DetectorInitResult{

--- a/new/detector/composition/javascript/javascript.go
+++ b/new/detector/composition/javascript/javascript.go
@@ -112,6 +112,7 @@ func New(rules map[string]*settings.Rule, classifier *classification.Classifier)
 
 	for ruleName, rule := range jsRules {
 		patterns := rule.Patterns
+		sanitizerRuleID := rule.SanitizerRuleID
 		localRuleName := ruleName
 
 		if !rule.IsAuxilary || presenceRules[ruleName] {
@@ -123,6 +124,7 @@ func New(rules map[string]*settings.Rule, classifier *classification.Classifier)
 				lang,
 				localRuleName,
 				patterns,
+				sanitizerRuleID,
 			)
 
 			receiver <- types.DetectorInitResult{

--- a/new/detector/composition/ruby/ruby.go
+++ b/new/detector/composition/ruby/ruby.go
@@ -111,6 +111,7 @@ func New(rules map[string]*settings.Rule, classifier *classification.Classifier)
 
 	for ruleName, rule := range rubyRules {
 		patterns := rule.Patterns
+		sanitizerRuleID := rule.SanitizerRuleID
 		localRuleName := ruleName
 
 		if !rule.IsAuxilary || presenceRules[ruleName] {
@@ -122,6 +123,7 @@ func New(rules map[string]*settings.Rule, classifier *classification.Classifier)
 				lang,
 				localRuleName,
 				patterns,
+				sanitizerRuleID,
 			)
 
 			receiver <- types.DetectorInitResult{

--- a/new/detector/implementation/generic/datatype/datatype.go
+++ b/new/detector/implementation/generic/datatype/datatype.go
@@ -42,7 +42,7 @@ func (detector *datatypeDetector) NestedDetections() bool {
 }
 
 func (detector *datatypeDetector) DetectAt(
-	node *tree.Node,
+	rootNode, node *tree.Node,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
 	objectDetections, err := evaluator.ForNode(node, "object", false)

--- a/new/detector/implementation/generic/insecureurl/insecureurl.go
+++ b/new/detector/implementation/generic/insecureurl/insecureurl.go
@@ -26,7 +26,7 @@ func (detector *insecureURLDetector) Name() string {
 }
 
 func (detector *insecureURLDetector) DetectAt(
-	node *tree.Node,
+	rootNode, node *tree.Node,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
 	detections, err := evaluator.ForNode(node, "string", false)

--- a/new/detector/implementation/generic/stringliteral/stringliteral.go
+++ b/new/detector/implementation/generic/stringliteral/stringliteral.go
@@ -21,7 +21,7 @@ func (detector *stringLiteralDetector) Name() string {
 }
 
 func (detector *stringLiteralDetector) DetectAt(
-	node *tree.Node,
+	rootNode, node *tree.Node,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
 	detections, err := evaluator.ForNode(node, "string", false)

--- a/new/detector/implementation/java/object/object.go
+++ b/new/detector/implementation/java/object/object.go
@@ -68,7 +68,7 @@ func (detector *objectDetector) NestedDetections() bool {
 }
 
 func (detector *objectDetector) DetectAt(
-	node *tree.Node,
+	rootNode, node *tree.Node,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
 	log.Debug().Msgf("node is %s", node.Debug())

--- a/new/detector/implementation/java/string/string.go
+++ b/new/detector/implementation/java/string/string.go
@@ -21,7 +21,7 @@ func (detector *stringDetector) Name() string {
 }
 
 func (detector *stringDetector) DetectAt(
-	node *tree.Node,
+	rootNode, node *tree.Node,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
 	if node.Type() == "string_literal" {

--- a/new/detector/implementation/javascript/object/object.go
+++ b/new/detector/implementation/javascript/object/object.go
@@ -113,7 +113,7 @@ func (detector *objectDetector) NestedDetections() bool {
 }
 
 func (detector *objectDetector) DetectAt(
-	node *tree.Node,
+	rootNode, node *tree.Node,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
 	detections, err := detector.getObject(node, evaluator)

--- a/new/detector/implementation/javascript/string/string.go
+++ b/new/detector/implementation/javascript/string/string.go
@@ -23,7 +23,7 @@ func (detector *stringDetector) Name() string {
 }
 
 func (detector *stringDetector) DetectAt(
-	node *tree.Node,
+	rootNode, node *tree.Node,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
 	switch node.Type() {

--- a/new/detector/implementation/ruby/object/object.go
+++ b/new/detector/implementation/ruby/object/object.go
@@ -92,7 +92,7 @@ func (detector *objectDetector) NestedDetections() bool {
 }
 
 func (detector *objectDetector) DetectAt(
-	node *tree.Node,
+	rootNode, node *tree.Node,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
 	detections, err := detector.getHash(node, evaluator)

--- a/new/detector/implementation/ruby/string/string.go
+++ b/new/detector/implementation/ruby/string/string.go
@@ -23,7 +23,7 @@ func (detector *stringDetector) Name() string {
 }
 
 func (detector *stringDetector) DetectAt(
-	node *tree.Node,
+	rootNode, node *tree.Node,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
 	switch node.Type() {

--- a/new/detector/set/set.go
+++ b/new/detector/set/set.go
@@ -39,7 +39,7 @@ func (set *set) NestedDetections(detectorType string) (bool, error) {
 }
 
 func (set *set) DetectAt(
-	node *tree.Node,
+	rootNode, node *tree.Node,
 	detectorType string,
 	evaluator types.Evaluator,
 ) ([]*types.Detection, error) {
@@ -48,7 +48,7 @@ func (set *set) DetectAt(
 		return nil, err
 	}
 
-	detectionsData, err := detector.DetectAt(node, evaluator)
+	detectionsData, err := detector.DetectAt(rootNode, node, evaluator)
 	if err != nil {
 		return nil, err
 	}

--- a/new/detector/types/types.go
+++ b/new/detector/types/types.go
@@ -22,7 +22,7 @@ type Evaluator interface {
 type DetectorSet interface {
 	NestedDetections(detectorType string) (bool, error)
 	DetectAt(
-		node *tree.Node,
+		rootNode, node *tree.Node,
 		detectorType string,
 		evaluator Evaluator,
 	) ([]*Detection, error)
@@ -30,7 +30,7 @@ type DetectorSet interface {
 
 type Detector interface {
 	Name() string
-	DetectAt(node *tree.Node, evaluator Evaluator) ([]interface{}, error)
+	DetectAt(rootNode, node *tree.Node, evaluator Evaluator) ([]interface{}, error)
 	NestedDetections() bool
 	Close()
 }

--- a/pkg/commands/process/balancer/process.go
+++ b/pkg/commands/process/balancer/process.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"time"
@@ -226,6 +227,7 @@ func (process *Process) monitorMemory(pid int) {
 	recovery := func() {
 		if r := recover(); r != nil {
 			log.Debug().Msgf("error recovered %s", r)
+			log.Print(string(debug.Stack()))
 		}
 	}
 	defer recovery()

--- a/pkg/commands/process/settings/rules.go
+++ b/pkg/commands/process/settings/rules.go
@@ -299,18 +299,20 @@ func BuildRules(definitions map[string]RuleDefinition, enabledRules map[string]s
 			Languages:          definition.Languages,
 			ParamParenting:     definition.ParamParenting,
 			Patterns:           definition.Patterns,
+			SanitizerRuleID:    definition.SanitizerRuleID,
 			DocumentationUrl:   definition.Metadata.DocumentationUrl,
 			HasDetailedContext: definition.HasDetailedContext,
 		}
 
 		for _, auxiliaryDefinition := range definition.Auxiliary {
 			rules[auxiliaryDefinition.Id] = &Rule{
-				Type:           defaultAuxiliaryRuleType,
-				Languages:      definition.Languages,
-				ParamParenting: auxiliaryDefinition.ParamParenting,
-				Patterns:       auxiliaryDefinition.Patterns,
-				Stored:         auxiliaryDefinition.Stored,
-				IsAuxilary:     true,
+				Type:            defaultAuxiliaryRuleType,
+				Languages:       definition.Languages,
+				ParamParenting:  auxiliaryDefinition.ParamParenting,
+				Patterns:        auxiliaryDefinition.Patterns,
+				SanitizerRuleID: auxiliaryDefinition.SanitizerRuleID,
+				Stored:          auxiliaryDefinition.Stored,
+				IsAuxilary:      true,
 			}
 		}
 	}

--- a/pkg/commands/process/settings/settings.go
+++ b/pkg/commands/process/settings/settings.go
@@ -108,6 +108,7 @@ type RuleDefinition struct {
 	Languages          []string               `mapstructure:"languages" json:"languages" yaml:"languages"`
 	ParamParenting     bool                   `mapstructure:"param_parenting" json:"param_parenting" yaml:"param_parenting"`
 	Patterns           []RulePattern          `mapstructure:"patterns" json:"patterns" yaml:"patterns"`
+	SanitizerRuleID    string                 `mapstructure:"sanitizer" json:"sanitizer" yaml:"sanitizer"`
 	Stored             bool                   `mapstructure:"stored" json:"stored" yaml:"stored"`
 	Detectors          []string               `mapstructure:"detectors" json:"detectors,omitempty" yaml:"detectors,omitempty"`
 	Processors         []string               `mapstructure:"processors" json:"processors,omitempty" yaml:"processors,omitempty"`
@@ -123,10 +124,11 @@ type RuleDefinition struct {
 }
 
 type Auxiliary struct {
-	Id        string        `mapstructure:"id" json:"id" yaml:"id"`
-	Type      string        `mapstructure:"type" json:"type" yaml:"type"`
-	Languages []string      `mapstructure:"languages" json:"languages" yaml:"languages"`
-	Patterns  []RulePattern `mapstructure:"patterns" json:"patterns" yaml:"patterns"`
+	Id              string        `mapstructure:"id" json:"id" yaml:"id"`
+	Type            string        `mapstructure:"type" json:"type" yaml:"type"`
+	Languages       []string      `mapstructure:"languages" json:"languages" yaml:"languages"`
+	Patterns        []RulePattern `mapstructure:"patterns" json:"patterns" yaml:"patterns"`
+	SanitizerRuleID string        `mapstructure:"sanitizer" json:"sanitizer" yaml:"sanitizer"`
 
 	RootSingularize bool `mapstructure:"root_singularize" yaml:"root_singularize" `
 	RootLowercase   bool `mapstructure:"root_lowercase" yaml:"root_lowercase"`
@@ -161,6 +163,7 @@ type Rule struct {
 	CWEIDs             []string      `mapstructure:"cwe_ids" json:"cwe_ids" yaml:"cwe_ids"`
 	Languages          []string      `mapstructure:"languages" json:"languages" yaml:"languages"`
 	Patterns           []RulePattern `mapstructure:"patterns" json:"patterns" yaml:"patterns"`
+	SanitizerRuleID    string        `mapstructure:"sanitizer" json:"sanitizer" yaml:"sanitizer"`
 	DocumentationUrl   string        `mapstructure:"documentation_url" json:"documentation_url" yaml:"documentation_url"`
 	IsAuxilary         bool          `mapstructure:"is_auxilary" json:"is_auxilary" yaml:"is_auxilary"`
 

--- a/pkg/detectors/detectors.go
+++ b/pkg/detectors/detectors.go
@@ -3,6 +3,7 @@ package detectors
 import (
 	"fmt"
 	"path/filepath"
+	"runtime/debug"
 
 	"github.com/bearer/bearer/new/scanner"
 	"github.com/bearer/bearer/pkg/commands/process/settings"
@@ -176,6 +177,7 @@ func ExtractWithDetectors(
 			recovery := func() {
 				if r := recover(); r != nil {
 					log.Printf("file %s -> error recovered %s", file.AbsolutePath, r)
+					log.Print(string(debug.Stack()))
 					report.AddError(file.Path.RelativePath, fmt.Errorf("skipping file: due to panic %s", r))
 				}
 			}


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Adds the ability for a rule to reference another rule as a sanitizer. Rules will not match if the sanitizer rule matches at any parent of a given node.

This will be used to address the problem mentioned in https://github.com/Bearer/bearer/issues/973 without needing to make bigger changes to the detection logic.

Also improves logging of errors that have been recovered.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
