### PR TITLE
docs: exclude shared rules from rule data

### DIFF
--- a/docs/_data/rules.js
+++ b/docs/_data/rules.js
@@ -47,7 +47,7 @@ async function fetchData(location) {
         // ex. looping through rules/ruby [lang, rails]
         subDirs.forEach(async (subDir) => {
           const subDirPath = path.join(dirPath, subDir);
-          if (isDirectory(subDirPath)) {
+          if (isDirectory(subDirPath) && subDir !== "shared") {
             const files = await readdir(subDirPath);
             const children = await fetchAllFiles(
               subDirPath,


### PR DESCRIPTION
## Description
Excludes shared rules from the the docs' rules datasource.

## Related
- close #1006 

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
