### PR TITLE
feat: add exclude-fingerprints flag

### DIFF
--- a/docs/_data/bearer_scan.yaml
+++ b/docs/_data/bearer_scan.yaml
@@ -30,6 +30,9 @@ options:
       default_value: 3s
       usage: |
         Set timeout when attempting to resolve detected domains during classification, e.g. --domain-resolution-timeout=3s
+    - name: exclude-fingerprints
+      usage: |
+        Specify the comma-separated fingerprints of the findings you would like to exclude from the report.
     - name: external-rule-dir
       default_value: '[]'
       usage: |

--- a/e2e/flags/.snapshots/TestInitCommand
+++ b/e2e/flags/.snapshots/TestInitCommand
@@ -1,5 +1,6 @@
 disable-version-check: false
 report:
+    exclude-fingerprints: []
     format: ""
     no-color: false
     output: ""

--- a/e2e/flags/.snapshots/TestMetadataFlags-help-scan
+++ b/e2e/flags/.snapshots/TestMetadataFlags-help-scan
@@ -10,10 +10,11 @@ Examples:
 
 
 Report Flags
-  -f, --format string     Specify report format (json, yaml, sarif, gitlab-sast)
-      --output string     Specify the output path for the report.
-      --report string     Specify the type of report (security, privacy, dataflow). (default "security")
-      --severity string   Specify which severities are included in the report. (default "critical,high,medium,low,warning")
+      --exclude-fingerprints strings   Specify the comma-separated fingerprints of the findings you would like to exclude from the report.
+  -f, --format string                  Specify report format (json, yaml, sarif, gitlab-sast)
+      --output string                  Specify the output path for the report.
+      --report string                  Specify the type of report (security, privacy, dataflow). (default "security")
+      --severity string                Specify which severities are included in the report. (default "critical,high,medium,low,warning")
 
 Rule Flags
       --disable-default-rules   Disables all default and built-in rules.

--- a/e2e/flags/.snapshots/TestMetadataFlags-scan-help
+++ b/e2e/flags/.snapshots/TestMetadataFlags-scan-help
@@ -10,10 +10,11 @@ Examples:
 
 
 Report Flags
-  -f, --format string     Specify report format (json, yaml, sarif, gitlab-sast)
-      --output string     Specify the output path for the report.
-      --report string     Specify the type of report (security, privacy, dataflow). (default "security")
-      --severity string   Specify which severities are included in the report. (default "critical,high,medium,low,warning")
+      --exclude-fingerprints strings   Specify the comma-separated fingerprints of the findings you would like to exclude from the report.
+  -f, --format string                  Specify report format (json, yaml, sarif, gitlab-sast)
+      --output string                  Specify the output path for the report.
+      --report string                  Specify the type of report (security, privacy, dataflow). (default "security")
+      --severity string                Specify which severities are included in the report. (default "critical,high,medium,low,warning")
 
 Rule Flags
       --disable-default-rules   Disables all default and built-in rules.

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-context-flag
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-context-flag
@@ -11,10 +11,11 @@ Examples:
 
 
 Report Flags
-  -f, --format string     Specify report format (json, yaml, sarif, gitlab-sast)
-      --output string     Specify the output path for the report.
-      --report string     Specify the type of report (security, privacy, dataflow). (default "security")
-      --severity string   Specify which severities are included in the report. (default "critical,high,medium,low,warning")
+      --exclude-fingerprints strings   Specify the comma-separated fingerprints of the findings you would like to exclude from the report.
+  -f, --format string                  Specify report format (json, yaml, sarif, gitlab-sast)
+      --output string                  Specify the output path for the report.
+      --report string                  Specify the type of report (security, privacy, dataflow). (default "security")
+      --severity string                Specify which severities are included in the report. (default "critical,high,medium,low,warning")
 
 Rule Flags
       --disable-default-rules   Disables all default and built-in rules.

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag
@@ -11,10 +11,11 @@ Examples:
 
 
 Report Flags
-  -f, --format string     Specify report format (json, yaml, sarif, gitlab-sast)
-      --output string     Specify the output path for the report.
-      --report string     Specify the type of report (security, privacy, dataflow). (default "security")
-      --severity string   Specify which severities are included in the report. (default "critical,high,medium,low,warning")
+      --exclude-fingerprints strings   Specify the comma-separated fingerprints of the findings you would like to exclude from the report.
+  -f, --format string                  Specify report format (json, yaml, sarif, gitlab-sast)
+      --output string                  Specify the output path for the report.
+      --report string                  Specify the type of report (security, privacy, dataflow). (default "security")
+      --severity string                Specify which severities are included in the report. (default "critical,high,medium,low,warning")
 
 Rule Flags
       --disable-default-rules   Disables all default and built-in rules.

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-report-flag
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-report-flag
@@ -11,10 +11,11 @@ Examples:
 
 
 Report Flags
-  -f, --format string     Specify report format (json, yaml, sarif, gitlab-sast)
-      --output string     Specify the output path for the report.
-      --report string     Specify the type of report (security, privacy, dataflow). (default "security")
-      --severity string   Specify which severities are included in the report. (default "critical,high,medium,low,warning")
+      --exclude-fingerprints strings   Specify the comma-separated fingerprints of the findings you would like to exclude from the report.
+  -f, --format string                  Specify report format (json, yaml, sarif, gitlab-sast)
+      --output string                  Specify the output path for the report.
+      --report string                  Specify the type of report (security, privacy, dataflow). (default "security")
+      --severity string                Specify which severities are included in the report. (default "critical,high,medium,low,warning")
 
 Rule Flags
       --disable-default-rules   Disables all default and built-in rules.

--- a/pkg/flag/report_flags.go
+++ b/pkg/flag/report_flags.go
@@ -53,28 +53,37 @@ var (
 		Value:      DefaultSeverity,
 		Usage:      "Specify which severities are included in the report.",
 	}
+	ExcludeFingerprintsFlag = Flag{
+		Name:       "exclude-fingerprints",
+		ConfigName: "report.exclude-fingerprints",
+		Value:      []string{},
+		Usage:      "Specify the comma-separated fingerprints of the findings you would like to exclude from the report.",
+	}
 )
 
 type ReportFlagGroup struct {
-	Format   *Flag
-	Report   *Flag
-	Output   *Flag
-	Severity *Flag
+	Format              *Flag
+	Report              *Flag
+	Output              *Flag
+	Severity            *Flag
+	ExcludeFingerprints *Flag
 }
 
 type ReportOptions struct {
-	Format   string          `mapstructure:"format" json:"format" yaml:"format"`
-	Report   string          `mapstructure:"report" json:"report" yaml:"report"`
-	Output   string          `mapstructure:"output" json:"output" yaml:"output"`
-	Severity map[string]bool `mapstructure:"severity" json:"severity" yaml:"severity"`
+	Format              string          `mapstructure:"format" json:"format" yaml:"format"`
+	Report              string          `mapstructure:"report" json:"report" yaml:"report"`
+	Output              string          `mapstructure:"output" json:"output" yaml:"output"`
+	Severity            map[string]bool `mapstructure:"severity" json:"severity" yaml:"severity"`
+	ExcludeFingerprints map[string]bool `mapstructure:"exclude_fingerprints" json:"exclude_fingerprints" yaml:"exclude_fingerprints"`
 }
 
 func NewReportFlagGroup() *ReportFlagGroup {
 	return &ReportFlagGroup{
-		Format:   &FormatFlag,
-		Report:   &ReportFlag,
-		Output:   &OutputFlag,
-		Severity: &SeverityFlag,
+		Format:              &FormatFlag,
+		Report:              &ReportFlag,
+		Output:              &OutputFlag,
+		Severity:            &SeverityFlag,
+		ExcludeFingerprints: &ExcludeFingerprintsFlag,
 	}
 }
 
@@ -88,6 +97,7 @@ func (f *ReportFlagGroup) Flags() []*Flag {
 		f.Report,
 		f.Output,
 		f.Severity,
+		f.ExcludeFingerprints,
 	}
 }
 
@@ -138,10 +148,18 @@ func (f *ReportFlagGroup) ToOptions() (ReportOptions, error) {
 		}
 	}
 
+	// turn string slice into map for ease of access
+	excludeFingerprints := getStringSlice(f.ExcludeFingerprints)
+	excludeFingerprintsMapping := make(map[string]bool)
+	for _, fingerprint := range excludeFingerprints {
+		excludeFingerprintsMapping[fingerprint] = true
+	}
+
 	return ReportOptions{
-		Format:   format,
-		Report:   report,
-		Output:   getString(f.Output),
-		Severity: severityMapping,
+		Format:              format,
+		Report:              report,
+		Output:              getString(f.Output),
+		Severity:            severityMapping,
+		ExcludeFingerprints: excludeFingerprintsMapping,
 	}, nil
 }

--- a/pkg/report/output/security/security.go
+++ b/pkg/report/output/security/security.go
@@ -18,8 +18,10 @@ import (
 	"github.com/bearer/bearer/pkg/util/set"
 	"github.com/fatih/color"
 	"github.com/hhatto/gocloc"
+	log "github.com/rs/zerolog/log"
 	"github.com/schollz/progressbar/v3"
 	"github.com/ssoroka/slice"
+
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 
@@ -191,6 +193,12 @@ func evaluateRules(
 				oldFingerprintId := fmt.Sprintf("%s_%s", rule.Id, output.FullFilename)
 				fingerprint := fmt.Sprintf("%x_%d", md5.Sum([]byte(fingerprintId)), i)
 				oldFingerprint := fmt.Sprintf("%x_%d", md5.Sum([]byte(oldFingerprintId)), i)
+
+				if config.Report.ExcludeFingerprints[fingerprint] {
+					// skip finding - fingerprint is in exclude list
+					log.Debug().Msgf("Excluding finding with fingerprint %s", fingerprint)
+					continue
+				}
 
 				result := Result{
 					Rule:             ruleSummary,


### PR DESCRIPTION
## Description

This is an initial step to fulfilling https://github.com/Bearer/bearer/issues/817. 

* Add `--exclude-fingerprints` flag that takes comma-separated list of fingerprints and excludes them from security report
* Flag is also included (by default) in bearer.yml file

Default bearer.yml file: 
```
disable-version-check: false
report:
    exclude-fingerprints: []
    format: ""
    no-color: false
    output: ""
    report: security
    severity: critical,high,medium,low,warning

...
```

And with fingerprints listed

```
disable-version-check: false
report:
    exclude-fingerprints:
        - b9c6f98c6ac3370da36e2846b99f2cde_0
    format: ""
    no-color: false
    output: ""
    report: security
    severity: critical,high,medium,low,warning

...
```
<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [x] I've updated or added documentation if required.
- [x] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
