### PR TITLE
fix: add import_specifier to js match node containers

### DIFF
--- a/new/detector/composition/javascript/.snapshots/import/TestImport--import.yml
+++ b/new/detector/composition/javascript/.snapshots/import/TestImport--import.yml
@@ -1,0 +1,147 @@
+high:
+    - rule:
+        cwe_ids:
+            - "42"
+        id: import_test
+        title: Test imports
+        description: Test imports
+        documentation_url: ""
+      line_number: 4
+      full_filename: import.js
+      filename: import.js
+      source:
+        location:
+            start: 4
+            end: 4
+            column:
+                start: 1
+                end: 8
+      sink:
+        location:
+            start: 4
+            end: 4
+            column:
+                start: 1
+                end: 8
+        content: lib.f()
+      parent_line_number: 4
+      snippet: lib.f()
+      fingerprint: 23ce8eb29bdfc7d63841656df3d9ae27_0
+      old_fingerprint: 23ce8eb29bdfc7d63841656df3d9ae27_0
+    - rule:
+        cwe_ids:
+            - "42"
+        id: import_test
+        title: Test imports
+        description: Test imports
+        documentation_url: ""
+      line_number: 5
+      full_filename: import.js
+      filename: import.js
+      source:
+        location:
+            start: 5
+            end: 5
+            column:
+                start: 1
+                end: 4
+      sink:
+        location:
+            start: 5
+            end: 5
+            column:
+                start: 1
+                end: 4
+        content: f()
+      parent_line_number: 5
+      snippet: f()
+      fingerprint: 23ce8eb29bdfc7d63841656df3d9ae27_1
+      old_fingerprint: 23ce8eb29bdfc7d63841656df3d9ae27_1
+    - rule:
+        cwe_ids:
+            - "42"
+        id: import_test
+        title: Test imports
+        description: Test imports
+        documentation_url: ""
+      line_number: 6
+      full_filename: import.js
+      filename: import.js
+      source:
+        location:
+            start: 6
+            end: 6
+            column:
+                start: 1
+                end: 4
+      sink:
+        location:
+            start: 6
+            end: 6
+            column:
+                start: 1
+                end: 4
+        content: x()
+      parent_line_number: 6
+      snippet: x()
+      fingerprint: 23ce8eb29bdfc7d63841656df3d9ae27_2
+      old_fingerprint: 23ce8eb29bdfc7d63841656df3d9ae27_2
+    - rule:
+        cwe_ids:
+            - "42"
+        id: import_test
+        title: Test imports
+        description: Test imports
+        documentation_url: ""
+      line_number: 9
+      full_filename: import.js
+      filename: import.js
+      source:
+        location:
+            start: 9
+            end: 9
+            column:
+                start: 1
+                end: 6
+      sink:
+        location:
+            start: 9
+            end: 9
+            column:
+                start: 1
+                end: 6
+        content: y.f()
+      parent_line_number: 9
+      snippet: y.f()
+      fingerprint: 23ce8eb29bdfc7d63841656df3d9ae27_3
+      old_fingerprint: 23ce8eb29bdfc7d63841656df3d9ae27_3
+    - rule:
+        cwe_ids:
+            - "42"
+        id: import_test
+        title: Test imports
+        description: Test imports
+        documentation_url: ""
+      line_number: 11
+      full_filename: import.js
+      filename: import.js
+      source:
+        location:
+            start: 11
+            end: 11
+            column:
+                start: 1
+                end: 4
+      sink:
+        location:
+            start: 11
+            end: 11
+            column:
+                start: 1
+                end: 4
+        content: f()
+      parent_line_number: 11
+      snippet: f()
+      fingerprint: 23ce8eb29bdfc7d63841656df3d9ae27_4
+      old_fingerprint: 23ce8eb29bdfc7d63841656df3d9ae27_4
+

--- a/new/detector/composition/javascript/javascript_test.go
+++ b/new/detector/composition/javascript/javascript_test.go
@@ -7,6 +7,9 @@ import (
 	"github.com/bearer/bearer/new/detector/composition/testhelper"
 )
 
+//go:embed testdata/import_rule.yml
+var importRule []byte
+
 //go:embed testdata/insecureURL.yml
 var insecureURLRule []byte
 
@@ -25,6 +28,10 @@ func TestFlow(t *testing.T) {
 
 func TestObjectDeconstructing(t *testing.T) {
 	testhelper.GetRunner(t, deconstructingRule, "Javascript").RunTest(t, "./testdata/testcases/object-deconstructing", ".snapshots/object-deconstructing/")
+}
+
+func TestImport(t *testing.T) {
+	testhelper.GetRunner(t, importRule, "Javascript").RunTest(t, "./testdata/import", ".snapshots/import/")
 }
 
 func TestString(t *testing.T) {

--- a/new/detector/composition/javascript/testdata/import/import.js
+++ b/new/detector/composition/javascript/testdata/import/import.js
@@ -1,0 +1,13 @@
+import lib, { f } from "library"
+import { f as x } from "library"
+
+lib.f()
+f()
+x()
+
+const y = require("library")
+y.f()
+const { f } = y
+f()
+
+ignored.f()

--- a/new/detector/composition/javascript/testdata/import_rule.yml
+++ b/new/detector/composition/javascript/testdata/import_rule.yml
@@ -1,0 +1,41 @@
+languages:
+  - javascript
+patterns:
+  - pattern: $<FUNCTION>()
+    filters:
+      - variable: FUNCTION
+        detection: import_test_function
+        scope: cursor
+auxiliary:
+  - id: import_test_library
+    patterns:
+      - import $<!>$<_>$<...> from "library"
+      - pattern: $<METHOD>($<NAME>)
+        filters:
+          - variable: METHOD
+            values:
+              - require
+              - import
+          - variable: NAME
+            string_regex: \Alibrary\z
+  - id: import_test_function
+    patterns:
+      - pattern: $<LIBRARY>.f
+        filters:
+          - variable: LIBRARY
+            detection: import_test_library
+            scope: cursor
+      - pattern: const { $<!>f } = $<LIBRARY>
+        filters:
+          - variable: LIBRARY
+            detection: import_test_library
+            scope: cursor
+      - import $<...>{ $<!>f } from "library"
+      - import $<...>{ f as $<!>$<_> } from "library"
+severity: high
+metadata:
+  description: Test imports
+  remediation_message: Test imports
+  cwe_id:
+    - 42
+  id: import_test

--- a/new/language/implementation/javascript/javascript.go
+++ b/new/language/implementation/javascript/javascript.go
@@ -28,7 +28,7 @@ var (
 	}
 
 	anonymousPatternNodeParentTypes = []string{}
-	patternMatchNodeContainerTypes  = []string{"import_clause", "required_parameter"}
+	patternMatchNodeContainerTypes  = []string{"import_clause", "import_specifier", "required_parameter"}
 
 	// $<name:type> or $<name:type1|type2> or $<name>
 	patternQueryVariableRegex = regexp.MustCompile(`\$<(?P<name>[^>:!\.]+)(?::(?P<types>[^>]+))?>`)


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Add `import_specifier` to Javascript match node container types. This ensures that a pattern like this:

```javascript
import { $<!>$<_> } from "somelib"
```

will match at the identifier node, rather than the import specifier. Without the change, rules cannot match usages of such imports.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [x] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
