### PR TITLE
chore: add profiling flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ temp/
 
 
 .envrc
+/*.pprof

--- a/pkg/commands/debugprofile/debugprofile.go
+++ b/pkg/commands/debugprofile/debugprofile.go
@@ -1,0 +1,46 @@
+package debugprofile
+
+import (
+	"os"
+	"runtime/pprof"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/viper"
+
+	"github.com/bearer/bearer/pkg/flag"
+)
+
+var file *os.File
+
+func Start() {
+	log.Debug().Msgf("starting cpu profiling")
+
+	processID := viper.GetString(flag.WorkerIDFlag.ConfigName)
+	if processID == "" {
+		processID = "main"
+	}
+
+	var err error
+	file, err = os.Create(processID + ".pprof")
+	if err != nil {
+		log.Err(err).Msg("failed to create profiling file")
+		return
+	}
+
+	if err := pprof.StartCPUProfile(file); err != nil {
+		log.Err(err).Msg("failed to start cpu profile")
+		file.Close()
+		file = nil
+		return
+	}
+}
+
+func Stop() {
+	if file == nil {
+		return
+	}
+
+	log.Debug().Msg("stopping cpu profiling")
+	pprof.StopCPUProfile()
+	file.Close()
+}

--- a/pkg/commands/process/settings/settings.go
+++ b/pkg/commands/process/settings/settings.go
@@ -19,6 +19,7 @@ var (
 	TimeoutFileMaximum        = 30 * time.Second  // Maximum timeout assigned for scanning each file. This config superseeds timeout-second-per-bytes
 	TimeoutFileBytesPerSecond = 1 * 1000          // 1 Kb/s minimum number of bytes per second allowed to scan a file
 	TimeoutWorkerOnline       = 60 * time.Second  // Maximum time to wait for a worker process to come online
+	TimeoutWorkerShutdown     = 5 * time.Second   // Maximum time to wait for a worker process to shut down cleanly
 	FileSizeMaximum           = 2 * 1000 * 1000   // 2 MB Ignore files larger than the specified value
 	FilesToBatch              = 1                 // Specify the number of files to batch per worker
 	MemoryMaximum             = 800 * 1000 * 1000 // 800 MB If the memory needed to scan a file surpasses the specified limit, skip the file.

--- a/pkg/commands/process/settings/settings.go
+++ b/pkg/commands/process/settings/settings.go
@@ -49,6 +49,7 @@ type Config struct {
 	CacheUsed          bool               `mapstructure:"cache_used" json:"cache_used" yaml:"cache_used"`
 	BearerRulesVersion string             `mapstructure:"bearer_rules_version" json:"bearer_rules_version" yaml:"bearer_rules_version"`
 	NoColor            bool               `mapstructure:"no_color" json:"no_color" yaml:"no_color"`
+	DebugProfile       bool               `mapstructure:"debug_profile" json:"debug_profile" yaml:"debug_profile"`
 }
 
 type Modules []*PolicyModule
@@ -299,6 +300,7 @@ func FromOptions(opts flag.Options, foundLanguages []string) (Config, error) {
 		Scan:               opts.ScanOptions,
 		Report:             opts.ReportOptions,
 		NoColor:            opts.GeneralOptions.NoColor || opts.ReportOptions.Output != "",
+		DebugProfile:       opts.GeneralOptions.DebugProfile,
 		Policies:           policies,
 		Rules:              result.Rules,
 		BuiltInRules:       result.BuiltInRules,

--- a/pkg/commands/process/worker/pool/pool.go
+++ b/pkg/commands/process/worker/pool/pool.go
@@ -30,6 +30,9 @@ func New(config settings.Config) *Pool {
 	if config.Scan.Debug {
 		baseArguments = append(baseArguments, "--debug")
 	}
+	if config.DebugProfile {
+		baseArguments = append(baseArguments, "--debug-profile")
+	}
 
 	return &Pool{
 		processOptions: ProcessOptions{

--- a/pkg/commands/processing_worker.go
+++ b/pkg/commands/processing_worker.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 
+	"github.com/bearer/bearer/pkg/commands/debugprofile"
 	"github.com/bearer/bearer/pkg/commands/process/worker"
 	"github.com/bearer/bearer/pkg/flag"
 	"github.com/bearer/bearer/pkg/util/output"
@@ -31,6 +32,10 @@ func NewProcessingWorkerCommand() *cobra.Command {
 				ProcessID: viper.GetString(flag.WorkerIDFlag.ConfigName),
 			})
 
+			if viper.GetBool(flag.WorkerDebugProfileFlag.ConfigName) {
+				debugprofile.Start()
+			}
+
 			processOptions, err := flags.ProcessFlagGroup.ToOptions()
 			if err != nil {
 				return fmt.Errorf("options binding error: %w", err)
@@ -38,7 +43,9 @@ func NewProcessingWorkerCommand() *cobra.Command {
 
 			log.Debug().Msgf("running scan worker on port `%s`", processOptions.Port)
 
-			return worker.Start(processOptions.Port)
+			err = worker.Start(processOptions.Port)
+			debugprofile.Stop()
+			return err
 		},
 		Hidden:        true,
 		SilenceErrors: true,

--- a/pkg/commands/scan.go
+++ b/pkg/commands/scan.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/bearer/bearer/pkg/commands/artifact"
+	"github.com/bearer/bearer/pkg/commands/debugprofile"
 	"github.com/bearer/bearer/pkg/flag"
 	"github.com/bearer/bearer/pkg/util/file"
 	"github.com/bearer/bearer/pkg/util/output"
@@ -61,6 +62,10 @@ func NewScanCommand() *cobra.Command {
 				ProcessID: "main",
 			})
 
+			if viper.GetBool(flag.DebugProfileFlag.ConfigName) {
+				debugprofile.Start()
+			}
+
 			configPath := viper.GetString(flag.ConfigFileFlag.ConfigName)
 			var defaultConfigPath = ""
 			if len(args) > 0 {
@@ -93,7 +98,9 @@ func NewScanCommand() *cobra.Command {
 
 			cmd.SilenceUsage = true
 
-			return artifact.Run(cmd.Context(), options, artifact.TargetFilesystem)
+			err = artifact.Run(cmd.Context(), options, artifact.TargetFilesystem)
+			debugprofile.Stop()
+			return err
 		},
 		SilenceErrors: false,
 		SilenceUsage:  false,

--- a/pkg/flag/general_flags.go
+++ b/pkg/flag/general_flags.go
@@ -45,11 +45,12 @@ var (
 		Usage:      "Disable color in output",
 	}
 	DebugProfileFlag = Flag{
-		Name:       "debug-profile",
-		ConfigName: "debug-profile",
-		Value:      false,
-		Usage:      "Generate profiling data for debugging",
-		Hide:       true,
+		Name:            "debug-profile",
+		ConfigName:      "debug-profile",
+		Value:           false,
+		Usage:           "Generate profiling data for debugging",
+		Hide:            true,
+		DisableInConfig: true,
 	}
 )
 

--- a/pkg/flag/general_flags.go
+++ b/pkg/flag/general_flags.go
@@ -44,6 +44,13 @@ var (
 		Value:      false,
 		Usage:      "Disable color in output",
 	}
+	DebugProfileFlag = Flag{
+		Name:       "debug-profile",
+		ConfigName: "debug-profile",
+		Value:      false,
+		Usage:      "Generate profiling data for debugging",
+		Hide:       true,
+	}
 )
 
 type GeneralFlagGroup struct {
@@ -52,6 +59,7 @@ type GeneralFlagGroup struct {
 	Host                *Flag
 	DisableVersionCheck *Flag
 	NoColor             *Flag
+	DebugProfile        *Flag
 }
 
 // GlobalOptions defines flags and other configuration parameters for all the subcommands
@@ -60,6 +68,7 @@ type GeneralOptions struct {
 	Client              *api.API
 	DisableVersionCheck bool
 	NoColor             bool `mapstructure:"no_color" json:"no_color" yaml:"no_color"`
+	DebugProfile        bool
 }
 
 func NewGeneralFlagGroup() *GeneralFlagGroup {
@@ -69,6 +78,7 @@ func NewGeneralFlagGroup() *GeneralFlagGroup {
 		Host:                &HostFlag,
 		DisableVersionCheck: &DisableVersionCheckFlag,
 		NoColor:             &NoColorFlag,
+		DebugProfile:        &DebugProfileFlag,
 	}
 }
 
@@ -83,6 +93,7 @@ func (f *GeneralFlagGroup) Flags() []*Flag {
 		f.Host,
 		f.DisableVersionCheck,
 		f.NoColor,
+		f.DebugProfile,
 	}
 }
 
@@ -109,5 +120,6 @@ func (f *GeneralFlagGroup) ToOptions() GeneralOptions {
 		ConfigFile:          getString(f.ConfigFile),
 		DisableVersionCheck: getBool(f.DisableVersionCheck),
 		NoColor:             getBool(f.NoColor),
+		DebugProfile:        getBool(f.DebugProfile),
 	}
 }

--- a/pkg/flag/process_flags.go
+++ b/pkg/flag/process_flags.go
@@ -15,22 +15,32 @@ var (
 		Value:      "",
 		Usage:      "Set the worker's identifier.",
 	}
+
+	WorkerDebugProfileFlag = Flag{
+		Name:       "debug-profile",
+		ConfigName: "process.debug-profile",
+		Value:      false,
+		Usage:      "Generate profiling data for debugging",
+	}
 )
 
 type ProcessFlagGroup struct {
-	PortFlag     *Flag
-	WorkerIDFlag *Flag
+	PortFlag               *Flag
+	WorkerIDFlag           *Flag
+	WorkerDebugProfileFlag *Flag
 }
 
 type ProcessOptions struct {
-	WorkerID string `mapstructure:"worker-id" json:"worker-id" yaml:"worker-id"`
-	Port     string `mapstructure:"port" json:"port" yaml:"port"`
+	WorkerID     string `mapstructure:"worker-id" json:"worker-id" yaml:"worker-id"`
+	Port         string `mapstructure:"port" json:"port" yaml:"port"`
+	DebugProfile bool   `mapstructure:"debug_profile" json:"debug_profile" yaml:"debug_profile"`
 }
 
 func NewProcessGroup() *ProcessFlagGroup {
 	return &ProcessFlagGroup{
-		PortFlag:     &PortFlag,
-		WorkerIDFlag: &WorkerIDFlag,
+		PortFlag:               &PortFlag,
+		WorkerIDFlag:           &WorkerIDFlag,
+		WorkerDebugProfileFlag: &WorkerDebugProfileFlag,
 	}
 }
 
@@ -42,6 +52,7 @@ func (f *ProcessFlagGroup) Flags() []*Flag {
 	return []*Flag{
 		f.PortFlag,
 		f.WorkerIDFlag,
+		f.WorkerDebugProfileFlag,
 	}
 }
 
@@ -50,7 +61,8 @@ func (f *ProcessFlagGroup) ToOptions() (ProcessOptions, error) {
 	workerID := getString(f.WorkerIDFlag)
 
 	return ProcessOptions{
-		Port:     port,
-		WorkerID: workerID,
+		Port:         port,
+		WorkerID:     workerID,
+		DebugProfile: getBool(f.WorkerDebugProfileFlag),
 	}, nil
 }


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Adds a hidden `--debug-profile` flag which creates CPU profiles for the main process and worker processes.

To view the files:

```shell
$ go tool pprof -web main.pprof
```

To ensure the profile is written completely, workers are now shut down in a more graceful way.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
