### PR TITLE
fix: allow calls to be traversed with result scope

### DIFF
--- a/new/language/implementation/java/java.go
+++ b/new/language/implementation/java/java.go
@@ -327,10 +327,5 @@ func (*javaImplementation) ContributesToResult(node *tree.Node) bool {
 		return false
 	}
 
-	// Must be the arguments of calls
-	if parent.Type() == "method_invocation" && !node.Equal(parent.ChildByFieldName("arguments")) {
-		return false
-	}
-
 	return true
 }

--- a/new/language/implementation/javascript/javascript.go
+++ b/new/language/implementation/javascript/javascript.go
@@ -292,10 +292,5 @@ func (*javascriptImplementation) ContributesToResult(node *tree.Node) bool {
 		return false
 	}
 
-	// Must be the arguments of calls
-	if parent.Type() == "call_expression" && !node.Equal(parent.ChildByFieldName("arguments")) {
-		return false
-	}
-
 	return true
 }

--- a/new/language/implementation/ruby/ruby.go
+++ b/new/language/implementation/ruby/ruby.go
@@ -325,10 +325,5 @@ func (*rubyImplementation) ContributesToResult(node *tree.Node) bool {
 		}
 	}
 
-	// Must be the arguments of calls
-	if parent.Type() == "call" && !node.Equal(parent.ChildByFieldName("arguments")) {
-		return false
-	}
-
 	return true
 }


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Allow non-argument call nodes to be traversed when using `scope: result`.

Prior to this change, only call arguments were traversed for result scope. This breaks some of our rules. eg. we have a Java rule that matches `request.getCookies()` and we expect that to match `cookies[0].getValue()`:

```java
        Cookie[] cookies = request.getCookies();
        String userProfile = cookies[0].getValue()
        File file = new File("user/profile/", userProfile);
```

We may be able to re-instate this logic later on with some rule improvements but it needs further investigation.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
