### PR TITLE
feat: add scope detection filter option

### DIFF
--- a/new/detector/composition/java/.snapshots/TestScope--scope.yml
+++ b/new/detector/composition/java/.snapshots/TestScope--scope.yml
@@ -1,0 +1,74 @@
+high:
+    - rule:
+        cwe_ids:
+            - "42"
+        id: scope_test
+        title: Test detection filter scopes
+        description: Test detection filter scopes
+        documentation_url: ""
+      line_number: 1
+      filename: scope.java
+      parent_line_number: 1
+      snippet: scopeCursor(request.getParameter("oops"))
+      fingerprint: bdbeee20feb34c6881d975716e2fe09f_0
+    - rule:
+        cwe_ids:
+            - "42"
+        id: scope_test
+        title: Test detection filter scopes
+        description: Test detection filter scopes
+        documentation_url: ""
+      line_number: 5
+      filename: scope.java
+      parent_line_number: 5
+      snippet: scopeNested(request.getParameter("oops"))
+      fingerprint: bdbeee20feb34c6881d975716e2fe09f_1
+    - rule:
+        cwe_ids:
+            - "42"
+        id: scope_test
+        title: Test detection filter scopes
+        description: Test detection filter scopes
+        documentation_url: ""
+      line_number: 6
+      filename: scope.java
+      parent_line_number: 6
+      snippet: 'scopeNested(x ? request.getParameter("oops") : y)'
+      fingerprint: bdbeee20feb34c6881d975716e2fe09f_2
+    - rule:
+        cwe_ids:
+            - "42"
+        id: scope_test
+        title: Test detection filter scopes
+        description: Test detection filter scopes
+        documentation_url: ""
+      line_number: 7
+      filename: scope.java
+      parent_line_number: 7
+      snippet: 'scopeNested(request.getParameter("oops") ? x : y)'
+      fingerprint: bdbeee20feb34c6881d975716e2fe09f_3
+    - rule:
+        cwe_ids:
+            - "42"
+        id: scope_test
+        title: Test detection filter scopes
+        description: Test detection filter scopes
+        documentation_url: ""
+      line_number: 9
+      filename: scope.java
+      parent_line_number: 9
+      snippet: scopeResult(request.getParameter("oops"))
+      fingerprint: bdbeee20feb34c6881d975716e2fe09f_4
+    - rule:
+        cwe_ids:
+            - "42"
+        id: scope_test
+        title: Test detection filter scopes
+        description: Test detection filter scopes
+        documentation_url: ""
+      line_number: 10
+      filename: scope.java
+      parent_line_number: 10
+      snippet: 'scopeResult(x ? request.getParameter("oops") : y)'
+      fingerprint: bdbeee20feb34c6881d975716e2fe09f_5
+

--- a/new/detector/composition/java/java.go
+++ b/new/detector/composition/java/java.go
@@ -197,7 +197,7 @@ func (composition *Composition) DetectFromFileWithTypes(file *file.FileInfo, det
 			tree.RootNode(),
 			detectorType,
 			rule.SanitizerRuleID,
-			settings.CONTAINS_SCOPE,
+			settings.NESTED_SCOPE,
 			false,
 		)
 		if err != nil {

--- a/new/detector/composition/java/java.go
+++ b/new/detector/composition/java/java.go
@@ -193,7 +193,13 @@ func (composition *Composition) DetectFromFileWithTypes(file *file.FileInfo, det
 	var result []*detectortypes.Detection
 	for _, detectorType := range detectorTypes {
 		rule := composition.rules[detectorType]
-		detections, err := evaluator.ForTree(tree.RootNode(), detectorType, rule.SanitizerRuleID, false)
+		detections, err := evaluator.Evaluate(
+			tree.RootNode(),
+			detectorType,
+			rule.SanitizerRuleID,
+			settings.CONTAINS_SCOPE,
+			false,
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/new/detector/composition/java/java_test.go
+++ b/new/detector/composition/java/java_test.go
@@ -10,7 +10,15 @@ import (
 //go:embed testdata/logger.yml
 var loggerRule []byte
 
+//go:embed testdata/scope_rule.yml
+var scopeRule []byte
+
 func TestFlow(t *testing.T) {
 	t.Parallel()
-	testhelper.GetRunner(t, loggerRule, "Javascript").RunTest(t, "./testdata/testcases/flow", ".snapshots/flow/")
+	testhelper.GetRunner(t, loggerRule, "Java").RunTest(t, "./testdata/testcases/flow", ".snapshots/flow/")
+}
+
+func TestScope(t *testing.T) {
+	t.Parallel()
+	testhelper.GetRunner(t, scopeRule, "Java").RunTest(t, "./testdata/scope", ".snapshots/")
 }

--- a/new/detector/composition/java/testdata/scope/scope.java
+++ b/new/detector/composition/java/testdata/scope/scope.java
@@ -1,0 +1,11 @@
+scopeCursor(request.getParameter("oops"))
+scopeCursor(x ? request.getParameter("ok") : y)
+scopeCursor(request.getParameter("ok") ? x : y)
+
+scopeNested(request.getParameter("oops"))
+scopeNested(x ? request.getParameter("oops") : y)
+scopeNested(request.getParameter("oops") ? x : y)
+
+scopeResult(request.getParameter("oops"))
+scopeResult(x ? request.getParameter("oops") : y)
+scopeResult(request.getParameter("ok") ? x : y)

--- a/new/detector/composition/java/testdata/scope_rule.yml
+++ b/new/detector/composition/java/testdata/scope_rule.yml
@@ -1,0 +1,29 @@
+languages:
+  - java
+patterns:
+  - pattern: scopeCursor($<USER_INPUT>)
+    filters:
+      - variable: USER_INPUT
+        detection: scope_test_user_input
+        scope: cursor
+  - pattern: scopeNested($<USER_INPUT>)
+    filters:
+      - variable: USER_INPUT
+        detection: scope_test_user_input
+        scope: nested
+  - pattern: scopeResult($<USER_INPUT>)
+    filters:
+      - variable: USER_INPUT
+        detection: scope_test_user_input
+        scope: result
+auxiliary:
+  - id: scope_test_user_input
+    patterns:
+      - request.getParameter()
+severity: high
+metadata:
+  description: Test detection filter scopes
+  remediation_message: Test detection filter scopes
+  cwe_id:
+    - 42
+  id: scope_test

--- a/new/detector/composition/javascript/.snapshots/TestScope--scope.yml
+++ b/new/detector/composition/javascript/.snapshots/TestScope--scope.yml
@@ -1,0 +1,74 @@
+high:
+    - rule:
+        cwe_ids:
+            - "42"
+        id: scope_test
+        title: Test detection filter scopes
+        description: Test detection filter scopes
+        documentation_url: ""
+      line_number: 1
+      filename: scope.js
+      parent_line_number: 1
+      snippet: scopeCursor(req.params.oops)
+      fingerprint: 408407aa362e0520faf6b66c3d59bb8c_0
+    - rule:
+        cwe_ids:
+            - "42"
+        id: scope_test
+        title: Test detection filter scopes
+        description: Test detection filter scopes
+        documentation_url: ""
+      line_number: 5
+      filename: scope.js
+      parent_line_number: 5
+      snippet: scopeNested(req.params.oops)
+      fingerprint: 408407aa362e0520faf6b66c3d59bb8c_1
+    - rule:
+        cwe_ids:
+            - "42"
+        id: scope_test
+        title: Test detection filter scopes
+        description: Test detection filter scopes
+        documentation_url: ""
+      line_number: 6
+      filename: scope.js
+      parent_line_number: 6
+      snippet: 'scopeNested(x ? req.params.oops : y)'
+      fingerprint: 408407aa362e0520faf6b66c3d59bb8c_2
+    - rule:
+        cwe_ids:
+            - "42"
+        id: scope_test
+        title: Test detection filter scopes
+        description: Test detection filter scopes
+        documentation_url: ""
+      line_number: 7
+      filename: scope.js
+      parent_line_number: 7
+      snippet: 'scopeNested(req.params.oops ? x : y)'
+      fingerprint: 408407aa362e0520faf6b66c3d59bb8c_3
+    - rule:
+        cwe_ids:
+            - "42"
+        id: scope_test
+        title: Test detection filter scopes
+        description: Test detection filter scopes
+        documentation_url: ""
+      line_number: 9
+      filename: scope.js
+      parent_line_number: 9
+      snippet: scopeResult(req.params.oops)
+      fingerprint: 408407aa362e0520faf6b66c3d59bb8c_4
+    - rule:
+        cwe_ids:
+            - "42"
+        id: scope_test
+        title: Test detection filter scopes
+        description: Test detection filter scopes
+        documentation_url: ""
+      line_number: 10
+      filename: scope.js
+      parent_line_number: 10
+      snippet: 'scopeResult(x ? req.params.oops : y)'
+      fingerprint: 408407aa362e0520faf6b66c3d59bb8c_5
+

--- a/new/detector/composition/javascript/javascript.go
+++ b/new/detector/composition/javascript/javascript.go
@@ -197,7 +197,7 @@ func (composition *Composition) DetectFromFileWithTypes(file *file.FileInfo, det
 			tree.RootNode(),
 			detectorType,
 			rule.SanitizerRuleID,
-			settings.CONTAINS_SCOPE,
+			settings.NESTED_SCOPE,
 			false,
 		)
 		if err != nil {

--- a/new/detector/composition/javascript/javascript.go
+++ b/new/detector/composition/javascript/javascript.go
@@ -193,7 +193,13 @@ func (composition *Composition) DetectFromFileWithTypes(file *file.FileInfo, det
 	var result []*detectortypes.Detection
 	for _, detectorType := range detectorTypes {
 		rule := composition.rules[detectorType]
-		detections, err := evaluator.ForTree(tree.RootNode(), detectorType, rule.SanitizerRuleID, false)
+		detections, err := evaluator.Evaluate(
+			tree.RootNode(),
+			detectorType,
+			rule.SanitizerRuleID,
+			settings.CONTAINS_SCOPE,
+			false,
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/new/detector/composition/javascript/javascript_test.go
+++ b/new/detector/composition/javascript/javascript_test.go
@@ -16,6 +16,9 @@ var datatypeRule []byte
 //go:embed testdata/deconstructing.yml
 var deconstructingRule []byte
 
+//go:embed testdata/scope_rule.yml
+var scopeRule []byte
+
 func TestFlow(t *testing.T) {
 	t.Parallel()
 	testhelper.GetRunner(t, datatypeRule, "Javascript").RunTest(t, "./testdata/testcases/flow", ".snapshots/flow/")
@@ -29,4 +32,9 @@ func TestObjectDeconstructing(t *testing.T) {
 func TestString(t *testing.T) {
 	t.Parallel()
 	testhelper.GetRunner(t, insecureURLRule, "Javascript").RunTest(t, "./testdata/testcases/string", ".snapshots/string/")
+}
+
+func TestScope(t *testing.T) {
+	t.Parallel()
+	testhelper.GetRunner(t, scopeRule, "Javascript").RunTest(t, "./testdata/scope", ".snapshots/")
 }

--- a/new/detector/composition/javascript/testdata/scope/scope.js
+++ b/new/detector/composition/javascript/testdata/scope/scope.js
@@ -1,0 +1,11 @@
+scopeCursor(req.params.oops)
+scopeCursor(x ? req.params.ok : y)
+scopeCursor(req.params.ok ? x : y)
+
+scopeNested(req.params.oops)
+scopeNested(x ? req.params.oops : y)
+scopeNested(req.params.oops ? x : y)
+
+scopeResult(req.params.oops)
+scopeResult(x ? req.params.oops : y)
+scopeResult(req.params.ok ? x : y)

--- a/new/detector/composition/javascript/testdata/scope_rule.yml
+++ b/new/detector/composition/javascript/testdata/scope_rule.yml
@@ -1,0 +1,29 @@
+languages:
+  - javascript
+patterns:
+  - pattern: scopeCursor($<USER_INPUT>)
+    filters:
+      - variable: USER_INPUT
+        detection: scope_test_user_input
+        scope: cursor
+  - pattern: scopeNested($<USER_INPUT>)
+    filters:
+      - variable: USER_INPUT
+        detection: scope_test_user_input
+        scope: nested
+  - pattern: scopeResult($<USER_INPUT>)
+    filters:
+      - variable: USER_INPUT
+        detection: scope_test_user_input
+        scope: result
+auxiliary:
+  - id: scope_test_user_input
+    patterns:
+      - req.params.$<_>
+severity: high
+metadata:
+  description: Test detection filter scopes
+  remediation_message: Test detection filter scopes
+  cwe_id:
+    - 42
+  id: scope_test

--- a/new/detector/composition/ruby/.snapshots/TestScope--scope.yml
+++ b/new/detector/composition/ruby/.snapshots/TestScope--scope.yml
@@ -1,0 +1,74 @@
+high:
+    - rule:
+        cwe_ids:
+            - "42"
+        id: scope_test
+        title: Test detection filter scopes
+        description: Test detection filter scopes
+        documentation_url: ""
+      line_number: 1
+      filename: scope.rb
+      parent_line_number: 1
+      snippet: scope_cursor(params[:oops])
+      fingerprint: 23e17866f80f43957a84e824da9ce255_0
+    - rule:
+        cwe_ids:
+            - "42"
+        id: scope_test
+        title: Test detection filter scopes
+        description: Test detection filter scopes
+        documentation_url: ""
+      line_number: 5
+      filename: scope.rb
+      parent_line_number: 5
+      snippet: scope_nested(params[:oops])
+      fingerprint: 23e17866f80f43957a84e824da9ce255_1
+    - rule:
+        cwe_ids:
+            - "42"
+        id: scope_test
+        title: Test detection filter scopes
+        description: Test detection filter scopes
+        documentation_url: ""
+      line_number: 6
+      filename: scope.rb
+      parent_line_number: 6
+      snippet: 'scope_nested(x ? params[:oops] : y)'
+      fingerprint: 23e17866f80f43957a84e824da9ce255_2
+    - rule:
+        cwe_ids:
+            - "42"
+        id: scope_test
+        title: Test detection filter scopes
+        description: Test detection filter scopes
+        documentation_url: ""
+      line_number: 7
+      filename: scope.rb
+      parent_line_number: 7
+      snippet: 'scope_nested(params[:oops] ? x : y)'
+      fingerprint: 23e17866f80f43957a84e824da9ce255_3
+    - rule:
+        cwe_ids:
+            - "42"
+        id: scope_test
+        title: Test detection filter scopes
+        description: Test detection filter scopes
+        documentation_url: ""
+      line_number: 9
+      filename: scope.rb
+      parent_line_number: 9
+      snippet: scope_result(params[:oops])
+      fingerprint: 23e17866f80f43957a84e824da9ce255_4
+    - rule:
+        cwe_ids:
+            - "42"
+        id: scope_test
+        title: Test detection filter scopes
+        description: Test detection filter scopes
+        documentation_url: ""
+      line_number: 10
+      filename: scope.rb
+      parent_line_number: 10
+      snippet: 'scope_result(x ? params[:oops] : y)'
+      fingerprint: 23e17866f80f43957a84e824da9ce255_5
+

--- a/new/detector/composition/ruby/ruby.go
+++ b/new/detector/composition/ruby/ruby.go
@@ -196,7 +196,7 @@ func (composition *Composition) DetectFromFileWithTypes(file *file.FileInfo, det
 			tree.RootNode(),
 			detectorType,
 			rule.SanitizerRuleID,
-			settings.CONTAINS_SCOPE,
+			settings.NESTED_SCOPE,
 			false,
 		)
 		if err != nil {

--- a/new/detector/composition/ruby/ruby.go
+++ b/new/detector/composition/ruby/ruby.go
@@ -192,7 +192,13 @@ func (composition *Composition) DetectFromFileWithTypes(file *file.FileInfo, det
 	var result []*detectortypes.Detection
 	for _, detectorType := range detectorTypes {
 		rule := composition.rules[detectorType]
-		detections, err := evaluator.ForTree(tree.RootNode(), detectorType, rule.SanitizerRuleID, false)
+		detections, err := evaluator.Evaluate(
+			tree.RootNode(),
+			detectorType,
+			rule.SanitizerRuleID,
+			settings.CONTAINS_SCOPE,
+			false,
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/new/detector/composition/ruby/ruby_test.go
+++ b/new/detector/composition/ruby/ruby_test.go
@@ -10,7 +10,15 @@ import (
 //go:embed testdata/rule.yml
 var loggerRule []byte
 
+//go:embed testdata/scope_rule.yml
+var scopeRule []byte
+
 func TestRuby(t *testing.T) {
 	t.Parallel()
 	testhelper.GetRunner(t, loggerRule, "Ruby").RunTest(t, "./testdata/testcases", ".snapshots/")
+}
+
+func TestScope(t *testing.T) {
+	t.Parallel()
+	testhelper.GetRunner(t, scopeRule, "Ruby").RunTest(t, "./testdata/scope", ".snapshots/")
 }

--- a/new/detector/composition/ruby/testdata/scope/scope.rb
+++ b/new/detector/composition/ruby/testdata/scope/scope.rb
@@ -1,0 +1,11 @@
+scope_cursor(params[:oops])
+scope_cursor(x ? params[:ok] : y)
+scope_cursor(params[:ok] ? x : y)
+
+scope_nested(params[:oops])
+scope_nested(x ? params[:oops] : y)
+scope_nested(params[:oops] ? x : y)
+
+scope_result(params[:oops])
+scope_result(x ? params[:oops] : y)
+scope_result(params[:ok] ? x : y)

--- a/new/detector/composition/ruby/testdata/scope_rule.yml
+++ b/new/detector/composition/ruby/testdata/scope_rule.yml
@@ -1,0 +1,29 @@
+languages:
+  - ruby
+patterns:
+  - pattern: scope_cursor($<USER_INPUT>)
+    filters:
+      - variable: USER_INPUT
+        detection: scope_test_user_input
+        scope: cursor
+  - pattern: scope_nested($<USER_INPUT>)
+    filters:
+      - variable: USER_INPUT
+        detection: scope_test_user_input
+        scope: nested
+  - pattern: scope_result($<USER_INPUT>)
+    filters:
+      - variable: USER_INPUT
+        detection: scope_test_user_input
+        scope: result
+auxiliary:
+  - id: scope_test_user_input
+    patterns:
+      - params[$<_>]
+severity: high
+metadata:
+  description: Test detection filter scopes
+  remediation_message: Test detection filter scopes
+  cwe_id:
+    - 42
+  id: scope_test

--- a/new/detector/implementation/custom/custom.go
+++ b/new/detector/implementation/custom/custom.go
@@ -62,6 +62,7 @@ func (detector *customDetector) Name() string {
 
 func (detector *customDetector) DetectAt(
 	node *tree.Node,
+	ruleReferenceType settings.RuleReferenceType,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
 	var detectionsData []interface{}
@@ -74,6 +75,7 @@ func (detector *customDetector) DetectAt(
 
 		for _, result := range results {
 			filtersMatch, datatypeDetections, variableNodes, err := matchAllFilters(
+				ruleReferenceType,
 				result,
 				evaluator,
 				pattern.Filters,

--- a/new/detector/implementation/custom/custom.go
+++ b/new/detector/implementation/custom/custom.go
@@ -62,7 +62,7 @@ func (detector *customDetector) Name() string {
 
 func (detector *customDetector) DetectAt(
 	node *tree.Node,
-	ruleReferenceType settings.RuleReferenceType,
+	ruleReferenceType settings.RuleReferenceScope,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
 	var detectionsData []interface{}

--- a/new/detector/implementation/custom/filter.go
+++ b/new/detector/implementation/custom/filter.go
@@ -14,6 +14,7 @@ import (
 )
 
 func matchFilter(
+	ruleReferenceType settings.RuleReferenceType,
 	result *languagetypes.PatternQueryResult,
 	evaluator types.Evaluator,
 	variableNodes map[string]*tree.Node,
@@ -21,7 +22,7 @@ func matchFilter(
 	rules map[string]*settings.Rule,
 ) (*bool, []*types.Detection, error) {
 	if filter.Not != nil {
-		match, _, err := matchFilter(result, evaluator, variableNodes, *filter.Not, rules)
+		match, _, err := matchFilter(ruleReferenceType, result, evaluator, variableNodes, *filter.Not, rules)
 		if match == nil {
 			return nil, nil, err
 		}
@@ -29,7 +30,7 @@ func matchFilter(
 	}
 
 	if len(filter.Either) != 0 {
-		return matchEitherFilters(result, evaluator, variableNodes, filter.Either, rules)
+		return matchEitherFilters(ruleReferenceType, result, evaluator, variableNodes, filter.Either, rules)
 	}
 
 	if filter.FilenameRegex != nil {
@@ -43,12 +44,18 @@ func matchFilter(
 	}
 
 	if filter.Detection != "" {
+		effectiveRuleReferenceType := filter.RuleType
+		if ruleReferenceType == settings.SOURCE_RULE_REFERENCE {
+			effectiveRuleReferenceType = ruleReferenceType
+		}
+
 		return matchDetectionFilter(
 			result,
 			evaluator,
 			variableNodes,
 			node,
 			filter.Detection,
+			effectiveRuleReferenceType,
 			filter.Contains == nil || *filter.Contains,
 			rules,
 		)
@@ -59,6 +66,7 @@ func matchFilter(
 }
 
 func matchAllFilters(
+	ruleReferenceType settings.RuleReferenceType,
 	result *languagetypes.PatternQueryResult,
 	evaluator types.Evaluator,
 	filters []settings.PatternFilter,
@@ -72,7 +80,7 @@ func matchAllFilters(
 	}
 
 	for _, filter := range filters {
-		matched, subDataTypeDetections, err := matchFilter(result, evaluator, variableNodes, filter, rules)
+		matched, subDataTypeDetections, err := matchFilter(ruleReferenceType, result, evaluator, variableNodes, filter, rules)
 		if matched == nil || !*matched || err != nil {
 			return false, nil, nil, err
 		}
@@ -84,6 +92,7 @@ func matchAllFilters(
 }
 
 func matchEitherFilters(
+	ruleReferenceType settings.RuleReferenceType,
 	result *languagetypes.PatternQueryResult,
 	evaluator types.Evaluator,
 	variableNodes map[string]*tree.Node,
@@ -95,7 +104,7 @@ func matchEitherFilters(
 	oneNotMatched := false
 
 	for _, subFilter := range filters {
-		subMatch, subDatatypeDetections, err := matchFilter(result, evaluator, variableNodes, subFilter, rules)
+		subMatch, subDatatypeDetections, err := matchFilter(ruleReferenceType, result, evaluator, variableNodes, subFilter, rules)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -122,14 +131,21 @@ func matchDetectionFilter(
 	variableNodes map[string]*tree.Node,
 	node *tree.Node,
 	detectorType string,
+	ruleReferenceType settings.RuleReferenceType,
 	contains bool,
 	rules map[string]*settings.Rule,
 ) (*bool, []*types.Detection, error) {
-	var evaluateDetections func(*tree.Node, string, string, bool) ([]*types.Detection, error)
-	if contains {
-		evaluateDetections = evaluator.ForTree
+	var evaluateDetections func(*tree.Node, string, string) ([]*types.Detection, error)
+	if ruleReferenceType == settings.SOURCE_RULE_REFERENCE {
+		evaluateDetections = evaluator.ForSource
+	} else if contains {
+		evaluateDetections = func(node *tree.Node, detectorType, sanitizerDetectorType string) ([]*types.Detection, error) {
+			return evaluator.ForTree(node, detectorType, sanitizerDetectorType, true)
+		}
 	} else {
-		evaluateDetections = evaluator.ForNode
+		evaluateDetections = func(node *tree.Node, detectorType, sanitizerDetectorType string) ([]*types.Detection, error) {
+			return evaluator.ForNode(node, detectorType, sanitizerDetectorType, true)
+		}
 	}
 
 	sanitizerRuleID := ""
@@ -138,12 +154,12 @@ func matchDetectionFilter(
 	}
 
 	if detectorType == "datatype" {
-		detections, err := evaluateDetections(node, "datatype", sanitizerRuleID, true)
+		detections, err := evaluateDetections(node, "datatype", sanitizerRuleID)
 
 		return boolPointer(len(detections) != 0), detections, err
 	}
 
-	detections, err := evaluateDetections(node, detectorType, sanitizerRuleID, true)
+	detections, err := evaluateDetections(node, detectorType, sanitizerRuleID)
 
 	var datatypeDetections []*types.Detection
 	ignoredVariables := getIgnoredVariables(detections)

--- a/new/detector/implementation/custom/filter.go
+++ b/new/detector/implementation/custom/filter.go
@@ -45,8 +45,8 @@ func matchFilter(
 
 	if filter.Detection != "" {
 		effectiveScope := filter.Scope
-		if scope == settings.VALUE_SCOPE {
-			effectiveScope = settings.VALUE_SCOPE
+		if scope == settings.RESULT_SCOPE {
+			effectiveScope = settings.RESULT_SCOPE
 		}
 
 		return matchDetectionFilter(

--- a/new/detector/implementation/generic/datatype/datatype.go
+++ b/new/detector/implementation/generic/datatype/datatype.go
@@ -6,6 +6,7 @@ import (
 	"github.com/bearer/bearer/new/language/tree"
 	languagetypes "github.com/bearer/bearer/new/language/types"
 	classificationschema "github.com/bearer/bearer/pkg/classification/schema"
+	"github.com/bearer/bearer/pkg/commands/process/settings"
 	"github.com/bearer/bearer/pkg/report/detectors"
 	"github.com/bearer/bearer/pkg/report/schema"
 	"github.com/bearer/bearer/pkg/util/classify"
@@ -43,6 +44,7 @@ func (detector *datatypeDetector) NestedDetections() bool {
 
 func (detector *datatypeDetector) DetectAt(
 	node *tree.Node,
+	ruleReferenceType settings.RuleReferenceType,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
 	objectDetections, err := evaluator.ForNode(node, "object", "", false)

--- a/new/detector/implementation/generic/datatype/datatype.go
+++ b/new/detector/implementation/generic/datatype/datatype.go
@@ -44,10 +44,10 @@ func (detector *datatypeDetector) NestedDetections() bool {
 
 func (detector *datatypeDetector) DetectAt(
 	node *tree.Node,
-	ruleReferenceType settings.RuleReferenceType,
+	_ settings.RuleReferenceScope,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
-	objectDetections, err := evaluator.ForNode(node, "object", "", false)
+	objectDetections, err := evaluator.Evaluate(node, "object", "", settings.CURSOR_SCOPE, false)
 	if err != nil {
 		return nil, err
 	}

--- a/new/detector/implementation/generic/generic.go
+++ b/new/detector/implementation/generic/generic.go
@@ -8,7 +8,10 @@ import (
 	"github.com/bearer/bearer/new/language/tree"
 )
 
-func GetNonVirtualObjects(evaluator types.Evaluator, node *tree.Node) ([]*types.Detection, error) {
+func GetNonVirtualObjects(
+	evaluator types.Evaluator,
+	node *tree.Node,
+) ([]*types.Detection, error) {
 	detections, err := evaluator.ForNode(node, "object", "", true)
 	if err != nil {
 		return nil, err

--- a/new/detector/implementation/generic/generic.go
+++ b/new/detector/implementation/generic/generic.go
@@ -6,13 +6,14 @@ import (
 	generictypes "github.com/bearer/bearer/new/detector/implementation/generic/types"
 	"github.com/bearer/bearer/new/detector/types"
 	"github.com/bearer/bearer/new/language/tree"
+	"github.com/bearer/bearer/pkg/commands/process/settings"
 )
 
 func GetNonVirtualObjects(
 	evaluator types.Evaluator,
 	node *tree.Node,
 ) ([]*types.Detection, error) {
-	detections, err := evaluator.ForNode(node, "object", "", true)
+	detections, err := evaluator.Evaluate(node, "object", "", settings.CURSOR_SCOPE, true)
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +88,7 @@ func ProjectObject(
 }
 
 func GetStringValue(node *tree.Node, evaluator types.Evaluator) (string, bool, error) {
-	detections, err := evaluator.ForNode(node, "string", "", true)
+	detections, err := evaluator.Evaluate(node, "string", "", settings.CURSOR_SCOPE, true)
 	if err != nil {
 		return "", false, err
 	}

--- a/new/detector/implementation/generic/insecureurl/insecureurl.go
+++ b/new/detector/implementation/generic/insecureurl/insecureurl.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/bearer/bearer/new/detector/types"
 	"github.com/bearer/bearer/new/language/tree"
+	"github.com/bearer/bearer/pkg/commands/process/settings"
 
 	generictypes "github.com/bearer/bearer/new/detector/implementation/generic/types"
 	languagetypes "github.com/bearer/bearer/new/language/types"
@@ -27,6 +28,7 @@ func (detector *insecureURLDetector) Name() string {
 
 func (detector *insecureURLDetector) DetectAt(
 	node *tree.Node,
+	ruleReferenceType settings.RuleReferenceType,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
 	detections, err := evaluator.ForNode(node, "string", "", false)

--- a/new/detector/implementation/generic/insecureurl/insecureurl.go
+++ b/new/detector/implementation/generic/insecureurl/insecureurl.go
@@ -28,10 +28,10 @@ func (detector *insecureURLDetector) Name() string {
 
 func (detector *insecureURLDetector) DetectAt(
 	node *tree.Node,
-	ruleReferenceType settings.RuleReferenceType,
+	_ settings.RuleReferenceScope,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
-	detections, err := evaluator.ForNode(node, "string", "", false)
+	detections, err := evaluator.Evaluate(node, "string", "", settings.CURSOR_SCOPE, false)
 	if err != nil {
 		return nil, err
 	}

--- a/new/detector/implementation/generic/stringliteral/stringliteral.go
+++ b/new/detector/implementation/generic/stringliteral/stringliteral.go
@@ -3,6 +3,7 @@ package stringliteral
 import (
 	"github.com/bearer/bearer/new/detector/types"
 	"github.com/bearer/bearer/new/language/tree"
+	"github.com/bearer/bearer/pkg/commands/process/settings"
 
 	generictypes "github.com/bearer/bearer/new/detector/implementation/generic/types"
 	languagetypes "github.com/bearer/bearer/new/language/types"
@@ -22,6 +23,7 @@ func (detector *stringLiteralDetector) Name() string {
 
 func (detector *stringLiteralDetector) DetectAt(
 	node *tree.Node,
+	ruleReferenceType settings.RuleReferenceType,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
 	detections, err := evaluator.ForNode(node, "string", "", false)

--- a/new/detector/implementation/generic/stringliteral/stringliteral.go
+++ b/new/detector/implementation/generic/stringliteral/stringliteral.go
@@ -23,10 +23,10 @@ func (detector *stringLiteralDetector) Name() string {
 
 func (detector *stringLiteralDetector) DetectAt(
 	node *tree.Node,
-	ruleReferenceType settings.RuleReferenceType,
+	_ settings.RuleReferenceScope,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
-	detections, err := evaluator.ForNode(node, "string", "", false)
+	detections, err := evaluator.Evaluate(node, "string", "", settings.CURSOR_SCOPE, false)
 	if err != nil {
 		return nil, err
 	}

--- a/new/detector/implementation/java/object/object.go
+++ b/new/detector/implementation/java/object/object.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/bearer/bearer/new/detector/types"
 	"github.com/bearer/bearer/new/language/tree"
+	"github.com/bearer/bearer/pkg/commands/process/settings"
 	"github.com/rs/zerolog/log"
 
 	"github.com/bearer/bearer/new/detector/implementation/generic"
@@ -69,6 +70,7 @@ func (detector *objectDetector) NestedDetections() bool {
 
 func (detector *objectDetector) DetectAt(
 	node *tree.Node,
+	ruleReferenceType settings.RuleReferenceType,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
 	log.Debug().Msgf("node is %s", node.Debug())

--- a/new/detector/implementation/java/object/object.go
+++ b/new/detector/implementation/java/object/object.go
@@ -70,7 +70,7 @@ func (detector *objectDetector) NestedDetections() bool {
 
 func (detector *objectDetector) DetectAt(
 	node *tree.Node,
-	ruleReferenceType settings.RuleReferenceType,
+	ruleReferenceType settings.RuleReferenceScope,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
 	log.Debug().Msgf("node is %s", node.Debug())

--- a/new/detector/implementation/java/string/string.go
+++ b/new/detector/implementation/java/string/string.go
@@ -3,6 +3,7 @@ package string
 import (
 	"github.com/bearer/bearer/new/detector/types"
 	"github.com/bearer/bearer/new/language/tree"
+	"github.com/bearer/bearer/pkg/commands/process/settings"
 
 	generictypes "github.com/bearer/bearer/new/detector/implementation/generic/types"
 	languagetypes "github.com/bearer/bearer/new/language/types"
@@ -22,6 +23,7 @@ func (detector *stringDetector) Name() string {
 
 func (detector *stringDetector) DetectAt(
 	node *tree.Node,
+	ruleReferenceType settings.RuleReferenceType,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
 	if node.Type() == "string_literal" {

--- a/new/detector/implementation/java/string/string.go
+++ b/new/detector/implementation/java/string/string.go
@@ -23,7 +23,7 @@ func (detector *stringDetector) Name() string {
 
 func (detector *stringDetector) DetectAt(
 	node *tree.Node,
-	ruleReferenceType settings.RuleReferenceType,
+	ruleReferenceType settings.RuleReferenceScope,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
 	if node.Type() == "string_literal" {

--- a/new/detector/implementation/javascript/object/object.go
+++ b/new/detector/implementation/javascript/object/object.go
@@ -177,7 +177,7 @@ func (detector *objectDetector) getObject(
 			continue
 		}
 
-		propertyObjects, err := evaluator.Evaluate(result["value"], "object", "", settings.CONTAINS_SCOPE, true)
+		propertyObjects, err := evaluator.Evaluate(result["value"], "object", "", settings.NESTED_SCOPE, true)
 		if err != nil {
 			return nil, err
 		}

--- a/new/detector/implementation/javascript/object/object.go
+++ b/new/detector/implementation/javascript/object/object.go
@@ -115,7 +115,7 @@ func (detector *objectDetector) NestedDetections() bool {
 
 func (detector *objectDetector) DetectAt(
 	node *tree.Node,
-	ruleReferenceType settings.RuleReferenceType,
+	_ settings.RuleReferenceScope,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
 	detections, err := detector.getObject(node, evaluator)
@@ -147,7 +147,7 @@ func (detector *objectDetector) getObject(
 	}
 
 	for _, spreadResult := range spreadResults {
-		detections, err := evaluator.ForNode(spreadResult["identifier"], "object", "", true)
+		detections, err := evaluator.Evaluate(spreadResult["identifier"], "object", "", settings.CURSOR_SCOPE, true)
 
 		if err != nil {
 			return nil, err
@@ -177,7 +177,7 @@ func (detector *objectDetector) getObject(
 			continue
 		}
 
-		propertyObjects, err := evaluator.ForTree(result["value"], "object", "", true)
+		propertyObjects, err := evaluator.Evaluate(result["value"], "object", "", settings.CONTAINS_SCOPE, true)
 		if err != nil {
 			return nil, err
 		}

--- a/new/detector/implementation/javascript/object/object.go
+++ b/new/detector/implementation/javascript/object/object.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/bearer/bearer/new/detector/types"
 	"github.com/bearer/bearer/new/language/tree"
+	"github.com/bearer/bearer/pkg/commands/process/settings"
 	"github.com/bearer/bearer/pkg/util/stringutil"
 
 	"github.com/bearer/bearer/new/detector/implementation/generic"
@@ -114,6 +115,7 @@ func (detector *objectDetector) NestedDetections() bool {
 
 func (detector *objectDetector) DetectAt(
 	node *tree.Node,
+	ruleReferenceType settings.RuleReferenceType,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
 	detections, err := detector.getObject(node, evaluator)

--- a/new/detector/implementation/javascript/object/projection.go
+++ b/new/detector/implementation/javascript/object/projection.go
@@ -5,6 +5,7 @@ import (
 	generictypes "github.com/bearer/bearer/new/detector/implementation/generic/types"
 	"github.com/bearer/bearer/new/detector/types"
 	"github.com/bearer/bearer/new/language/tree"
+	"github.com/bearer/bearer/pkg/commands/process/settings"
 	"github.com/bearer/bearer/pkg/util/stringutil"
 )
 
@@ -97,7 +98,7 @@ func (detector *objectDetector) getCallProjections(
 
 	var properties []generictypes.Property
 
-	functionDetections, err := evaluator.ForTree(result["function"], "object", "", true)
+	functionDetections, err := evaluator.Evaluate(result["function"], "object", "", settings.CONTAINS_SCOPE, true)
 	if len(functionDetections) == 0 || err != nil {
 		return nil, err
 	}

--- a/new/detector/implementation/javascript/object/projection.go
+++ b/new/detector/implementation/javascript/object/projection.go
@@ -98,7 +98,7 @@ func (detector *objectDetector) getCallProjections(
 
 	var properties []generictypes.Property
 
-	functionDetections, err := evaluator.Evaluate(result["function"], "object", "", settings.CONTAINS_SCOPE, true)
+	functionDetections, err := evaluator.Evaluate(result["function"], "object", "", settings.NESTED_SCOPE, true)
 	if len(functionDetections) == 0 || err != nil {
 		return nil, err
 	}

--- a/new/detector/implementation/javascript/string/string.go
+++ b/new/detector/implementation/javascript/string/string.go
@@ -3,6 +3,7 @@ package string
 import (
 	"github.com/bearer/bearer/new/detector/types"
 	"github.com/bearer/bearer/new/language/tree"
+	"github.com/bearer/bearer/pkg/commands/process/settings"
 	"github.com/bearer/bearer/pkg/util/stringutil"
 
 	"github.com/bearer/bearer/new/detector/implementation/generic"
@@ -24,6 +25,7 @@ func (detector *stringDetector) Name() string {
 
 func (detector *stringDetector) DetectAt(
 	node *tree.Node,
+	ruleReferenceType settings.RuleReferenceType,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
 	switch node.Type() {

--- a/new/detector/implementation/javascript/string/string.go
+++ b/new/detector/implementation/javascript/string/string.go
@@ -25,7 +25,7 @@ func (detector *stringDetector) Name() string {
 
 func (detector *stringDetector) DetectAt(
 	node *tree.Node,
-	ruleReferenceType settings.RuleReferenceType,
+	ruleReferenceType settings.RuleReferenceScope,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
 	switch node.Type() {

--- a/new/detector/implementation/ruby/object/object.go
+++ b/new/detector/implementation/ruby/object/object.go
@@ -138,7 +138,7 @@ func (detector *objectDetector) getHash(
 			continue
 		}
 
-		propertyObjects, err := evaluator.Evaluate(result["value"], "object", "", settings.CONTAINS_SCOPE, true)
+		propertyObjects, err := evaluator.Evaluate(result["value"], "object", "", settings.NESTED_SCOPE, true)
 		if err != nil {
 			return nil, err
 		}
@@ -178,7 +178,7 @@ func (detector *objectDetector) getKeywordArgument(
 		return nil, nil
 	}
 
-	propertyObjects, err := evaluator.Evaluate(result["value"], "object", "", settings.CONTAINS_SCOPE, true)
+	propertyObjects, err := evaluator.Evaluate(result["value"], "object", "", settings.NESTED_SCOPE, true)
 	if err != nil {
 		return nil, err
 	}

--- a/new/detector/implementation/ruby/object/object.go
+++ b/new/detector/implementation/ruby/object/object.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/bearer/bearer/new/detector/types"
 	"github.com/bearer/bearer/new/language/tree"
+	"github.com/bearer/bearer/pkg/commands/process/settings"
 
 	"github.com/bearer/bearer/new/detector/implementation/generic"
 	generictypes "github.com/bearer/bearer/new/detector/implementation/generic/types"
@@ -93,6 +94,7 @@ func (detector *objectDetector) NestedDetections() bool {
 
 func (detector *objectDetector) DetectAt(
 	node *tree.Node,
+	ruleReferenceType settings.RuleReferenceType,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
 	detections, err := detector.getHash(node, evaluator)

--- a/new/detector/implementation/ruby/object/object.go
+++ b/new/detector/implementation/ruby/object/object.go
@@ -94,7 +94,7 @@ func (detector *objectDetector) NestedDetections() bool {
 
 func (detector *objectDetector) DetectAt(
 	node *tree.Node,
-	ruleReferenceType settings.RuleReferenceType,
+	_ settings.RuleReferenceScope,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
 	detections, err := detector.getHash(node, evaluator)
@@ -138,7 +138,7 @@ func (detector *objectDetector) getHash(
 			continue
 		}
 
-		propertyObjects, err := evaluator.ForTree(result["value"], "object", "", true)
+		propertyObjects, err := evaluator.Evaluate(result["value"], "object", "", settings.CONTAINS_SCOPE, true)
 		if err != nil {
 			return nil, err
 		}
@@ -178,7 +178,7 @@ func (detector *objectDetector) getKeywordArgument(
 		return nil, nil
 	}
 
-	propertyObjects, err := evaluator.ForTree(result["value"], "object", "", true)
+	propertyObjects, err := evaluator.Evaluate(result["value"], "object", "", settings.CONTAINS_SCOPE, true)
 	if err != nil {
 		return nil, err
 	}

--- a/new/detector/implementation/ruby/string/string.go
+++ b/new/detector/implementation/ruby/string/string.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/bearer/bearer/new/detector/types"
 	"github.com/bearer/bearer/new/language/tree"
+	"github.com/bearer/bearer/pkg/commands/process/settings"
 
 	generictypes "github.com/bearer/bearer/new/detector/implementation/generic/types"
 	languagetypes "github.com/bearer/bearer/new/language/types"
@@ -24,6 +25,7 @@ func (detector *stringDetector) Name() string {
 
 func (detector *stringDetector) DetectAt(
 	node *tree.Node,
+	ruleReferenceType settings.RuleReferenceType,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
 	switch node.Type() {

--- a/new/detector/implementation/ruby/string/string.go
+++ b/new/detector/implementation/ruby/string/string.go
@@ -25,7 +25,7 @@ func (detector *stringDetector) Name() string {
 
 func (detector *stringDetector) DetectAt(
 	node *tree.Node,
-	ruleReferenceType settings.RuleReferenceType,
+	_ settings.RuleReferenceScope,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
 	switch node.Type() {
@@ -55,7 +55,7 @@ func concatenateChildren(node *tree.Node, evaluator types.Evaluator) ([]interfac
 			continue
 		}
 
-		detections, err := evaluator.ForNode(child, "string", "", true)
+		detections, err := evaluator.Evaluate(child, "string", "", settings.CURSOR_SCOPE, true)
 		if err != nil {
 			return nil, err
 		}

--- a/new/detector/set/set.go
+++ b/new/detector/set/set.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/bearer/bearer/new/detector/types"
 	"github.com/bearer/bearer/new/language/tree"
+	"github.com/bearer/bearer/pkg/commands/process/settings"
 )
 
 type set struct {
@@ -41,6 +42,7 @@ func (set *set) NestedDetections(detectorType string) (bool, error) {
 func (set *set) DetectAt(
 	node *tree.Node,
 	detectorType string,
+	ruleReferenceType settings.RuleReferenceType,
 	evaluator types.Evaluator,
 ) ([]*types.Detection, error) {
 	detector, err := set.lookupDetector(detectorType)
@@ -48,7 +50,7 @@ func (set *set) DetectAt(
 		return nil, err
 	}
 
-	detectionsData, err := detector.DetectAt(node, evaluator)
+	detectionsData, err := detector.DetectAt(node, ruleReferenceType, evaluator)
 	if err != nil {
 		return nil, err
 	}

--- a/new/detector/set/set.go
+++ b/new/detector/set/set.go
@@ -42,7 +42,7 @@ func (set *set) NestedDetections(detectorType string) (bool, error) {
 func (set *set) DetectAt(
 	node *tree.Node,
 	detectorType string,
-	ruleReferenceType settings.RuleReferenceType,
+	ruleReferenceType settings.RuleReferenceScope,
 	evaluator types.Evaluator,
 ) ([]*types.Detection, error) {
 	detector, err := set.lookupDetector(detectorType)

--- a/new/detector/types/types.go
+++ b/new/detector/types/types.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"github.com/bearer/bearer/new/language/tree"
+	"github.com/bearer/bearer/pkg/commands/process/settings"
 	"github.com/bearer/bearer/pkg/util/file"
 )
 
@@ -13,6 +14,7 @@ type Detection struct {
 
 type Evaluator interface {
 	ForTree(rootNode *tree.Node, detectorType, sanitizerDetectorType string, followFlow bool) ([]*Detection, error)
+	ForSource(rootNode *tree.Node, detectorType, sanitizerDetectorType string) ([]*Detection, error)
 	ForNode(node *tree.Node, detectorType, sanitizerDetectorType string, followFlow bool) ([]*Detection, error)
 	TreeHas(rootNode *tree.Node, detectorType, sanitizerDetectorType string) (bool, error)
 	NodeHas(node *tree.Node, detectorType, sanitizerDetectorType string) (bool, error)
@@ -24,13 +26,18 @@ type DetectorSet interface {
 	DetectAt(
 		node *tree.Node,
 		detectorType string,
+		ruleReferenceType settings.RuleReferenceType,
 		evaluator Evaluator,
 	) ([]*Detection, error)
 }
 
 type Detector interface {
 	Name() string
-	DetectAt(node *tree.Node, evaluator Evaluator) ([]interface{}, error)
+	DetectAt(
+		node *tree.Node,
+		ruleReferenceType settings.RuleReferenceType,
+		evaluator Evaluator,
+	) ([]interface{}, error)
 	NestedDetections() bool
 	Close()
 }

--- a/new/detector/types/types.go
+++ b/new/detector/types/types.go
@@ -13,11 +13,13 @@ type Detection struct {
 }
 
 type Evaluator interface {
-	ForTree(rootNode *tree.Node, detectorType, sanitizerDetectorType string, followFlow bool) ([]*Detection, error)
-	ForSource(rootNode *tree.Node, detectorType, sanitizerDetectorType string) ([]*Detection, error)
-	ForNode(node *tree.Node, detectorType, sanitizerDetectorType string, followFlow bool) ([]*Detection, error)
-	TreeHas(rootNode *tree.Node, detectorType, sanitizerDetectorType string) (bool, error)
-	NodeHas(node *tree.Node, detectorType, sanitizerDetectorType string) (bool, error)
+	Evaluate(
+		rootNode *tree.Node,
+		detectorType,
+		sanitizerDetectorType string,
+		scope settings.RuleReferenceScope,
+		followFlow bool,
+	) ([]*Detection, error)
 	FileName() string
 }
 
@@ -26,7 +28,7 @@ type DetectorSet interface {
 	DetectAt(
 		node *tree.Node,
 		detectorType string,
-		ruleReferenceType settings.RuleReferenceType,
+		ruleReferenceType settings.RuleReferenceScope,
 		evaluator Evaluator,
 	) ([]*Detection, error)
 }
@@ -35,7 +37,7 @@ type Detector interface {
 	Name() string
 	DetectAt(
 		node *tree.Node,
-		ruleReferenceType settings.RuleReferenceType,
+		ruleReferenceType settings.RuleReferenceScope,
 		evaluator Evaluator,
 	) ([]interface{}, error)
 	NestedDetections() bool

--- a/new/language/implementation/implementation.go
+++ b/new/language/implementation/implementation.go
@@ -121,6 +121,8 @@ type Implementation interface {
 	ShouldSkipNode(node *tree.Node) bool
 
 	PassthroughNested(node *tree.Node) bool
+
+	IsDataFor(rootNode, node *tree.Node) bool
 }
 
 type Scope struct {

--- a/new/language/implementation/implementation.go
+++ b/new/language/implementation/implementation.go
@@ -122,7 +122,7 @@ type Implementation interface {
 
 	PassthroughNested(node *tree.Node) bool
 
-	IsDataFor(rootNode, node *tree.Node) bool
+	ContributesToValue(node *tree.Node) bool
 }
 
 type Scope struct {

--- a/new/language/implementation/implementation.go
+++ b/new/language/implementation/implementation.go
@@ -122,7 +122,7 @@ type Implementation interface {
 
 	PassthroughNested(node *tree.Node) bool
 
-	ContributesToValue(node *tree.Node) bool
+	ContributesToResult(node *tree.Node) bool
 }
 
 type Scope struct {

--- a/new/language/implementation/java/java.go
+++ b/new/language/implementation/java/java.go
@@ -306,6 +306,6 @@ func (*javaImplementation) PassthroughNested(node *tree.Node) bool {
 	return slices.Contains(passthroughMethods, method) || slices.Contains(passthroughMethods, wildcardMethod)
 }
 
-func (*javaImplementation) IsDataFor(rootNode, node *tree.Node) bool {
+func (*javaImplementation) ContributesToValue(node *tree.Node) bool {
 	return true
 }

--- a/new/language/implementation/java/java.go
+++ b/new/language/implementation/java/java.go
@@ -306,6 +306,31 @@ func (*javaImplementation) PassthroughNested(node *tree.Node) bool {
 	return slices.Contains(passthroughMethods, method) || slices.Contains(passthroughMethods, wildcardMethod)
 }
 
-func (*javaImplementation) ContributesToValue(node *tree.Node) bool {
+func (*javaImplementation) ContributesToResult(node *tree.Node) bool {
+	// Statements don't have results
+	if strings.HasSuffix(node.Type(), "_statement") {
+		return false
+	}
+
+	// Switch case
+	if node.Type() == "switch_label" {
+		return false
+	}
+
+	parent := node.Parent()
+	if parent == nil {
+		return true
+	}
+
+	// Must not be a ternary/switch condition
+	if node.Equal(parent.ChildByFieldName("condition")) {
+		return false
+	}
+
+	// Must be the arguments of calls
+	if parent.Type() == "method_invocation" && !node.Equal(parent.ChildByFieldName("arguments")) {
+		return false
+	}
+
 	return true
 }

--- a/new/language/implementation/java/java.go
+++ b/new/language/implementation/java/java.go
@@ -305,3 +305,7 @@ func (*javaImplementation) PassthroughNested(node *tree.Node) bool {
 
 	return slices.Contains(passthroughMethods, method) || slices.Contains(passthroughMethods, wildcardMethod)
 }
+
+func (*javaImplementation) IsDataFor(rootNode, node *tree.Node) bool {
+	return true
+}

--- a/new/language/implementation/javascript/javascript.go
+++ b/new/language/implementation/javascript/javascript.go
@@ -275,3 +275,7 @@ func (*javascriptImplementation) PassthroughNested(node *tree.Node) bool {
 
 	return slices.Contains(passthroughMethods, method) || slices.Contains(passthroughMethods, wildcardMethod)
 }
+
+func (*javascriptImplementation) IsDataFor(rootNode, node *tree.Node) bool {
+	return true
+}

--- a/new/language/implementation/javascript/javascript.go
+++ b/new/language/implementation/javascript/javascript.go
@@ -276,6 +276,6 @@ func (*javascriptImplementation) PassthroughNested(node *tree.Node) bool {
 	return slices.Contains(passthroughMethods, method) || slices.Contains(passthroughMethods, wildcardMethod)
 }
 
-func (*javascriptImplementation) IsDataFor(rootNode, node *tree.Node) bool {
+func (*javascriptImplementation) ContributesToValue(node *tree.Node) bool {
 	return true
 }

--- a/new/language/implementation/javascript/javascript.go
+++ b/new/language/implementation/javascript/javascript.go
@@ -276,6 +276,26 @@ func (*javascriptImplementation) PassthroughNested(node *tree.Node) bool {
 	return slices.Contains(passthroughMethods, method) || slices.Contains(passthroughMethods, wildcardMethod)
 }
 
-func (*javascriptImplementation) ContributesToValue(node *tree.Node) bool {
+func (*javascriptImplementation) ContributesToResult(node *tree.Node) bool {
+	// Statements don't have results
+	if strings.HasSuffix(node.Type(), "_statement") {
+		return false
+	}
+
+	parent := node.Parent()
+	if parent == nil {
+		return true
+	}
+
+	// Must not be a ternary condition
+	if parent.Type() == "ternary_expression" && node.Equal(parent.ChildByFieldName("condition")) {
+		return false
+	}
+
+	// Must be the arguments of calls
+	if parent.Type() == "call_expression" && !node.Equal(parent.ChildByFieldName("arguments")) {
+		return false
+	}
+
 	return true
 }

--- a/new/language/implementation/ruby/ruby.go
+++ b/new/language/implementation/ruby/ruby.go
@@ -297,7 +297,7 @@ func (*rubyImplementation) PassthroughNested(node *tree.Node) bool {
 	return slices.Contains(passthroughMethods, receiverMethod) || slices.Contains(passthroughMethods, wildcardMethod)
 }
 
-func (*rubyImplementation) ContributesToValue(node *tree.Node) bool {
+func (*rubyImplementation) ContributesToResult(node *tree.Node) bool {
 	parent := node.Parent()
 	if parent == nil {
 		return true
@@ -305,6 +305,16 @@ func (*rubyImplementation) ContributesToValue(node *tree.Node) bool {
 
 	// Must not be a condition
 	if node.Equal(parent.ChildByFieldName("condition")) {
+		return false
+	}
+
+	// Must not be a case value
+	if parent.Type() == "case" && node.Equal(parent.ChildByFieldName("value")) {
+		return false
+	}
+
+	// Must not be a case-when pattern
+	if parent.Type() == "when" && node.Equal(parent.ChildByFieldName("pattern")) {
 		return false
 	}
 

--- a/new/language/implementation/ruby/ruby.go
+++ b/new/language/implementation/ruby/ruby.go
@@ -296,3 +296,29 @@ func (*rubyImplementation) PassthroughNested(node *tree.Node) bool {
 
 	return slices.Contains(passthroughMethods, receiverMethod) || slices.Contains(passthroughMethods, wildcardMethod)
 }
+
+func (*rubyImplementation) IsDataFor(rootNode, node *tree.Node) bool {
+	parent := node.Parent()
+	if parent == nil {
+		return true
+	}
+
+	// Must not be a condition
+	if node.Equal(parent.ChildByFieldName("condition")) {
+		return false
+	}
+
+	// Must be the last expression in an expression block
+	if slices.Contains([]string{"then", "else"}, parent.Type()) {
+		if !node.Equal(parent.Child(parent.ChildCount() - 1)) {
+			return false
+		}
+	}
+
+	// Must be the arguments of calls
+	if parent.Type() == "call" && !node.Equal(parent.ChildByFieldName("arguments")) {
+		return false
+	}
+
+	return true
+}

--- a/new/language/implementation/ruby/ruby.go
+++ b/new/language/implementation/ruby/ruby.go
@@ -297,7 +297,7 @@ func (*rubyImplementation) PassthroughNested(node *tree.Node) bool {
 	return slices.Contains(passthroughMethods, receiverMethod) || slices.Contains(passthroughMethods, wildcardMethod)
 }
 
-func (*rubyImplementation) IsDataFor(rootNode, node *tree.Node) bool {
+func (*rubyImplementation) ContributesToValue(node *tree.Node) bool {
 	parent := node.Parent()
 	if parent == nil {
 		return true

--- a/pkg/commands/process/settings/settings.go
+++ b/pkg/commands/process/settings/settings.go
@@ -74,6 +74,12 @@ const (
 	STORED_DATA_TYPES MatchOn = "stored_data_types"
 )
 
+type RuleReferenceType string
+
+const (
+	SOURCE_RULE_REFERENCE RuleReferenceType = "source"
+)
+
 type LoadRulesResult struct {
 	BuiltInRules       map[string]*Rule
 	Rules              map[string]*Rule
@@ -176,20 +182,21 @@ type Rule struct {
 }
 
 type PatternFilter struct {
-	Not                *PatternFilter  `mapstructure:"not" json:"not" yaml:"not"`
-	Either             []PatternFilter `mapstructure:"either" json:"either" yaml:"either"`
-	Variable           string          `mapstructure:"variable" json:"variable" yaml:"variable"`
-	Detection          string          `mapstructure:"detection" json:"detection" yaml:"detection"`
-	Contains           *bool           `mapstructure:"contains" json:"contains" yaml:"contains"`
-	Regex              *Regexp         `mapstructure:"regex" json:"regex" yaml:"regex"`
-	Values             []string        `mapstructure:"values" json:"values" yaml:"values"`
-	LengthLessThan     *int            `mapstructure:"length_less_than" json:"length_less_than" yaml:"length_less_than"`
-	LessThan           *int            `mapstructure:"less_than" json:"less_than" yaml:"less_than"`
-	LessThanOrEqual    *int            `mapstructure:"less_than_or_equal" json:"less_than_or_equal" yaml:"less_than_or_equal"`
-	GreaterThan        *int            `mapstructure:"greater_than" json:"greater_than" yaml:"greater_than"`
-	GreaterThanOrEqual *int            `mapstructure:"greater_than_or_equal" json:"greater_than_or_equal" yaml:"greater_than_or_equal"`
-	StringRegex        *Regexp         `mapstructure:"string_regex" json:"string_regex" yaml:"string_regex"`
-	FilenameRegex      *Regexp         `mapstructure:"filename_regex" json:"filename_regex" yaml:"filename_regex"`
+	Not                *PatternFilter    `mapstructure:"not" json:"not" yaml:"not"`
+	Either             []PatternFilter   `mapstructure:"either" json:"either" yaml:"either"`
+	Variable           string            `mapstructure:"variable" json:"variable" yaml:"variable"`
+	Detection          string            `mapstructure:"detection" json:"detection" yaml:"detection"`
+	RuleType           RuleReferenceType `mapstructure:"rule_type" json:"rule_type" yaml:"rule_type"`
+	Contains           *bool             `mapstructure:"contains" json:"contains" yaml:"contains"`
+	Regex              *Regexp           `mapstructure:"regex" json:"regex" yaml:"regex"`
+	Values             []string          `mapstructure:"values" json:"values" yaml:"values"`
+	LengthLessThan     *int              `mapstructure:"length_less_than" json:"length_less_than" yaml:"length_less_than"`
+	LessThan           *int              `mapstructure:"less_than" json:"less_than" yaml:"less_than"`
+	LessThanOrEqual    *int              `mapstructure:"less_than_or_equal" json:"less_than_or_equal" yaml:"less_than_or_equal"`
+	GreaterThan        *int              `mapstructure:"greater_than" json:"greater_than" yaml:"greater_than"`
+	GreaterThanOrEqual *int              `mapstructure:"greater_than_or_equal" json:"greater_than_or_equal" yaml:"greater_than_or_equal"`
+	StringRegex        *Regexp           `mapstructure:"string_regex" json:"string_regex" yaml:"string_regex"`
+	FilenameRegex      *Regexp           `mapstructure:"filename_regex" json:"filename_regex" yaml:"filename_regex"`
 }
 
 type RulePattern struct {

--- a/pkg/commands/process/settings/settings.go
+++ b/pkg/commands/process/settings/settings.go
@@ -77,9 +77,9 @@ const (
 type RuleReferenceScope string
 
 const (
-	CURSOR_SCOPE   RuleReferenceScope = "cursor"
-	CONTAINS_SCOPE RuleReferenceScope = "contains"
-	VALUE_SCOPE    RuleReferenceScope = "value"
+	CURSOR_SCOPE RuleReferenceScope = "cursor"
+	NESTED_SCOPE RuleReferenceScope = "nested"
+	RESULT_SCOPE RuleReferenceScope = "result"
 )
 
 type LoadRulesResult struct {
@@ -339,7 +339,7 @@ func (filter *PatternFilter) UnmarshalYAML(unmarshal func(interface{}) error) er
 			}
 		}
 		if filter.Scope == "" {
-			filter.Scope = CONTAINS_SCOPE
+			filter.Scope = NESTED_SCOPE
 		}
 	}
 


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Adds a `scope` option that applies when `detection` is specified for a filter. This deprecates the `contains` option as it is a superset of it's behaviour (backwards compatibility is maintained). Scope is an enum with the following possibilities:
- `cursor` - Match at the cursor position only (`contains: false` currently)
- `nested` - Match at the cursor position, or any descendent (default behaviour, equivalent to `contains: true`)
- `result` - Match at the cursor position, or any descendent used in the resultant value of the cursor

Consider the following SQL injection example:

```ruby
operator = params[:direction] == "past" ? "<" : ">"
current_user.messages.where("id #{operator} ?", message_id)
```

Currently, we would find the usage of params in the conditional and return a false positive for this code. After this change, if the rule is updated to use the `result` scope for matching the user input, then only the two result nodes (`">"`, `"<"`) will be matched against.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [x] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
