### PR TITLE
test: make e2e snapshots consistent

### DIFF
--- a/e2e/internal/testhelper/testhelper.go
+++ b/e2e/internal/testhelper/testhelper.go
@@ -51,7 +51,10 @@ func executeApp(t *testing.T, arguments []string) (string, error) {
 
 	timer := time.NewTimer(TestTimeout)
 	commandFinished := make(chan struct{}, 1)
-	combinedOutput := func() string { return buffOut.String() + "\n--\n" + buffErr.String() }
+	combinedOutput := func() string {
+		errStr := strings.TrimSuffix(buffErr.String(), "exit status 1\n")
+		return buffOut.String() + "\n--\n" + errStr
+	}
 
 	go func() {
 		err = cmd.Start()

--- a/e2e/internal/testhelper/testhelper.go
+++ b/e2e/internal/testhelper/testhelper.go
@@ -88,6 +88,7 @@ func CreateCommand(arguments []string) (*exec.Cmd, context.CancelFunc) {
 		cmd = exec.CommandContext(ctx, "go", arguments...)
 	}
 
+	cmd.Env = append(os.Environ(), "BEARER_DEFAULT_PARALLEL=2")
 	cmd.Dir = os.Getenv("GITHUB_WORKSPACE")
 
 	return cmd, cancel

--- a/pkg/flag/scan_flags.go
+++ b/pkg/flag/scan_flags.go
@@ -3,7 +3,9 @@ package flag
 import (
 	"errors"
 	"math"
+	"os"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -20,8 +22,10 @@ const (
 	ScannerSecrets = "secrets"
 )
 
-var ErrInvalidContext = errors.New("invalid context argument; supported values: health")
-var ErrInvalidScanner = errors.New("invalid scanner argument; supported values: sast, secrets")
+var (
+	ErrInvalidContext = errors.New("invalid context argument; supported values: health")
+	ErrInvalidScanner = errors.New("invalid scanner argument; supported values: sast, secrets")
+)
 
 var (
 	SkipPathFlag = Flag{
@@ -93,7 +97,7 @@ var (
 	ParallelFlag = Flag{
 		Name:       "parallel",
 		ConfigName: "scan.parallel",
-		Value:      int(math.Min(float64(runtime.NumCPU()), 4)),
+		Value:      parallelValue(),
 		Usage:      "Specify the amount of parallelism to use during the scan",
 	}
 )
@@ -214,4 +218,14 @@ func getContext(flag *Flag) Context {
 
 	flagStr := strings.ToLower(getString(flag))
 	return Context(flagStr)
+}
+
+func parallelValue() int {
+	if overrideStr := os.Getenv("BEARER_DEFAULT_PARALLEL"); overrideStr != "" {
+		if override, err := strconv.Atoi(overrideStr); err == nil {
+			return override
+		}
+	}
+
+	return int(math.Min(float64(runtime.NumCPU()), 4))
 }


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Make E2E test snapshots consistent locally and in CI, and with or without the binary:
- Override default parallel value, making it independent of the number of CPUs in the environment
- Strip the "exit status 1" text that `go run` adds

## Related
- Close #1039 

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
