### PR TITLE
fix: result scope following testing

### DIFF
--- a/new/detector/composition/java/java.go
+++ b/new/detector/composition/java/java.go
@@ -201,7 +201,7 @@ func (composition *Composition) DetectFromFileWithTypes(file *file.FileInfo, det
 			tree.RootNode(),
 			detectorType,
 			sanitizerRuleID,
-			settings.NESTED_SCOPE,
+			settings.DefaultScope,
 			false,
 		)
 		if err != nil {

--- a/new/detector/composition/java/java_test.go
+++ b/new/detector/composition/java/java_test.go
@@ -14,11 +14,9 @@ var loggerRule []byte
 var scopeRule []byte
 
 func TestFlow(t *testing.T) {
-	t.Parallel()
 	testhelper.GetRunner(t, loggerRule, "Java").RunTest(t, "./testdata/testcases/flow", ".snapshots/flow/")
 }
 
 func TestScope(t *testing.T) {
-	t.Parallel()
 	testhelper.GetRunner(t, scopeRule, "Java").RunTest(t, "./testdata/scope", ".snapshots/")
 }

--- a/new/detector/composition/javascript/javascript.go
+++ b/new/detector/composition/javascript/javascript.go
@@ -201,7 +201,7 @@ func (composition *Composition) DetectFromFileWithTypes(file *file.FileInfo, det
 			tree.RootNode(),
 			detectorType,
 			sanitizerRuleID,
-			settings.NESTED_SCOPE,
+			settings.DefaultScope,
 			false,
 		)
 		if err != nil {

--- a/new/detector/composition/javascript/javascript_test.go
+++ b/new/detector/composition/javascript/javascript_test.go
@@ -20,21 +20,17 @@ var deconstructingRule []byte
 var scopeRule []byte
 
 func TestFlow(t *testing.T) {
-	t.Parallel()
 	testhelper.GetRunner(t, datatypeRule, "Javascript").RunTest(t, "./testdata/testcases/flow", ".snapshots/flow/")
 }
 
 func TestObjectDeconstructing(t *testing.T) {
-	t.Parallel()
 	testhelper.GetRunner(t, deconstructingRule, "Javascript").RunTest(t, "./testdata/testcases/object-deconstructing", ".snapshots/object-deconstructing/")
 }
 
 func TestString(t *testing.T) {
-	t.Parallel()
 	testhelper.GetRunner(t, insecureURLRule, "Javascript").RunTest(t, "./testdata/testcases/string", ".snapshots/string/")
 }
 
 func TestScope(t *testing.T) {
-	t.Parallel()
 	testhelper.GetRunner(t, scopeRule, "Javascript").RunTest(t, "./testdata/scope", ".snapshots/")
 }

--- a/new/detector/composition/ruby/ruby.go
+++ b/new/detector/composition/ruby/ruby.go
@@ -200,7 +200,7 @@ func (composition *Composition) DetectFromFileWithTypes(file *file.FileInfo, det
 			tree.RootNode(),
 			detectorType,
 			sanitizerRuleID,
-			settings.NESTED_SCOPE,
+			settings.DefaultScope,
 			false,
 		)
 		if err != nil {

--- a/new/detector/composition/ruby/ruby_test.go
+++ b/new/detector/composition/ruby/ruby_test.go
@@ -14,11 +14,9 @@ var loggerRule []byte
 var scopeRule []byte
 
 func TestRuby(t *testing.T) {
-	t.Parallel()
 	testhelper.GetRunner(t, loggerRule, "Ruby").RunTest(t, "./testdata/testcases", ".snapshots/")
 }
 
 func TestScope(t *testing.T) {
-	t.Parallel()
 	testhelper.GetRunner(t, scopeRule, "Ruby").RunTest(t, "./testdata/scope", ".snapshots/")
 }

--- a/new/detector/evaluator/evaluator.go
+++ b/new/detector/evaluator/evaluator.go
@@ -182,7 +182,7 @@ func (evaluator *evaluator) sanitizedNodeDetections(
 	scope settings.RuleReferenceScope,
 ) ([]*types.Detection, bool, error) {
 	if sanitizerDetectorType != "" {
-		sanitizerDetections, err := evaluator.nonUnifiedNodeDetections(node, sanitizerDetectorType, scope)
+		sanitizerDetections, err := evaluator.nonUnifiedNodeDetections(node, sanitizerDetectorType, settings.DefaultScope)
 		if len(sanitizerDetections) != 0 || err != nil {
 			return nil, true, err
 		}

--- a/new/detector/implementation/custom/custom.go
+++ b/new/detector/implementation/custom/custom.go
@@ -62,7 +62,7 @@ func (detector *customDetector) Name() string {
 
 func (detector *customDetector) DetectAt(
 	node *tree.Node,
-	ruleReferenceType settings.RuleReferenceScope,
+	scope settings.RuleReferenceScope,
 	evaluator types.Evaluator,
 ) ([]interface{}, error) {
 	var detectionsData []interface{}
@@ -75,7 +75,7 @@ func (detector *customDetector) DetectAt(
 
 		for _, result := range results {
 			filtersMatch, datatypeDetections, variableNodes, err := matchAllFilters(
-				ruleReferenceType,
+				scope,
 				result,
 				evaluator,
 				pattern.Filters,

--- a/new/detector/implementation/custom/filter.go
+++ b/new/detector/implementation/custom/filter.go
@@ -45,7 +45,7 @@ func matchFilter(
 
 	if filter.Detection != "" {
 		effectiveScope := filter.Scope
-		if scope == settings.RESULT_SCOPE {
+		if filter.Scope == settings.NESTED_SCOPE && scope == settings.RESULT_SCOPE {
 			effectiveScope = settings.RESULT_SCOPE
 		}
 

--- a/new/detector/implementation/custom/filter.go
+++ b/new/detector/implementation/custom/filter.go
@@ -45,7 +45,7 @@ func matchFilter(
 
 	if filter.Detection != "" {
 		effectiveScope := filter.Scope
-		if filter.Scope == settings.NESTED_SCOPE && scope == settings.RESULT_SCOPE {
+		if effectiveScope == settings.NESTED_SCOPE && scope == settings.RESULT_SCOPE {
 			effectiveScope = settings.RESULT_SCOPE
 		}
 

--- a/pkg/commands/process/settings/settings.go
+++ b/pkg/commands/process/settings/settings.go
@@ -79,6 +79,8 @@ const (
 	CURSOR_SCOPE RuleReferenceScope = "cursor"
 	NESTED_SCOPE RuleReferenceScope = "nested"
 	RESULT_SCOPE RuleReferenceScope = "result"
+
+	DefaultScope = NESTED_SCOPE
 )
 
 type LoadRulesResult struct {


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

- Fixes `effectiveScope` by ensuring we only convert nested scope to result scope. Prior to this change, we were converting cursor scope into result scope.
- Run sanitizer rules in the default nested scope

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
