### PR TITLE
fix: ruby element reference query

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,5 +21,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: 1.19
-      - name: Run tests
+      - name: Run package tests
         run: go test -v ./pkg/...
+      - name: Run detector tests
+        run: go test -v ./new/detector/...

--- a/new/detector/composition/java/.snapshots/TestScope--scope.yml
+++ b/new/detector/composition/java/.snapshots/TestScope--scope.yml
@@ -7,10 +7,27 @@ high:
         description: Test detection filter scopes
         documentation_url: ""
       line_number: 1
+      full_filename: scope.java
       filename: scope.java
+      source:
+        location:
+            start: 1
+            end: 1
+            column:
+                start: 1
+                end: 42
+      sink:
+        location:
+            start: 1
+            end: 1
+            column:
+                start: 1
+                end: 42
+        content: scopeCursor(request.getParameter("oops"))
       parent_line_number: 1
       snippet: scopeCursor(request.getParameter("oops"))
       fingerprint: bdbeee20feb34c6881d975716e2fe09f_0
+      old_fingerprint: bdbeee20feb34c6881d975716e2fe09f_0
     - rule:
         cwe_ids:
             - "42"
@@ -19,10 +36,27 @@ high:
         description: Test detection filter scopes
         documentation_url: ""
       line_number: 5
+      full_filename: scope.java
       filename: scope.java
+      source:
+        location:
+            start: 5
+            end: 5
+            column:
+                start: 1
+                end: 42
+      sink:
+        location:
+            start: 5
+            end: 5
+            column:
+                start: 1
+                end: 42
+        content: scopeNested(request.getParameter("oops"))
       parent_line_number: 5
       snippet: scopeNested(request.getParameter("oops"))
       fingerprint: bdbeee20feb34c6881d975716e2fe09f_1
+      old_fingerprint: bdbeee20feb34c6881d975716e2fe09f_1
     - rule:
         cwe_ids:
             - "42"
@@ -31,10 +65,27 @@ high:
         description: Test detection filter scopes
         documentation_url: ""
       line_number: 6
+      full_filename: scope.java
       filename: scope.java
+      source:
+        location:
+            start: 6
+            end: 6
+            column:
+                start: 1
+                end: 50
+      sink:
+        location:
+            start: 6
+            end: 6
+            column:
+                start: 1
+                end: 50
+        content: 'scopeNested(x ? request.getParameter("oops") : y)'
       parent_line_number: 6
       snippet: 'scopeNested(x ? request.getParameter("oops") : y)'
       fingerprint: bdbeee20feb34c6881d975716e2fe09f_2
+      old_fingerprint: bdbeee20feb34c6881d975716e2fe09f_2
     - rule:
         cwe_ids:
             - "42"
@@ -43,10 +94,27 @@ high:
         description: Test detection filter scopes
         documentation_url: ""
       line_number: 7
+      full_filename: scope.java
       filename: scope.java
+      source:
+        location:
+            start: 7
+            end: 7
+            column:
+                start: 1
+                end: 50
+      sink:
+        location:
+            start: 7
+            end: 7
+            column:
+                start: 1
+                end: 50
+        content: 'scopeNested(request.getParameter("oops") ? x : y)'
       parent_line_number: 7
       snippet: 'scopeNested(request.getParameter("oops") ? x : y)'
       fingerprint: bdbeee20feb34c6881d975716e2fe09f_3
+      old_fingerprint: bdbeee20feb34c6881d975716e2fe09f_3
     - rule:
         cwe_ids:
             - "42"
@@ -55,10 +123,27 @@ high:
         description: Test detection filter scopes
         documentation_url: ""
       line_number: 9
+      full_filename: scope.java
       filename: scope.java
+      source:
+        location:
+            start: 9
+            end: 9
+            column:
+                start: 1
+                end: 42
+      sink:
+        location:
+            start: 9
+            end: 9
+            column:
+                start: 1
+                end: 42
+        content: scopeResult(request.getParameter("oops"))
       parent_line_number: 9
       snippet: scopeResult(request.getParameter("oops"))
       fingerprint: bdbeee20feb34c6881d975716e2fe09f_4
+      old_fingerprint: bdbeee20feb34c6881d975716e2fe09f_4
     - rule:
         cwe_ids:
             - "42"
@@ -67,8 +152,25 @@ high:
         description: Test detection filter scopes
         documentation_url: ""
       line_number: 10
+      full_filename: scope.java
       filename: scope.java
+      source:
+        location:
+            start: 10
+            end: 10
+            column:
+                start: 1
+                end: 50
+      sink:
+        location:
+            start: 10
+            end: 10
+            column:
+                start: 1
+                end: 50
+        content: 'scopeResult(x ? request.getParameter("oops") : y)'
       parent_line_number: 10
       snippet: 'scopeResult(x ? request.getParameter("oops") : y)'
       fingerprint: bdbeee20feb34c6881d975716e2fe09f_5
+      old_fingerprint: bdbeee20feb34c6881d975716e2fe09f_5
 

--- a/new/detector/composition/java/java.go
+++ b/new/detector/composition/java/java.go
@@ -193,10 +193,14 @@ func (composition *Composition) DetectFromFileWithTypes(file *file.FileInfo, det
 	var result []*detectortypes.Detection
 	for _, detectorType := range detectorTypes {
 		rule := composition.rules[detectorType]
+		sanitizerRuleID := ""
+		if rule != nil {
+			sanitizerRuleID = rule.SanitizerRuleID
+		}
 		detections, err := evaluator.Evaluate(
 			tree.RootNode(),
 			detectorType,
-			rule.SanitizerRuleID,
+			sanitizerRuleID,
 			settings.NESTED_SCOPE,
 			false,
 		)

--- a/new/detector/composition/javascript/.snapshots/TestScope--scope.yml
+++ b/new/detector/composition/javascript/.snapshots/TestScope--scope.yml
@@ -7,10 +7,27 @@ high:
         description: Test detection filter scopes
         documentation_url: ""
       line_number: 1
+      full_filename: scope.js
       filename: scope.js
+      source:
+        location:
+            start: 1
+            end: 1
+            column:
+                start: 1
+                end: 29
+      sink:
+        location:
+            start: 1
+            end: 1
+            column:
+                start: 1
+                end: 29
+        content: scopeCursor(req.params.oops)
       parent_line_number: 1
       snippet: scopeCursor(req.params.oops)
       fingerprint: 408407aa362e0520faf6b66c3d59bb8c_0
+      old_fingerprint: 408407aa362e0520faf6b66c3d59bb8c_0
     - rule:
         cwe_ids:
             - "42"
@@ -19,10 +36,27 @@ high:
         description: Test detection filter scopes
         documentation_url: ""
       line_number: 5
+      full_filename: scope.js
       filename: scope.js
+      source:
+        location:
+            start: 5
+            end: 5
+            column:
+                start: 1
+                end: 29
+      sink:
+        location:
+            start: 5
+            end: 5
+            column:
+                start: 1
+                end: 29
+        content: scopeNested(req.params.oops)
       parent_line_number: 5
       snippet: scopeNested(req.params.oops)
       fingerprint: 408407aa362e0520faf6b66c3d59bb8c_1
+      old_fingerprint: 408407aa362e0520faf6b66c3d59bb8c_1
     - rule:
         cwe_ids:
             - "42"
@@ -31,10 +65,27 @@ high:
         description: Test detection filter scopes
         documentation_url: ""
       line_number: 6
+      full_filename: scope.js
       filename: scope.js
+      source:
+        location:
+            start: 6
+            end: 6
+            column:
+                start: 1
+                end: 37
+      sink:
+        location:
+            start: 6
+            end: 6
+            column:
+                start: 1
+                end: 37
+        content: 'scopeNested(x ? req.params.oops : y)'
       parent_line_number: 6
       snippet: 'scopeNested(x ? req.params.oops : y)'
       fingerprint: 408407aa362e0520faf6b66c3d59bb8c_2
+      old_fingerprint: 408407aa362e0520faf6b66c3d59bb8c_2
     - rule:
         cwe_ids:
             - "42"
@@ -43,10 +94,27 @@ high:
         description: Test detection filter scopes
         documentation_url: ""
       line_number: 7
+      full_filename: scope.js
       filename: scope.js
+      source:
+        location:
+            start: 7
+            end: 7
+            column:
+                start: 1
+                end: 37
+      sink:
+        location:
+            start: 7
+            end: 7
+            column:
+                start: 1
+                end: 37
+        content: 'scopeNested(req.params.oops ? x : y)'
       parent_line_number: 7
       snippet: 'scopeNested(req.params.oops ? x : y)'
       fingerprint: 408407aa362e0520faf6b66c3d59bb8c_3
+      old_fingerprint: 408407aa362e0520faf6b66c3d59bb8c_3
     - rule:
         cwe_ids:
             - "42"
@@ -55,10 +123,27 @@ high:
         description: Test detection filter scopes
         documentation_url: ""
       line_number: 9
+      full_filename: scope.js
       filename: scope.js
+      source:
+        location:
+            start: 9
+            end: 9
+            column:
+                start: 1
+                end: 29
+      sink:
+        location:
+            start: 9
+            end: 9
+            column:
+                start: 1
+                end: 29
+        content: scopeResult(req.params.oops)
       parent_line_number: 9
       snippet: scopeResult(req.params.oops)
       fingerprint: 408407aa362e0520faf6b66c3d59bb8c_4
+      old_fingerprint: 408407aa362e0520faf6b66c3d59bb8c_4
     - rule:
         cwe_ids:
             - "42"
@@ -67,8 +152,25 @@ high:
         description: Test detection filter scopes
         documentation_url: ""
       line_number: 10
+      full_filename: scope.js
       filename: scope.js
+      source:
+        location:
+            start: 10
+            end: 10
+            column:
+                start: 1
+                end: 37
+      sink:
+        location:
+            start: 10
+            end: 10
+            column:
+                start: 1
+                end: 37
+        content: 'scopeResult(x ? req.params.oops : y)'
       parent_line_number: 10
       snippet: 'scopeResult(x ? req.params.oops : y)'
       fingerprint: 408407aa362e0520faf6b66c3d59bb8c_5
+      old_fingerprint: 408407aa362e0520faf6b66c3d59bb8c_5
 

--- a/new/detector/composition/javascript/javascript.go
+++ b/new/detector/composition/javascript/javascript.go
@@ -193,10 +193,14 @@ func (composition *Composition) DetectFromFileWithTypes(file *file.FileInfo, det
 	var result []*detectortypes.Detection
 	for _, detectorType := range detectorTypes {
 		rule := composition.rules[detectorType]
+		sanitizerRuleID := ""
+		if rule != nil {
+			sanitizerRuleID = rule.SanitizerRuleID
+		}
 		detections, err := evaluator.Evaluate(
 			tree.RootNode(),
 			detectorType,
-			rule.SanitizerRuleID,
+			sanitizerRuleID,
 			settings.NESTED_SCOPE,
 			false,
 		)

--- a/new/detector/composition/ruby/.snapshots/TestScope--scope.yml
+++ b/new/detector/composition/ruby/.snapshots/TestScope--scope.yml
@@ -7,10 +7,27 @@ high:
         description: Test detection filter scopes
         documentation_url: ""
       line_number: 1
+      full_filename: scope.rb
       filename: scope.rb
+      source:
+        location:
+            start: 1
+            end: 1
+            column:
+                start: 1
+                end: 28
+      sink:
+        location:
+            start: 1
+            end: 1
+            column:
+                start: 1
+                end: 28
+        content: scope_cursor(params[:oops])
       parent_line_number: 1
       snippet: scope_cursor(params[:oops])
       fingerprint: 23e17866f80f43957a84e824da9ce255_0
+      old_fingerprint: 23e17866f80f43957a84e824da9ce255_0
     - rule:
         cwe_ids:
             - "42"
@@ -19,10 +36,27 @@ high:
         description: Test detection filter scopes
         documentation_url: ""
       line_number: 5
+      full_filename: scope.rb
       filename: scope.rb
+      source:
+        location:
+            start: 5
+            end: 5
+            column:
+                start: 1
+                end: 28
+      sink:
+        location:
+            start: 5
+            end: 5
+            column:
+                start: 1
+                end: 28
+        content: scope_nested(params[:oops])
       parent_line_number: 5
       snippet: scope_nested(params[:oops])
       fingerprint: 23e17866f80f43957a84e824da9ce255_1
+      old_fingerprint: 23e17866f80f43957a84e824da9ce255_1
     - rule:
         cwe_ids:
             - "42"
@@ -31,10 +65,27 @@ high:
         description: Test detection filter scopes
         documentation_url: ""
       line_number: 6
+      full_filename: scope.rb
       filename: scope.rb
+      source:
+        location:
+            start: 6
+            end: 6
+            column:
+                start: 1
+                end: 36
+      sink:
+        location:
+            start: 6
+            end: 6
+            column:
+                start: 1
+                end: 36
+        content: 'scope_nested(x ? params[:oops] : y)'
       parent_line_number: 6
       snippet: 'scope_nested(x ? params[:oops] : y)'
       fingerprint: 23e17866f80f43957a84e824da9ce255_2
+      old_fingerprint: 23e17866f80f43957a84e824da9ce255_2
     - rule:
         cwe_ids:
             - "42"
@@ -43,10 +94,27 @@ high:
         description: Test detection filter scopes
         documentation_url: ""
       line_number: 7
+      full_filename: scope.rb
       filename: scope.rb
+      source:
+        location:
+            start: 7
+            end: 7
+            column:
+                start: 1
+                end: 36
+      sink:
+        location:
+            start: 7
+            end: 7
+            column:
+                start: 1
+                end: 36
+        content: 'scope_nested(params[:oops] ? x : y)'
       parent_line_number: 7
       snippet: 'scope_nested(params[:oops] ? x : y)'
       fingerprint: 23e17866f80f43957a84e824da9ce255_3
+      old_fingerprint: 23e17866f80f43957a84e824da9ce255_3
     - rule:
         cwe_ids:
             - "42"
@@ -55,10 +123,27 @@ high:
         description: Test detection filter scopes
         documentation_url: ""
       line_number: 9
+      full_filename: scope.rb
       filename: scope.rb
+      source:
+        location:
+            start: 9
+            end: 9
+            column:
+                start: 1
+                end: 28
+      sink:
+        location:
+            start: 9
+            end: 9
+            column:
+                start: 1
+                end: 28
+        content: scope_result(params[:oops])
       parent_line_number: 9
       snippet: scope_result(params[:oops])
       fingerprint: 23e17866f80f43957a84e824da9ce255_4
+      old_fingerprint: 23e17866f80f43957a84e824da9ce255_4
     - rule:
         cwe_ids:
             - "42"
@@ -67,8 +152,25 @@ high:
         description: Test detection filter scopes
         documentation_url: ""
       line_number: 10
+      full_filename: scope.rb
       filename: scope.rb
+      source:
+        location:
+            start: 10
+            end: 10
+            column:
+                start: 1
+                end: 36
+      sink:
+        location:
+            start: 10
+            end: 10
+            column:
+                start: 1
+                end: 36
+        content: 'scope_result(x ? params[:oops] : y)'
       parent_line_number: 10
       snippet: 'scope_result(x ? params[:oops] : y)'
       fingerprint: 23e17866f80f43957a84e824da9ce255_5
+      old_fingerprint: 23e17866f80f43957a84e824da9ce255_5
 

--- a/new/detector/composition/ruby/ruby.go
+++ b/new/detector/composition/ruby/ruby.go
@@ -192,10 +192,14 @@ func (composition *Composition) DetectFromFileWithTypes(file *file.FileInfo, det
 	var result []*detectortypes.Detection
 	for _, detectorType := range detectorTypes {
 		rule := composition.rules[detectorType]
+		sanitizerRuleID := ""
+		if rule != nil {
+			sanitizerRuleID = rule.SanitizerRuleID
+		}
 		detections, err := evaluator.Evaluate(
 			tree.RootNode(),
 			detectorType,
-			rule.SanitizerRuleID,
+			sanitizerRuleID,
 			settings.NESTED_SCOPE,
 			false,
 		)

--- a/new/detector/composition/testhelper/testhelper.go
+++ b/new/detector/composition/testhelper/testhelper.go
@@ -13,7 +13,6 @@ import (
 	"github.com/bearer/bearer/pkg/commands/process/worker/work"
 	"github.com/bearer/bearer/pkg/flag"
 	"github.com/bearer/bearer/pkg/report/output"
-	reportoutput "github.com/bearer/bearer/pkg/report/output"
 	"github.com/bearer/bearer/pkg/types"
 	"github.com/bradleyjkemp/cupaloy"
 	"gopkg.in/yaml.v3"
@@ -70,7 +69,7 @@ func getRulesFromYaml(t *testing.T, ruleBytes []byte) map[string]*settings.Rule 
 		ruleDefinition.Metadata.ID: ruleDefinition,
 	}
 	enabledRules := map[string]struct{}{
-		ruleDefinition.Metadata.ID: struct{}{},
+		ruleDefinition.Metadata.ID: {},
 	}
 
 	return settings.BuildRules(rules, enabledRules)
@@ -127,7 +126,7 @@ func (runner *Runner) scanSingleFile(t *testing.T, testDataPath string, fileRela
 		},
 		runner.config,
 	)
-	report, _ := reportoutput.ReportYAML(detections)
+	report, _ := output.ReportYAML(detections)
 
 	cupaloyCopy := cupaloy.NewDefaultConfig().WithOptions(cupaloy.SnapshotSubdirectory(snapshotsPath))
 	cupaloyCopy.SnapshotT(t, *report)

--- a/new/detector/implementation/generic/.snapshots/TestDatatypeDetector-datatype
+++ b/new/detector/implementation/generic/.snapshots/TestDatatypeDetector-datatype
@@ -70,6 +70,41 @@
                                                     state: valid
                                                     reason: known_pattern
                                               datatype: null
+                    - name: "y"
+                      node: {}
+                      classification:
+                        name: "y"
+                        datatype: null
+                        decision:
+                            state: valid
+                            reason: invalid_object_with_valid_properties
+                      datatype:
+                        detectortype: datatype
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: first_name
+                                  node: {}
+                                  classification:
+                                    name: first name
+                                    datatype:
+                                        name: Firstname
+                                        uuid: 380c8cde-ca2e-44ed-82db-2ab1e7c255c7
+                                        category_uuid: 14124881-6b92-4fc5-8005-ea7c1c09592e
+                                        category:
+                                            name: Identification
+                                            uuid: 14124881-6b92-4fc5-8005-ea7c1c09592e
+                                            groups:
+                                                172d90e3-cb9a-46b6-90e5-dd7169c3af54:
+                                                    name: PII
+                                                    uuid: 172d90e3-cb9a-46b6-90e5-dd7169c3af54
+                                                e1d3135b-3c0f-4b55-abce-19f27a26cbb3:
+                                                    name: Personal Data
+                                                    uuid: e1d3135b-3c0f-4b55-abce-19f27a26cbb3
+                                    decision:
+                                        state: valid
+                                        reason: valid_unknown_pattern
+                                  datatype: null
                     - name: email
                       node: {}
                       classification:
@@ -92,4 +127,163 @@
                             state: valid
                             reason: valid_unknown_pattern
                       datatype: null
+- position: "1:5"
+  content: |-
+    {
+      y: {
+        user: { first_name: "" }
+      },
+      email: ""
+    }
+  data:
+    properties:
+        - name: "y"
+          node: {}
+          classification:
+            name: "y"
+            datatype: null
+            decision:
+                state: invalid
+                reason: belongs_to_invalid_object
+          datatype:
+            detectortype: datatype
+            matchnode: {}
+            data:
+                properties:
+                    - name: user
+                      node: {}
+                      classification:
+                        name: user
+                        datatype: null
+                        decision:
+                            state: valid
+                            reason: valid_object_with_valid_properties
+                      datatype:
+                        detectortype: datatype
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: first_name
+                                  node: {}
+                                  classification:
+                                    name: first name
+                                    subject_name: User
+                                    datatype:
+                                        name: Firstname
+                                        uuid: 380c8cde-ca2e-44ed-82db-2ab1e7c255c7
+                                        category_uuid: 14124881-6b92-4fc5-8005-ea7c1c09592e
+                                        category:
+                                            name: Identification
+                                            uuid: 14124881-6b92-4fc5-8005-ea7c1c09592e
+                                            groups:
+                                                172d90e3-cb9a-46b6-90e5-dd7169c3af54:
+                                                    name: PII
+                                                    uuid: 172d90e3-cb9a-46b6-90e5-dd7169c3af54
+                                                e1d3135b-3c0f-4b55-abce-19f27a26cbb3:
+                                                    name: Personal Data
+                                                    uuid: e1d3135b-3c0f-4b55-abce-19f27a26cbb3
+                                    decision:
+                                        state: valid
+                                        reason: known_pattern
+                                  datatype: null
+        - name: "y"
+          node: {}
+          classification:
+            name: "y"
+            datatype: null
+            decision:
+                state: valid
+                reason: invalid_object_with_valid_properties
+          datatype:
+            detectortype: datatype
+            matchnode: {}
+            data:
+                properties:
+                    - name: first_name
+                      node: {}
+                      classification:
+                        name: first name
+                        datatype:
+                            name: Firstname
+                            uuid: 380c8cde-ca2e-44ed-82db-2ab1e7c255c7
+                            category_uuid: 14124881-6b92-4fc5-8005-ea7c1c09592e
+                            category:
+                                name: Identification
+                                uuid: 14124881-6b92-4fc5-8005-ea7c1c09592e
+                                groups:
+                                    172d90e3-cb9a-46b6-90e5-dd7169c3af54:
+                                        name: PII
+                                        uuid: 172d90e3-cb9a-46b6-90e5-dd7169c3af54
+                                    e1d3135b-3c0f-4b55-abce-19f27a26cbb3:
+                                        name: Personal Data
+                                        uuid: e1d3135b-3c0f-4b55-abce-19f27a26cbb3
+                        decision:
+                            state: valid
+                            reason: valid_unknown_pattern
+                      datatype: null
+        - name: email
+          node: {}
+          classification:
+            name: email
+            datatype: null
+            decision:
+                state: invalid
+                reason: belongs_to_invalid_object
+          datatype: null
+- position: "2:6"
+  content: |-
+    {
+        user: { first_name: "" }
+      }
+  data:
+    properties:
+        - name: user
+          node: {}
+          classification:
+            name: user
+            datatype: null
+            decision:
+                state: valid
+                reason: valid_object_with_valid_properties
+          datatype:
+            detectortype: datatype
+            matchnode: {}
+            data:
+                properties:
+                    - name: first_name
+                      node: {}
+                      classification:
+                        name: first name
+                        subject_name: User
+                        datatype:
+                            name: Firstname
+                            uuid: 380c8cde-ca2e-44ed-82db-2ab1e7c255c7
+                            category_uuid: 14124881-6b92-4fc5-8005-ea7c1c09592e
+                            category:
+                                name: Identification
+                                uuid: 14124881-6b92-4fc5-8005-ea7c1c09592e
+                                groups:
+                                    172d90e3-cb9a-46b6-90e5-dd7169c3af54:
+                                        name: PII
+                                        uuid: 172d90e3-cb9a-46b6-90e5-dd7169c3af54
+                                    e1d3135b-3c0f-4b55-abce-19f27a26cbb3:
+                                        name: Personal Data
+                                        uuid: e1d3135b-3c0f-4b55-abce-19f27a26cbb3
+                        decision:
+                            state: valid
+                            reason: known_pattern
+                      datatype: null
+- position: "3:11"
+  content: '{ first_name: "" }'
+  data:
+    properties:
+        - name: first_name
+          node: {}
+          classification:
+            name: first name
+            datatype: null
+            decision:
+                state: invalid
+                reason: belongs_to_invalid_object
+          datatype: null
 

--- a/new/detector/implementation/generic/.snapshots/TestInsecureUrlDetector-insecure_url
+++ b/new/detector/implementation/generic/.snapshots/TestInsecureUrlDetector-insecure_url
@@ -1,7 +1,4 @@
 - position: "2:1"
   content: '"http://api.insecure.com"'
   data: null
-- position: "2:2"
-  content: http://api.insecure.com
-  data: null
 

--- a/new/detector/implementation/javascript/.snapshots/TestJavascriptFileTypes-file_type_jsx
+++ b/new/detector/implementation/javascript/.snapshots/TestJavascriptFileTypes-file_type_jsx
@@ -14,4 +14,12 @@
                       object: null
                 isvirtual: false
     isvirtual: true
+- position: "1:33"
+  content: '{ email: "jhon@gmail.com" }'
+  data:
+    properties:
+        - name: email
+          node: {}
+          object: null
+    isvirtual: false
 

--- a/new/detector/implementation/javascript/.snapshots/TestJavascriptFileTypes-file_type_tsx
+++ b/new/detector/implementation/javascript/.snapshots/TestJavascriptFileTypes-file_type_tsx
@@ -14,4 +14,12 @@
                       object: null
                 isvirtual: false
     isvirtual: true
+- position: "1:33"
+  content: '{ email: "jhon@gmail.com" }'
+  data:
+    properties:
+        - name: email
+          node: {}
+          object: null
+    isvirtual: false
 

--- a/new/detector/implementation/javascript/.snapshots/TestJavascriptObjectDetector-object_object
+++ b/new/detector/implementation/javascript/.snapshots/TestJavascriptObjectDetector-object_object
@@ -14,6 +14,14 @@
                       object: null
                 isvirtual: false
     isvirtual: true
+- position: "1:14"
+  content: '{ "a": 123 }'
+  data:
+    properties:
+        - name: a
+          node: {}
+          object: null
+    isvirtual: false
 - position: "3:6"
   content: |-
     {
@@ -59,6 +67,58 @@
                                   node: {}
                                   object: null
                             isvirtual: false
+                    - name: "n"
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: a
+                                  node: {}
+                                  object: null
+                            isvirtual: false
+                isvirtual: false
+        - name: x
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: nested
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: a
+                                  node: {}
+                                  object: null
+                            isvirtual: false
+                isvirtual: true
+        - name: x
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: a
+                      node: {}
+                      object: null
+                isvirtual: false
+        - name: x
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: a
+                      node: {}
+                      object: null
                 isvirtual: false
         - name: "y"
           node: {}
@@ -71,5 +131,59 @@
                       node: {}
                       object: null
                 isvirtual: false
+    isvirtual: false
+- position: "4:6"
+  content: '{ n: nested }'
+  data:
+    properties:
+        - name: "n"
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: nested
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: a
+                                  node: {}
+                                  object: null
+                            isvirtual: false
+                isvirtual: true
+        - name: "n"
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: a
+                      node: {}
+                      object: null
+                isvirtual: false
+        - name: "n"
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: a
+                      node: {}
+                      object: null
+                isvirtual: false
+    isvirtual: false
+- position: "5:6"
+  content: '{ b: 4 }'
+  data:
+    properties:
+        - name: b
+          node: {}
+          object: null
     isvirtual: false
 

--- a/new/detector/implementation/javascript/.snapshots/TestJavascriptObjectDetector-object_projection
+++ b/new/detector/implementation/javascript/.snapshots/TestJavascriptObjectDetector-object_projection
@@ -28,11 +28,84 @@
                                               object: null
                                         isvirtual: false
                             isvirtual: false
+                    - name: x
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: i
+                                  node: {}
+                                  object: null
+                            isvirtual: false
                     - name: "y"
                       node: {}
                       object: null
                 isvirtual: false
     isvirtual: true
+- position: "1:11"
+  content: '{ x: { a: { i: 3 } }, y: 4 }'
+  data:
+    properties:
+        - name: x
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: a
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: i
+                                  node: {}
+                                  object: null
+                            isvirtual: false
+                isvirtual: false
+        - name: x
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: i
+                      node: {}
+                      object: null
+                isvirtual: false
+        - name: "y"
+          node: {}
+          object: null
+    isvirtual: false
+- position: "1:16"
+  content: '{ a: { i: 3 } }'
+  data:
+    properties:
+        - name: a
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: i
+                      node: {}
+                      object: null
+                isvirtual: false
+    isvirtual: false
+- position: "1:21"
+  content: '{ i: 3 }'
+  data:
+    properties:
+        - name: i
+          node: {}
+          object: null
+    isvirtual: false
 - position: "4:1"
   content: obj.x
   data:
@@ -71,6 +144,30 @@
                                   node: {}
                                   object: null
                             isvirtual: false
+                isvirtual: false
+    isvirtual: true
+- position: "4:1"
+  content: obj.x
+  data:
+    properties:
+        - name: i
+          node: {}
+          object: null
+    isvirtual: false
+- position: "4:1"
+  content: obj.x
+  data:
+    properties:
+        - name: x
+          node: null
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: i
+                      node: {}
+                      object: null
                 isvirtual: false
     isvirtual: true
 - position: "4:1"
@@ -125,6 +222,86 @@
             data:
                 properties:
                     - name: a
+                      node: null
+                      object: null
+                isvirtual: true
+    isvirtual: true
+- position: "5:1"
+  content: obj["x"]
+  data:
+    properties:
+        - name: a
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: i
+                      node: {}
+                      object: null
+                isvirtual: false
+    isvirtual: false
+- position: "5:1"
+  content: obj["x"]
+  data:
+    properties:
+        - name: x
+          node: null
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: a
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: i
+                                  node: {}
+                                  object: null
+                            isvirtual: false
+                isvirtual: false
+    isvirtual: true
+- position: "5:1"
+  content: obj["x"]
+  data:
+    properties:
+        - name: i
+          node: {}
+          object: null
+    isvirtual: false
+- position: "5:1"
+  content: obj["x"]
+  data:
+    properties:
+        - name: x
+          node: null
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: i
+                      node: {}
+                      object: null
+                isvirtual: false
+    isvirtual: true
+- position: "5:1"
+  content: obj["x"]
+  data:
+    properties:
+        - name: obj
+          node: null
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: x
                       node: null
                       object: null
                 isvirtual: true
@@ -218,6 +395,36 @@
             matchnode: {}
             data:
                 properties:
+                    - name: i
+                      node: {}
+                      object: null
+                isvirtual: false
+        - name: ""
+          node: null
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: x
+                      node: null
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: i
+                                  node: {}
+                                  object: null
+                            isvirtual: false
+                isvirtual: true
+        - name: ""
+          node: null
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
                     - name: obj
                       node: null
                       object:
@@ -230,7 +437,294 @@
                                   object: null
                             isvirtual: true
                 isvirtual: true
+        - name: ""
+          node: null
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: obj
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: x
+                                  node: {}
+                                  object:
+                                    detectortype: object
+                                    matchnode: {}
+                                    data:
+                                        properties:
+                                            - name: a
+                                              node: {}
+                                              object:
+                                                detectortype: object
+                                                matchnode: {}
+                                                data:
+                                                    properties:
+                                                        - name: i
+                                                          node: {}
+                                                          object: null
+                                                    isvirtual: false
+                                        isvirtual: false
+                                - name: x
+                                  node: {}
+                                  object:
+                                    detectortype: object
+                                    matchnode: {}
+                                    data:
+                                        properties:
+                                            - name: i
+                                              node: {}
+                                              object: null
+                                        isvirtual: false
+                                - name: "y"
+                                  node: {}
+                                  object: null
+                            isvirtual: false
+                isvirtual: true
+        - name: ""
+          node: null
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: x
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: a
+                                  node: {}
+                                  object:
+                                    detectortype: object
+                                    matchnode: {}
+                                    data:
+                                        properties:
+                                            - name: i
+                                              node: {}
+                                              object: null
+                                        isvirtual: false
+                            isvirtual: false
+                    - name: x
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: i
+                                  node: {}
+                                  object: null
+                            isvirtual: false
+                    - name: "y"
+                      node: {}
+                      object: null
+                isvirtual: false
+        - name: ""
+          node: null
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: a
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: i
+                                  node: {}
+                                  object: null
+                            isvirtual: false
+                isvirtual: false
+        - name: ""
+          node: null
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: i
+                      node: {}
+                      object: null
+                isvirtual: false
+        - name: ""
+          node: null
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: x
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: a
+                                  node: {}
+                                  object:
+                                    detectortype: object
+                                    matchnode: {}
+                                    data:
+                                        properties:
+                                            - name: i
+                                              node: {}
+                                              object: null
+                                        isvirtual: false
+                            isvirtual: false
+                    - name: x
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: i
+                                  node: {}
+                                  object: null
+                            isvirtual: false
+                    - name: "y"
+                      node: {}
+                      object: null
+                isvirtual: false
+        - name: ""
+          node: null
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: a
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: i
+                                  node: {}
+                                  object: null
+                            isvirtual: false
+                isvirtual: false
+        - name: ""
+          node: null
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: i
+                      node: {}
+                      object: null
+                isvirtual: false
     isvirtual: true
+- position: "12:1"
+  content: obj.x
+  data:
+    properties:
+        - name: a
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: i
+                      node: {}
+                      object: null
+                isvirtual: false
+    isvirtual: false
+- position: "12:1"
+  content: obj.x
+  data:
+    properties:
+        - name: x
+          node: null
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: a
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: i
+                                  node: {}
+                                  object: null
+                            isvirtual: false
+                isvirtual: false
+    isvirtual: true
+- position: "12:1"
+  content: obj.x
+  data:
+    properties:
+        - name: i
+          node: {}
+          object: null
+    isvirtual: false
+- position: "12:1"
+  content: obj.x
+  data:
+    properties:
+        - name: x
+          node: null
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: i
+                      node: {}
+                      object: null
+                isvirtual: false
+    isvirtual: true
+- position: "12:1"
+  content: obj.x
+  data:
+    properties:
+        - name: obj
+          node: null
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: x
+                      node: null
+                      object: null
+                isvirtual: true
+    isvirtual: true
+- position: "12:7"
+  content: '{ email: " " }'
+  data:
+    properties:
+        - name: email
+          node: {}
+          object: null
+    isvirtual: false
+- position: "12:23"
+  content: '{ first_name: "" }'
+  data:
+    properties:
+        - name: first_name
+          node: {}
+          object: null
+    isvirtual: false
 - position: "13:1"
   content: 'obj.x({ email: " " }, { first_name: "" }).a'
   data:
@@ -247,6 +741,393 @@
                       object: null
                 isvirtual: true
     isvirtual: true
+- position: "13:1"
+  content: 'obj.x({ email: " " }, { first_name: "" })'
+  data:
+    properties:
+        - name: ""
+          node: null
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: a
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: i
+                                  node: {}
+                                  object: null
+                            isvirtual: false
+                isvirtual: false
+        - name: ""
+          node: null
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: x
+                      node: null
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: a
+                                  node: {}
+                                  object:
+                                    detectortype: object
+                                    matchnode: {}
+                                    data:
+                                        properties:
+                                            - name: i
+                                              node: {}
+                                              object: null
+                                        isvirtual: false
+                            isvirtual: false
+                isvirtual: true
+        - name: ""
+          node: null
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: i
+                      node: {}
+                      object: null
+                isvirtual: false
+        - name: ""
+          node: null
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: x
+                      node: null
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: i
+                                  node: {}
+                                  object: null
+                            isvirtual: false
+                isvirtual: true
+        - name: ""
+          node: null
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: obj
+                      node: null
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: x
+                                  node: null
+                                  object: null
+                            isvirtual: true
+                isvirtual: true
+        - name: ""
+          node: null
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: obj
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: x
+                                  node: {}
+                                  object:
+                                    detectortype: object
+                                    matchnode: {}
+                                    data:
+                                        properties:
+                                            - name: a
+                                              node: {}
+                                              object:
+                                                detectortype: object
+                                                matchnode: {}
+                                                data:
+                                                    properties:
+                                                        - name: i
+                                                          node: {}
+                                                          object: null
+                                                    isvirtual: false
+                                        isvirtual: false
+                                - name: x
+                                  node: {}
+                                  object:
+                                    detectortype: object
+                                    matchnode: {}
+                                    data:
+                                        properties:
+                                            - name: i
+                                              node: {}
+                                              object: null
+                                        isvirtual: false
+                                - name: "y"
+                                  node: {}
+                                  object: null
+                            isvirtual: false
+                isvirtual: true
+        - name: ""
+          node: null
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: x
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: a
+                                  node: {}
+                                  object:
+                                    detectortype: object
+                                    matchnode: {}
+                                    data:
+                                        properties:
+                                            - name: i
+                                              node: {}
+                                              object: null
+                                        isvirtual: false
+                            isvirtual: false
+                    - name: x
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: i
+                                  node: {}
+                                  object: null
+                            isvirtual: false
+                    - name: "y"
+                      node: {}
+                      object: null
+                isvirtual: false
+        - name: ""
+          node: null
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: a
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: i
+                                  node: {}
+                                  object: null
+                            isvirtual: false
+                isvirtual: false
+        - name: ""
+          node: null
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: i
+                      node: {}
+                      object: null
+                isvirtual: false
+        - name: ""
+          node: null
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: x
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: a
+                                  node: {}
+                                  object:
+                                    detectortype: object
+                                    matchnode: {}
+                                    data:
+                                        properties:
+                                            - name: i
+                                              node: {}
+                                              object: null
+                                        isvirtual: false
+                            isvirtual: false
+                    - name: x
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: i
+                                  node: {}
+                                  object: null
+                            isvirtual: false
+                    - name: "y"
+                      node: {}
+                      object: null
+                isvirtual: false
+        - name: ""
+          node: null
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: a
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: i
+                                  node: {}
+                                  object: null
+                            isvirtual: false
+                isvirtual: false
+        - name: ""
+          node: null
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: i
+                      node: {}
+                      object: null
+                isvirtual: false
+    isvirtual: true
+- position: "13:1"
+  content: obj.x
+  data:
+    properties:
+        - name: a
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: i
+                      node: {}
+                      object: null
+                isvirtual: false
+    isvirtual: false
+- position: "13:1"
+  content: obj.x
+  data:
+    properties:
+        - name: x
+          node: null
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: a
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: i
+                                  node: {}
+                                  object: null
+                            isvirtual: false
+                isvirtual: false
+    isvirtual: true
+- position: "13:1"
+  content: obj.x
+  data:
+    properties:
+        - name: i
+          node: {}
+          object: null
+    isvirtual: false
+- position: "13:1"
+  content: obj.x
+  data:
+    properties:
+        - name: x
+          node: null
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: i
+                      node: {}
+                      object: null
+                isvirtual: false
+    isvirtual: true
+- position: "13:1"
+  content: obj.x
+  data:
+    properties:
+        - name: obj
+          node: null
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: x
+                      node: null
+                      object: null
+                isvirtual: true
+    isvirtual: true
+- position: "13:7"
+  content: '{ email: " " }'
+  data:
+    properties:
+        - name: email
+          node: {}
+          object: null
+    isvirtual: false
+- position: "13:23"
+  content: '{ first_name: "" }'
+  data:
+    properties:
+        - name: first_name
+          node: {}
+          object: null
+    isvirtual: false
 - position: "16:7"
   content: x
   data:
@@ -285,6 +1166,30 @@
                                   node: {}
                                   object: null
                             isvirtual: false
+                isvirtual: false
+    isvirtual: true
+- position: "16:7"
+  content: x
+  data:
+    properties:
+        - name: i
+          node: {}
+          object: null
+    isvirtual: false
+- position: "16:7"
+  content: x
+  data:
+    properties:
+        - name: x
+          node: null
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: i
+                      node: {}
+                      object: null
                 isvirtual: false
     isvirtual: true
 - position: "16:7"

--- a/new/detector/implementation/javascript/.snapshots/TestJavascriptObjectDetector-object_spread
+++ b/new/detector/implementation/javascript/.snapshots/TestJavascriptObjectDetector-object_spread
@@ -14,6 +14,14 @@
                       object: null
                 isvirtual: false
     isvirtual: true
+- position: "1:12"
+  content: '{ a: 123 }'
+  data:
+    properties:
+        - name: a
+          node: {}
+          object: null
+    isvirtual: false
 - position: "2:5"
   content: 'nested = { ...user, b: 456 }'
   data:
@@ -44,6 +52,28 @@
                       object: null
                 isvirtual: false
     isvirtual: true
+- position: "2:14"
+  content: '{ ...user, b: 456 }'
+  data:
+    properties:
+        - name: user
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: a
+                      node: {}
+                      object: null
+                isvirtual: false
+        - name: a
+          node: {}
+          object: null
+        - name: b
+          node: {}
+          object: null
+    isvirtual: false
 - position: "4:6"
   content: |-
     {
@@ -117,6 +147,278 @@
                                   node: {}
                                   object: null
                             isvirtual: false
+                    - name: "n"
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: user
+                                  node: {}
+                                  object:
+                                    detectortype: object
+                                    matchnode: {}
+                                    data:
+                                        properties:
+                                            - name: a
+                                              node: {}
+                                              object: null
+                                        isvirtual: false
+                            isvirtual: true
+                    - name: "n"
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: a
+                                  node: {}
+                                  object: null
+                            isvirtual: false
+                    - name: "n"
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: a
+                                  node: {}
+                                  object: null
+                            isvirtual: false
+                    - name: "n"
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: user
+                                  node: {}
+                                  object:
+                                    detectortype: object
+                                    matchnode: {}
+                                    data:
+                                        properties:
+                                            - name: a
+                                              node: {}
+                                              object: null
+                                        isvirtual: false
+                                - name: a
+                                  node: {}
+                                  object: null
+                                - name: b
+                                  node: {}
+                                  object: null
+                            isvirtual: false
+                    - name: "n"
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: user
+                                  node: {}
+                                  object:
+                                    detectortype: object
+                                    matchnode: {}
+                                    data:
+                                        properties:
+                                            - name: a
+                                              node: {}
+                                              object: null
+                                        isvirtual: false
+                            isvirtual: true
+                    - name: "n"
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: a
+                                  node: {}
+                                  object: null
+                            isvirtual: false
+                    - name: "n"
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: a
+                                  node: {}
+                                  object: null
+                            isvirtual: false
+                isvirtual: false
+        - name: x
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: nested
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: user
+                                  node: {}
+                                  object:
+                                    detectortype: object
+                                    matchnode: {}
+                                    data:
+                                        properties:
+                                            - name: a
+                                              node: {}
+                                              object: null
+                                        isvirtual: false
+                                - name: a
+                                  node: {}
+                                  object: null
+                                - name: b
+                                  node: {}
+                                  object: null
+                            isvirtual: false
+                isvirtual: true
+        - name: x
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: user
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: a
+                                  node: {}
+                                  object: null
+                            isvirtual: false
+                    - name: a
+                      node: {}
+                      object: null
+                    - name: b
+                      node: {}
+                      object: null
+                isvirtual: false
+        - name: x
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: user
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: a
+                                  node: {}
+                                  object: null
+                            isvirtual: false
+                isvirtual: true
+        - name: x
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: a
+                      node: {}
+                      object: null
+                isvirtual: false
+        - name: x
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: a
+                      node: {}
+                      object: null
+                isvirtual: false
+        - name: x
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: user
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: a
+                                  node: {}
+                                  object: null
+                            isvirtual: false
+                    - name: a
+                      node: {}
+                      object: null
+                    - name: b
+                      node: {}
+                      object: null
+                isvirtual: false
+        - name: x
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: user
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: a
+                                  node: {}
+                                  object: null
+                            isvirtual: false
+                isvirtual: true
+        - name: x
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: a
+                      node: {}
+                      object: null
+                isvirtual: false
+        - name: x
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: a
+                      node: {}
+                      object: null
                 isvirtual: false
         - name: "y"
           node: {}
@@ -129,5 +431,183 @@
                       node: {}
                       object: null
                 isvirtual: false
+    isvirtual: false
+- position: "5:6"
+  content: '{ n: nested }'
+  data:
+    properties:
+        - name: "n"
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: nested
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: user
+                                  node: {}
+                                  object:
+                                    detectortype: object
+                                    matchnode: {}
+                                    data:
+                                        properties:
+                                            - name: a
+                                              node: {}
+                                              object: null
+                                        isvirtual: false
+                                - name: a
+                                  node: {}
+                                  object: null
+                                - name: b
+                                  node: {}
+                                  object: null
+                            isvirtual: false
+                isvirtual: true
+        - name: "n"
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: user
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: a
+                                  node: {}
+                                  object: null
+                            isvirtual: false
+                    - name: a
+                      node: {}
+                      object: null
+                    - name: b
+                      node: {}
+                      object: null
+                isvirtual: false
+        - name: "n"
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: user
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: a
+                                  node: {}
+                                  object: null
+                            isvirtual: false
+                isvirtual: true
+        - name: "n"
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: a
+                      node: {}
+                      object: null
+                isvirtual: false
+        - name: "n"
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: a
+                      node: {}
+                      object: null
+                isvirtual: false
+        - name: "n"
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: user
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: a
+                                  node: {}
+                                  object: null
+                            isvirtual: false
+                    - name: a
+                      node: {}
+                      object: null
+                    - name: b
+                      node: {}
+                      object: null
+                isvirtual: false
+        - name: "n"
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: user
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: a
+                                  node: {}
+                                  object: null
+                            isvirtual: false
+                isvirtual: true
+        - name: "n"
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: a
+                      node: {}
+                      object: null
+                isvirtual: false
+        - name: "n"
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: a
+                      node: {}
+                      object: null
+                isvirtual: false
+    isvirtual: false
+- position: "6:6"
+  content: '{ c: 4 }'
+  data:
+    properties:
+        - name: c
+          node: {}
+          object: null
     isvirtual: false
 

--- a/new/detector/implementation/javascript/.snapshots/TestJavascriptStringDetector-string_literal
+++ b/new/detector/implementation/javascript/.snapshots/TestJavascriptStringDetector-string_literal
@@ -8,16 +8,6 @@
   data:
     value: ab
     isliteral: true
-- position: "3:1"
-  content: '"a"'
-  data:
-    value: a
-    isliteral: true
-- position: "3:7"
-  content: '"b"'
-  data:
-    value: b
-    isliteral: true
 - position: "5:5"
   content: '"a"'
   data:

--- a/new/detector/implementation/javascript/.snapshots/TestJavascriptStringDetector-string_non_literal
+++ b/new/detector/implementation/javascript/.snapshots/TestJavascriptStringDetector-string_non_literal
@@ -3,11 +3,6 @@
   data:
     value: a*
     isliteral: false
-- position: "1:1"
-  content: '"a"'
-  data:
-    value: a
-    isliteral: true
 - position: "3:1"
   content: '`${x} b`'
   data:

--- a/new/detector/implementation/javascript/.snapshots/TestJavascriptTypes-typed_object_const
+++ b/new/detector/implementation/javascript/.snapshots/TestJavascriptTypes-typed_object_const
@@ -14,4 +14,12 @@
                       object: null
                 isvirtual: false
     isvirtual: true
+- position: "1:33"
+  content: '{ email: "jhon@gmail.com" }'
+  data:
+    properties:
+        - name: email
+          node: {}
+          object: null
+    isvirtual: false
 

--- a/new/detector/implementation/javascript/.snapshots/TestJavascriptTypes-typed_object_let
+++ b/new/detector/implementation/javascript/.snapshots/TestJavascriptTypes-typed_object_let
@@ -14,4 +14,12 @@
                       object: null
                 isvirtual: false
     isvirtual: true
+- position: "1:31"
+  content: '{ email: "jhon@gmail.com" }'
+  data:
+    properties:
+        - name: email
+          node: {}
+          object: null
+    isvirtual: false
 

--- a/new/detector/implementation/javascript/.snapshots/TestJavascriptTypes-typed_object_var
+++ b/new/detector/implementation/javascript/.snapshots/TestJavascriptTypes-typed_object_var
@@ -14,4 +14,12 @@
                       object: null
                 isvirtual: false
     isvirtual: true
+- position: "1:31"
+  content: '{ email: "jhon@gmail.com" }'
+  data:
+    properties:
+        - name: email
+          node: {}
+          object: null
+    isvirtual: false
 

--- a/new/detector/implementation/ruby/.snapshots/TestRubyObjectDetector-object_hash
+++ b/new/detector/implementation/ruby/.snapshots/TestRubyObjectDetector-object_hash
@@ -21,6 +21,21 @@
                       object: null
                 isvirtual: false
     isvirtual: true
+- position: "1:10"
+  content: |-
+    {
+      "one" => 42,
+      "two" => "hi"
+    }
+  data:
+    properties:
+        - name: one
+          node: {}
+          object: null
+        - name: two
+          node: {}
+          object: null
+    isvirtual: false
 - position: "6:6"
   content: |-
     {
@@ -72,6 +87,70 @@
                                   node: {}
                                   object: null
                             isvirtual: false
+                    - name: "n"
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: one
+                                  node: {}
+                                  object: null
+                                - name: two
+                                  node: {}
+                                  object: null
+                            isvirtual: false
+                isvirtual: false
+        - name: x
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: nested
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: one
+                                  node: {}
+                                  object: null
+                                - name: two
+                                  node: {}
+                                  object: null
+                            isvirtual: false
+                isvirtual: true
+        - name: x
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: one
+                      node: {}
+                      object: null
+                    - name: two
+                      node: {}
+                      object: null
+                isvirtual: false
+        - name: x
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: one
+                      node: {}
+                      object: null
+                    - name: two
+                      node: {}
+                      object: null
                 isvirtual: false
         - name: "y"
           node: {}
@@ -84,5 +163,68 @@
                       node: {}
                       object: null
                 isvirtual: false
+    isvirtual: false
+- position: "7:6"
+  content: '{ n: nested }'
+  data:
+    properties:
+        - name: "n"
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: nested
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: one
+                                  node: {}
+                                  object: null
+                                - name: two
+                                  node: {}
+                                  object: null
+                            isvirtual: false
+                isvirtual: true
+        - name: "n"
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: one
+                      node: {}
+                      object: null
+                    - name: two
+                      node: {}
+                      object: null
+                isvirtual: false
+        - name: "n"
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: one
+                      node: {}
+                      object: null
+                    - name: two
+                      node: {}
+                      object: null
+                isvirtual: false
+    isvirtual: false
+- position: "8:6"
+  content: '{ b: 4 }'
+  data:
+    properties:
+        - name: b
+          node: {}
+          object: null
     isvirtual: false
 

--- a/new/detector/implementation/ruby/.snapshots/TestRubyObjectDetector-object_projection
+++ b/new/detector/implementation/ruby/.snapshots/TestRubyObjectDetector-object_projection
@@ -28,11 +28,84 @@
                                               object: null
                                         isvirtual: false
                             isvirtual: false
+                    - name: x
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: i
+                                  node: {}
+                                  object: null
+                            isvirtual: false
                     - name: "y"
                       node: {}
                       object: null
                 isvirtual: false
     isvirtual: true
+- position: "1:11"
+  content: '{ x: { a: { i: 3 } }, y: 4 }'
+  data:
+    properties:
+        - name: x
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: a
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: i
+                                  node: {}
+                                  object: null
+                            isvirtual: false
+                isvirtual: false
+        - name: x
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: i
+                      node: {}
+                      object: null
+                isvirtual: false
+        - name: "y"
+          node: {}
+          object: null
+    isvirtual: false
+- position: "1:16"
+  content: '{ a: { i: 3 } }'
+  data:
+    properties:
+        - name: a
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: i
+                      node: {}
+                      object: null
+                isvirtual: false
+    isvirtual: false
+- position: "1:21"
+  content: '{ i: 3 }'
+  data:
+    properties:
+        - name: i
+          node: {}
+          object: null
+    isvirtual: false
 - position: "4:1"
   content: obj.x
   data:
@@ -71,6 +144,30 @@
                                   node: {}
                                   object: null
                             isvirtual: false
+                isvirtual: false
+    isvirtual: true
+- position: "4:1"
+  content: obj.x
+  data:
+    properties:
+        - name: i
+          node: {}
+          object: null
+    isvirtual: false
+- position: "4:1"
+  content: obj.x
+  data:
+    properties:
+        - name: x
+          node: null
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: i
+                      node: {}
+                      object: null
                 isvirtual: false
     isvirtual: true
 - position: "4:1"
@@ -125,6 +222,86 @@
             data:
                 properties:
                     - name: a
+                      node: null
+                      object: null
+                isvirtual: true
+    isvirtual: true
+- position: "5:1"
+  content: obj["x"]
+  data:
+    properties:
+        - name: a
+          node: {}
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: i
+                      node: {}
+                      object: null
+                isvirtual: false
+    isvirtual: false
+- position: "5:1"
+  content: obj["x"]
+  data:
+    properties:
+        - name: x
+          node: null
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: a
+                      node: {}
+                      object:
+                        detectortype: object
+                        matchnode: {}
+                        data:
+                            properties:
+                                - name: i
+                                  node: {}
+                                  object: null
+                            isvirtual: false
+                isvirtual: false
+    isvirtual: true
+- position: "5:1"
+  content: obj["x"]
+  data:
+    properties:
+        - name: i
+          node: {}
+          object: null
+    isvirtual: false
+- position: "5:1"
+  content: obj["x"]
+  data:
+    properties:
+        - name: x
+          node: null
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: i
+                      node: {}
+                      object: null
+                isvirtual: false
+    isvirtual: true
+- position: "5:1"
+  content: obj["x"]
+  data:
+    properties:
+        - name: obj
+          node: null
+          object:
+            detectortype: object
+            matchnode: {}
+            data:
+                properties:
+                    - name: x
                       node: null
                       object: null
                 isvirtual: true

--- a/new/detector/implementation/ruby/.snapshots/TestRubyStringDetector-string_literal
+++ b/new/detector/implementation/ruby/.snapshots/TestRubyStringDetector-string_literal
@@ -3,43 +3,13 @@
   data:
     value: ab
     isliteral: true
-- position: "1:2"
-  content: ab
-  data:
-    value: ab
-    isliteral: true
 - position: "3:1"
   content: '"a" + "b"'
   data:
     value: ab
     isliteral: true
-- position: "3:1"
-  content: '"a"'
-  data:
-    value: a
-    isliteral: true
-- position: "3:2"
-  content: a
-  data:
-    value: a
-    isliteral: true
-- position: "3:7"
-  content: '"b"'
-  data:
-    value: b
-    isliteral: true
-- position: "3:8"
-  content: b
-  data:
-    value: b
-    isliteral: true
 - position: "5:5"
   content: '"a"'
-  data:
-    value: a
-    isliteral: true
-- position: "5:6"
-  content: a
   data:
     value: a
     isliteral: true
@@ -47,15 +17,5 @@
   content: '"#{x} b"'
   data:
     value: a b
-    isliteral: true
-- position: "6:2"
-  content: '#{x}'
-  data:
-    value: a
-    isliteral: true
-- position: "6:6"
-  content: ' b'
-  data:
-    value: ' b'
     isliteral: true
 

--- a/new/detector/implementation/ruby/.snapshots/TestRubyStringDetector-string_non_literal
+++ b/new/detector/implementation/ruby/.snapshots/TestRubyStringDetector-string_non_literal
@@ -3,29 +3,9 @@
   data:
     value: a*
     isliteral: false
-- position: "1:1"
-  content: '"a"'
-  data:
-    value: a
-    isliteral: true
-- position: "1:2"
-  content: a
-  data:
-    value: a
-    isliteral: true
 - position: "3:1"
   content: '"#{x} b"'
   data:
     value: '* b'
     isliteral: false
-- position: "3:2"
-  content: '#{x}'
-  data:
-    value: '*'
-    isliteral: false
-- position: "3:6"
-  content: ' b'
-  data:
-    value: ' b'
-    isliteral: true
 

--- a/new/detector/implementation/ruby/object/object.go
+++ b/new/detector/implementation/ruby/object/object.go
@@ -69,7 +69,7 @@ func New(lang languagetypes.Language) (types.Detector, error) {
 	}
 
 	// user[:name]
-	elementReferenceQuery, err := lang.CompileQuery(`(element_reference object: (_) @object (_) @key) @root`)
+	elementReferenceQuery, err := lang.CompileQuery(`(element_reference object: (_) @object . (_) @key . ) @root`)
 	if err != nil {
 		return nil, fmt.Errorf("error compiling element reference query %s", err)
 	}

--- a/new/detector/implementation/ruby/testdata/object_projection.rb
+++ b/new/detector/implementation/ruby/testdata/object_projection.rb
@@ -8,3 +8,7 @@ obj["x"].a
 obj.z
 @myvar.x
 @myvar["w"]
+
+# Multiple index
+foo = [:a, :b, :c, :d, :e]
+foo[0, 2]


### PR DESCRIPTION
## Description

Our element reference query was matching on things like `foo_array[0, 2]`. This was causing issue with the pattern matching returning multiple results. 
To address this, we add some anchors to the query so that we now match only on the simple hash access case e.g. `foo[:bar]`.

Closes #1005 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
