### PR TITLE
fix: exclude doc folders and files from gitleaks detection

### DIFF
--- a/pkg/detectors/gitleaks/gitlab_config.toml
+++ b/pkg/detectors/gitleaks/gitlab_config.toml
@@ -840,5 +840,6 @@ keywords = [
 description = "global allow lists"
 paths = [
     '''gitleaks.toml''',
-    '''(.*?)(jpg|gif|doc|pdf|bin|svg|socket)$'''
+    '''(.*?)(jpg|gif|doc|pdf|bin|svg|socket)$''',
+    '''(\A|/|\\)doc(?s)(/|\\)(.*).md\z'''
 ]

--- a/pkg/detectors/gitleaks/testdata/docs/example.md
+++ b/pkg/detectors/gitleaks/testdata/docs/example.md
@@ -1,0 +1,1 @@
+export CI_REPOSITORY_URL="https://gitlab-ci-token:[masked]@example.com/gitlab-org/gitlab.git"


### PR DESCRIPTION
## Description

While doing the KPI scans on real-world repositories such as GitLab we found a lot of "secrets" that were not secrets but were examples in a markdown file in a docs folder.

This PR proposes to exclude any `.md` files within a `doc/s` folder from the gitleaks check. 

As a related note, further false positives were found on e.g. grafana project but these were within test data folders making them a bit trickier to isolate (i.e. not clear `.md` formats). 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
