### PR TITLE
fix: allow string regex filter to match against empty string literals

### DIFF
--- a/new/detector/implementation/custom/filter.go
+++ b/new/detector/implementation/custom/filter.go
@@ -211,8 +211,8 @@ func matchContentFilter(filter settings.PatternFilter, evaluator types.Evaluator
 	}
 
 	if filter.StringRegex != nil {
-		value, _, err := generic.GetStringValue(node, evaluator)
-		if err != nil || value == "" {
+		value, isLiteral, err := generic.GetStringValue(node, evaluator)
+		if err != nil || (value == "" && !isLiteral) {
 			return nil, err
 		}
 


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Currently an empty string literal is treated as not having a string value. It should be treated as a string value that is empty instead.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
