### PR TITLE
fix: prefer fingerprint to fingerprints to match other flags

### DIFF
--- a/docs/_data/bearer_scan.yaml
+++ b/docs/_data/bearer_scan.yaml
@@ -30,7 +30,8 @@ options:
       default_value: 3s
       usage: |
         Set timeout when attempting to resolve detected domains during classification, e.g. --domain-resolution-timeout=3s
-    - name: exclude-fingerprints
+    - name: exclude-fingerprint
+      default_value: '[]'
       usage: |
         Specify the comma-separated fingerprints of the findings you would like to exclude from the report.
     - name: external-rule-dir

--- a/e2e/flags/.snapshots/TestInitCommand
+++ b/e2e/flags/.snapshots/TestInitCommand
@@ -1,6 +1,6 @@
 disable-version-check: false
 report:
-    exclude-fingerprints: []
+    exclude-fingerprint: []
     format: ""
     no-color: false
     output: ""

--- a/e2e/flags/.snapshots/TestMetadataFlags-help-scan
+++ b/e2e/flags/.snapshots/TestMetadataFlags-help-scan
@@ -10,11 +10,11 @@ Examples:
 
 
 Report Flags
-      --exclude-fingerprints strings   Specify the comma-separated fingerprints of the findings you would like to exclude from the report.
-  -f, --format string                  Specify report format (json, yaml, sarif, gitlab-sast)
-      --output string                  Specify the output path for the report.
-      --report string                  Specify the type of report (security, privacy, dataflow). (default "security")
-      --severity string                Specify which severities are included in the report. (default "critical,high,medium,low,warning")
+      --exclude-fingerprint strings   Specify the comma-separated fingerprints of the findings you would like to exclude from the report.
+  -f, --format string                 Specify report format (json, yaml, sarif, gitlab-sast)
+      --output string                 Specify the output path for the report.
+      --report string                 Specify the type of report (security, privacy, dataflow). (default "security")
+      --severity string               Specify which severities are included in the report. (default "critical,high,medium,low,warning")
 
 Rule Flags
       --disable-default-rules   Disables all default and built-in rules.

--- a/e2e/flags/.snapshots/TestMetadataFlags-scan-help
+++ b/e2e/flags/.snapshots/TestMetadataFlags-scan-help
@@ -10,11 +10,11 @@ Examples:
 
 
 Report Flags
-      --exclude-fingerprints strings   Specify the comma-separated fingerprints of the findings you would like to exclude from the report.
-  -f, --format string                  Specify report format (json, yaml, sarif, gitlab-sast)
-      --output string                  Specify the output path for the report.
-      --report string                  Specify the type of report (security, privacy, dataflow). (default "security")
-      --severity string                Specify which severities are included in the report. (default "critical,high,medium,low,warning")
+      --exclude-fingerprint strings   Specify the comma-separated fingerprints of the findings you would like to exclude from the report.
+  -f, --format string                 Specify report format (json, yaml, sarif, gitlab-sast)
+      --output string                 Specify the output path for the report.
+      --report string                 Specify the type of report (security, privacy, dataflow). (default "security")
+      --severity string               Specify which severities are included in the report. (default "critical,high,medium,low,warning")
 
 Rule Flags
       --disable-default-rules   Disables all default and built-in rules.

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-context-flag
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-context-flag
@@ -11,11 +11,11 @@ Examples:
 
 
 Report Flags
-      --exclude-fingerprints strings   Specify the comma-separated fingerprints of the findings you would like to exclude from the report.
-  -f, --format string                  Specify report format (json, yaml, sarif, gitlab-sast)
-      --output string                  Specify the output path for the report.
-      --report string                  Specify the type of report (security, privacy, dataflow). (default "security")
-      --severity string                Specify which severities are included in the report. (default "critical,high,medium,low,warning")
+      --exclude-fingerprint strings   Specify the comma-separated fingerprints of the findings you would like to exclude from the report.
+  -f, --format string                 Specify report format (json, yaml, sarif, gitlab-sast)
+      --output string                 Specify the output path for the report.
+      --report string                 Specify the type of report (security, privacy, dataflow). (default "security")
+      --severity string               Specify which severities are included in the report. (default "critical,high,medium,low,warning")
 
 Rule Flags
       --disable-default-rules   Disables all default and built-in rules.

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag
@@ -11,11 +11,11 @@ Examples:
 
 
 Report Flags
-      --exclude-fingerprints strings   Specify the comma-separated fingerprints of the findings you would like to exclude from the report.
-  -f, --format string                  Specify report format (json, yaml, sarif, gitlab-sast)
-      --output string                  Specify the output path for the report.
-      --report string                  Specify the type of report (security, privacy, dataflow). (default "security")
-      --severity string                Specify which severities are included in the report. (default "critical,high,medium,low,warning")
+      --exclude-fingerprint strings   Specify the comma-separated fingerprints of the findings you would like to exclude from the report.
+  -f, --format string                 Specify report format (json, yaml, sarif, gitlab-sast)
+      --output string                 Specify the output path for the report.
+      --report string                 Specify the type of report (security, privacy, dataflow). (default "security")
+      --severity string               Specify which severities are included in the report. (default "critical,high,medium,low,warning")
 
 Rule Flags
       --disable-default-rules   Disables all default and built-in rules.

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-report-flag
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-report-flag
@@ -11,11 +11,11 @@ Examples:
 
 
 Report Flags
-      --exclude-fingerprints strings   Specify the comma-separated fingerprints of the findings you would like to exclude from the report.
-  -f, --format string                  Specify report format (json, yaml, sarif, gitlab-sast)
-      --output string                  Specify the output path for the report.
-      --report string                  Specify the type of report (security, privacy, dataflow). (default "security")
-      --severity string                Specify which severities are included in the report. (default "critical,high,medium,low,warning")
+      --exclude-fingerprint strings   Specify the comma-separated fingerprints of the findings you would like to exclude from the report.
+  -f, --format string                 Specify report format (json, yaml, sarif, gitlab-sast)
+      --output string                 Specify the output path for the report.
+      --report string                 Specify the type of report (security, privacy, dataflow). (default "security")
+      --severity string               Specify which severities are included in the report. (default "critical,high,medium,low,warning")
 
 Rule Flags
       --disable-default-rules   Disables all default and built-in rules.

--- a/pkg/flag/report_flags.go
+++ b/pkg/flag/report_flags.go
@@ -53,37 +53,37 @@ var (
 		Value:      DefaultSeverity,
 		Usage:      "Specify which severities are included in the report.",
 	}
-	ExcludeFingerprintsFlag = Flag{
-		Name:       "exclude-fingerprints",
-		ConfigName: "report.exclude-fingerprints",
+	ExcludeFingerprintFlag = Flag{
+		Name:       "exclude-fingerprint",
+		ConfigName: "report.exclude-fingerprint",
 		Value:      []string{},
 		Usage:      "Specify the comma-separated fingerprints of the findings you would like to exclude from the report.",
 	}
 )
 
 type ReportFlagGroup struct {
-	Format              *Flag
-	Report              *Flag
-	Output              *Flag
-	Severity            *Flag
-	ExcludeFingerprints *Flag
+	Format             *Flag
+	Report             *Flag
+	Output             *Flag
+	Severity           *Flag
+	ExcludeFingerprint *Flag
 }
 
 type ReportOptions struct {
-	Format              string          `mapstructure:"format" json:"format" yaml:"format"`
-	Report              string          `mapstructure:"report" json:"report" yaml:"report"`
-	Output              string          `mapstructure:"output" json:"output" yaml:"output"`
-	Severity            map[string]bool `mapstructure:"severity" json:"severity" yaml:"severity"`
-	ExcludeFingerprints map[string]bool `mapstructure:"exclude_fingerprints" json:"exclude_fingerprints" yaml:"exclude_fingerprints"`
+	Format             string          `mapstructure:"format" json:"format" yaml:"format"`
+	Report             string          `mapstructure:"report" json:"report" yaml:"report"`
+	Output             string          `mapstructure:"output" json:"output" yaml:"output"`
+	Severity           map[string]bool `mapstructure:"severity" json:"severity" yaml:"severity"`
+	ExcludeFingerprint map[string]bool `mapstructure:"exclude_fingerprints" json:"exclude_fingerprints" yaml:"exclude_fingerprints"`
 }
 
 func NewReportFlagGroup() *ReportFlagGroup {
 	return &ReportFlagGroup{
-		Format:              &FormatFlag,
-		Report:              &ReportFlag,
-		Output:              &OutputFlag,
-		Severity:            &SeverityFlag,
-		ExcludeFingerprints: &ExcludeFingerprintsFlag,
+		Format:             &FormatFlag,
+		Report:             &ReportFlag,
+		Output:             &OutputFlag,
+		Severity:           &SeverityFlag,
+		ExcludeFingerprint: &ExcludeFingerprintFlag,
 	}
 }
 
@@ -97,7 +97,7 @@ func (f *ReportFlagGroup) Flags() []*Flag {
 		f.Report,
 		f.Output,
 		f.Severity,
-		f.ExcludeFingerprints,
+		f.ExcludeFingerprint,
 	}
 }
 
@@ -149,17 +149,17 @@ func (f *ReportFlagGroup) ToOptions() (ReportOptions, error) {
 	}
 
 	// turn string slice into map for ease of access
-	excludeFingerprints := getStringSlice(f.ExcludeFingerprints)
+	excludeFingerprints := getStringSlice(f.ExcludeFingerprint)
 	excludeFingerprintsMapping := make(map[string]bool)
 	for _, fingerprint := range excludeFingerprints {
 		excludeFingerprintsMapping[fingerprint] = true
 	}
 
 	return ReportOptions{
-		Format:              format,
-		Report:              report,
-		Output:              getString(f.Output),
-		Severity:            severityMapping,
-		ExcludeFingerprints: excludeFingerprintsMapping,
+		Format:             format,
+		Report:             report,
+		Output:             getString(f.Output),
+		Severity:           severityMapping,
+		ExcludeFingerprint: excludeFingerprintsMapping,
 	}, nil
 }

--- a/pkg/report/output/security/security.go
+++ b/pkg/report/output/security/security.go
@@ -194,7 +194,7 @@ func evaluateRules(
 				fingerprint := fmt.Sprintf("%x_%d", md5.Sum([]byte(fingerprintId)), i)
 				oldFingerprint := fmt.Sprintf("%x_%d", md5.Sum([]byte(oldFingerprintId)), i)
 
-				if config.Report.ExcludeFingerprints[fingerprint] {
+				if config.Report.ExcludeFingerprint[fingerprint] {
 					// skip finding - fingerprint is in exclude list
 					log.Debug().Msgf("Excluding finding with fingerprint %s", fingerprint)
 					continue


### PR DESCRIPTION
## Description

Fix to follow convention of other list flags e.g. `skip-rule`, `only-rule`, `skip-path` we change `exclude-fingerprints` to `exclude-fingerprint` (single). We keep the `exclude` terminology since we are not skipping anything here (that is, the findings are still "found"); we are simply excluding them from showing up in the report

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
