### PR TITLE
docs: add redirect for removed ruby encryption rule

### DIFF
--- a/docs/_redirects
+++ b/docs/_redirects
@@ -8,3 +8,4 @@
 /reference/rules/javascript_express_insecure_template_rendering /reference/rules/javascript_lang_raw_html_using_user_input
 /reference/rules/javascript_aws_lambda_os_command_injection /reference/rules/javascript_lang_os_command_injection
 /reference/rules/javascript_aws_lambda_query_injection /reference/rules/javascript_third_parties_dynamodb_query_injection
+/reference/rules/ruby_lang_weak_encryption /reference/rules


### PR DESCRIPTION
## Description
Since we have replaced the Ruby weak encryption rule by several separate encryption rules, we add a redirect for the old docs page

Relates to https://github.com/Bearer/bearer-rules/pull/83

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
