### PR TITLE
fix: switch back to yaml v3 for report

### DIFF
--- a/e2e/rules/.snapshots/TestAuxilary-testdata-data-auxilary
+++ b/e2e/rules/.snapshots/TestAuxilary-testdata-data-auxilary
@@ -1,49 +1,49 @@
 high:
-- rule:
-    cwe_ids:
-    - "201"
-    id: javascript_third_parties_datadog_test
-    title: Do not send sensitive data to Datadog.
-    description: |
-      ## Description
-      Leaking sensitive data to third-party loggers is a common cause of data leaks and can lead to data breaches. This rule looks for instances of sensitive data sent to Datadog.
+    - rule:
+        cwe_ids:
+            - "201"
+        id: javascript_third_parties_datadog_test
+        title: Do not send sensitive data to Datadog.
+        description: |
+            ## Description
+            Leaking sensitive data to third-party loggers is a common cause of data leaks and can lead to data breaches. This rule looks for instances of sensitive data sent to Datadog.
 
-      ## Remediations
+            ## Remediations
 
-      When logging errors or events, ensure all sensitive data is removed.
+            When logging errors or events, ensure all sensitive data is removed.
 
-      ## Resources
-      - [Datadog docs](https://docs.datadoghq.com)
-      - [Scrubbing data](https://docs.datadoghq.com/tracing/configure_data_security/?tab=mongodb#scrub-sensitive-data-from-your-spans)
-    documentation_url: ""
-  line_number: 3
-  full_filename: e2e/rules/testdata/data/auxilary/unsecure.js
-  filename: unsecure.js
-  data_type:
-    category_uuid: 14124881-6b92-4fc5-8005-ea7c1c09592e
-    name: Fullname
-  category_groups:
-  - PII
-  - Personal Data
-  source:
-    location:
-      start: 3
-      end: 3
-      column:
-        start: 16
-        end: 28
-  sink:
-    location:
-      start: 11
-      end: 11
-      column:
-        start: 1
-        end: 44
-    content: client.event("user", "logged_in", {}, user)
-  parent_line_number: 11
-  snippet: client.event("user", "logged_in", {}, user)
-  fingerprint: 68427732321c4df53052a341ac8da647_0
-  old_fingerprint: 4d54a4b735da21fbdcb2d2662977b033_0
+            ## Resources
+            - [Datadog docs](https://docs.datadoghq.com)
+            - [Scrubbing data](https://docs.datadoghq.com/tracing/configure_data_security/?tab=mongodb#scrub-sensitive-data-from-your-spans)
+        documentation_url: ""
+      line_number: 3
+      full_filename: e2e/rules/testdata/data/auxilary/unsecure.js
+      filename: unsecure.js
+      data_type:
+        category_uuid: 14124881-6b92-4fc5-8005-ea7c1c09592e
+        name: Fullname
+      category_groups:
+        - PII
+        - Personal Data
+      source:
+        location:
+            start: 3
+            end: 3
+            column:
+                start: 16
+                end: 28
+      sink:
+        location:
+            start: 11
+            end: 11
+            column:
+                start: 1
+                end: 44
+        content: client.event("user", "logged_in", {}, user)
+      parent_line_number: 11
+      snippet: client.event("user", "logged_in", {}, user)
+      fingerprint: 68427732321c4df53052a341ac8da647_0
+      old_fingerprint: 4d54a4b735da21fbdcb2d2662977b033_0
 
 
 --

--- a/e2e/rules/.snapshots/TestRubyRailsDefaultEncryptionSchema-testdata-data-ruby_rails_default_encryption_schema_rb
+++ b/e2e/rules/.snapshots/TestRubyRailsDefaultEncryptionSchema-testdata-data-ruby_rails_default_encryption_schema_rb
@@ -1,58 +1,58 @@
 warning:
-- rule:
-    cwe_ids:
-    - "312"
-    id: ruby_rails_default_encryption
-    title: Missing application-level encryption of sensitive data detected.
-    description: |
-      ## Description
-      Application-level encryption greatly reduces the risk of a data breach or data leak by making data unreadable. This rule checks if sensitive data types found in records are encrypted.
+    - rule:
+        cwe_ids:
+            - "312"
+        id: ruby_rails_default_encryption
+        title: Missing application-level encryption of sensitive data detected.
+        description: |
+            ## Description
+            Application-level encryption greatly reduces the risk of a data breach or data leak by making data unreadable. This rule checks if sensitive data types found in records are encrypted.
 
-      ## Remediations
-      Whenever storing sensitive data to a datastore, make sure to encrypt the entire record, or the field itself.
+            ## Remediations
+            Whenever storing sensitive data to a datastore, make sure to encrypt the entire record, or the field itself.
 
-      ## Resources
-      - [Ruby on Rails Active Record encryption](https://guides.rubyonrails.org/active_record_encryption.html)
-    documentation_url: ""
-  line_number: 4
-  full_filename: e2e/rules/testdata/data/ruby_rails_default_encryption_schema_rb/db/schema.rb
-  filename: db/schema.rb
-  category_groups:
-  - PII
-  - Personal Data
-  source:
-    location:
-      start: 4
-      end: 4
-      column:
-        start: 14
-        end: 20
-  sink:
-    location:
-      start: 2
-      end: 8
-      column:
-        start: 3
-        end: 6
-    content: |-
-      create_table "users", force: :cascade do |t|
-          t.string "email", null: false
-          t.string "name"
-          t.string "encrypted_password", null: false
-          t.datetime "created_at", null: false
-          t.datetime "updated_at", null: false
-        end
-  parent_line_number: 2
-  snippet: |-
-    create_table "users", force: :cascade do |t|
-        t.string "email", null: false
-        t.string "name"
-        t.string "encrypted_password", null: false
-        t.datetime "created_at", null: false
-        t.datetime "updated_at", null: false
-      end
-  fingerprint: a6e77c6d42db8f03ffbe5acae290f72c_0
-  old_fingerprint: 4b6d6e98ae7d9908efdf9a7984c7db05_0
+            ## Resources
+            - [Ruby on Rails Active Record encryption](https://guides.rubyonrails.org/active_record_encryption.html)
+        documentation_url: ""
+      line_number: 4
+      full_filename: e2e/rules/testdata/data/ruby_rails_default_encryption_schema_rb/db/schema.rb
+      filename: db/schema.rb
+      category_groups:
+        - PII
+        - Personal Data
+      source:
+        location:
+            start: 4
+            end: 4
+            column:
+                start: 14
+                end: 20
+      sink:
+        location:
+            start: 2
+            end: 8
+            column:
+                start: 3
+                end: 6
+        content: |-
+            create_table "users", force: :cascade do |t|
+                t.string "email", null: false
+                t.string "name"
+                t.string "encrypted_password", null: false
+                t.datetime "created_at", null: false
+                t.datetime "updated_at", null: false
+              end
+      parent_line_number: 2
+      snippet: |-
+        create_table "users", force: :cascade do |t|
+            t.string "email", null: false
+            t.string "name"
+            t.string "encrypted_password", null: false
+            t.datetime "created_at", null: false
+            t.datetime "updated_at", null: false
+          end
+      fingerprint: a6e77c6d42db8f03ffbe5acae290f72c_0
+      old_fingerprint: 4b6d6e98ae7d9908efdf9a7984c7db05_0
 
 
 --

--- a/e2e/rules/.snapshots/TestRubyRailsDefaultEncryptionStructure-testdata-data-ruby_rails_default_encryption_structure_sql
+++ b/e2e/rules/.snapshots/TestRubyRailsDefaultEncryptionStructure-testdata-data-ruby_rails_default_encryption_structure_sql
@@ -1,60 +1,60 @@
 warning:
-- rule:
-    cwe_ids:
-    - "312"
-    id: ruby_rails_default_encryption
-    title: Missing application-level encryption of sensitive data detected.
-    description: |
-      ## Description
-      Application-level encryption greatly reduces the risk of a data breach or data leak by making data unreadable. This rule checks if sensitive data types found in records are encrypted.
+    - rule:
+        cwe_ids:
+            - "312"
+        id: ruby_rails_default_encryption
+        title: Missing application-level encryption of sensitive data detected.
+        description: |
+            ## Description
+            Application-level encryption greatly reduces the risk of a data breach or data leak by making data unreadable. This rule checks if sensitive data types found in records are encrypted.
 
-      ## Remediations
-      Whenever storing sensitive data to a datastore, make sure to encrypt the entire record, or the field itself.
+            ## Remediations
+            Whenever storing sensitive data to a datastore, make sure to encrypt the entire record, or the field itself.
 
-      ## Resources
-      - [Ruby on Rails Active Record encryption](https://guides.rubyonrails.org/active_record_encryption.html)
-    documentation_url: ""
-  line_number: 3
-  full_filename: e2e/rules/testdata/data/ruby_rails_default_encryption_structure_sql/db/structure.sql
-  filename: db/structure.sql
-  category_groups:
-  - PII
-  - Personal Data
-  source:
-    location:
-      start: 3
-      end: 3
-      column:
-        start: 3
-        end: 7
-  sink:
-    location:
-      start: 1
-      end: 8
-      column:
-        start: 1
-        end: 2
-    content: |-
-      CREATE TABLE public.users (
-        id bigint NOT NULL,
-        name character varying,
-        password character varying,
-        created_at timestamp(6) without time zone NOT NULL,
-        updated_at timestamp(6) without time zone NOT NULL,
-        email character varying DEFAULT ''::character varying NOT NULL
-      )
-  parent_line_number: 1
-  snippet: |-
-    CREATE TABLE public.users (
-      id bigint NOT NULL,
-      name character varying,
-      password character varying,
-      created_at timestamp(6) without time zone NOT NULL,
-      updated_at timestamp(6) without time zone NOT NULL,
-      email character varying DEFAULT ''::character varying NOT NULL
-    )
-  fingerprint: e5e17cede9a731da09a639c9c78af007_0
-  old_fingerprint: 86b02d158d5ef7e6b68f6979f4f789aa_0
+            ## Resources
+            - [Ruby on Rails Active Record encryption](https://guides.rubyonrails.org/active_record_encryption.html)
+        documentation_url: ""
+      line_number: 3
+      full_filename: e2e/rules/testdata/data/ruby_rails_default_encryption_structure_sql/db/structure.sql
+      filename: db/structure.sql
+      category_groups:
+        - PII
+        - Personal Data
+      source:
+        location:
+            start: 3
+            end: 3
+            column:
+                start: 3
+                end: 7
+      sink:
+        location:
+            start: 1
+            end: 8
+            column:
+                start: 1
+                end: 2
+        content: |-
+            CREATE TABLE public.users (
+              id bigint NOT NULL,
+              name character varying,
+              password character varying,
+              created_at timestamp(6) without time zone NOT NULL,
+              updated_at timestamp(6) without time zone NOT NULL,
+              email character varying DEFAULT ''::character varying NOT NULL
+            )
+      parent_line_number: 1
+      snippet: |-
+        CREATE TABLE public.users (
+          id bigint NOT NULL,
+          name character varying,
+          password character varying,
+          created_at timestamp(6) without time zone NOT NULL,
+          updated_at timestamp(6) without time zone NOT NULL,
+          email character varying DEFAULT ''::character varying NOT NULL
+        )
+      fingerprint: e5e17cede9a731da09a639c9c78af007_0
+      old_fingerprint: 86b02d158d5ef7e6b68f6979f4f789aa_0
 
 
 --

--- a/e2e/rules/.snapshots/TestSanitizer-testdata-data-sanitizer
+++ b/e2e/rules/.snapshots/TestSanitizer-testdata-data-sanitizer
@@ -1,74 +1,74 @@
 critical:
-- rule:
-    cwe_ids:
-    - "42"
-    id: sanitizer_test
-    title: Test sanitizer
-    description: Test sanitizer
-    documentation_url: ""
-  line_number: 1
-  full_filename: e2e/rules/testdata/data/sanitizer/sanitizer.rb
-  filename: sanitizer.rb
-  data_type:
-    category_uuid: cef587dd-76db-430b-9e18-7b031e1a193b
-    name: Email Address
-  category_groups:
-  - PII
-  - Personal Data
-  source:
-    location:
-      start: 1
-      end: 1
-      column:
-        start: 5
-        end: 15
-  sink:
-    location:
-      start: 5
-      end: 5
-      column:
-        start: 1
-        end: 15
-    content: log("abc" + x)
-  parent_line_number: 5
-  snippet: log("abc" + x)
-  fingerprint: 6c505050fabde2c4ed17380d19fab254_0
-  old_fingerprint: d2e829ba86a33c5a52844641617ad8a7_0
-- rule:
-    cwe_ids:
-    - "42"
-    id: sanitizer_test
-    title: Test sanitizer
-    description: Test sanitizer
-    documentation_url: ""
-  line_number: 4
-  full_filename: e2e/rules/testdata/data/sanitizer/sanitizer.rb
-  filename: sanitizer.rb
-  data_type:
-    category_uuid: cef587dd-76db-430b-9e18-7b031e1a193b
-    name: Email Address
-  category_groups:
-  - PII
-  - Personal Data
-  source:
-    location:
-      start: 4
-      end: 4
-      column:
-        start: 13
-        end: 23
-  sink:
-    location:
-      start: 4
-      end: 4
-      column:
-        start: 1
-        end: 24
-    content: log("abc" + user.email)
-  parent_line_number: 4
-  snippet: log("abc" + user.email)
-  fingerprint: 6c505050fabde2c4ed17380d19fab254_2
-  old_fingerprint: d2e829ba86a33c5a52844641617ad8a7_2
+    - rule:
+        cwe_ids:
+            - "42"
+        id: sanitizer_test
+        title: Test sanitizer
+        description: Test sanitizer
+        documentation_url: ""
+      line_number: 1
+      full_filename: e2e/rules/testdata/data/sanitizer/sanitizer.rb
+      filename: sanitizer.rb
+      data_type:
+        category_uuid: cef587dd-76db-430b-9e18-7b031e1a193b
+        name: Email Address
+      category_groups:
+        - PII
+        - Personal Data
+      source:
+        location:
+            start: 1
+            end: 1
+            column:
+                start: 5
+                end: 15
+      sink:
+        location:
+            start: 5
+            end: 5
+            column:
+                start: 1
+                end: 15
+        content: log("abc" + x)
+      parent_line_number: 5
+      snippet: log("abc" + x)
+      fingerprint: 6c505050fabde2c4ed17380d19fab254_0
+      old_fingerprint: d2e829ba86a33c5a52844641617ad8a7_0
+    - rule:
+        cwe_ids:
+            - "42"
+        id: sanitizer_test
+        title: Test sanitizer
+        description: Test sanitizer
+        documentation_url: ""
+      line_number: 4
+      full_filename: e2e/rules/testdata/data/sanitizer/sanitizer.rb
+      filename: sanitizer.rb
+      data_type:
+        category_uuid: cef587dd-76db-430b-9e18-7b031e1a193b
+        name: Email Address
+      category_groups:
+        - PII
+        - Personal Data
+      source:
+        location:
+            start: 4
+            end: 4
+            column:
+                start: 13
+                end: 23
+      sink:
+        location:
+            start: 4
+            end: 4
+            column:
+                start: 1
+                end: 24
+        content: log("abc" + user.email)
+      parent_line_number: 4
+      snippet: log("abc" + user.email)
+      fingerprint: 6c505050fabde2c4ed17380d19fab254_2
+      old_fingerprint: d2e829ba86a33c5a52844641617ad8a7_2
 
 
 --

--- a/e2e/rules/.snapshots/TestSecrets-secrets
+++ b/e2e/rules/.snapshots/TestSecrets-secrets
@@ -1,46 +1,44 @@
 high:
-- rule:
-    cwe_ids:
-    - "798"
-    id: gitleaks
-    title: Hard-coded secret detected.
-    description: |
-      ## Description
+    - rule:
+        cwe_ids:
+            - "798"
+        id: gitleaks
+        title: Hard-coded secret detected.
+        description: |
+            ## Description
 
-      Hard-coding secrets in a project opens them up to leakage. This rule checks for common secret types such as keys, tokens, and passwords using the popular Gitleaks library and ensures they aren't hard-coded.
+            Hard-coding secrets in a project opens them up to leakage. This rule checks for common secret types such as keys, tokens, and passwords using the popular Gitleaks library and ensures they aren't hard-coded.
 
-      ## Remediations
+            ## Remediations
 
-      Do not hard-code secrets in committed code. Instead, use environment variables and a secret management system.
+            Do not hard-code secrets in committed code. Instead, use environment variables and a secret management system.
 
-      ## Resources
-      - [Gitleaks](https://gitleaks.io/)
-    documentation_url: ""
-  line_number: 3
-  full_filename: e2e/rules/testdata/data/secrets/leaked.rb
-  filename: leaked.rb
-  source:
-    location:
-      start: 3
-      end: 3
-      column:
-        start: 24
-        end: 60
-  sink:
-    location:
-      start: 3
-      end: 3
-      column:
-        start: 24
-        end: 60
-    content: '    @private_key ||= ''-----BEGIN PGP PRIVATE KEY BLOCK-----asdf-----END
-      PGP PRIVATE KEY BLOCK-----'''
-  parent_line_number: 3
-  snippet: '    @private_key ||= ''-----BEGIN PGP PRIVATE KEY BLOCK-----asdf-----END
-    PGP PRIVATE KEY BLOCK-----'''
-  fingerprint: d0914f16c16550b40063c4f3fb14839e_0
-  old_fingerprint: 47146043fab58ba5fc86fd0c716b20d8_0
-  detailed_context: PGP private key
+            ## Resources
+            - [Gitleaks](https://gitleaks.io/)
+        documentation_url: ""
+      line_number: 3
+      full_filename: e2e/rules/testdata/data/secrets/leaked.rb
+      filename: leaked.rb
+      source:
+        location:
+            start: 3
+            end: 3
+            column:
+                start: 24
+                end: 60
+      sink:
+        location:
+            start: 3
+            end: 3
+            column:
+                start: 24
+                end: 60
+        content: '    @private_key ||= ''-----BEGIN PGP PRIVATE KEY BLOCK-----asdf-----END PGP PRIVATE KEY BLOCK-----'''
+      parent_line_number: 3
+      snippet: '    @private_key ||= ''-----BEGIN PGP PRIVATE KEY BLOCK-----asdf-----END PGP PRIVATE KEY BLOCK-----'''
+      fingerprint: d0914f16c16550b40063c4f3fb14839e_0
+      old_fingerprint: 47146043fab58ba5fc86fd0c716b20d8_0
+      detailed_context: PGP private key
 
 
 --

--- a/e2e/rules/.snapshots/TestSimpleRuby-testdata-data-simple_ruby
+++ b/e2e/rules/.snapshots/TestSimpleRuby-testdata-data-simple_ruby
@@ -1,52 +1,52 @@
 medium:
-- rule:
-    cwe_ids:
-    - "319"
-    id: ruby_rails_insecure_communication_test
-    title: Force all incoming communication through SSL.
-    description: |
-      ## Description
-      When applications process sensitive data, they should default to always use SSL when available. This rule checks if force SSL is enabled at the application level.
+    - rule:
+        cwe_ids:
+            - "319"
+        id: ruby_rails_insecure_communication_test
+        title: Force all incoming communication through SSL.
+        description: |
+            ## Description
+            When applications process sensitive data, they should default to always use SSL when available. This rule checks if force SSL is enabled at the application level.
 
-      ### Remediations
-      This helps avoid attacks like [session hijacking](https://guides.rubyonrails.org/security.html#session-hijacking). More importantly, unencrypted HTTP communication sends all requests as plain text, meaning anyone listening in can see all the traffic and extract user data.
+            ### Remediations
+            This helps avoid attacks like [session hijacking](https://guides.rubyonrails.org/security.html#session-hijacking). More importantly, unencrypted HTTP communication sends all requests as plain text, meaning anyone listening in can see all the traffic and extract user data.
 
-      While you want to avoid sending sensitive data whenever possible, it's unavoidable so protecting the connection is an important method of improving your rails application data security.
+            While you want to avoid sending sensitive data whenever possible, it's unavoidable so protecting the connection is an important method of improving your rails application data security.
 
-      ✅ To force all traffic to your application to be encrypted though SSL, use the following Rails configuration option:
+            ✅ To force all traffic to your application to be encrypted though SSL, use the following Rails configuration option:
 
-      ```ruby
-      config.force_ssl = true
-      ```
+            ```ruby
+            config.force_ssl = true
+            ```
 
-      ## Resources
-      - [Configuring Rails Applications - Ruby on Rails Guides](https://guides.rubyonrails.org/configuring.html#config-force-ssl)
-    documentation_url: ""
-  line_number: 7
-  full_filename: e2e/rules/testdata/data/simple_ruby/unsecure.rb
-  filename: unsecure.rb
-  category_groups:
-  - PII
-  - Personal Data
-  source:
-    location:
-      start: 7
-      end: 7
-      column:
-        start: 5
-        end: 29
-  sink:
-    location:
-      start: 7
-      end: 7
-      column:
-        start: 5
-        end: 29
-    content: config.force_ssl = false
-  parent_line_number: 7
-  snippet: config.force_ssl = false
-  fingerprint: 52ee98cc601d1c1bd772ff548ee32425_0
-  old_fingerprint: 28ca51516a8b388cb7065c1f0df8b093_0
+            ## Resources
+            - [Configuring Rails Applications - Ruby on Rails Guides](https://guides.rubyonrails.org/configuring.html#config-force-ssl)
+        documentation_url: ""
+      line_number: 7
+      full_filename: e2e/rules/testdata/data/simple_ruby/unsecure.rb
+      filename: unsecure.rb
+      category_groups:
+        - PII
+        - Personal Data
+      source:
+        location:
+            start: 7
+            end: 7
+            column:
+                start: 5
+                end: 29
+      sink:
+        location:
+            start: 7
+            end: 7
+            column:
+                start: 5
+                end: 29
+        content: config.force_ssl = false
+      parent_line_number: 7
+      snippet: config.force_ssl = false
+      fingerprint: 52ee98cc601d1c1bd772ff548ee32425_0
+      old_fingerprint: 28ca51516a8b388cb7065c1f0df8b093_0
 
 
 --

--- a/go.mod
+++ b/go.mod
@@ -121,6 +121,6 @@ require (
 	golang.org/x/text v0.9.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2
 	gopkg.in/ini.v1 v1.67.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -361,6 +361,7 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/struCoder/pidusage v0.2.1 h1:dFiEgUDkubeIj0XA1NpQ6+8LQmKrLi7NiIQl86E6BoY=

--- a/new/detector/composition/java/.snapshots/TestScope--scope.yml
+++ b/new/detector/composition/java/.snapshots/TestScope--scope.yml
@@ -1,176 +1,176 @@
 high:
-- rule:
-    cwe_ids:
-    - "42"
-    id: scope_test
-    title: Test detection filter scopes
-    description: Test detection filter scopes
-    documentation_url: ""
-  line_number: 1
-  full_filename: scope.java
-  filename: scope.java
-  source:
-    location:
-      start: 1
-      end: 1
-      column:
-        start: 1
-        end: 42
-  sink:
-    location:
-      start: 1
-      end: 1
-      column:
-        start: 1
-        end: 42
-    content: scopeCursor(request.getParameter("oops"))
-  parent_line_number: 1
-  snippet: scopeCursor(request.getParameter("oops"))
-  fingerprint: bdbeee20feb34c6881d975716e2fe09f_0
-  old_fingerprint: bdbeee20feb34c6881d975716e2fe09f_0
-- rule:
-    cwe_ids:
-    - "42"
-    id: scope_test
-    title: Test detection filter scopes
-    description: Test detection filter scopes
-    documentation_url: ""
-  line_number: 5
-  full_filename: scope.java
-  filename: scope.java
-  source:
-    location:
-      start: 5
-      end: 5
-      column:
-        start: 1
-        end: 42
-  sink:
-    location:
-      start: 5
-      end: 5
-      column:
-        start: 1
-        end: 42
-    content: scopeNested(request.getParameter("oops"))
-  parent_line_number: 5
-  snippet: scopeNested(request.getParameter("oops"))
-  fingerprint: bdbeee20feb34c6881d975716e2fe09f_1
-  old_fingerprint: bdbeee20feb34c6881d975716e2fe09f_1
-- rule:
-    cwe_ids:
-    - "42"
-    id: scope_test
-    title: Test detection filter scopes
-    description: Test detection filter scopes
-    documentation_url: ""
-  line_number: 6
-  full_filename: scope.java
-  filename: scope.java
-  source:
-    location:
-      start: 6
-      end: 6
-      column:
-        start: 1
-        end: 50
-  sink:
-    location:
-      start: 6
-      end: 6
-      column:
-        start: 1
-        end: 50
-    content: 'scopeNested(x ? request.getParameter("oops") : y)'
-  parent_line_number: 6
-  snippet: 'scopeNested(x ? request.getParameter("oops") : y)'
-  fingerprint: bdbeee20feb34c6881d975716e2fe09f_2
-  old_fingerprint: bdbeee20feb34c6881d975716e2fe09f_2
-- rule:
-    cwe_ids:
-    - "42"
-    id: scope_test
-    title: Test detection filter scopes
-    description: Test detection filter scopes
-    documentation_url: ""
-  line_number: 7
-  full_filename: scope.java
-  filename: scope.java
-  source:
-    location:
-      start: 7
-      end: 7
-      column:
-        start: 1
-        end: 50
-  sink:
-    location:
-      start: 7
-      end: 7
-      column:
-        start: 1
-        end: 50
-    content: 'scopeNested(request.getParameter("oops") ? x : y)'
-  parent_line_number: 7
-  snippet: 'scopeNested(request.getParameter("oops") ? x : y)'
-  fingerprint: bdbeee20feb34c6881d975716e2fe09f_3
-  old_fingerprint: bdbeee20feb34c6881d975716e2fe09f_3
-- rule:
-    cwe_ids:
-    - "42"
-    id: scope_test
-    title: Test detection filter scopes
-    description: Test detection filter scopes
-    documentation_url: ""
-  line_number: 9
-  full_filename: scope.java
-  filename: scope.java
-  source:
-    location:
-      start: 9
-      end: 9
-      column:
-        start: 1
-        end: 42
-  sink:
-    location:
-      start: 9
-      end: 9
-      column:
-        start: 1
-        end: 42
-    content: scopeResult(request.getParameter("oops"))
-  parent_line_number: 9
-  snippet: scopeResult(request.getParameter("oops"))
-  fingerprint: bdbeee20feb34c6881d975716e2fe09f_4
-  old_fingerprint: bdbeee20feb34c6881d975716e2fe09f_4
-- rule:
-    cwe_ids:
-    - "42"
-    id: scope_test
-    title: Test detection filter scopes
-    description: Test detection filter scopes
-    documentation_url: ""
-  line_number: 10
-  full_filename: scope.java
-  filename: scope.java
-  source:
-    location:
-      start: 10
-      end: 10
-      column:
-        start: 1
-        end: 50
-  sink:
-    location:
-      start: 10
-      end: 10
-      column:
-        start: 1
-        end: 50
-    content: 'scopeResult(x ? request.getParameter("oops") : y)'
-  parent_line_number: 10
-  snippet: 'scopeResult(x ? request.getParameter("oops") : y)'
-  fingerprint: bdbeee20feb34c6881d975716e2fe09f_5
-  old_fingerprint: bdbeee20feb34c6881d975716e2fe09f_5
+    - rule:
+        cwe_ids:
+            - "42"
+        id: scope_test
+        title: Test detection filter scopes
+        description: Test detection filter scopes
+        documentation_url: ""
+      line_number: 1
+      full_filename: scope.java
+      filename: scope.java
+      source:
+        location:
+            start: 1
+            end: 1
+            column:
+                start: 1
+                end: 42
+      sink:
+        location:
+            start: 1
+            end: 1
+            column:
+                start: 1
+                end: 42
+        content: scopeCursor(request.getParameter("oops"))
+      parent_line_number: 1
+      snippet: scopeCursor(request.getParameter("oops"))
+      fingerprint: bdbeee20feb34c6881d975716e2fe09f_0
+      old_fingerprint: bdbeee20feb34c6881d975716e2fe09f_0
+    - rule:
+        cwe_ids:
+            - "42"
+        id: scope_test
+        title: Test detection filter scopes
+        description: Test detection filter scopes
+        documentation_url: ""
+      line_number: 5
+      full_filename: scope.java
+      filename: scope.java
+      source:
+        location:
+            start: 5
+            end: 5
+            column:
+                start: 1
+                end: 42
+      sink:
+        location:
+            start: 5
+            end: 5
+            column:
+                start: 1
+                end: 42
+        content: scopeNested(request.getParameter("oops"))
+      parent_line_number: 5
+      snippet: scopeNested(request.getParameter("oops"))
+      fingerprint: bdbeee20feb34c6881d975716e2fe09f_1
+      old_fingerprint: bdbeee20feb34c6881d975716e2fe09f_1
+    - rule:
+        cwe_ids:
+            - "42"
+        id: scope_test
+        title: Test detection filter scopes
+        description: Test detection filter scopes
+        documentation_url: ""
+      line_number: 6
+      full_filename: scope.java
+      filename: scope.java
+      source:
+        location:
+            start: 6
+            end: 6
+            column:
+                start: 1
+                end: 50
+      sink:
+        location:
+            start: 6
+            end: 6
+            column:
+                start: 1
+                end: 50
+        content: 'scopeNested(x ? request.getParameter("oops") : y)'
+      parent_line_number: 6
+      snippet: 'scopeNested(x ? request.getParameter("oops") : y)'
+      fingerprint: bdbeee20feb34c6881d975716e2fe09f_2
+      old_fingerprint: bdbeee20feb34c6881d975716e2fe09f_2
+    - rule:
+        cwe_ids:
+            - "42"
+        id: scope_test
+        title: Test detection filter scopes
+        description: Test detection filter scopes
+        documentation_url: ""
+      line_number: 7
+      full_filename: scope.java
+      filename: scope.java
+      source:
+        location:
+            start: 7
+            end: 7
+            column:
+                start: 1
+                end: 50
+      sink:
+        location:
+            start: 7
+            end: 7
+            column:
+                start: 1
+                end: 50
+        content: 'scopeNested(request.getParameter("oops") ? x : y)'
+      parent_line_number: 7
+      snippet: 'scopeNested(request.getParameter("oops") ? x : y)'
+      fingerprint: bdbeee20feb34c6881d975716e2fe09f_3
+      old_fingerprint: bdbeee20feb34c6881d975716e2fe09f_3
+    - rule:
+        cwe_ids:
+            - "42"
+        id: scope_test
+        title: Test detection filter scopes
+        description: Test detection filter scopes
+        documentation_url: ""
+      line_number: 9
+      full_filename: scope.java
+      filename: scope.java
+      source:
+        location:
+            start: 9
+            end: 9
+            column:
+                start: 1
+                end: 42
+      sink:
+        location:
+            start: 9
+            end: 9
+            column:
+                start: 1
+                end: 42
+        content: scopeResult(request.getParameter("oops"))
+      parent_line_number: 9
+      snippet: scopeResult(request.getParameter("oops"))
+      fingerprint: bdbeee20feb34c6881d975716e2fe09f_4
+      old_fingerprint: bdbeee20feb34c6881d975716e2fe09f_4
+    - rule:
+        cwe_ids:
+            - "42"
+        id: scope_test
+        title: Test detection filter scopes
+        description: Test detection filter scopes
+        documentation_url: ""
+      line_number: 10
+      full_filename: scope.java
+      filename: scope.java
+      source:
+        location:
+            start: 10
+            end: 10
+            column:
+                start: 1
+                end: 50
+      sink:
+        location:
+            start: 10
+            end: 10
+            column:
+                start: 1
+                end: 50
+        content: 'scopeResult(x ? request.getParameter("oops") : y)'
+      parent_line_number: 10
+      snippet: 'scopeResult(x ? request.getParameter("oops") : y)'
+      fingerprint: bdbeee20feb34c6881d975716e2fe09f_5
+      old_fingerprint: bdbeee20feb34c6881d975716e2fe09f_5
 

--- a/new/detector/composition/java/.snapshots/flow/TestFlow--different-line.yml
+++ b/new/detector/composition/java/.snapshots/flow/TestFlow--different-line.yml
@@ -1,36 +1,36 @@
 high:
-- rule:
-    cwe_ids: []
-    id: java_rule_logger_test
-    title: ""
-    description: ""
-    documentation_url: ""
-  line_number: 2
-  full_filename: different-line.java
-  filename: different-line.java
-  data_type:
-    category_uuid: 14124881-6b92-4fc5-8005-ea7c1c09592e
-    name: Fullname
-  category_groups:
-  - PII
-  - Personal Data
-  source:
-    location:
-      start: 2
-      end: 2
-      column:
-        start: 15
-        end: 24
-  sink:
-    location:
-      start: 3
-      end: 3
-      column:
-        start: 1
-        end: 19
-    content: logger.error(name)
-  parent_line_number: 3
-  snippet: logger.error(name)
-  fingerprint: b08f2b317021ef0197dc9286477e251d_0
-  old_fingerprint: b08f2b317021ef0197dc9286477e251d_0
+    - rule:
+        cwe_ids: []
+        id: java_rule_logger_test
+        title: ""
+        description: ""
+        documentation_url: ""
+      line_number: 2
+      full_filename: different-line.java
+      filename: different-line.java
+      data_type:
+        category_uuid: 14124881-6b92-4fc5-8005-ea7c1c09592e
+        name: Fullname
+      category_groups:
+        - PII
+        - Personal Data
+      source:
+        location:
+            start: 2
+            end: 2
+            column:
+                start: 15
+                end: 24
+      sink:
+        location:
+            start: 3
+            end: 3
+            column:
+                start: 1
+                end: 19
+        content: logger.error(name)
+      parent_line_number: 3
+      snippet: logger.error(name)
+      fingerprint: b08f2b317021ef0197dc9286477e251d_0
+      old_fingerprint: b08f2b317021ef0197dc9286477e251d_0
 

--- a/new/detector/composition/java/.snapshots/flow/TestFlow--same-line.yml
+++ b/new/detector/composition/java/.snapshots/flow/TestFlow--same-line.yml
@@ -1,36 +1,36 @@
 high:
-- rule:
-    cwe_ids: []
-    id: java_rule_logger_test
-    title: ""
-    description: ""
-    documentation_url: ""
-  line_number: 1
-  full_filename: same-line.java
-  filename: same-line.java
-  data_type:
-    category_uuid: 14124881-6b92-4fc5-8005-ea7c1c09592e
-    name: Fullname
-  category_groups:
-  - PII
-  - Personal Data
-  source:
-    location:
-      start: 1
-      end: 1
-      column:
-        start: 14
-        end: 23
-  sink:
-    location:
-      start: 1
-      end: 1
-      column:
-        start: 1
-        end: 24
-    content: logger.error(user.name)
-  parent_line_number: 1
-  snippet: logger.error(user.name)
-  fingerprint: b000c2a9a82d59a1e826bc709cca9307_0
-  old_fingerprint: b000c2a9a82d59a1e826bc709cca9307_0
+    - rule:
+        cwe_ids: []
+        id: java_rule_logger_test
+        title: ""
+        description: ""
+        documentation_url: ""
+      line_number: 1
+      full_filename: same-line.java
+      filename: same-line.java
+      data_type:
+        category_uuid: 14124881-6b92-4fc5-8005-ea7c1c09592e
+        name: Fullname
+      category_groups:
+        - PII
+        - Personal Data
+      source:
+        location:
+            start: 1
+            end: 1
+            column:
+                start: 14
+                end: 23
+      sink:
+        location:
+            start: 1
+            end: 1
+            column:
+                start: 1
+                end: 24
+        content: logger.error(user.name)
+      parent_line_number: 1
+      snippet: logger.error(user.name)
+      fingerprint: b000c2a9a82d59a1e826bc709cca9307_0
+      old_fingerprint: b000c2a9a82d59a1e826bc709cca9307_0
 

--- a/new/detector/composition/javascript/.snapshots/TestScope--scope.yml
+++ b/new/detector/composition/javascript/.snapshots/TestScope--scope.yml
@@ -1,176 +1,176 @@
 high:
-- rule:
-    cwe_ids:
-    - "42"
-    id: scope_test
-    title: Test detection filter scopes
-    description: Test detection filter scopes
-    documentation_url: ""
-  line_number: 1
-  full_filename: scope.js
-  filename: scope.js
-  source:
-    location:
-      start: 1
-      end: 1
-      column:
-        start: 1
-        end: 29
-  sink:
-    location:
-      start: 1
-      end: 1
-      column:
-        start: 1
-        end: 29
-    content: scopeCursor(req.params.oops)
-  parent_line_number: 1
-  snippet: scopeCursor(req.params.oops)
-  fingerprint: 408407aa362e0520faf6b66c3d59bb8c_0
-  old_fingerprint: 408407aa362e0520faf6b66c3d59bb8c_0
-- rule:
-    cwe_ids:
-    - "42"
-    id: scope_test
-    title: Test detection filter scopes
-    description: Test detection filter scopes
-    documentation_url: ""
-  line_number: 5
-  full_filename: scope.js
-  filename: scope.js
-  source:
-    location:
-      start: 5
-      end: 5
-      column:
-        start: 1
-        end: 29
-  sink:
-    location:
-      start: 5
-      end: 5
-      column:
-        start: 1
-        end: 29
-    content: scopeNested(req.params.oops)
-  parent_line_number: 5
-  snippet: scopeNested(req.params.oops)
-  fingerprint: 408407aa362e0520faf6b66c3d59bb8c_1
-  old_fingerprint: 408407aa362e0520faf6b66c3d59bb8c_1
-- rule:
-    cwe_ids:
-    - "42"
-    id: scope_test
-    title: Test detection filter scopes
-    description: Test detection filter scopes
-    documentation_url: ""
-  line_number: 6
-  full_filename: scope.js
-  filename: scope.js
-  source:
-    location:
-      start: 6
-      end: 6
-      column:
-        start: 1
-        end: 37
-  sink:
-    location:
-      start: 6
-      end: 6
-      column:
-        start: 1
-        end: 37
-    content: 'scopeNested(x ? req.params.oops : y)'
-  parent_line_number: 6
-  snippet: 'scopeNested(x ? req.params.oops : y)'
-  fingerprint: 408407aa362e0520faf6b66c3d59bb8c_2
-  old_fingerprint: 408407aa362e0520faf6b66c3d59bb8c_2
-- rule:
-    cwe_ids:
-    - "42"
-    id: scope_test
-    title: Test detection filter scopes
-    description: Test detection filter scopes
-    documentation_url: ""
-  line_number: 7
-  full_filename: scope.js
-  filename: scope.js
-  source:
-    location:
-      start: 7
-      end: 7
-      column:
-        start: 1
-        end: 37
-  sink:
-    location:
-      start: 7
-      end: 7
-      column:
-        start: 1
-        end: 37
-    content: 'scopeNested(req.params.oops ? x : y)'
-  parent_line_number: 7
-  snippet: 'scopeNested(req.params.oops ? x : y)'
-  fingerprint: 408407aa362e0520faf6b66c3d59bb8c_3
-  old_fingerprint: 408407aa362e0520faf6b66c3d59bb8c_3
-- rule:
-    cwe_ids:
-    - "42"
-    id: scope_test
-    title: Test detection filter scopes
-    description: Test detection filter scopes
-    documentation_url: ""
-  line_number: 9
-  full_filename: scope.js
-  filename: scope.js
-  source:
-    location:
-      start: 9
-      end: 9
-      column:
-        start: 1
-        end: 29
-  sink:
-    location:
-      start: 9
-      end: 9
-      column:
-        start: 1
-        end: 29
-    content: scopeResult(req.params.oops)
-  parent_line_number: 9
-  snippet: scopeResult(req.params.oops)
-  fingerprint: 408407aa362e0520faf6b66c3d59bb8c_4
-  old_fingerprint: 408407aa362e0520faf6b66c3d59bb8c_4
-- rule:
-    cwe_ids:
-    - "42"
-    id: scope_test
-    title: Test detection filter scopes
-    description: Test detection filter scopes
-    documentation_url: ""
-  line_number: 10
-  full_filename: scope.js
-  filename: scope.js
-  source:
-    location:
-      start: 10
-      end: 10
-      column:
-        start: 1
-        end: 37
-  sink:
-    location:
-      start: 10
-      end: 10
-      column:
-        start: 1
-        end: 37
-    content: 'scopeResult(x ? req.params.oops : y)'
-  parent_line_number: 10
-  snippet: 'scopeResult(x ? req.params.oops : y)'
-  fingerprint: 408407aa362e0520faf6b66c3d59bb8c_5
-  old_fingerprint: 408407aa362e0520faf6b66c3d59bb8c_5
+    - rule:
+        cwe_ids:
+            - "42"
+        id: scope_test
+        title: Test detection filter scopes
+        description: Test detection filter scopes
+        documentation_url: ""
+      line_number: 1
+      full_filename: scope.js
+      filename: scope.js
+      source:
+        location:
+            start: 1
+            end: 1
+            column:
+                start: 1
+                end: 29
+      sink:
+        location:
+            start: 1
+            end: 1
+            column:
+                start: 1
+                end: 29
+        content: scopeCursor(req.params.oops)
+      parent_line_number: 1
+      snippet: scopeCursor(req.params.oops)
+      fingerprint: 408407aa362e0520faf6b66c3d59bb8c_0
+      old_fingerprint: 408407aa362e0520faf6b66c3d59bb8c_0
+    - rule:
+        cwe_ids:
+            - "42"
+        id: scope_test
+        title: Test detection filter scopes
+        description: Test detection filter scopes
+        documentation_url: ""
+      line_number: 5
+      full_filename: scope.js
+      filename: scope.js
+      source:
+        location:
+            start: 5
+            end: 5
+            column:
+                start: 1
+                end: 29
+      sink:
+        location:
+            start: 5
+            end: 5
+            column:
+                start: 1
+                end: 29
+        content: scopeNested(req.params.oops)
+      parent_line_number: 5
+      snippet: scopeNested(req.params.oops)
+      fingerprint: 408407aa362e0520faf6b66c3d59bb8c_1
+      old_fingerprint: 408407aa362e0520faf6b66c3d59bb8c_1
+    - rule:
+        cwe_ids:
+            - "42"
+        id: scope_test
+        title: Test detection filter scopes
+        description: Test detection filter scopes
+        documentation_url: ""
+      line_number: 6
+      full_filename: scope.js
+      filename: scope.js
+      source:
+        location:
+            start: 6
+            end: 6
+            column:
+                start: 1
+                end: 37
+      sink:
+        location:
+            start: 6
+            end: 6
+            column:
+                start: 1
+                end: 37
+        content: 'scopeNested(x ? req.params.oops : y)'
+      parent_line_number: 6
+      snippet: 'scopeNested(x ? req.params.oops : y)'
+      fingerprint: 408407aa362e0520faf6b66c3d59bb8c_2
+      old_fingerprint: 408407aa362e0520faf6b66c3d59bb8c_2
+    - rule:
+        cwe_ids:
+            - "42"
+        id: scope_test
+        title: Test detection filter scopes
+        description: Test detection filter scopes
+        documentation_url: ""
+      line_number: 7
+      full_filename: scope.js
+      filename: scope.js
+      source:
+        location:
+            start: 7
+            end: 7
+            column:
+                start: 1
+                end: 37
+      sink:
+        location:
+            start: 7
+            end: 7
+            column:
+                start: 1
+                end: 37
+        content: 'scopeNested(req.params.oops ? x : y)'
+      parent_line_number: 7
+      snippet: 'scopeNested(req.params.oops ? x : y)'
+      fingerprint: 408407aa362e0520faf6b66c3d59bb8c_3
+      old_fingerprint: 408407aa362e0520faf6b66c3d59bb8c_3
+    - rule:
+        cwe_ids:
+            - "42"
+        id: scope_test
+        title: Test detection filter scopes
+        description: Test detection filter scopes
+        documentation_url: ""
+      line_number: 9
+      full_filename: scope.js
+      filename: scope.js
+      source:
+        location:
+            start: 9
+            end: 9
+            column:
+                start: 1
+                end: 29
+      sink:
+        location:
+            start: 9
+            end: 9
+            column:
+                start: 1
+                end: 29
+        content: scopeResult(req.params.oops)
+      parent_line_number: 9
+      snippet: scopeResult(req.params.oops)
+      fingerprint: 408407aa362e0520faf6b66c3d59bb8c_4
+      old_fingerprint: 408407aa362e0520faf6b66c3d59bb8c_4
+    - rule:
+        cwe_ids:
+            - "42"
+        id: scope_test
+        title: Test detection filter scopes
+        description: Test detection filter scopes
+        documentation_url: ""
+      line_number: 10
+      full_filename: scope.js
+      filename: scope.js
+      source:
+        location:
+            start: 10
+            end: 10
+            column:
+                start: 1
+                end: 37
+      sink:
+        location:
+            start: 10
+            end: 10
+            column:
+                start: 1
+                end: 37
+        content: 'scopeResult(x ? req.params.oops : y)'
+      parent_line_number: 10
+      snippet: 'scopeResult(x ? req.params.oops : y)'
+      fingerprint: 408407aa362e0520faf6b66c3d59bb8c_5
+      old_fingerprint: 408407aa362e0520faf6b66c3d59bb8c_5
 

--- a/new/detector/composition/javascript/.snapshots/flow/TestFlow--assigment-expression.yml
+++ b/new/detector/composition/javascript/.snapshots/flow/TestFlow--assigment-expression.yml
@@ -1,36 +1,36 @@
 high:
-- rule:
-    cwe_ids: []
-    id: javascript_test_datatype_rule
-    title: ""
-    description: ""
-    documentation_url: ""
-  line_number: 1
-  full_filename: assigment-expression.js
-  filename: assigment-expression.js
-  data_type:
-    category_uuid: 14124881-6b92-4fc5-8005-ea7c1c09592e
-    name: Fullname
-  category_groups:
-  - PII
-  - Personal Data
-  source:
-    location:
-      start: 1
-      end: 1
-      column:
-        start: 16
-        end: 28
-  sink:
-    location:
-      start: 2
-      end: 2
-      column:
-        start: 1
-        end: 18
-    content: console.log(user)
-  parent_line_number: 2
-  snippet: console.log(user)
-  fingerprint: 3c919e47299fa396f901d19edaad859c_0
-  old_fingerprint: 3c919e47299fa396f901d19edaad859c_0
+    - rule:
+        cwe_ids: []
+        id: javascript_test_datatype_rule
+        title: ""
+        description: ""
+        documentation_url: ""
+      line_number: 1
+      full_filename: assigment-expression.js
+      filename: assigment-expression.js
+      data_type:
+        category_uuid: 14124881-6b92-4fc5-8005-ea7c1c09592e
+        name: Fullname
+      category_groups:
+        - PII
+        - Personal Data
+      source:
+        location:
+            start: 1
+            end: 1
+            column:
+                start: 16
+                end: 28
+      sink:
+        location:
+            start: 2
+            end: 2
+            column:
+                start: 1
+                end: 18
+        content: console.log(user)
+      parent_line_number: 2
+      snippet: console.log(user)
+      fingerprint: 3c919e47299fa396f901d19edaad859c_0
+      old_fingerprint: 3c919e47299fa396f901d19edaad859c_0
 

--- a/new/detector/composition/javascript/.snapshots/flow/TestFlow--variable-declarator.yml
+++ b/new/detector/composition/javascript/.snapshots/flow/TestFlow--variable-declarator.yml
@@ -1,36 +1,36 @@
 high:
-- rule:
-    cwe_ids: []
-    id: javascript_test_datatype_rule
-    title: ""
-    description: ""
-    documentation_url: ""
-  line_number: 1
-  full_filename: variable-declarator.js
-  filename: variable-declarator.js
-  data_type:
-    category_uuid: 14124881-6b92-4fc5-8005-ea7c1c09592e
-    name: Fullname
-  category_groups:
-  - PII
-  - Personal Data
-  source:
-    location:
-      start: 1
-      end: 1
-      column:
-        start: 16
-        end: 28
-  sink:
-    location:
-      start: 2
-      end: 2
-      column:
-        start: 1
-        end: 18
-    content: console.log(user)
-  parent_line_number: 2
-  snippet: console.log(user)
-  fingerprint: 5d86ec557137111caf0eca9a7d304c91_0
-  old_fingerprint: 5d86ec557137111caf0eca9a7d304c91_0
+    - rule:
+        cwe_ids: []
+        id: javascript_test_datatype_rule
+        title: ""
+        description: ""
+        documentation_url: ""
+      line_number: 1
+      full_filename: variable-declarator.js
+      filename: variable-declarator.js
+      data_type:
+        category_uuid: 14124881-6b92-4fc5-8005-ea7c1c09592e
+        name: Fullname
+      category_groups:
+        - PII
+        - Personal Data
+      source:
+        location:
+            start: 1
+            end: 1
+            column:
+                start: 16
+                end: 28
+      sink:
+        location:
+            start: 2
+            end: 2
+            column:
+                start: 1
+                end: 18
+        content: console.log(user)
+      parent_line_number: 2
+      snippet: console.log(user)
+      fingerprint: 5d86ec557137111caf0eca9a7d304c91_0
+      old_fingerprint: 5d86ec557137111caf0eca9a7d304c91_0
 

--- a/new/detector/composition/javascript/.snapshots/import/TestImport--import.yml
+++ b/new/detector/composition/javascript/.snapshots/import/TestImport--import.yml
@@ -1,147 +1,147 @@
 high:
-- rule:
-    cwe_ids:
-    - "42"
-    id: import_test
-    title: Test imports
-    description: Test imports
-    documentation_url: ""
-  line_number: 4
-  full_filename: import.js
-  filename: import.js
-  source:
-    location:
-      start: 4
-      end: 4
-      column:
-        start: 1
-        end: 8
-  sink:
-    location:
-      start: 4
-      end: 4
-      column:
-        start: 1
-        end: 8
-    content: lib.f()
-  parent_line_number: 4
-  snippet: lib.f()
-  fingerprint: 23ce8eb29bdfc7d63841656df3d9ae27_0
-  old_fingerprint: 23ce8eb29bdfc7d63841656df3d9ae27_0
-- rule:
-    cwe_ids:
-    - "42"
-    id: import_test
-    title: Test imports
-    description: Test imports
-    documentation_url: ""
-  line_number: 5
-  full_filename: import.js
-  filename: import.js
-  source:
-    location:
-      start: 5
-      end: 5
-      column:
-        start: 1
-        end: 4
-  sink:
-    location:
-      start: 5
-      end: 5
-      column:
-        start: 1
-        end: 4
-    content: f()
-  parent_line_number: 5
-  snippet: f()
-  fingerprint: 23ce8eb29bdfc7d63841656df3d9ae27_1
-  old_fingerprint: 23ce8eb29bdfc7d63841656df3d9ae27_1
-- rule:
-    cwe_ids:
-    - "42"
-    id: import_test
-    title: Test imports
-    description: Test imports
-    documentation_url: ""
-  line_number: 6
-  full_filename: import.js
-  filename: import.js
-  source:
-    location:
-      start: 6
-      end: 6
-      column:
-        start: 1
-        end: 4
-  sink:
-    location:
-      start: 6
-      end: 6
-      column:
-        start: 1
-        end: 4
-    content: x()
-  parent_line_number: 6
-  snippet: x()
-  fingerprint: 23ce8eb29bdfc7d63841656df3d9ae27_2
-  old_fingerprint: 23ce8eb29bdfc7d63841656df3d9ae27_2
-- rule:
-    cwe_ids:
-    - "42"
-    id: import_test
-    title: Test imports
-    description: Test imports
-    documentation_url: ""
-  line_number: 9
-  full_filename: import.js
-  filename: import.js
-  source:
-    location:
-      start: 9
-      end: 9
-      column:
-        start: 1
-        end: 6
-  sink:
-    location:
-      start: 9
-      end: 9
-      column:
-        start: 1
-        end: 6
-    content: y.f()
-  parent_line_number: 9
-  snippet: y.f()
-  fingerprint: 23ce8eb29bdfc7d63841656df3d9ae27_3
-  old_fingerprint: 23ce8eb29bdfc7d63841656df3d9ae27_3
-- rule:
-    cwe_ids:
-    - "42"
-    id: import_test
-    title: Test imports
-    description: Test imports
-    documentation_url: ""
-  line_number: 11
-  full_filename: import.js
-  filename: import.js
-  source:
-    location:
-      start: 11
-      end: 11
-      column:
-        start: 1
-        end: 4
-  sink:
-    location:
-      start: 11
-      end: 11
-      column:
-        start: 1
-        end: 4
-    content: f()
-  parent_line_number: 11
-  snippet: f()
-  fingerprint: 23ce8eb29bdfc7d63841656df3d9ae27_4
-  old_fingerprint: 23ce8eb29bdfc7d63841656df3d9ae27_4
+    - rule:
+        cwe_ids:
+            - "42"
+        id: import_test
+        title: Test imports
+        description: Test imports
+        documentation_url: ""
+      line_number: 4
+      full_filename: import.js
+      filename: import.js
+      source:
+        location:
+            start: 4
+            end: 4
+            column:
+                start: 1
+                end: 8
+      sink:
+        location:
+            start: 4
+            end: 4
+            column:
+                start: 1
+                end: 8
+        content: lib.f()
+      parent_line_number: 4
+      snippet: lib.f()
+      fingerprint: 23ce8eb29bdfc7d63841656df3d9ae27_0
+      old_fingerprint: 23ce8eb29bdfc7d63841656df3d9ae27_0
+    - rule:
+        cwe_ids:
+            - "42"
+        id: import_test
+        title: Test imports
+        description: Test imports
+        documentation_url: ""
+      line_number: 5
+      full_filename: import.js
+      filename: import.js
+      source:
+        location:
+            start: 5
+            end: 5
+            column:
+                start: 1
+                end: 4
+      sink:
+        location:
+            start: 5
+            end: 5
+            column:
+                start: 1
+                end: 4
+        content: f()
+      parent_line_number: 5
+      snippet: f()
+      fingerprint: 23ce8eb29bdfc7d63841656df3d9ae27_1
+      old_fingerprint: 23ce8eb29bdfc7d63841656df3d9ae27_1
+    - rule:
+        cwe_ids:
+            - "42"
+        id: import_test
+        title: Test imports
+        description: Test imports
+        documentation_url: ""
+      line_number: 6
+      full_filename: import.js
+      filename: import.js
+      source:
+        location:
+            start: 6
+            end: 6
+            column:
+                start: 1
+                end: 4
+      sink:
+        location:
+            start: 6
+            end: 6
+            column:
+                start: 1
+                end: 4
+        content: x()
+      parent_line_number: 6
+      snippet: x()
+      fingerprint: 23ce8eb29bdfc7d63841656df3d9ae27_2
+      old_fingerprint: 23ce8eb29bdfc7d63841656df3d9ae27_2
+    - rule:
+        cwe_ids:
+            - "42"
+        id: import_test
+        title: Test imports
+        description: Test imports
+        documentation_url: ""
+      line_number: 9
+      full_filename: import.js
+      filename: import.js
+      source:
+        location:
+            start: 9
+            end: 9
+            column:
+                start: 1
+                end: 6
+      sink:
+        location:
+            start: 9
+            end: 9
+            column:
+                start: 1
+                end: 6
+        content: y.f()
+      parent_line_number: 9
+      snippet: y.f()
+      fingerprint: 23ce8eb29bdfc7d63841656df3d9ae27_3
+      old_fingerprint: 23ce8eb29bdfc7d63841656df3d9ae27_3
+    - rule:
+        cwe_ids:
+            - "42"
+        id: import_test
+        title: Test imports
+        description: Test imports
+        documentation_url: ""
+      line_number: 11
+      full_filename: import.js
+      filename: import.js
+      source:
+        location:
+            start: 11
+            end: 11
+            column:
+                start: 1
+                end: 4
+      sink:
+        location:
+            start: 11
+            end: 11
+            column:
+                start: 1
+                end: 4
+        content: f()
+      parent_line_number: 11
+      snippet: f()
+      fingerprint: 23ce8eb29bdfc7d63841656df3d9ae27_4
+      old_fingerprint: 23ce8eb29bdfc7d63841656df3d9ae27_4
 

--- a/new/detector/composition/javascript/.snapshots/object-deconstructing/TestObjectDeconstructing--deconstructing.yml
+++ b/new/detector/composition/javascript/.snapshots/object-deconstructing/TestObjectDeconstructing--deconstructing.yml
@@ -1,30 +1,30 @@
 low:
-- rule:
-    cwe_ids: []
-    id: javascript_deconstructing
-    title: ""
-    description: ""
-    documentation_url: ""
-  line_number: 1
-  full_filename: deconstructing.js
-  filename: deconstructing.js
-  source:
-    location:
-      start: 1
-      end: 1
-      column:
-        start: 9
-        end: 13
-  sink:
-    location:
-      start: 1
-      end: 1
-      column:
-        start: 9
-        end: 13
-    content: user
-  parent_line_number: 1
-  snippet: user
-  fingerprint: 391f0431340399f3f30398341feeb70a_0
-  old_fingerprint: 391f0431340399f3f30398341feeb70a_0
+    - rule:
+        cwe_ids: []
+        id: javascript_deconstructing
+        title: ""
+        description: ""
+        documentation_url: ""
+      line_number: 1
+      full_filename: deconstructing.js
+      filename: deconstructing.js
+      source:
+        location:
+            start: 1
+            end: 1
+            column:
+                start: 9
+                end: 13
+      sink:
+        location:
+            start: 1
+            end: 1
+            column:
+                start: 9
+                end: 13
+        content: user
+      parent_line_number: 1
+      snippet: user
+      fingerprint: 391f0431340399f3f30398341feeb70a_0
+      old_fingerprint: 391f0431340399f3f30398341feeb70a_0
 

--- a/new/detector/composition/javascript/.snapshots/object-deconstructing/TestObjectDeconstructing--multiple_objects.yml
+++ b/new/detector/composition/javascript/.snapshots/object-deconstructing/TestObjectDeconstructing--multiple_objects.yml
@@ -1,30 +1,30 @@
 low:
-- rule:
-    cwe_ids: []
-    id: javascript_deconstructing
-    title: ""
-    description: ""
-    documentation_url: ""
-  line_number: 1
-  full_filename: multiple_objects.js
-  filename: multiple_objects.js
-  source:
-    location:
-      start: 1
-      end: 1
-      column:
-        start: 9
-        end: 13
-  sink:
-    location:
-      start: 1
-      end: 1
-      column:
-        start: 9
-        end: 13
-    content: user
-  parent_line_number: 1
-  snippet: user
-  fingerprint: 83d173c5a31e8a9fc4b42968d18f584f_0
-  old_fingerprint: 83d173c5a31e8a9fc4b42968d18f584f_0
+    - rule:
+        cwe_ids: []
+        id: javascript_deconstructing
+        title: ""
+        description: ""
+        documentation_url: ""
+      line_number: 1
+      full_filename: multiple_objects.js
+      filename: multiple_objects.js
+      source:
+        location:
+            start: 1
+            end: 1
+            column:
+                start: 9
+                end: 13
+      sink:
+        location:
+            start: 1
+            end: 1
+            column:
+                start: 9
+                end: 13
+        content: user
+      parent_line_number: 1
+      snippet: user
+      fingerprint: 83d173c5a31e8a9fc4b42968d18f584f_0
+      old_fingerprint: 83d173c5a31e8a9fc4b42968d18f584f_0
 

--- a/new/detector/composition/javascript/.snapshots/string/TestString--concatanation.yml
+++ b/new/detector/composition/javascript/.snapshots/string/TestString--concatanation.yml
@@ -1,36 +1,36 @@
 high:
-- rule:
-    cwe_ids: []
-    id: javascript_insecure_url_test
-    title: ""
-    description: ""
-    documentation_url: ""
-  line_number: 1
-  full_filename: concatanation.js
-  filename: concatanation.js
-  data_type:
-    category_uuid: 14124881-6b92-4fc5-8005-ea7c1c09592e
-    name: Fullname
-  category_groups:
-  - PII
-  - Personal Data
-  source:
-    location:
-      start: 1
-      end: 1
-      column:
-        start: 29
-        end: 38
-  sink:
-    location:
-      start: 1
-      end: 1
-      column:
-        start: 1
-        end: 39
-    content: console.log("ht" + "tp://", user.name)
-  parent_line_number: 1
-  snippet: console.log("ht" + "tp://", user.name)
-  fingerprint: 272ebbd3e69ab1032f6fb14b69a79ae8_0
-  old_fingerprint: 272ebbd3e69ab1032f6fb14b69a79ae8_0
+    - rule:
+        cwe_ids: []
+        id: javascript_insecure_url_test
+        title: ""
+        description: ""
+        documentation_url: ""
+      line_number: 1
+      full_filename: concatanation.js
+      filename: concatanation.js
+      data_type:
+        category_uuid: 14124881-6b92-4fc5-8005-ea7c1c09592e
+        name: Fullname
+      category_groups:
+        - PII
+        - Personal Data
+      source:
+        location:
+            start: 1
+            end: 1
+            column:
+                start: 29
+                end: 38
+      sink:
+        location:
+            start: 1
+            end: 1
+            column:
+                start: 1
+                end: 39
+        content: console.log("ht" + "tp://", user.name)
+      parent_line_number: 1
+      snippet: console.log("ht" + "tp://", user.name)
+      fingerprint: 272ebbd3e69ab1032f6fb14b69a79ae8_0
+      old_fingerprint: 272ebbd3e69ab1032f6fb14b69a79ae8_0
 

--- a/new/detector/composition/javascript/.snapshots/string/TestString--simple.yml
+++ b/new/detector/composition/javascript/.snapshots/string/TestString--simple.yml
@@ -1,36 +1,36 @@
 high:
-- rule:
-    cwe_ids: []
-    id: javascript_insecure_url_test
-    title: ""
-    description: ""
-    documentation_url: ""
-  line_number: 1
-  full_filename: simple.js
-  filename: simple.js
-  data_type:
-    category_uuid: 14124881-6b92-4fc5-8005-ea7c1c09592e
-    name: Fullname
-  category_groups:
-  - PII
-  - Personal Data
-  source:
-    location:
-      start: 1
-      end: 1
-      column:
-        start: 24
-        end: 33
-  sink:
-    location:
-      start: 1
-      end: 1
-      column:
-        start: 1
-        end: 34
-    content: console.log("http://", user.name)
-  parent_line_number: 1
-  snippet: console.log("http://", user.name)
-  fingerprint: 971b852ae8266c6d2b25437584017e2c_0
-  old_fingerprint: 971b852ae8266c6d2b25437584017e2c_0
+    - rule:
+        cwe_ids: []
+        id: javascript_insecure_url_test
+        title: ""
+        description: ""
+        documentation_url: ""
+      line_number: 1
+      full_filename: simple.js
+      filename: simple.js
+      data_type:
+        category_uuid: 14124881-6b92-4fc5-8005-ea7c1c09592e
+        name: Fullname
+      category_groups:
+        - PII
+        - Personal Data
+      source:
+        location:
+            start: 1
+            end: 1
+            column:
+                start: 24
+                end: 33
+      sink:
+        location:
+            start: 1
+            end: 1
+            column:
+                start: 1
+                end: 34
+        content: console.log("http://", user.name)
+      parent_line_number: 1
+      snippet: console.log("http://", user.name)
+      fingerprint: 971b852ae8266c6d2b25437584017e2c_0
+      old_fingerprint: 971b852ae8266c6d2b25437584017e2c_0
 

--- a/new/detector/composition/javascript/.snapshots/string/TestString--single-quotes.yml
+++ b/new/detector/composition/javascript/.snapshots/string/TestString--single-quotes.yml
@@ -1,36 +1,36 @@
 high:
-- rule:
-    cwe_ids: []
-    id: javascript_insecure_url_test
-    title: ""
-    description: ""
-    documentation_url: ""
-  line_number: 2
-  full_filename: single-quotes.js
-  filename: single-quotes.js
-  data_type:
-    category_uuid: 14124881-6b92-4fc5-8005-ea7c1c09592e
-    name: Fullname
-  category_groups:
-  - PII
-  - Personal Data
-  source:
-    location:
-      start: 2
-      end: 2
-      column:
-        start: 24
-        end: 33
-  sink:
-    location:
-      start: 2
-      end: 2
-      column:
-        start: 1
-        end: 34
-    content: console.log('http://', user.name)
-  parent_line_number: 2
-  snippet: console.log('http://', user.name)
-  fingerprint: d85fed5722eb11c71ff861517e929da1_0
-  old_fingerprint: d85fed5722eb11c71ff861517e929da1_0
+    - rule:
+        cwe_ids: []
+        id: javascript_insecure_url_test
+        title: ""
+        description: ""
+        documentation_url: ""
+      line_number: 2
+      full_filename: single-quotes.js
+      filename: single-quotes.js
+      data_type:
+        category_uuid: 14124881-6b92-4fc5-8005-ea7c1c09592e
+        name: Fullname
+      category_groups:
+        - PII
+        - Personal Data
+      source:
+        location:
+            start: 2
+            end: 2
+            column:
+                start: 24
+                end: 33
+      sink:
+        location:
+            start: 2
+            end: 2
+            column:
+                start: 1
+                end: 34
+        content: console.log('http://', user.name)
+      parent_line_number: 2
+      snippet: console.log('http://', user.name)
+      fingerprint: d85fed5722eb11c71ff861517e929da1_0
+      old_fingerprint: d85fed5722eb11c71ff861517e929da1_0
 

--- a/new/detector/composition/javascript/.snapshots/string/TestString--template-variable-reconciliation.yml
+++ b/new/detector/composition/javascript/.snapshots/string/TestString--template-variable-reconciliation.yml
@@ -1,36 +1,36 @@
 high:
-- rule:
-    cwe_ids: []
-    id: javascript_insecure_url_test
-    title: ""
-    description: ""
-    documentation_url: ""
-  line_number: 3
-  full_filename: template-variable-reconciliation.js
-  filename: template-variable-reconciliation.js
-  data_type:
-    category_uuid: 14124881-6b92-4fc5-8005-ea7c1c09592e
-    name: Fullname
-  category_groups:
-  - PII
-  - Personal Data
-  source:
-    location:
-      start: 3
-      end: 3
-      column:
-        start: 41
-        end: 50
-  sink:
-    location:
-      start: 3
-      end: 3
-      column:
-        start: 1
-        end: 51
-    content: console.log(`h${path}${config.domain}`, user.name)
-  parent_line_number: 3
-  snippet: console.log(`h${path}${config.domain}`, user.name)
-  fingerprint: bbac16a148474689a2cb1b5e2d40ada2_0
-  old_fingerprint: bbac16a148474689a2cb1b5e2d40ada2_0
+    - rule:
+        cwe_ids: []
+        id: javascript_insecure_url_test
+        title: ""
+        description: ""
+        documentation_url: ""
+      line_number: 3
+      full_filename: template-variable-reconciliation.js
+      filename: template-variable-reconciliation.js
+      data_type:
+        category_uuid: 14124881-6b92-4fc5-8005-ea7c1c09592e
+        name: Fullname
+      category_groups:
+        - PII
+        - Personal Data
+      source:
+        location:
+            start: 3
+            end: 3
+            column:
+                start: 41
+                end: 50
+      sink:
+        location:
+            start: 3
+            end: 3
+            column:
+                start: 1
+                end: 51
+        content: console.log(`h${path}${config.domain}`, user.name)
+      parent_line_number: 3
+      snippet: console.log(`h${path}${config.domain}`, user.name)
+      fingerprint: bbac16a148474689a2cb1b5e2d40ada2_0
+      old_fingerprint: bbac16a148474689a2cb1b5e2d40ada2_0
 

--- a/new/detector/composition/javascript/.snapshots/string/TestString--template.yml
+++ b/new/detector/composition/javascript/.snapshots/string/TestString--template.yml
@@ -1,36 +1,36 @@
 high:
-- rule:
-    cwe_ids: []
-    id: javascript_insecure_url_test
-    title: ""
-    description: ""
-    documentation_url: ""
-  line_number: 1
-  full_filename: template.js
-  filename: template.js
-  data_type:
-    category_uuid: 14124881-6b92-4fc5-8005-ea7c1c09592e
-    name: Fullname
-  category_groups:
-  - PII
-  - Personal Data
-  source:
-    location:
-      start: 1
-      end: 1
-      column:
-        start: 40
-        end: 49
-  sink:
-    location:
-      start: 1
-      end: 1
-      column:
-        start: 1
-        end: 50
-    content: console.log(`http://${config.domain}`, user.name)
-  parent_line_number: 1
-  snippet: console.log(`http://${config.domain}`, user.name)
-  fingerprint: 5f1137c9ab0489aed97dddee99bff779_0
-  old_fingerprint: 5f1137c9ab0489aed97dddee99bff779_0
+    - rule:
+        cwe_ids: []
+        id: javascript_insecure_url_test
+        title: ""
+        description: ""
+        documentation_url: ""
+      line_number: 1
+      full_filename: template.js
+      filename: template.js
+      data_type:
+        category_uuid: 14124881-6b92-4fc5-8005-ea7c1c09592e
+        name: Fullname
+      category_groups:
+        - PII
+        - Personal Data
+      source:
+        location:
+            start: 1
+            end: 1
+            column:
+                start: 40
+                end: 49
+      sink:
+        location:
+            start: 1
+            end: 1
+            column:
+                start: 1
+                end: 50
+        content: console.log(`http://${config.domain}`, user.name)
+      parent_line_number: 1
+      snippet: console.log(`http://${config.domain}`, user.name)
+      fingerprint: 5f1137c9ab0489aed97dddee99bff779_0
+      old_fingerprint: 5f1137c9ab0489aed97dddee99bff779_0
 

--- a/new/detector/composition/ruby/.snapshots/TestRuby--call.yml
+++ b/new/detector/composition/ruby/.snapshots/TestRuby--call.yml
@@ -1,36 +1,36 @@
 high:
-- rule:
-    cwe_ids: []
-    id: logger_test_rule
-    title: ""
-    description: ""
-    documentation_url: ""
-  line_number: 1
-  full_filename: call.rb
-  filename: call.rb
-  data_type:
-    category_uuid: 14124881-6b92-4fc5-8005-ea7c1c09592e
-    name: Fullname
-  category_groups:
-  - PII
-  - Personal Data
-  source:
-    location:
-      start: 1
-      end: 1
-      column:
-        start: 13
-        end: 22
-  sink:
-    location:
-      start: 1
-      end: 1
-      column:
-        start: 1
-        end: 23
-    content: logger.info(user.name)
-  parent_line_number: 1
-  snippet: logger.info(user.name)
-  fingerprint: e61c5d04fc38732e3374bc499d4daec1_0
-  old_fingerprint: e61c5d04fc38732e3374bc499d4daec1_0
+    - rule:
+        cwe_ids: []
+        id: logger_test_rule
+        title: ""
+        description: ""
+        documentation_url: ""
+      line_number: 1
+      full_filename: call.rb
+      filename: call.rb
+      data_type:
+        category_uuid: 14124881-6b92-4fc5-8005-ea7c1c09592e
+        name: Fullname
+      category_groups:
+        - PII
+        - Personal Data
+      source:
+        location:
+            start: 1
+            end: 1
+            column:
+                start: 13
+                end: 22
+      sink:
+        location:
+            start: 1
+            end: 1
+            column:
+                start: 1
+                end: 23
+        content: logger.info(user.name)
+      parent_line_number: 1
+      snippet: logger.info(user.name)
+      fingerprint: e61c5d04fc38732e3374bc499d4daec1_0
+      old_fingerprint: e61c5d04fc38732e3374bc499d4daec1_0
 

--- a/new/detector/composition/ruby/.snapshots/TestRuby--object-variable-reconciliation.yml
+++ b/new/detector/composition/ruby/.snapshots/TestRuby--object-variable-reconciliation.yml
@@ -1,36 +1,36 @@
 high:
-- rule:
-    cwe_ids: []
-    id: logger_test_rule
-    title: ""
-    description: ""
-    documentation_url: ""
-  line_number: 1
-  full_filename: object-variable-reconciliation.rb
-  filename: object-variable-reconciliation.rb
-  data_type:
-    category_uuid: 14124881-6b92-4fc5-8005-ea7c1c09592e
-    name: Fullname
-  category_groups:
-  - PII
-  - Personal Data
-  source:
-    location:
-      start: 1
-      end: 1
-      column:
-        start: 10
-        end: 22
-  sink:
-    location:
-      start: 2
-      end: 2
-      column:
-        start: 1
-        end: 18
-    content: logger.info(user)
-  parent_line_number: 2
-  snippet: logger.info(user)
-  fingerprint: 50cde2c647d72172d49858483ecb0b57_0
-  old_fingerprint: 50cde2c647d72172d49858483ecb0b57_0
+    - rule:
+        cwe_ids: []
+        id: logger_test_rule
+        title: ""
+        description: ""
+        documentation_url: ""
+      line_number: 1
+      full_filename: object-variable-reconciliation.rb
+      filename: object-variable-reconciliation.rb
+      data_type:
+        category_uuid: 14124881-6b92-4fc5-8005-ea7c1c09592e
+        name: Fullname
+      category_groups:
+        - PII
+        - Personal Data
+      source:
+        location:
+            start: 1
+            end: 1
+            column:
+                start: 10
+                end: 22
+      sink:
+        location:
+            start: 2
+            end: 2
+            column:
+                start: 1
+                end: 18
+        content: logger.info(user)
+      parent_line_number: 2
+      snippet: logger.info(user)
+      fingerprint: 50cde2c647d72172d49858483ecb0b57_0
+      old_fingerprint: 50cde2c647d72172d49858483ecb0b57_0
 

--- a/new/detector/composition/ruby/.snapshots/TestScope--scope.yml
+++ b/new/detector/composition/ruby/.snapshots/TestScope--scope.yml
@@ -1,176 +1,176 @@
 high:
-- rule:
-    cwe_ids:
-    - "42"
-    id: scope_test
-    title: Test detection filter scopes
-    description: Test detection filter scopes
-    documentation_url: ""
-  line_number: 1
-  full_filename: scope.rb
-  filename: scope.rb
-  source:
-    location:
-      start: 1
-      end: 1
-      column:
-        start: 1
-        end: 28
-  sink:
-    location:
-      start: 1
-      end: 1
-      column:
-        start: 1
-        end: 28
-    content: scope_cursor(params[:oops])
-  parent_line_number: 1
-  snippet: scope_cursor(params[:oops])
-  fingerprint: 23e17866f80f43957a84e824da9ce255_0
-  old_fingerprint: 23e17866f80f43957a84e824da9ce255_0
-- rule:
-    cwe_ids:
-    - "42"
-    id: scope_test
-    title: Test detection filter scopes
-    description: Test detection filter scopes
-    documentation_url: ""
-  line_number: 5
-  full_filename: scope.rb
-  filename: scope.rb
-  source:
-    location:
-      start: 5
-      end: 5
-      column:
-        start: 1
-        end: 28
-  sink:
-    location:
-      start: 5
-      end: 5
-      column:
-        start: 1
-        end: 28
-    content: scope_nested(params[:oops])
-  parent_line_number: 5
-  snippet: scope_nested(params[:oops])
-  fingerprint: 23e17866f80f43957a84e824da9ce255_1
-  old_fingerprint: 23e17866f80f43957a84e824da9ce255_1
-- rule:
-    cwe_ids:
-    - "42"
-    id: scope_test
-    title: Test detection filter scopes
-    description: Test detection filter scopes
-    documentation_url: ""
-  line_number: 6
-  full_filename: scope.rb
-  filename: scope.rb
-  source:
-    location:
-      start: 6
-      end: 6
-      column:
-        start: 1
-        end: 36
-  sink:
-    location:
-      start: 6
-      end: 6
-      column:
-        start: 1
-        end: 36
-    content: 'scope_nested(x ? params[:oops] : y)'
-  parent_line_number: 6
-  snippet: 'scope_nested(x ? params[:oops] : y)'
-  fingerprint: 23e17866f80f43957a84e824da9ce255_2
-  old_fingerprint: 23e17866f80f43957a84e824da9ce255_2
-- rule:
-    cwe_ids:
-    - "42"
-    id: scope_test
-    title: Test detection filter scopes
-    description: Test detection filter scopes
-    documentation_url: ""
-  line_number: 7
-  full_filename: scope.rb
-  filename: scope.rb
-  source:
-    location:
-      start: 7
-      end: 7
-      column:
-        start: 1
-        end: 36
-  sink:
-    location:
-      start: 7
-      end: 7
-      column:
-        start: 1
-        end: 36
-    content: 'scope_nested(params[:oops] ? x : y)'
-  parent_line_number: 7
-  snippet: 'scope_nested(params[:oops] ? x : y)'
-  fingerprint: 23e17866f80f43957a84e824da9ce255_3
-  old_fingerprint: 23e17866f80f43957a84e824da9ce255_3
-- rule:
-    cwe_ids:
-    - "42"
-    id: scope_test
-    title: Test detection filter scopes
-    description: Test detection filter scopes
-    documentation_url: ""
-  line_number: 9
-  full_filename: scope.rb
-  filename: scope.rb
-  source:
-    location:
-      start: 9
-      end: 9
-      column:
-        start: 1
-        end: 28
-  sink:
-    location:
-      start: 9
-      end: 9
-      column:
-        start: 1
-        end: 28
-    content: scope_result(params[:oops])
-  parent_line_number: 9
-  snippet: scope_result(params[:oops])
-  fingerprint: 23e17866f80f43957a84e824da9ce255_4
-  old_fingerprint: 23e17866f80f43957a84e824da9ce255_4
-- rule:
-    cwe_ids:
-    - "42"
-    id: scope_test
-    title: Test detection filter scopes
-    description: Test detection filter scopes
-    documentation_url: ""
-  line_number: 10
-  full_filename: scope.rb
-  filename: scope.rb
-  source:
-    location:
-      start: 10
-      end: 10
-      column:
-        start: 1
-        end: 36
-  sink:
-    location:
-      start: 10
-      end: 10
-      column:
-        start: 1
-        end: 36
-    content: 'scope_result(x ? params[:oops] : y)'
-  parent_line_number: 10
-  snippet: 'scope_result(x ? params[:oops] : y)'
-  fingerprint: 23e17866f80f43957a84e824da9ce255_5
-  old_fingerprint: 23e17866f80f43957a84e824da9ce255_5
+    - rule:
+        cwe_ids:
+            - "42"
+        id: scope_test
+        title: Test detection filter scopes
+        description: Test detection filter scopes
+        documentation_url: ""
+      line_number: 1
+      full_filename: scope.rb
+      filename: scope.rb
+      source:
+        location:
+            start: 1
+            end: 1
+            column:
+                start: 1
+                end: 28
+      sink:
+        location:
+            start: 1
+            end: 1
+            column:
+                start: 1
+                end: 28
+        content: scope_cursor(params[:oops])
+      parent_line_number: 1
+      snippet: scope_cursor(params[:oops])
+      fingerprint: 23e17866f80f43957a84e824da9ce255_0
+      old_fingerprint: 23e17866f80f43957a84e824da9ce255_0
+    - rule:
+        cwe_ids:
+            - "42"
+        id: scope_test
+        title: Test detection filter scopes
+        description: Test detection filter scopes
+        documentation_url: ""
+      line_number: 5
+      full_filename: scope.rb
+      filename: scope.rb
+      source:
+        location:
+            start: 5
+            end: 5
+            column:
+                start: 1
+                end: 28
+      sink:
+        location:
+            start: 5
+            end: 5
+            column:
+                start: 1
+                end: 28
+        content: scope_nested(params[:oops])
+      parent_line_number: 5
+      snippet: scope_nested(params[:oops])
+      fingerprint: 23e17866f80f43957a84e824da9ce255_1
+      old_fingerprint: 23e17866f80f43957a84e824da9ce255_1
+    - rule:
+        cwe_ids:
+            - "42"
+        id: scope_test
+        title: Test detection filter scopes
+        description: Test detection filter scopes
+        documentation_url: ""
+      line_number: 6
+      full_filename: scope.rb
+      filename: scope.rb
+      source:
+        location:
+            start: 6
+            end: 6
+            column:
+                start: 1
+                end: 36
+      sink:
+        location:
+            start: 6
+            end: 6
+            column:
+                start: 1
+                end: 36
+        content: 'scope_nested(x ? params[:oops] : y)'
+      parent_line_number: 6
+      snippet: 'scope_nested(x ? params[:oops] : y)'
+      fingerprint: 23e17866f80f43957a84e824da9ce255_2
+      old_fingerprint: 23e17866f80f43957a84e824da9ce255_2
+    - rule:
+        cwe_ids:
+            - "42"
+        id: scope_test
+        title: Test detection filter scopes
+        description: Test detection filter scopes
+        documentation_url: ""
+      line_number: 7
+      full_filename: scope.rb
+      filename: scope.rb
+      source:
+        location:
+            start: 7
+            end: 7
+            column:
+                start: 1
+                end: 36
+      sink:
+        location:
+            start: 7
+            end: 7
+            column:
+                start: 1
+                end: 36
+        content: 'scope_nested(params[:oops] ? x : y)'
+      parent_line_number: 7
+      snippet: 'scope_nested(params[:oops] ? x : y)'
+      fingerprint: 23e17866f80f43957a84e824da9ce255_3
+      old_fingerprint: 23e17866f80f43957a84e824da9ce255_3
+    - rule:
+        cwe_ids:
+            - "42"
+        id: scope_test
+        title: Test detection filter scopes
+        description: Test detection filter scopes
+        documentation_url: ""
+      line_number: 9
+      full_filename: scope.rb
+      filename: scope.rb
+      source:
+        location:
+            start: 9
+            end: 9
+            column:
+                start: 1
+                end: 28
+      sink:
+        location:
+            start: 9
+            end: 9
+            column:
+                start: 1
+                end: 28
+        content: scope_result(params[:oops])
+      parent_line_number: 9
+      snippet: scope_result(params[:oops])
+      fingerprint: 23e17866f80f43957a84e824da9ce255_4
+      old_fingerprint: 23e17866f80f43957a84e824da9ce255_4
+    - rule:
+        cwe_ids:
+            - "42"
+        id: scope_test
+        title: Test detection filter scopes
+        description: Test detection filter scopes
+        documentation_url: ""
+      line_number: 10
+      full_filename: scope.rb
+      filename: scope.rb
+      source:
+        location:
+            start: 10
+            end: 10
+            column:
+                start: 1
+                end: 36
+      sink:
+        location:
+            start: 10
+            end: 10
+            column:
+                start: 1
+                end: 36
+        content: 'scope_result(x ? params[:oops] : y)'
+      parent_line_number: 10
+      snippet: 'scope_result(x ? params[:oops] : y)'
+      fingerprint: 23e17866f80f43957a84e824da9ce255_5
+      old_fingerprint: 23e17866f80f43957a84e824da9ce255_5
 

--- a/pkg/commands/process/settings/settings.go
+++ b/pkg/commands/process/settings/settings.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/rs/zerolog/log"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/bearer/bearer/api"
 	"github.com/bearer/bearer/pkg/flag"

--- a/pkg/util/output/output.go
+++ b/pkg/util/output/output.go
@@ -9,7 +9,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 var (


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Switches the YAML library version back to v3 for reports. https://github.com/Bearer/bearer/pull/1030 had inadvertently changed it to v2 which is outputting slightly different whitespace. This is affecting test snapshots.

Also changes the only other place we were using v2 for consistency.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [x] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
