### PR TITLE
feat: changes to support JS dangerous html rule

### DIFF
--- a/new/detector/composition/java/java.go
+++ b/new/detector/composition/java/java.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bearer/bearer/pkg/classification"
 	"github.com/bearer/bearer/pkg/commands/process/settings"
+	"github.com/bearer/bearer/pkg/report/customdetectors"
 	"github.com/bearer/bearer/pkg/util/file"
 
 	"github.com/bearer/bearer/new/detector/composition/types"
@@ -117,7 +118,7 @@ func New(rules map[string]*settings.Rule, classifier *classification.Classifier)
 		patterns := rule.Patterns
 		localRuleName := ruleName
 
-		if !rule.IsAuxilary || presenceRules[ruleName] {
+		if (!rule.IsAuxilary && rule.Type != customdetectors.TypeShared) || presenceRules[ruleName] {
 			composition.customDetectorTypes = append(composition.customDetectorTypes, ruleName)
 		}
 

--- a/new/detector/composition/javascript/javascript.go
+++ b/new/detector/composition/javascript/javascript.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bearer/bearer/pkg/classification"
 	"github.com/bearer/bearer/pkg/commands/process/settings"
+	"github.com/bearer/bearer/pkg/report/customdetectors"
 	"github.com/bearer/bearer/pkg/util/file"
 
 	"github.com/bearer/bearer/new/detector/composition/types"
@@ -117,7 +118,7 @@ func New(rules map[string]*settings.Rule, classifier *classification.Classifier)
 		patterns := rule.Patterns
 		localRuleName := ruleName
 
-		if !rule.IsAuxilary || presenceRules[ruleName] {
+		if (!rule.IsAuxilary && rule.Type != customdetectors.TypeShared) || presenceRules[ruleName] {
 			composition.customDetectorTypes = append(composition.customDetectorTypes, ruleName)
 		}
 

--- a/new/detector/composition/ruby/ruby.go
+++ b/new/detector/composition/ruby/ruby.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/bearer/bearer/pkg/classification"
 	"github.com/bearer/bearer/pkg/commands/process/settings"
+	"github.com/bearer/bearer/pkg/report/customdetectors"
 	"github.com/bearer/bearer/pkg/util/file"
 
 	stringdetector "github.com/bearer/bearer/new/detector/implementation/ruby/string"
@@ -116,7 +117,7 @@ func New(rules map[string]*settings.Rule, classifier *classification.Classifier)
 		patterns := rule.Patterns
 		localRuleName := ruleName
 
-		if !rule.IsAuxilary || presenceRules[ruleName] {
+		if (!rule.IsAuxilary && rule.Type != customdetectors.TypeShared) || presenceRules[ruleName] {
 			composition.customDetectorTypes = append(composition.customDetectorTypes, ruleName)
 		}
 

--- a/new/detector/evaluator/evaluator.go
+++ b/new/detector/evaluator/evaluator.go
@@ -91,7 +91,7 @@ func (evaluator *evaluator) Evaluate(
 
 		result = append(result, detections...)
 
-		if scope != settings.CURSOR_SCOPE {
+		if scope != settings.CURSOR_SCOPE && !evaluator.langImplementation.IsMatchLeaf(node) {
 			parentNestedMode := nestedMode
 
 			if len(detections) != 0 && nestedDetections {

--- a/new/detector/implementation/custom/custom.go
+++ b/new/detector/implementation/custom/custom.go
@@ -36,7 +36,7 @@ func New(
 ) (types.Detector, error) {
 	var compiledPatterns []Pattern
 	for _, pattern := range patterns {
-		patternQuery, err := lang.CompilePatternQuery(pattern.Pattern)
+		patternQuery, err := lang.CompilePatternQuery(pattern.Pattern, pattern.Focus)
 		if err != nil {
 			return nil, fmt.Errorf("error compiling pattern: %s", err)
 		}

--- a/new/language/base/base.go
+++ b/new/language/base/base.go
@@ -32,6 +32,6 @@ func (lang *Language) CompileQuery(input string) (*tree.Query, error) {
 	return tree.CompileQuery(lang.implementation.SitterLanguage(), input)
 }
 
-func (lang *Language) CompilePatternQuery(input string) (types.PatternQuery, error) {
-	return patternquery.Compile(lang, lang.implementation, input)
+func (lang *Language) CompilePatternQuery(input, focusedVariable string) (types.PatternQuery, error) {
+	return patternquery.Compile(lang, lang.implementation, input, focusedVariable)
 }

--- a/new/language/implementation/implementation.go
+++ b/new/language/implementation/implementation.go
@@ -123,6 +123,25 @@ type Implementation interface {
 	PassthroughNested(node *tree.Node) bool
 
 	ContributesToResult(node *tree.Node) bool
+	IsMatchLeaf(node *tree.Node) bool
+}
+
+type Base struct{}
+
+func (implementation *Base) IsMatchLeaf(node *tree.Node) bool {
+	return false
+}
+
+func (*Base) TranslatePatternContent(fromNodeType, toNodeType, content string) string {
+	return content
+}
+
+func (*Base) IsRootOfRuleQuery(node *tree.Node) bool {
+	return true
+}
+
+func (*Base) ShouldSkipNode(node *tree.Node) bool {
+	return false
 }
 
 type Scope struct {

--- a/new/language/implementation/java/java.go
+++ b/new/language/implementation/java/java.go
@@ -322,5 +322,15 @@ func (*javaImplementation) ContributesToResult(node *tree.Node) bool {
 		return false
 	}
 
+	// Not the name part of a declaration
+	if parent.Type() == "variable_declarator" && node.Equal(parent.ChildByFieldName("name")) {
+		return false
+	}
+
+	// Not the left part of an assignment
+	if parent.Type() == "assignment_expression" && node.Equal(parent.ChildByFieldName("left")) {
+		return false
+	}
+
 	return true
 }

--- a/new/language/implementation/java/java.go
+++ b/new/language/implementation/java/java.go
@@ -41,7 +41,9 @@ var (
 	passthroughMethods = []string{}
 )
 
-type javaImplementation struct{}
+type javaImplementation struct {
+	implementation.Base
+}
 
 func Get() implementation.Implementation {
 	return &javaImplementation{}
@@ -225,10 +227,6 @@ func (implementation *javaImplementation) PatternMatchNodeContainerTypes() []str
 	return patternMatchNodeContainerTypes
 }
 
-func (javaImplementation *javaImplementation) ShouldSkipNode(node *tree.Node) bool {
-	return false
-}
-
 func (*javaImplementation) PatternLeafContentTypes() []string {
 	return []string{
 		// todo: see if type identifier should be removed from here (User user) `User` is type
@@ -272,10 +270,6 @@ func (implementation *javaImplementation) PatternNodeTypes(node *tree.Node) []st
 	}
 
 	return []string{node.Type()}
-}
-
-func (implementation *javaImplementation) TranslatePatternContent(fromNodeType, toNodeType, content string) string {
-	return content
 }
 
 func (*javaImplementation) PassthroughNested(node *tree.Node) bool {

--- a/new/language/implementation/javascript/javascript.go
+++ b/new/language/implementation/javascript/javascript.go
@@ -301,6 +301,16 @@ func (*javascriptImplementation) ContributesToResult(node *tree.Node) bool {
 		return false
 	}
 
+	// Not the name part of a declaration
+	if parent.Type() == "variable_declarator" && node.Equal(parent.ChildByFieldName("name")) {
+		return false
+	}
+
+	// Not the left part of an assignment
+	if parent.Type() == "assignment_expression" && node.Equal(parent.ChildByFieldName("left")) {
+		return false
+	}
+
 	return true
 }
 

--- a/new/language/implementation/javascript/javascript.go
+++ b/new/language/implementation/javascript/javascript.go
@@ -41,7 +41,9 @@ var (
 	passthroughMethods = []string{"JSON.parse", "JSON.stringify"}
 )
 
-type javascriptImplementation struct{}
+type javascriptImplementation struct {
+	implementation.Base
+}
 
 func Get() implementation.Implementation {
 	return &javascriptImplementation{}
@@ -140,6 +142,10 @@ func (*javascriptImplementation) AnalyzeFlow(rootNode *tree.Node) error {
 
 		return visitChildren()
 	})
+}
+
+func (implementation *javascriptImplementation) IsMatchLeaf(node *tree.Node) bool {
+	return node.Type() == "string"
 }
 
 func (implementation *javascriptImplementation) ExtractPatternVariables(input string) (string, []patternquerytypes.Variable, error) {
@@ -248,10 +254,6 @@ func (implementation *javascriptImplementation) PatternNodeTypes(node *tree.Node
 	}
 
 	return []string{node.Type()}
-}
-
-func (implementation *javascriptImplementation) TranslatePatternContent(fromNodeType, toNodeType, content string) string {
-	return content
 }
 
 func (*javascriptImplementation) PassthroughNested(node *tree.Node) bool {

--- a/new/language/implementation/ruby/ruby.go
+++ b/new/language/implementation/ruby/ruby.go
@@ -34,7 +34,9 @@ var (
 	passthroughMethods = []string{"JSON.parse", "JSON.parse!", "*.to_json"}
 )
 
-type rubyImplementation struct{}
+type rubyImplementation struct {
+	implementation.Base
+}
 
 func Get() implementation.Implementation {
 	return &rubyImplementation{}
@@ -172,10 +174,6 @@ func (*rubyImplementation) AnonymousPatternNodeParentTypes() []string {
 	return anonymousPatternNodeParentTypes
 }
 
-func (*rubyImplementation) ShouldSkipNode(node *tree.Node) bool {
-	return false
-}
-
 func (*rubyImplementation) PatternMatchNodeContainerTypes() []string {
 	return patternMatchNodeContainerTypes
 }
@@ -263,10 +261,6 @@ func (*rubyImplementation) TranslatePatternContent(fromNodeType, toNodeType, con
 	}
 
 	return content
-}
-
-func (implementation *rubyImplementation) IsRootOfRuleQuery(node *tree.Node) bool {
-	return true
 }
 
 func (*rubyImplementation) PassthroughNested(node *tree.Node) bool {

--- a/new/language/implementation/ruby/ruby.go
+++ b/new/language/implementation/ruby/ruby.go
@@ -312,6 +312,11 @@ func (*rubyImplementation) ContributesToResult(node *tree.Node) bool {
 		return false
 	}
 
+	// Not the left part of an assignment
+	if parent.Type() == "assignment" && node.Equal(parent.ChildByFieldName("left")) {
+		return false
+	}
+
 	// Must be the last expression in an expression block
 	if slices.Contains([]string{"then", "else"}, parent.Type()) {
 		if !node.Equal(parent.Child(parent.ChildCount() - 1)) {

--- a/new/language/patternquery/patternquery.go
+++ b/new/language/patternquery/patternquery.go
@@ -21,8 +21,9 @@ func Compile(
 	lang languagetypes.Language,
 	langImplementation implementation.Implementation,
 	input string,
+	focusedVariable string,
 ) (*Query, error) {
-	builderResult, err := builder.Build(lang, langImplementation, input)
+	builderResult, err := builder.Build(lang, langImplementation, input, focusedVariable)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build: %s", err)
 	}

--- a/new/language/types/types.go
+++ b/new/language/types/types.go
@@ -16,5 +16,5 @@ type PatternQuery interface {
 type Language interface {
 	Parse(input string) (*tree.Tree, error)
 	CompileQuery(input string) (*tree.Query, error)
-	CompilePatternQuery(input string) (PatternQuery, error)
+	CompilePatternQuery(input, focusedVariable string) (PatternQuery, error)
 }

--- a/pkg/commands/process/settings/settings.go
+++ b/pkg/commands/process/settings/settings.go
@@ -207,6 +207,7 @@ type PatternFilter struct {
 
 type RulePattern struct {
 	Pattern string          `mapstructure:"pattern" json:"pattern" yaml:"pattern"`
+	Focus   string          `mapstructure:"focus" json:"focus" yaml:"focus"`
 	Filters []PatternFilter `mapstructure:"filters" json:"filters" yaml:"filters"`
 }
 


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Changes to support the Javascript dangerously set HTML rule:
- Don't match against `string_fragments` (children of `string`)
- Don't include the left hand side of assignments when using result scope
- `focus` option for patterns, this specifies a variable to focus, as an alternative to `$<!>`

Also stops running shared rules at the top level, they will now only be used when referenced from a another rule.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
