### PR TITLE
chore: ignore -min.js as well as .min.js files

### DIFF
--- a/pkg/commands/process/orchestrator/fileignore/fileignore.go
+++ b/pkg/commands/process/orchestrator/fileignore/fileignore.go
@@ -67,6 +67,10 @@ func isMinified(fullPath string, size int64, goclocResult *gocloc.Result) bool {
 		return true
 	}
 
+	if strings.HasSuffix(fullPath, "-min.js") {
+		return true
+	}
+
 	if strings.HasSuffix(fullPath, ".js") {
 		goclocFileResult := goclocResult.Files[fullPath]
 

--- a/pkg/util/file/file.go
+++ b/pkg/util/file/file.go
@@ -34,7 +34,7 @@ var ignoredFilenames = []*regexp.Regexp{
 	regexp.MustCompile(`(^|/)_*samples?_*/`),
 	regexp.MustCompile(`(^|/)node_modules/`),
 	regexp.MustCompile(`(^|/)tmp/`),
-	regexp.MustCompile(`\.min\.js$`),
+	regexp.MustCompile(`[.-]min\.js$`),
 	regexp.MustCompile(`\.map\.js$`),
 }
 


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

We should ignore both `<something>-min.js` and `<something>.min.js`

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
