### PR TITLE
docs: add redirect for removed Java weak encryption rule

### DIFF
--- a/docs/_redirects
+++ b/docs/_redirects
@@ -8,6 +8,7 @@
 /reference/rules/javascript_express_insecure_template_rendering /reference/rules/javascript_lang_raw_html_using_user_input
 /reference/rules/javascript_aws_lambda_os_command_injection /reference/rules/javascript_lang_os_command_injection
 /reference/rules/javascript_aws_lambda_query_injection /reference/rules/javascript_third_parties_dynamodb_query_injection
-/reference/rules/ruby_lang_weak_encryption /reference/rules
 /reference/rules/javascript_lang_weak_encryption /reference/rules
 /reference/rules/javascript_lang_weak_password_encryption /reference/rules
+/reference/rules/ruby_lang_weak_encryption /reference/rules
+/reference/rules/java_lang_weak_encryption /reference/rules


### PR DESCRIPTION
## Description

Add redirect for removed Java weak encryption rule 

Relates to https://github.com/Bearer/bearer-rules/issues/82

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
