### PR TITLE
feat: javascript import support

### DIFF
--- a/new/language/patternquery/builder/builder.go
+++ b/new/language/patternquery/builder/builder.go
@@ -275,7 +275,7 @@ func (builder *builder) getVariableFor(node *tree.Node) *types.Variable {
 			continue
 		}
 
-		if node.Content() == variable.DummyValue {
+		if node.ChildCount() == 0 && node.Content() == variable.DummyValue {
 			return &variable
 		}
 	}

--- a/pkg/commands/process/worker/pool/process.go
+++ b/pkg/commands/process/worker/pool/process.go
@@ -92,7 +92,8 @@ func (process *Process) start(config settings.Config) error {
 		var result = strings.Split(err.Error(), "failed to create detector customDetector:")
 		if len(result) > 1 {
 			// custom detector issue ; assume custom rule parse issue
-			var ruleName = strings.Split(result[1], ":")[0]
+			var ruleName = strings.TrimSpace(strings.Split(result[1], ":")[0])
+			log.Debug().Msgf(err.Error())
 			log.Fatal().Msgf("could not parse rule %s. Is this a custom rule? See documentation on rule patterns and format https://docs.bearer.com/guides/custom-rule/", ruleName)
 		} else {
 			log.Fatal().Msgf("failed to start bearer, error with your configuration %s", err)


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

For Javascript:
- Add imported variables to the scope. This allows a rule with an import pattern to later be used with eg. a call pattern.
- Make named imports unanchored by default, so ellipsis isn't required in patterns.

Also:
- Fixes a bug where pattern variables would not be the leaf node they should be, but could end up replacing a parent instead.
- Logs rule errors for debugging

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
