### PR TITLE
feat: add fingerprint to report and move skip rule to docs

### DIFF
--- a/docs/reference/rule-pages.njk
+++ b/docs/reference/rule-pages.njk
@@ -59,5 +59,18 @@ rule.metadata %}
         {% endfor %}
       </ul>
     {% endif %}
-
   {% endif %}
+
+{% renderTemplate "liquid,md", rule.metadata %}
+  ## Configuration
+
+  To skip this rule during a scan, use the following flag
+  ```shell
+  bearer scan /path/to/your-project/ --skip-rule={{id}}
+  ```
+
+  To run _only_ this rule during a scan, use the following flag
+  ```shell
+  bearer scan /path/to/your-project/ --only-rule={{id}}
+  ```
+{% endrenderTemplate %}

--- a/pkg/report/output/security/.snapshots/TestBuildReportString
+++ b/pkg/report/output/security/.snapshots/TestBuildReportString
@@ -10,7 +10,7 @@ Rules:
 
 CRITICAL: Sensitive data sent to Rails loggers detected. [CWE-209, CWE-532]
 https://docs.bearer.com/reference/rules/ruby_rails_logger
-To skip this rule, use the flag --skip-rule=ruby_rails_logger
+To exclude this finding, use the flag --exclude-fingerprint=375d7c2e9977cf2ce5dbf04b04237bea_0
 
 File: :1
 
@@ -18,7 +18,7 @@ File: :1
 
 HIGH: Missing SSL certificate verification detected. [CWE-295]
 https://docs.bearer.com/reference/rules/ruby_lang_ssl_verification
-To skip this rule, use the flag --skip-rule=ruby_lang_ssl_verification
+To exclude this finding, use the flag --exclude-fingerprint=9005ef3db844b32c1a0317e032f4a16a_0
 
 File: :2
 

--- a/pkg/report/output/security/security.go
+++ b/pkg/report/output/security/security.go
@@ -523,7 +523,7 @@ func writeFailureToString(reportStr *strings.Builder, result Result, severity st
 		reportStr.WriteString(color.HiBlackString(result.DocumentationUrl + "\n"))
 	}
 
-	reportStr.WriteString(color.HiBlackString("To skip this rule, use the flag --skip-rule=" + result.Id + "\n"))
+	reportStr.WriteString(color.HiBlackString("To exclude this finding, use the flag --exclude-fingerprint=" + result.Fingerprint + "\n"))
 	reportStr.WriteString("\n")
 	if result.DetailedContext != "" {
 		reportStr.WriteString("Detected: " + result.DetailedContext + "\n\n")


### PR DESCRIPTION
## Description
With the introduction of the `--exclude-fingerprint` flag, we replace the `--skip-rule=rule_id` line in the security report with the finding's fingerprint `--exclude-fingerprint=0fd..._1`


<img width="564" alt="Screenshot 2023-05-31 at 12 25 58" src="https://github.com/Bearer/bearer/assets/4560746/769ee0ec-218e-47c4-a7c1-fa77c333a557">


We move the more general `--skip-rule` copy to the documentation itself

<img width="793" alt="Screenshot 2023-05-31 at 11 28 13" src="https://github.com/Bearer/bearer/assets/4560746/8ebb8697-bd9e-44ff-a68b-6a9b66b51495">

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
