### PR TITLE
feat: add no-color flag

### DIFF
--- a/docs/_data/bearer_scan.yaml
+++ b/docs/_data/bearer_scan.yaml
@@ -51,6 +51,9 @@ options:
       default_value: '[]'
       usage: |
         Define regular expressions for better classification of private or unreachable domains e.g. --internal-domains=".*.my-company.com,private.sh"
+    - name: no-color
+      default_value: "false"
+      usage: Disable color in output
     - name: only-rule
       default_value: '[]'
       usage: |

--- a/e2e/flags/.snapshots/TestInitCommand
+++ b/e2e/flags/.snapshots/TestInitCommand
@@ -1,6 +1,7 @@
 disable-version-check: false
 report:
     format: ""
+    no-color: false
     output: ""
     report: security
     severity: critical,high,medium,low,warning

--- a/e2e/flags/.snapshots/TestMetadataFlags-help-scan
+++ b/e2e/flags/.snapshots/TestMetadataFlags-help-scan
@@ -36,6 +36,7 @@ Scan Flags
 General Flags
       --config-file string      Load configuration from the specified path. (default "bearer.yml")
       --disable-version-check   Disable Bearer version checking
+      --no-color                Disable color in output
 
 
 --

--- a/e2e/flags/.snapshots/TestMetadataFlags-scan-help
+++ b/e2e/flags/.snapshots/TestMetadataFlags-scan-help
@@ -36,6 +36,7 @@ Scan Flags
 General Flags
       --config-file string      Load configuration from the specified path. (default "bearer.yml")
       --disable-version-check   Disable Bearer version checking
+      --no-color                Disable color in output
 
 
 --

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-context-flag
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-context-flag
@@ -37,6 +37,7 @@ Scan Flags
 General Flags
       --config-file string      Load configuration from the specified path. (default "bearer.yml")
       --disable-version-check   Disable Bearer version checking
+      --no-color                Disable color in output
 
 
 flag error: scan flag error: invalid context argument; supported values: health

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag
@@ -37,6 +37,7 @@ Scan Flags
 General Flags
       --config-file string      Load configuration from the specified path. (default "bearer.yml")
       --disable-version-check   Disable Bearer version checking
+      --no-color                Disable color in output
 
 
 flag error: report flags error: invalid format argument; supported values: json, yaml, sarif, gitlab-sast

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-report-flag
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-report-flag
@@ -37,6 +37,7 @@ Scan Flags
 General Flags
       --config-file string      Load configuration from the specified path. (default "bearer.yml")
       --disable-version-check   Disable Bearer version checking
+      --no-color                Disable color in output
 
 
 flag error: report flags error: invalid report argument; supported values: security, privacy

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -330,7 +330,7 @@ func (r *runner) Report(config settings.Config, report types.Report) (bool, erro
 			return false, err
 		}
 
-		outputhandler.StdOutLogger().Msg(placeholderStr.String())
+		logger.Msg(placeholderStr.String())
 		return true, nil
 	}
 
@@ -340,7 +340,7 @@ func (r *runner) Report(config settings.Config, report types.Report) (bool, erro
 			detectionReport := detections.(*security.Results)
 			reportStr, reportPassed := security.BuildReportString(config, detectionReport, report.Inputgocloc, dataflow)
 
-			outputhandler.StdOutLogger().Msg(reportStr.String())
+			logger.Msg(reportStr.String())
 
 			return reportPassed, nil
 		} else if config.Report.Report == flag.ReportPrivacy {
@@ -350,7 +350,7 @@ func (r *runner) Report(config settings.Config, report types.Report) (bool, erro
 				return false, fmt.Errorf("error generating report %s", err)
 			}
 
-			outputhandler.StdOutLogger().Msg(*content)
+			logger.Msg(*content)
 
 			return true, nil
 		}

--- a/pkg/commands/process/settings/settings.go
+++ b/pkg/commands/process/settings/settings.go
@@ -50,6 +50,7 @@ type Config struct {
 	BuiltInRules       map[string]*Rule   `mapstructure:"built_in_rules" json:"built_in_rules" yaml:"built_in_rules"`
 	CacheUsed          bool               `mapstructure:"cache_used" json:"cache_used" yaml:"cache_used"`
 	BearerRulesVersion string             `mapstructure:"bearer_rules_version" json:"bearer_rules_version" yaml:"bearer_rules_version"`
+	NoColor            bool               `mapstructure:"no_color" json:"no_color" yaml:"no_color"`
 }
 
 type Modules []*PolicyModule
@@ -298,6 +299,7 @@ func FromOptions(opts flag.Options, foundLanguages []string) (Config, error) {
 		Worker:             workerOptions,
 		Scan:               opts.ScanOptions,
 		Report:             opts.ReportOptions,
+		NoColor:            opts.GeneralOptions.NoColor || opts.ReportOptions.Output != "",
 		Policies:           policies,
 		Rules:              result.Rules,
 		BuiltInRules:       result.BuiltInRules,

--- a/pkg/flag/general_flags.go
+++ b/pkg/flag/general_flags.go
@@ -38,6 +38,12 @@ var (
 		Value:      false,
 		Usage:      "Disable Bearer version checking",
 	}
+	NoColorFlag = Flag{
+		Name:       "no-color",
+		ConfigName: "report.no-color",
+		Value:      false,
+		Usage:      "Disable color in output",
+	}
 )
 
 type GeneralFlagGroup struct {
@@ -45,6 +51,7 @@ type GeneralFlagGroup struct {
 	APIKey              *Flag
 	Host                *Flag
 	DisableVersionCheck *Flag
+	NoColor             *Flag
 }
 
 // GlobalOptions defines flags and other configuration parameters for all the subcommands
@@ -52,6 +59,7 @@ type GeneralOptions struct {
 	ConfigFile          string `json:"config_file" yaml:"config_file"`
 	Client              *api.API
 	DisableVersionCheck bool
+	NoColor             bool `mapstructure:"no_color" json:"no_color" yaml:"no_color"`
 }
 
 func NewGeneralFlagGroup() *GeneralFlagGroup {
@@ -60,6 +68,7 @@ func NewGeneralFlagGroup() *GeneralFlagGroup {
 		APIKey:              &APIKeyFlag,
 		Host:                &HostFlag,
 		DisableVersionCheck: &DisableVersionCheckFlag,
+		NoColor:             &NoColorFlag,
 	}
 }
 
@@ -73,6 +82,7 @@ func (f *GeneralFlagGroup) Flags() []*Flag {
 		f.APIKey,
 		f.Host,
 		f.DisableVersionCheck,
+		f.NoColor,
 	}
 }
 
@@ -98,5 +108,6 @@ func (f *GeneralFlagGroup) ToOptions() GeneralOptions {
 		Client:              client,
 		ConfigFile:          getString(f.ConfigFile),
 		DisableVersionCheck: getBool(f.DisableVersionCheck),
+		NoColor:             getBool(f.NoColor),
 	}
 }

--- a/pkg/report/output/security/security.go
+++ b/pkg/report/output/security/security.go
@@ -230,7 +230,6 @@ func evaluateRules(
 }
 
 func BuildReportString(config settings.Config, results *Results, lineOfCodeOutput *gocloc.Result, dataflow *dataflow.DataFlow) (*strings.Builder, bool) {
-	withoutColor := config.Report.Output != ""
 	severityForFailure := config.Report.Severity
 	reportStr := &strings.Builder{}
 
@@ -238,7 +237,7 @@ func BuildReportString(config settings.Config, results *Results, lineOfCodeOutpu
 	reportStr.WriteString("\n=====================================")
 
 	initialColorSetting := color.NoColor
-	if withoutColor && !initialColorSetting {
+	if config.NoColor && !initialColorSetting {
 		color.NoColor = true
 	}
 


### PR DESCRIPTION
## Description

Add no-color flag so that we can disable colour output. Defaults to `false`

Example usage: 

```
  bearer scan . --no-color=true
```

Closes #917 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [x] I've updated or added documentation if required.
- [x] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
