### PR TITLE
docs: adds cloud waitlist CTA to docs site

### DIFF
--- a/docs/_src/_includes/layouts/doc.njk
+++ b/docs/_src/_includes/layouts/doc.njk
@@ -35,7 +35,6 @@ layout: layouts/base.njk
 				</button>
 			</div>
 			<div id="toc-container" class="hidden md:block px-4 pb-4">
-
 				<a href="#" class="hover:underline">Overview</a>
 				{{ content | toc | safe }}
 				<h2 class="mt-2 font-bold text-md">Contribute</h2>
@@ -51,6 +50,3 @@ layout: layouts/base.njk
 		</aside>
 	</div>
 </main>
-<footer class="p-4 mt-4 text-center">
-	<nav></nav>
-</footer>

--- a/docs/_src/_includes/layouts/doc.njk
+++ b/docs/_src/_includes/layouts/doc.njk
@@ -25,6 +25,10 @@ layout: layouts/base.njk
 				{% include 'breadcrumbs.njk' %}
 			{% endif %}
 			{{ content | safe }}
+			<div class="md:hidden p-4 border-solid border-2 border-neutral-200 dark:border-neutral-500 rounded-md">
+				<p>Ready to take the next step? <a class="text-main dark:text-main-300 hover:underline plausible-event-name--DocsCloudSignup plausible-event-location--mobile" href="https://www.bearer.com">Join the Bearer Cloud waitlist.</a>
+				</p>
+			</div>
 		</article>
 		<aside class="self-start col-span-3 sm:col-span-2 md:col-span-1  md:top-heading-offset  dark:text-neutral-200 md:flex md:flex-col md:sticky text-sm gap-4 justify-between md:mb-4 ">
 			<div class=" border-solid border-2 border-neutral-200 dark:border-neutral-500 rounded-md">
@@ -50,7 +54,7 @@ layout: layouts/base.njk
 				</div>
 			</div>
 			<div class="hidden md:block p-4 border-solid border-2 border-neutral-200 dark:border-neutral-500 rounded-md">
-				<p>Ready to take the next step? <a class="text-main dark:text-main-300 hover:underline" href="http://www.bearer.com">Join the Bearer Cloud waitlist.</a>
+				<p>Ready to take the next step? <a class="text-main dark:text-main-300 hover:underline plausible-event-name--DocsCloudSignup plausible-event-location--sidebar" href="https://www.bearer.com">Join the Bearer Cloud waitlist.</a>
 				</p>
 			</div>
 		</aside>

--- a/docs/_src/_includes/layouts/doc.njk
+++ b/docs/_src/_includes/layouts/doc.njk
@@ -26,26 +26,32 @@ layout: layouts/base.njk
 			{% endif %}
 			{{ content | safe }}
 		</article>
-		<aside class="self-start col-span-3 sm:col-span-2 md:col-span-1 md:max-h-[80vh] md:top-heading-offset overflow-y-scroll dark:text-neutral-200 md:block md:sticky text-sm border-solid border-2 border-neutral-200 dark:border-neutral-500 rounded-md">
-			<div class="flex justify-between relative p-4">
-				<h2 class="font-bold text-md">On this page</h2>
-				<button id="js-toggle-toc" class="md:hidden absolute top-0 left-0 right-0 bottom-0 text-right flex justify-end items-center pr-3">
-					<span class="sr-only">Toggle menu</span>
-					<div class="">{% include 'icon-chevron.njk'%}</div>
-				</button>
+		<aside class="self-start col-span-3 sm:col-span-2 md:col-span-1  md:top-heading-offset  dark:text-neutral-200 md:flex md:flex-col md:sticky text-sm gap-4 justify-between md:mb-4 ">
+			<div class=" border-solid border-2 border-neutral-200 dark:border-neutral-500 rounded-md">
+				<div class="flex justify-between relative p-4">
+					<h2 class="font-bold text-md">On this page</h2>
+					<button id="js-toggle-toc" class="md:hidden absolute top-0 left-0 right-0 bottom-0 text-right flex justify-end items-center pr-3">
+						<span class="sr-only">Toggle menu</span>
+						<div class="">{% include 'icon-chevron.njk'%}</div>
+					</button>
+				</div>
+				<div id="toc-container" class="hidden md:block px-4 pb-4 overflow-y-scroll md:max-h-[50vh]">
+					<a href="#" class="hover:underline">Overview</a>
+					{{ content | toc | safe }}
+					<h2 class="mt-2 font-bold text-md">Contribute</h2>
+					<ul>
+						<li>
+							<a class="hover:underline" href="{{meta.sourcePath}}/blob/main/docs/{{ page.inputPath }}">Edit this page</a>
+						</li>
+						<li>
+							<a href="{{meta.sourcePath}}/issues/new/choose" class="hover:underline">Leave feedback</a>
+						</li>
+					</ul>
+				</div>
 			</div>
-			<div id="toc-container" class="hidden md:block px-4 pb-4">
-				<a href="#" class="hover:underline">Overview</a>
-				{{ content | toc | safe }}
-				<h2 class="mt-2 font-bold text-md">Contribute</h2>
-				<ul>
-					<li>
-						<a class="hover:underline" href="{{meta.sourcePath}}/blob/main/docs/{{ page.inputPath }}">Edit this page</a>
-					</li>
-					<li>
-						<a href="{{meta.sourcePath}}/issues/new/choose" class="hover:underline">Leave feedback</a>
-					</li>
-				</ul>
+			<div class="hidden md:block p-4 border-solid border-2 border-neutral-200 dark:border-neutral-500 rounded-md">
+				<p>Ready to take the next step? <a class="text-main dark:text-main-300 hover:underline" href="http://www.bearer.com">Join the Bearer Cloud waitlist.</a>
+				</p>
 			</div>
 		</aside>
 	</div>

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -68,5 +68,3 @@ We'd love to see the impact you can bring to Bearer CLI. Our contributing docume
 - [Set up Bearer CLI locally to contribute code](/contributing/code/)
 - [Help improve and apply fixes to the documentation](/contributing/docs/)
 - [Add new recipes to Bearer CLI's database](/contributing/recipes/)
-  
-![Sunglasses Bear](/assets/img/contribute-bearer.png)


### PR DESCRIPTION
## Description
Adds two cloud waitlist CTAs
- One in the on-page sidebar after the table of contents
- One on mobile viewports that don't have the sidebar, located at the very end of each page.

To accommodate, this PR also updates the way the sidebar is rendered.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
