### PR TITLE
feat: official support for shared rules

### DIFF
--- a/pkg/commands/process/settings/settings.go
+++ b/pkg/commands/process/settings/settings.go
@@ -106,6 +106,7 @@ type RuleDefinition struct {
 	Disabled           bool                   `mapstructure:"disabled" json:"disabled" yaml:"disabled"`
 	Type               string                 `mapstructure:"type" json:"type" yaml:"type"`
 	Languages          []string               `mapstructure:"languages" json:"languages" yaml:"languages"`
+	Imports            []string               `mapstructure:"imports" json:"imports" yaml:"imports"`
 	ParamParenting     bool                   `mapstructure:"param_parenting" json:"param_parenting" yaml:"param_parenting"`
 	Patterns           []RulePattern          `mapstructure:"patterns" json:"patterns" yaml:"patterns"`
 	SanitizerRuleID    string                 `mapstructure:"sanitizer" json:"sanitizer" yaml:"sanitizer"`

--- a/pkg/report/customdetectors/customdetectors.go
+++ b/pkg/report/customdetectors/customdetectors.go
@@ -3,3 +3,4 @@ package customdetectors
 const TypeRisk = "risk"
 const TypeDatatype = "data_type"
 const TypeVerifier = "verifier"
+const TypeShared = "shared"

--- a/pkg/report/output/dataflow/dataflow.go
+++ b/pkg/report/output/dataflow/dataflow.go
@@ -119,6 +119,7 @@ func GetOutput(input []interface{}, config settings.Config, isInternal bool) (*D
 
 			switch customDetector.Type {
 			case customdetectors.TypeVerifier:
+			case customdetectors.TypeShared:
 				continue
 			case customdetectors.TypeRisk:
 				err := risksHolder.AddSchema(castDetection)

--- a/pkg/util/set/set.go
+++ b/pkg/util/set/set.go
@@ -1,5 +1,7 @@
 package set
 
+import "golang.org/x/exp/maps"
+
 type Set[T comparable] map[T]struct{}
 
 func New[T comparable]() Set[T] {
@@ -15,7 +17,17 @@ func (set Set[T]) Add(item T) bool {
 	return true
 }
 
+func (set Set[T]) AddAll(items []T) {
+	for _, item := range items {
+		set[item] = struct{}{}
+	}
+}
+
 func (set Set[T]) Has(item T) bool {
 	_, exists := set[item]
 	return exists
+}
+
+func (set Set[T]) Items() []T {
+	return maps.Keys(set)
 }


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

It's currently possible to put common patterns into separate rules, and then use these from another rule. This PR makes that more explicit/officially supported:
- Support for a new rule type `shared`
- Ability to list a number of other rules as `imports`
- Some basic validation of rules, including:
  - checking all rules referenced from a filter/sanitizer are either local or imported.
  - shared rules have a limited set of attributes, eg. no severity or remediation message.
- When `--only-rule` is used, automatically include any needed imported rules.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
