### PR TITLE
fix: use new package name for reviewdog

### DIFF
--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -372,7 +372,7 @@ func (r *runner) Report(config settings.Config, report types.Report) (bool, erro
 		if err != nil {
 			return false, fmt.Errorf("error generating reviewdog report %s", err)
 		}
-		content, err := reportoutput.ReportJSON(sastContent)
+		content, err := outputhandler.ReportJSON(sastContent)
 		if err != nil {
 			return false, fmt.Errorf("error generating JSON report %s", err)
 		}

--- a/pkg/report/output/reviewdog/reviewdog_test.go
+++ b/pkg/report/output/reviewdog/reviewdog_test.go
@@ -6,9 +6,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/bearer/bearer/pkg/report/output"
-	"github.com/bearer/bearer/pkg/report/output/security"
 	"github.com/bradleyjkemp/cupaloy"
+
+	"github.com/bearer/bearer/pkg/report/output/security"
+	"github.com/bearer/bearer/pkg/util/output"
 )
 
 func TestRailsGoatReviewdog(t *testing.T) {


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Fix output package name in runner.

Main is currently broken due to a clash from https://github.com/Bearer/bearer/pull/1028 and https://github.com/Bearer/bearer/pull/1030.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
