### PR TITLE
fix: Java string detector (strip quotes)

### DIFF
--- a/new/detector/implementation/java/.snapshots/TestJavaString-string_literal
+++ b/new/detector/implementation/java/.snapshots/TestJavaString-string_literal
@@ -1,0 +1,6 @@
+- position: "2:20"
+  content: '"Hello World"'
+  data:
+    value: Hello World
+    isliteral: true
+

--- a/new/detector/implementation/java/java_test.go
+++ b/new/detector/implementation/java/java_test.go
@@ -12,6 +12,10 @@ func TestJavaObjects(t *testing.T) {
 	runTest(t, "object_no_class", "object", "testdata/no_class.java")
 }
 
+func TestJavaString(t *testing.T) {
+	runTest(t, "string_literal", "string", "testdata/string_literal.java")
+}
+
 func runTest(t *testing.T, name, detectorType, fileName string) {
 	testhelper.RunTest(t, name, java.New, detectorType, fileName)
 }

--- a/new/detector/implementation/java/string/string.go
+++ b/new/detector/implementation/java/string/string.go
@@ -4,6 +4,7 @@ import (
 	"github.com/bearer/bearer/new/detector/types"
 	"github.com/bearer/bearer/new/language/tree"
 	"github.com/bearer/bearer/pkg/commands/process/settings"
+	"github.com/bearer/bearer/pkg/util/stringutil"
 
 	generictypes "github.com/bearer/bearer/new/detector/implementation/generic/types"
 	languagetypes "github.com/bearer/bearer/new/language/types"
@@ -28,7 +29,7 @@ func (detector *stringDetector) DetectAt(
 ) ([]interface{}, error) {
 	if node.Type() == "string_literal" {
 		return []interface{}{generictypes.String{
-			Value:     node.Content(),
+			Value:     stringutil.StripQuotes(node.Content()),
 			IsLiteral: true,
 		}}, nil
 	}

--- a/new/detector/implementation/java/testdata/string_literal.java
+++ b/new/detector/implementation/java/testdata/string_literal.java
@@ -1,0 +1,3 @@
+public class Greet {
+  const Greeting = "Hello World";
+}


### PR DESCRIPTION
## Description

Fix Java string detector so that it now strips quotation marks from string literals.

Note: there is further work remaining to bring Java string detector up to standard of other languages, e.g. support for interpolation

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [x] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
