### PR TITLE
fix(java): add try statement as unanchored pattern

### DIFF
--- a/new/language/implementation/java/java.go
+++ b/new/language/implementation/java/java.go
@@ -251,7 +251,8 @@ func (implementation *javaImplementation) PatternIsAnchored(node *tree.Node) (bo
 	// Class body class_body
 	// function block
 	// lambda () -> {} block
-	unAnchored := []string{"class_body", "block"}
+	// try {} catch () {}
+	unAnchored := []string{"class_body", "block", "try_statement"}
 
 	isUnanchored := !slices.Contains(unAnchored, parent.Type())
 	return isUnanchored, isUnanchored


### PR DESCRIPTION
## Description

Try statement is like a block and should be unanchored

```java
try {}
catch(Exception e) {
	e.printStackTrace();
}
```

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
