### PR TITLE
fix: handle flow correctly for sanitizer rules

### DIFF
--- a/e2e/rules/.snapshots/TestSanitizer-testdata-data-sanitizer
+++ b/e2e/rules/.snapshots/TestSanitizer-testdata-data-sanitizer
@@ -1,0 +1,35 @@
+critical:
+    - rule:
+        cwe_ids:
+            - "42"
+        id: sanitizer_test
+        title: Test sanitizer
+        description: Test sanitizer
+        documentation_url: ""
+      line_number: 1
+      filename: e2e/rules/testdata/data/sanitizer/sanitizer.rb
+      category_groups:
+        - PII
+        - Personal Data
+      parent_line_number: 5
+      snippet: log("abc" + x)
+      fingerprint: d2e829ba86a33c5a52844641617ad8a7_0
+    - rule:
+        cwe_ids:
+            - "42"
+        id: sanitizer_test
+        title: Test sanitizer
+        description: Test sanitizer
+        documentation_url: ""
+      line_number: 4
+      filename: e2e/rules/testdata/data/sanitizer/sanitizer.rb
+      category_groups:
+        - PII
+        - Personal Data
+      parent_line_number: 4
+      snippet: log("abc" + user.email)
+      fingerprint: d2e829ba86a33c5a52844641617ad8a7_2
+
+
+--
+

--- a/e2e/rules/rules_test.go
+++ b/e2e/rules/rules_test.go
@@ -33,6 +33,11 @@ func TestAuxilary(t *testing.T) {
 	runRulesTest("auxilary", "javascript_third_parties_datadog_test", t)
 }
 
+func TestSanitizer(t *testing.T) {
+	t.Parallel()
+	runRulesTest("sanitizer", "sanitizer_test", t)
+}
+
 func TestSimpleRuby(t *testing.T) {
 	t.Parallel()
 	runRulesTest("simple_ruby", "ruby_rails_insecure_communication_test", t)

--- a/e2e/rules/testdata/data/sanitizer/sanitizer.rb
+++ b/e2e/rules/testdata/data/sanitizer/sanitizer.rb
@@ -1,0 +1,10 @@
+x = user.email
+
+# unsanitized
+log("abc" + user.email)
+log("abc" + x)
+
+# sanitized
+y = hash(x)
+log("abc" + hash(user.email))
+log("abc" + y)

--- a/e2e/rules/testdata/rules/sanitizer.yml
+++ b/e2e/rules/testdata/rules/sanitizer.yml
@@ -1,0 +1,27 @@
+languages:
+  - ruby
+patterns:
+  - pattern: |
+      log($<DATA>)
+    filters:
+      - variable: DATA
+        detection: sanitizer_test_data
+auxiliary:
+  - id: sanitizer_test_data
+    sanitizer: sanitizer_test_sanitizer
+    patterns:
+      - pattern: $<DATA_TYPE>
+        filters:
+          - variable: DATA_TYPE
+            detection: datatype
+            contains: false
+  - id: sanitizer_test_sanitizer
+    patterns:
+      - hash($<!>$<_>)
+severity: high
+metadata:
+  description: Test sanitizer
+  remediation_message: Test sanitizer
+  cwe_id:
+    - 42
+  id: sanitizer_test

--- a/new/detector/implementation/generic/datatype/datatype.go
+++ b/new/detector/implementation/generic/datatype/datatype.go
@@ -42,10 +42,10 @@ func (detector *datatypeDetector) NestedDetections() bool {
 }
 
 func (detector *datatypeDetector) DetectAt(
-	evaluationContext types.EvaluationContext,
+	node *tree.Node,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
-	objectDetections, err := evaluator.ForNode(evaluationContext.Cursor(), "object", false)
+	objectDetections, err := evaluator.ForNode(node, "object", "", false)
 	if err != nil {
 		return nil, err
 	}

--- a/new/detector/implementation/generic/datatype/datatype.go
+++ b/new/detector/implementation/generic/datatype/datatype.go
@@ -42,10 +42,10 @@ func (detector *datatypeDetector) NestedDetections() bool {
 }
 
 func (detector *datatypeDetector) DetectAt(
-	rootNode, node *tree.Node,
+	evaluationContext types.EvaluationContext,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
-	objectDetections, err := evaluator.ForNode(node, "object", false)
+	objectDetections, err := evaluator.ForNode(evaluationContext.Cursor(), "object", false)
 	if err != nil {
 		return nil, err
 	}

--- a/new/detector/implementation/generic/generic.go
+++ b/new/detector/implementation/generic/generic.go
@@ -9,7 +9,7 @@ import (
 )
 
 func GetNonVirtualObjects(evaluator types.Evaluator, node *tree.Node) ([]*types.Detection, error) {
-	detections, err := evaluator.ForNode(node, "object", true)
+	detections, err := evaluator.ForNode(node, "object", "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +84,7 @@ func ProjectObject(
 }
 
 func GetStringValue(node *tree.Node, evaluator types.Evaluator) (string, bool, error) {
-	detections, err := evaluator.ForNode(node, "string", true)
+	detections, err := evaluator.ForNode(node, "string", "", true)
 	if err != nil {
 		return "", false, err
 	}

--- a/new/detector/implementation/generic/insecureurl/insecureurl.go
+++ b/new/detector/implementation/generic/insecureurl/insecureurl.go
@@ -4,7 +4,6 @@ import (
 	"regexp"
 
 	"github.com/bearer/bearer/new/detector/types"
-	"github.com/bearer/bearer/new/language/tree"
 
 	generictypes "github.com/bearer/bearer/new/detector/implementation/generic/types"
 	languagetypes "github.com/bearer/bearer/new/language/types"
@@ -26,10 +25,10 @@ func (detector *insecureURLDetector) Name() string {
 }
 
 func (detector *insecureURLDetector) DetectAt(
-	rootNode, node *tree.Node,
+	evaluationContext types.EvaluationContext,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
-	detections, err := evaluator.ForNode(node, "string", false)
+	detections, err := evaluator.ForNode(evaluationContext.Cursor(), "string", false)
 	if err != nil {
 		return nil, err
 	}

--- a/new/detector/implementation/generic/insecureurl/insecureurl.go
+++ b/new/detector/implementation/generic/insecureurl/insecureurl.go
@@ -4,6 +4,7 @@ import (
 	"regexp"
 
 	"github.com/bearer/bearer/new/detector/types"
+	"github.com/bearer/bearer/new/language/tree"
 
 	generictypes "github.com/bearer/bearer/new/detector/implementation/generic/types"
 	languagetypes "github.com/bearer/bearer/new/language/types"
@@ -25,10 +26,10 @@ func (detector *insecureURLDetector) Name() string {
 }
 
 func (detector *insecureURLDetector) DetectAt(
-	evaluationContext types.EvaluationContext,
+	node *tree.Node,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
-	detections, err := evaluator.ForNode(evaluationContext.Cursor(), "string", false)
+	detections, err := evaluator.ForNode(node, "string", "", false)
 	if err != nil {
 		return nil, err
 	}

--- a/new/detector/implementation/generic/stringliteral/stringliteral.go
+++ b/new/detector/implementation/generic/stringliteral/stringliteral.go
@@ -2,6 +2,7 @@ package stringliteral
 
 import (
 	"github.com/bearer/bearer/new/detector/types"
+	"github.com/bearer/bearer/new/language/tree"
 
 	generictypes "github.com/bearer/bearer/new/detector/implementation/generic/types"
 	languagetypes "github.com/bearer/bearer/new/language/types"
@@ -20,12 +21,10 @@ func (detector *stringLiteralDetector) Name() string {
 }
 
 func (detector *stringLiteralDetector) DetectAt(
-	evaluationContext types.EvaluationContext,
+	node *tree.Node,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
-	node := evaluationContext.Cursor()
-
-	detections, err := evaluator.ForNode(node, "string", false)
+	detections, err := evaluator.ForNode(node, "string", "", false)
 	if err != nil {
 		return nil, err
 	}

--- a/new/detector/implementation/generic/stringliteral/stringliteral.go
+++ b/new/detector/implementation/generic/stringliteral/stringliteral.go
@@ -2,7 +2,6 @@ package stringliteral
 
 import (
 	"github.com/bearer/bearer/new/detector/types"
-	"github.com/bearer/bearer/new/language/tree"
 
 	generictypes "github.com/bearer/bearer/new/detector/implementation/generic/types"
 	languagetypes "github.com/bearer/bearer/new/language/types"
@@ -21,9 +20,11 @@ func (detector *stringLiteralDetector) Name() string {
 }
 
 func (detector *stringLiteralDetector) DetectAt(
-	rootNode, node *tree.Node,
+	evaluationContext types.EvaluationContext,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
+	node := evaluationContext.Cursor()
+
 	detections, err := evaluator.ForNode(node, "string", false)
 	if err != nil {
 		return nil, err

--- a/new/detector/implementation/java/object/object.go
+++ b/new/detector/implementation/java/object/object.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/bearer/bearer/new/detector/types"
 	"github.com/bearer/bearer/new/language/tree"
+	"github.com/rs/zerolog/log"
 
 	"github.com/bearer/bearer/new/detector/implementation/generic"
 	generictypes "github.com/bearer/bearer/new/detector/implementation/generic/types"
@@ -67,10 +68,10 @@ func (detector *objectDetector) NestedDetections() bool {
 }
 
 func (detector *objectDetector) DetectAt(
-	evaluationContext types.EvaluationContext,
+	node *tree.Node,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
-	node := evaluationContext.Cursor()
+	log.Debug().Msgf("node is %s", node.Debug())
 
 	detections, err := detector.getAssignment(node, evaluator)
 	if len(detections) != 0 || err != nil {

--- a/new/detector/implementation/java/object/object.go
+++ b/new/detector/implementation/java/object/object.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/bearer/bearer/new/detector/types"
 	"github.com/bearer/bearer/new/language/tree"
-	"github.com/rs/zerolog/log"
 
 	"github.com/bearer/bearer/new/detector/implementation/generic"
 	generictypes "github.com/bearer/bearer/new/detector/implementation/generic/types"
@@ -68,10 +67,10 @@ func (detector *objectDetector) NestedDetections() bool {
 }
 
 func (detector *objectDetector) DetectAt(
-	rootNode, node *tree.Node,
+	evaluationContext types.EvaluationContext,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
-	log.Debug().Msgf("node is %s", node.Debug())
+	node := evaluationContext.Cursor()
 
 	detections, err := detector.getAssignment(node, evaluator)
 	if len(detections) != 0 || err != nil {

--- a/new/detector/implementation/java/string/string.go
+++ b/new/detector/implementation/java/string/string.go
@@ -2,7 +2,6 @@ package string
 
 import (
 	"github.com/bearer/bearer/new/detector/types"
-	"github.com/bearer/bearer/new/language/tree"
 
 	generictypes "github.com/bearer/bearer/new/detector/implementation/generic/types"
 	languagetypes "github.com/bearer/bearer/new/language/types"
@@ -21,9 +20,11 @@ func (detector *stringDetector) Name() string {
 }
 
 func (detector *stringDetector) DetectAt(
-	rootNode, node *tree.Node,
+	evaluationContext types.EvaluationContext,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
+	node := evaluationContext.Cursor()
+
 	if node.Type() == "string_literal" {
 		return []interface{}{generictypes.String{
 			Value:     node.Content(),

--- a/new/detector/implementation/java/string/string.go
+++ b/new/detector/implementation/java/string/string.go
@@ -2,6 +2,7 @@ package string
 
 import (
 	"github.com/bearer/bearer/new/detector/types"
+	"github.com/bearer/bearer/new/language/tree"
 
 	generictypes "github.com/bearer/bearer/new/detector/implementation/generic/types"
 	languagetypes "github.com/bearer/bearer/new/language/types"
@@ -20,11 +21,9 @@ func (detector *stringDetector) Name() string {
 }
 
 func (detector *stringDetector) DetectAt(
-	evaluationContext types.EvaluationContext,
+	node *tree.Node,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
-	node := evaluationContext.Cursor()
-
 	if node.Type() == "string_literal" {
 		return []interface{}{generictypes.String{
 			Value:     node.Content(),

--- a/new/detector/implementation/javascript/object/object.go
+++ b/new/detector/implementation/javascript/object/object.go
@@ -113,11 +113,9 @@ func (detector *objectDetector) NestedDetections() bool {
 }
 
 func (detector *objectDetector) DetectAt(
-	evaluationContext types.EvaluationContext,
+	node *tree.Node,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
-	node := evaluationContext.Cursor()
-
 	detections, err := detector.getObject(node, evaluator)
 	if len(detections) != 0 || err != nil {
 		return detections, err
@@ -147,7 +145,7 @@ func (detector *objectDetector) getObject(
 	}
 
 	for _, spreadResult := range spreadResults {
-		detections, err := evaluator.ForNode(spreadResult["identifier"], "object", true)
+		detections, err := evaluator.ForNode(spreadResult["identifier"], "object", "", true)
 
 		if err != nil {
 			return nil, err
@@ -177,7 +175,7 @@ func (detector *objectDetector) getObject(
 			continue
 		}
 
-		propertyObjects, err := evaluator.ForTree(result["value"], "object", true)
+		propertyObjects, err := evaluator.ForTree(result["value"], "object", "", true)
 		if err != nil {
 			return nil, err
 		}

--- a/new/detector/implementation/javascript/object/object.go
+++ b/new/detector/implementation/javascript/object/object.go
@@ -113,9 +113,11 @@ func (detector *objectDetector) NestedDetections() bool {
 }
 
 func (detector *objectDetector) DetectAt(
-	rootNode, node *tree.Node,
+	evaluationContext types.EvaluationContext,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
+	node := evaluationContext.Cursor()
+
 	detections, err := detector.getObject(node, evaluator)
 	if len(detections) != 0 || err != nil {
 		return detections, err

--- a/new/detector/implementation/javascript/object/projection.go
+++ b/new/detector/implementation/javascript/object/projection.go
@@ -97,7 +97,7 @@ func (detector *objectDetector) getCallProjections(
 
 	var properties []generictypes.Property
 
-	functionDetections, err := evaluator.ForTree(result["function"], "object", true)
+	functionDetections, err := evaluator.ForTree(result["function"], "object", "", true)
 	if len(functionDetections) == 0 || err != nil {
 		return nil, err
 	}

--- a/new/detector/implementation/javascript/string/string.go
+++ b/new/detector/implementation/javascript/string/string.go
@@ -23,9 +23,11 @@ func (detector *stringDetector) Name() string {
 }
 
 func (detector *stringDetector) DetectAt(
-	rootNode, node *tree.Node,
+	evaluationContext types.EvaluationContext,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
+	node := evaluationContext.Cursor()
+
 	switch node.Type() {
 	case "string":
 		return []interface{}{generictypes.String{

--- a/new/detector/implementation/javascript/string/string.go
+++ b/new/detector/implementation/javascript/string/string.go
@@ -23,11 +23,9 @@ func (detector *stringDetector) Name() string {
 }
 
 func (detector *stringDetector) DetectAt(
-	evaluationContext types.EvaluationContext,
+	node *tree.Node,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
-	node := evaluationContext.Cursor()
-
 	switch node.Type() {
 	case "string":
 		return []interface{}{generictypes.String{

--- a/new/detector/implementation/ruby/object/object.go
+++ b/new/detector/implementation/ruby/object/object.go
@@ -92,11 +92,9 @@ func (detector *objectDetector) NestedDetections() bool {
 }
 
 func (detector *objectDetector) DetectAt(
-	evaluationContext types.EvaluationContext,
+	node *tree.Node,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
-	node := evaluationContext.Cursor()
-
 	detections, err := detector.getHash(node, evaluator)
 	if len(detections) != 0 || err != nil {
 		return detections, err
@@ -138,7 +136,7 @@ func (detector *objectDetector) getHash(
 			continue
 		}
 
-		propertyObjects, err := evaluator.ForTree(result["value"], "object", true)
+		propertyObjects, err := evaluator.ForTree(result["value"], "object", "", true)
 		if err != nil {
 			return nil, err
 		}
@@ -178,7 +176,7 @@ func (detector *objectDetector) getKeywordArgument(
 		return nil, nil
 	}
 
-	propertyObjects, err := evaluator.ForTree(result["value"], "object", true)
+	propertyObjects, err := evaluator.ForTree(result["value"], "object", "", true)
 	if err != nil {
 		return nil, err
 	}

--- a/new/detector/implementation/ruby/object/object.go
+++ b/new/detector/implementation/ruby/object/object.go
@@ -92,9 +92,11 @@ func (detector *objectDetector) NestedDetections() bool {
 }
 
 func (detector *objectDetector) DetectAt(
-	rootNode, node *tree.Node,
+	evaluationContext types.EvaluationContext,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
+	node := evaluationContext.Cursor()
+
 	detections, err := detector.getHash(node, evaluator)
 	if len(detections) != 0 || err != nil {
 		return detections, err

--- a/new/detector/implementation/ruby/string/string.go
+++ b/new/detector/implementation/ruby/string/string.go
@@ -23,11 +23,9 @@ func (detector *stringDetector) Name() string {
 }
 
 func (detector *stringDetector) DetectAt(
-	evaluationContext types.EvaluationContext,
+	node *tree.Node,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
-	node := evaluationContext.Cursor()
-
 	switch node.Type() {
 	case "string_content":
 		return []interface{}{generictypes.String{
@@ -55,7 +53,7 @@ func concatenateChildren(node *tree.Node, evaluator types.Evaluator) ([]interfac
 			continue
 		}
 
-		detections, err := evaluator.ForNode(child, "string", true)
+		detections, err := evaluator.ForNode(child, "string", "", true)
 		if err != nil {
 			return nil, err
 		}

--- a/new/detector/implementation/ruby/string/string.go
+++ b/new/detector/implementation/ruby/string/string.go
@@ -23,9 +23,11 @@ func (detector *stringDetector) Name() string {
 }
 
 func (detector *stringDetector) DetectAt(
-	rootNode, node *tree.Node,
+	evaluationContext types.EvaluationContext,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
+	node := evaluationContext.Cursor()
+
 	switch node.Type() {
 	case "string_content":
 		return []interface{}{generictypes.String{

--- a/new/detector/set/set.go
+++ b/new/detector/set/set.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/bearer/bearer/new/detector/types"
-	"github.com/bearer/bearer/new/language/tree"
 )
 
 type set struct {
@@ -39,7 +38,7 @@ func (set *set) NestedDetections(detectorType string) (bool, error) {
 }
 
 func (set *set) DetectAt(
-	rootNode, node *tree.Node,
+	evaluationContext types.EvaluationContext,
 	detectorType string,
 	evaluator types.Evaluator,
 ) ([]*types.Detection, error) {
@@ -48,7 +47,7 @@ func (set *set) DetectAt(
 		return nil, err
 	}
 
-	detectionsData, err := detector.DetectAt(rootNode, node, evaluator)
+	detectionsData, err := detector.DetectAt(evaluationContext, evaluator)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +56,7 @@ func (set *set) DetectAt(
 	for i, data := range detectionsData {
 		detections[i] = &types.Detection{
 			DetectorType: detectorType,
-			MatchNode:    node,
+			MatchNode:    evaluationContext.Cursor(),
 			Data:         data,
 		}
 	}

--- a/new/detector/set/set.go
+++ b/new/detector/set/set.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/bearer/bearer/new/detector/types"
+	"github.com/bearer/bearer/new/language/tree"
 )
 
 type set struct {
@@ -38,7 +39,7 @@ func (set *set) NestedDetections(detectorType string) (bool, error) {
 }
 
 func (set *set) DetectAt(
-	evaluationContext types.EvaluationContext,
+	node *tree.Node,
 	detectorType string,
 	evaluator types.Evaluator,
 ) ([]*types.Detection, error) {
@@ -47,7 +48,7 @@ func (set *set) DetectAt(
 		return nil, err
 	}
 
-	detectionsData, err := detector.DetectAt(evaluationContext, evaluator)
+	detectionsData, err := detector.DetectAt(node, evaluator)
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +57,7 @@ func (set *set) DetectAt(
 	for i, data := range detectionsData {
 		detections[i] = &types.Detection{
 			DetectorType: detectorType,
-			MatchNode:    evaluationContext.Cursor(),
+			MatchNode:    node,
 			Data:         data,
 		}
 	}

--- a/new/detector/types/types.go
+++ b/new/detector/types/types.go
@@ -1,8 +1,6 @@
 package types
 
 import (
-	"crypto/sha256"
-
 	"github.com/bearer/bearer/new/language/tree"
 	"github.com/bearer/bearer/pkg/util/file"
 )
@@ -13,40 +11,18 @@ type Detection struct {
 	Data         interface{}
 }
 
-type EvaluationContext []EvaluationScope
-
-func (context EvaluationContext) Cursor() *tree.Node {
-	return context[len(context)-1].Cursor
-}
-
-func (context EvaluationContext) CursorKey() string {
-	hash := sha256.New()
-
-	for _, scope := range context {
-		hash.Write([]byte(scope.Cursor.IDString()))
-		hash.Write([]byte(","))
-	}
-
-	return string(hash.Sum(nil))
-}
-
-type EvaluationScope struct {
-	Root   *tree.Node
-	Cursor *tree.Node
-}
-
 type Evaluator interface {
-	ForTree(rootNode *tree.Node, detectorType string, followFlow bool) ([]*Detection, error)
-	ForNode(node *tree.Node, detectorType string, followFlow bool) ([]*Detection, error)
-	TreeHas(rootNode *tree.Node, detectorType string) (bool, error)
-	NodeHas(node *tree.Node, detectorType string) (bool, error)
+	ForTree(rootNode *tree.Node, detectorType, sanitizerDetectorType string, followFlow bool) ([]*Detection, error)
+	ForNode(node *tree.Node, detectorType, sanitizerDetectorType string, followFlow bool) ([]*Detection, error)
+	TreeHas(rootNode *tree.Node, detectorType, sanitizerDetectorType string) (bool, error)
+	NodeHas(node *tree.Node, detectorType, sanitizerDetectorType string) (bool, error)
 	FileName() string
 }
 
 type DetectorSet interface {
 	NestedDetections(detectorType string) (bool, error)
 	DetectAt(
-		evaluationContext EvaluationContext,
+		node *tree.Node,
 		detectorType string,
 		evaluator Evaluator,
 	) ([]*Detection, error)
@@ -54,7 +30,7 @@ type DetectorSet interface {
 
 type Detector interface {
 	Name() string
-	DetectAt(evaluationContext EvaluationContext, evaluator Evaluator) ([]interface{}, error)
+	DetectAt(node *tree.Node, evaluator Evaluator) ([]interface{}, error)
 	NestedDetections() bool
 	Close()
 }

--- a/new/language/tree/node.go
+++ b/new/language/tree/node.go
@@ -1,22 +1,29 @@
 package tree
 
 import (
+	"strconv"
+
 	sitter "github.com/smacker/go-tree-sitter"
 )
 
 type Node struct {
+	id         int
 	tree       *Tree
 	sitterNode *sitter.Node
 }
 
-type NodeID *sitter.Node
+type NodeID int
 
 func (node *Node) Debug() string {
 	return node.sitterNode.String()
 }
 
 func (node *Node) ID() NodeID {
-	return node.sitterNode
+	return NodeID(node.id)
+}
+
+func (node *Node) IDString() string {
+	return strconv.Itoa(node.id)
 }
 
 func (node *Node) Equal(other *Node) bool {

--- a/new/language/tree/node.go
+++ b/new/language/tree/node.go
@@ -1,29 +1,22 @@
 package tree
 
 import (
-	"strconv"
-
 	sitter "github.com/smacker/go-tree-sitter"
 )
 
 type Node struct {
-	id         int
 	tree       *Tree
 	sitterNode *sitter.Node
 }
 
-type NodeID int
+type NodeID *sitter.Node
 
 func (node *Node) Debug() string {
 	return node.sitterNode.String()
 }
 
 func (node *Node) ID() NodeID {
-	return NodeID(node.id)
-}
-
-func (node *Node) IDString() string {
-	return strconv.Itoa(node.id)
+	return node.sitterNode
 }
 
 func (node *Node) Equal(other *Node) bool {

--- a/new/language/tree/tree.go
+++ b/new/language/tree/tree.go
@@ -10,8 +10,6 @@ type Tree struct {
 	input        []byte
 	sitterTree   *sitter.Tree
 	unifiedNodes map[NodeID][]*Node
-	nextNodeId   int
-	nodeCache    map[*sitter.Node]*Node
 	queryCache   map[int]map[NodeID][]QueryResult
 }
 
@@ -32,7 +30,6 @@ func Parse(sitterLanguage *sitter.Language, input string) (*Tree, error) {
 		input:        inputBytes,
 		sitterTree:   sitterTree,
 		unifiedNodes: make(map[NodeID][]*Node),
-		nodeCache:    make(map[*sitter.Node]*Node),
 		queryCache:   make(map[int]map[NodeID][]QueryResult),
 	}, nil
 }
@@ -50,14 +47,7 @@ func (tree *Tree) wrap(sitterNode *sitter.Node) *Node {
 		return nil
 	}
 
-	if node, cached := tree.nodeCache[sitterNode]; cached {
-		return node
-	}
-
-	node := &Node{tree: tree, sitterNode: sitterNode, id: tree.nextNodeId}
-	tree.nodeCache[sitterNode] = node
-	tree.nextNodeId++
-	return node
+	return &Node{tree: tree, sitterNode: sitterNode}
 }
 
 func (tree *Tree) unifyNodes(laterNode *Node, earlierNode *Node) {

--- a/new/language/tree/tree.go
+++ b/new/language/tree/tree.go
@@ -10,6 +10,8 @@ type Tree struct {
 	input        []byte
 	sitterTree   *sitter.Tree
 	unifiedNodes map[NodeID][]*Node
+	nextNodeId   int
+	nodeCache    map[*sitter.Node]*Node
 	queryCache   map[int]map[NodeID][]QueryResult
 }
 
@@ -30,6 +32,7 @@ func Parse(sitterLanguage *sitter.Language, input string) (*Tree, error) {
 		input:        inputBytes,
 		sitterTree:   sitterTree,
 		unifiedNodes: make(map[NodeID][]*Node),
+		nodeCache:    make(map[*sitter.Node]*Node),
 		queryCache:   make(map[int]map[NodeID][]QueryResult),
 	}, nil
 }
@@ -47,7 +50,14 @@ func (tree *Tree) wrap(sitterNode *sitter.Node) *Node {
 		return nil
 	}
 
-	return &Node{tree: tree, sitterNode: sitterNode}
+	if node, cached := tree.nodeCache[sitterNode]; cached {
+		return node
+	}
+
+	node := &Node{tree: tree, sitterNode: sitterNode, id: tree.nextNodeId}
+	tree.nodeCache[sitterNode] = node
+	tree.nextNodeId++
+	return node
 }
 
 func (tree *Tree) unifyNodes(laterNode *Node, earlierNode *Node) {


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Moves the responsibility for sanitization rules to the evaluator. This allows us to terminate the match properly in the presence of flow/unified nodes.

Previously we wouldn't consider this case sanitized:

```ruby
x = params[:oops]
y = sanitize(x)

unsafe_call(y)
```

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [x] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
