### PR TITLE
perf: various performance enhancements

### DIFF
--- a/e2e/flags/.snapshots/TestInitCommand
+++ b/e2e/flags/.snapshots/TestInitCommand
@@ -13,12 +13,12 @@ rule:
 scan:
     context: ""
     data_subject_mapping: ""
-    debug: false
     disable-domain-resolution: true
     domain-resolution-timeout: 3s
     external-rule-dir: []
     force: false
     internal-domains: []
+    log-level: info
     parallel: 0
     quiet: false
     scanner:

--- a/e2e/flags/.snapshots/TestMetadataFlags-help-scan
+++ b/e2e/flags/.snapshots/TestMetadataFlags-help-scan
@@ -24,12 +24,13 @@ Rule Flags
 Scan Flags
       --context string                       Expand context of schema classification e.g., --context=health, to include data types particular to health
       --data-subject-mapping string          Override default data subject mapping by providing a path to a custom mapping JSON file
-      --debug                                Enable debug logs
+      --debug                                Enable debug logs. Equivalent to --log-level=debug
       --disable-domain-resolution            Do not attempt to resolve detected domains during classification (default true)
       --domain-resolution-timeout duration   Set timeout when attempting to resolve detected domains during classification, e.g. --domain-resolution-timeout=3s (default 3s)
       --external-rule-dir strings            Specify directories paths that contain .yaml files with external rules configuration
       --force                                Disable the cache and runs the detections again
       --internal-domains strings             Define regular expressions for better classification of private or unreachable domains e.g. --internal-domains=".*.my-company.com,private.sh"
+      --log-level string                     Set log level (error, info, debug, trace) (default "info")
       --parallel int                         Specify the amount of parallelism to use during the scan
       --quiet                                Suppress non-essential messages
       --scanner strings                      Specify which scanner to use e.g. --scanner=secrets, --scanner=secrets,sast (default [sast])

--- a/e2e/flags/.snapshots/TestMetadataFlags-scan-help
+++ b/e2e/flags/.snapshots/TestMetadataFlags-scan-help
@@ -24,12 +24,13 @@ Rule Flags
 Scan Flags
       --context string                       Expand context of schema classification e.g., --context=health, to include data types particular to health
       --data-subject-mapping string          Override default data subject mapping by providing a path to a custom mapping JSON file
-      --debug                                Enable debug logs
+      --debug                                Enable debug logs. Equivalent to --log-level=debug
       --disable-domain-resolution            Do not attempt to resolve detected domains during classification (default true)
       --domain-resolution-timeout duration   Set timeout when attempting to resolve detected domains during classification, e.g. --domain-resolution-timeout=3s (default 3s)
       --external-rule-dir strings            Specify directories paths that contain .yaml files with external rules configuration
       --force                                Disable the cache and runs the detections again
       --internal-domains strings             Define regular expressions for better classification of private or unreachable domains e.g. --internal-domains=".*.my-company.com,private.sh"
+      --log-level string                     Set log level (error, info, debug, trace) (default "info")
       --parallel int                         Specify the amount of parallelism to use during the scan
       --quiet                                Suppress non-essential messages
       --scanner strings                      Specify which scanner to use e.g. --scanner=secrets, --scanner=secrets,sast (default [sast])

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-context-flag
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-context-flag
@@ -25,12 +25,13 @@ Rule Flags
 Scan Flags
       --context string                       Expand context of schema classification e.g., --context=health, to include data types particular to health
       --data-subject-mapping string          Override default data subject mapping by providing a path to a custom mapping JSON file
-      --debug                                Enable debug logs
+      --debug                                Enable debug logs. Equivalent to --log-level=debug
       --disable-domain-resolution            Do not attempt to resolve detected domains during classification (default true)
       --domain-resolution-timeout duration   Set timeout when attempting to resolve detected domains during classification, e.g. --domain-resolution-timeout=3s (default 3s)
       --external-rule-dir strings            Specify directories paths that contain .yaml files with external rules configuration
       --force                                Disable the cache and runs the detections again
       --internal-domains strings             Define regular expressions for better classification of private or unreachable domains e.g. --internal-domains=".*.my-company.com,private.sh"
+      --log-level string                     Set log level (error, info, debug, trace) (default "info")
       --parallel int                         Specify the amount of parallelism to use during the scan
       --quiet                                Suppress non-essential messages
       --scanner strings                      Specify which scanner to use e.g. --scanner=secrets, --scanner=secrets,sast (default [sast])

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag
@@ -25,12 +25,13 @@ Rule Flags
 Scan Flags
       --context string                       Expand context of schema classification e.g., --context=health, to include data types particular to health
       --data-subject-mapping string          Override default data subject mapping by providing a path to a custom mapping JSON file
-      --debug                                Enable debug logs
+      --debug                                Enable debug logs. Equivalent to --log-level=debug
       --disable-domain-resolution            Do not attempt to resolve detected domains during classification (default true)
       --domain-resolution-timeout duration   Set timeout when attempting to resolve detected domains during classification, e.g. --domain-resolution-timeout=3s (default 3s)
       --external-rule-dir strings            Specify directories paths that contain .yaml files with external rules configuration
       --force                                Disable the cache and runs the detections again
       --internal-domains strings             Define regular expressions for better classification of private or unreachable domains e.g. --internal-domains=".*.my-company.com,private.sh"
+      --log-level string                     Set log level (error, info, debug, trace) (default "info")
       --parallel int                         Specify the amount of parallelism to use during the scan
       --quiet                                Suppress non-essential messages
       --scanner strings                      Specify which scanner to use e.g. --scanner=secrets, --scanner=secrets,sast (default [sast])

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-report-flag
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-report-flag
@@ -25,12 +25,13 @@ Rule Flags
 Scan Flags
       --context string                       Expand context of schema classification e.g., --context=health, to include data types particular to health
       --data-subject-mapping string          Override default data subject mapping by providing a path to a custom mapping JSON file
-      --debug                                Enable debug logs
+      --debug                                Enable debug logs. Equivalent to --log-level=debug
       --disable-domain-resolution            Do not attempt to resolve detected domains during classification (default true)
       --domain-resolution-timeout duration   Set timeout when attempting to resolve detected domains during classification, e.g. --domain-resolution-timeout=3s (default 3s)
       --external-rule-dir strings            Specify directories paths that contain .yaml files with external rules configuration
       --force                                Disable the cache and runs the detections again
       --internal-domains strings             Define regular expressions for better classification of private or unreachable domains e.g. --internal-domains=".*.my-company.com,private.sh"
+      --log-level string                     Set log level (error, info, debug, trace) (default "info")
       --parallel int                         Specify the amount of parallelism to use during the scan
       --quiet                                Suppress non-essential messages
       --scanner strings                      Specify which scanner to use e.g. --scanner=secrets, --scanner=secrets,sast (default [sast])

--- a/new/detector/composition/composition.go
+++ b/new/detector/composition/composition.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/gertd/go-pluralize"
 
+	"github.com/bearer/bearer/new/detector/detection"
 	"github.com/bearer/bearer/new/detector/implementation/custom"
 	"github.com/bearer/bearer/new/detector/implementation/generic/datatype"
-	detectortypes "github.com/bearer/bearer/new/detector/types"
 	reportdetections "github.com/bearer/bearer/pkg/report/detections"
 	"github.com/bearer/bearer/pkg/report/detectors"
 	"github.com/bearer/bearer/pkg/report/schema"
@@ -15,7 +15,7 @@ import (
 	"github.com/bearer/bearer/pkg/util/file"
 )
 
-func ReportDetections(report reportdetections.ReportDetection, file *file.FileInfo, detections []*detectortypes.Detection) {
+func ReportDetections(report reportdetections.ReportDetection, file *file.FileInfo, detections []*detection.Detection) {
 	pluralizer := pluralize.NewClient()
 
 	for _, detection := range detections {
@@ -63,7 +63,7 @@ func reportDatatypeDetection(
 	file *file.FileInfo,
 	detectorType detectors.Type,
 	detection,
-	datatypeDetection *detectortypes.Detection,
+	datatypeDetection *detection.Detection,
 	objectName string,
 ) {
 	data := datatypeDetection.Data.(datatype.Data)

--- a/new/detector/composition/java/java.go
+++ b/new/detector/composition/java/java.go
@@ -1,6 +1,7 @@
 package java
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -186,8 +187,12 @@ func (composition *Composition) Close() {
 	}
 }
 
-func (composition *Composition) DetectFromFile(file *file.FileInfo) ([]*detection.Detection, error) {
+func (composition *Composition) DetectFromFile(
+	ctx context.Context,
+	file *file.FileInfo,
+) ([]*detection.Detection, error) {
 	return composition.DetectFromFileWithTypes(
+		ctx,
 		file,
 		composition.customDetectorTypes,
 		composition.sharedDetectorTypes,
@@ -195,6 +200,7 @@ func (composition *Composition) DetectFromFile(file *file.FileInfo) ([]*detectio
 }
 
 func (composition *Composition) DetectFromFileWithTypes(
+	ctx context.Context,
 	file *file.FileInfo,
 	detectorTypes, sharedDetectorTypes []string,
 ) ([]*detection.Detection, error) {
@@ -207,12 +213,13 @@ func (composition *Composition) DetectFromFileWithTypes(
 		return nil, fmt.Errorf("failed to read file %s", err)
 	}
 
-	tree, err := composition.lang.Parse(string(fileContent))
+	tree, err := composition.lang.Parse(ctx, string(fileContent))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse file %s", err)
 	}
 
 	evaluator := evaluator.New(
+		ctx,
 		composition.langImplementation,
 		composition.lang,
 		composition.detectorSet,

--- a/new/detector/composition/javascript/javascript.go
+++ b/new/detector/composition/javascript/javascript.go
@@ -1,6 +1,7 @@
 package javascript
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -186,8 +187,12 @@ func (composition *Composition) Close() {
 	}
 }
 
-func (composition *Composition) DetectFromFile(file *file.FileInfo) ([]*detection.Detection, error) {
+func (composition *Composition) DetectFromFile(
+	ctx context.Context,
+	file *file.FileInfo,
+) ([]*detection.Detection, error) {
 	return composition.DetectFromFileWithTypes(
+		ctx,
 		file,
 		composition.customDetectorTypes,
 		composition.sharedDetectorTypes,
@@ -195,6 +200,7 @@ func (composition *Composition) DetectFromFile(file *file.FileInfo) ([]*detectio
 }
 
 func (composition *Composition) DetectFromFileWithTypes(
+	ctx context.Context,
 	file *file.FileInfo,
 	detectorTypes, sharedDetectorTypes []string,
 ) ([]*detection.Detection, error) {
@@ -207,12 +213,13 @@ func (composition *Composition) DetectFromFileWithTypes(
 		return nil, fmt.Errorf("failed to read file %s", err)
 	}
 
-	tree, err := composition.lang.Parse(string(fileContent))
+	tree, err := composition.lang.Parse(ctx, string(fileContent))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse file %s", err)
 	}
 
 	evaluator := evaluator.New(
+		ctx,
 		composition.langImplementation,
 		composition.lang,
 		composition.detectorSet,

--- a/new/detector/composition/javascript/javascript.go
+++ b/new/detector/composition/javascript/javascript.go
@@ -10,11 +10,13 @@ import (
 	"github.com/bearer/bearer/pkg/commands/process/settings"
 	"github.com/bearer/bearer/pkg/report/customdetectors"
 	"github.com/bearer/bearer/pkg/util/file"
+	"github.com/rs/zerolog/log"
 
 	"github.com/bearer/bearer/new/detector/composition/types"
 	"github.com/bearer/bearer/new/detector/detection"
 	"github.com/bearer/bearer/new/detector/evaluator"
 	cachepkg "github.com/bearer/bearer/new/detector/evaluator/cache"
+	"github.com/bearer/bearer/new/detector/evaluator/stats"
 	"github.com/bearer/bearer/new/detector/implementation/custom"
 	"github.com/bearer/bearer/new/detector/implementation/generic/datatype"
 	"github.com/bearer/bearer/new/detector/implementation/generic/insecureurl"
@@ -38,9 +40,14 @@ type Composition struct {
 	lang                languagetypes.Language
 	closers             []func()
 	rules               map[string]*settings.Rule
+	stats               *stats.Stats
 }
 
-func New(rules map[string]*settings.Rule, classifier *classification.Classifier) (detectortypes.Composition, error) {
+func New(
+	debugProfile bool,
+	rules map[string]*settings.Rule,
+	classifier *classification.Classifier,
+) (detectortypes.Composition, error) {
 	lang, err := language.Get("javascript")
 	if err != nil {
 		return nil, fmt.Errorf("failed to lookup language: %s", err)
@@ -49,6 +56,10 @@ func New(rules map[string]*settings.Rule, classifier *classification.Classifier)
 	composition := &Composition{
 		langImplementation: javascript.Get(),
 		lang:               lang,
+	}
+
+	if debugProfile {
+		composition.stats = stats.New()
 	}
 
 	staticDetectors := []struct {
@@ -166,6 +177,10 @@ func New(rules map[string]*settings.Rule, classifier *classification.Classifier)
 }
 
 func (composition *Composition) Close() {
+	if composition.stats != nil {
+		log.Debug().Msgf("javascript stats:\n%s", composition.stats)
+	}
+
 	for _, closeFunc := range composition.closers {
 		closeFunc()
 	}
@@ -203,6 +218,7 @@ func (composition *Composition) DetectFromFileWithTypes(
 		composition.detectorSet,
 		tree,
 		file.FileInfo.Name(),
+		composition.stats,
 	)
 
 	sharedCache := cachepkg.NewShared(sharedDetectorTypes)

--- a/new/detector/composition/javascript/javascript.go
+++ b/new/detector/composition/javascript/javascript.go
@@ -12,7 +12,9 @@ import (
 	"github.com/bearer/bearer/pkg/util/file"
 
 	"github.com/bearer/bearer/new/detector/composition/types"
+	"github.com/bearer/bearer/new/detector/detection"
 	"github.com/bearer/bearer/new/detector/evaluator"
+	cachepkg "github.com/bearer/bearer/new/detector/evaluator/cache"
 	"github.com/bearer/bearer/new/detector/implementation/custom"
 	"github.com/bearer/bearer/new/detector/implementation/generic/datatype"
 	"github.com/bearer/bearer/new/detector/implementation/generic/insecureurl"
@@ -30,6 +32,7 @@ import (
 
 type Composition struct {
 	customDetectorTypes []string
+	sharedDetectorTypes []string
 	detectorSet         detectortypes.DetectorSet
 	langImplementation  implementation.Implementation
 	lang                languagetypes.Language
@@ -118,8 +121,12 @@ func New(rules map[string]*settings.Rule, classifier *classification.Classifier)
 		patterns := rule.Patterns
 		localRuleName := ruleName
 
-		if (!rule.IsAuxilary && rule.Type != customdetectors.TypeShared) || presenceRules[ruleName] {
-			composition.customDetectorTypes = append(composition.customDetectorTypes, ruleName)
+		if rule.Type == customdetectors.TypeShared {
+			composition.sharedDetectorTypes = append(composition.sharedDetectorTypes, ruleName)
+		} else {
+			if !rule.IsAuxilary || presenceRules[ruleName] {
+				composition.customDetectorTypes = append(composition.customDetectorTypes, ruleName)
+			}
 		}
 
 		go func() {
@@ -164,11 +171,18 @@ func (composition *Composition) Close() {
 	}
 }
 
-func (composition *Composition) DetectFromFile(file *file.FileInfo) ([]*detectortypes.Detection, error) {
-	return composition.DetectFromFileWithTypes(file, composition.customDetectorTypes)
+func (composition *Composition) DetectFromFile(file *file.FileInfo) ([]*detection.Detection, error) {
+	return composition.DetectFromFileWithTypes(
+		file,
+		composition.customDetectorTypes,
+		composition.sharedDetectorTypes,
+	)
 }
 
-func (composition *Composition) DetectFromFileWithTypes(file *file.FileInfo, detectorTypes []string) ([]*detectortypes.Detection, error) {
+func (composition *Composition) DetectFromFileWithTypes(
+	file *file.FileInfo,
+	detectorTypes, sharedDetectorTypes []string,
+) ([]*detection.Detection, error) {
 	if file.Language != "JavaScript" && file.Language != "TypeScript" && file.Language != "TSX" {
 		return nil, nil
 	}
@@ -191,8 +205,11 @@ func (composition *Composition) DetectFromFileWithTypes(file *file.FileInfo, det
 		file.FileInfo.Name(),
 	)
 
-	var result []*detectortypes.Detection
+	sharedCache := cachepkg.NewShared(sharedDetectorTypes)
+
+	var result []*detection.Detection
 	for _, detectorType := range detectorTypes {
+		cache := cachepkg.NewCache(sharedCache)
 		rule := composition.rules[detectorType]
 		sanitizerRuleID := ""
 		if rule != nil {
@@ -202,6 +219,7 @@ func (composition *Composition) DetectFromFileWithTypes(file *file.FileInfo, det
 			tree.RootNode(),
 			detectorType,
 			sanitizerRuleID,
+			cache,
 			settings.DefaultScope,
 			false,
 		)

--- a/new/detector/composition/ruby/ruby.go
+++ b/new/detector/composition/ruby/ruby.go
@@ -1,6 +1,7 @@
 package ruby
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -185,8 +186,12 @@ func (composition *Composition) Close() {
 	}
 }
 
-func (composition *Composition) DetectFromFile(file *file.FileInfo) ([]*detection.Detection, error) {
+func (composition *Composition) DetectFromFile(
+	ctx context.Context,
+	file *file.FileInfo,
+) ([]*detection.Detection, error) {
 	return composition.DetectFromFileWithTypes(
+		ctx,
 		file,
 		composition.customDetectorTypes,
 		composition.sharedDetectorTypes,
@@ -194,6 +199,7 @@ func (composition *Composition) DetectFromFile(file *file.FileInfo) ([]*detectio
 }
 
 func (composition *Composition) DetectFromFileWithTypes(
+	ctx context.Context,
 	file *file.FileInfo,
 	detectorTypes, sharedDetectorTypes []string,
 ) ([]*detection.Detection, error) {
@@ -206,12 +212,13 @@ func (composition *Composition) DetectFromFileWithTypes(
 		return nil, fmt.Errorf("failed to read file %s", err)
 	}
 
-	tree, err := composition.lang.Parse(string(fileContent))
+	tree, err := composition.lang.Parse(ctx, string(fileContent))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse file %s", err)
 	}
 
 	evaluator := evaluator.New(
+		ctx,
 		composition.langImplementation,
 		composition.lang,
 		composition.detectorSet,

--- a/new/detector/composition/ruby/ruby.go
+++ b/new/detector/composition/ruby/ruby.go
@@ -7,7 +7,9 @@ import (
 	"golang.org/x/exp/slices"
 
 	"github.com/bearer/bearer/new/detector/composition/types"
+	"github.com/bearer/bearer/new/detector/detection"
 	"github.com/bearer/bearer/new/detector/evaluator"
+	cachepkg "github.com/bearer/bearer/new/detector/evaluator/cache"
 	"github.com/bearer/bearer/new/detector/implementation/custom"
 	"github.com/bearer/bearer/new/detector/implementation/generic/datatype"
 	"github.com/bearer/bearer/new/detector/implementation/generic/insecureurl"
@@ -30,6 +32,7 @@ import (
 
 type Composition struct {
 	customDetectorTypes []string
+	sharedDetectorTypes []string
 	detectorSet         detectortypes.DetectorSet
 	langImplementation  implementation.Implementation
 	lang                languagetypes.Language
@@ -117,8 +120,12 @@ func New(rules map[string]*settings.Rule, classifier *classification.Classifier)
 		patterns := rule.Patterns
 		localRuleName := ruleName
 
-		if (!rule.IsAuxilary && rule.Type != customdetectors.TypeShared) || presenceRules[ruleName] {
-			composition.customDetectorTypes = append(composition.customDetectorTypes, ruleName)
+		if rule.Type == customdetectors.TypeShared {
+			composition.sharedDetectorTypes = append(composition.sharedDetectorTypes, ruleName)
+		} else {
+			if !rule.IsAuxilary || presenceRules[ruleName] {
+				composition.customDetectorTypes = append(composition.customDetectorTypes, ruleName)
+			}
 		}
 
 		go func() {
@@ -163,11 +170,18 @@ func (composition *Composition) Close() {
 	}
 }
 
-func (composition *Composition) DetectFromFile(file *file.FileInfo) ([]*detectortypes.Detection, error) {
-	return composition.DetectFromFileWithTypes(file, composition.customDetectorTypes)
+func (composition *Composition) DetectFromFile(file *file.FileInfo) ([]*detection.Detection, error) {
+	return composition.DetectFromFileWithTypes(
+		file,
+		composition.customDetectorTypes,
+		composition.sharedDetectorTypes,
+	)
 }
 
-func (composition *Composition) DetectFromFileWithTypes(file *file.FileInfo, detectorTypes []string) ([]*detectortypes.Detection, error) {
+func (composition *Composition) DetectFromFileWithTypes(
+	file *file.FileInfo,
+	detectorTypes, sharedDetectorTypes []string,
+) ([]*detection.Detection, error) {
 	if file.Language != "Ruby" {
 		return nil, nil
 	}
@@ -190,8 +204,11 @@ func (composition *Composition) DetectFromFileWithTypes(file *file.FileInfo, det
 		file.FileInfo.Name(),
 	)
 
-	var result []*detectortypes.Detection
+	sharedCache := cachepkg.NewShared(sharedDetectorTypes)
+
+	var result []*detection.Detection
 	for _, detectorType := range detectorTypes {
+		cache := cachepkg.NewCache(sharedCache)
 		rule := composition.rules[detectorType]
 		sanitizerRuleID := ""
 		if rule != nil {
@@ -201,6 +218,7 @@ func (composition *Composition) DetectFromFileWithTypes(file *file.FileInfo, det
 			tree.RootNode(),
 			detectorType,
 			sanitizerRuleID,
+			cache,
 			settings.DefaultScope,
 			false,
 		)

--- a/new/detector/composition/testhelper/testhelper.go
+++ b/new/detector/composition/testhelper/testhelper.go
@@ -1,6 +1,7 @@
 package testhelper
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -118,7 +119,7 @@ func (runner *Runner) scanSingleFile(t *testing.T, testDataPath string, fileRela
 		t.Fatalf("failed to get absolute path of report file: %s", err)
 	}
 
-	err = runner.worker.Scan(work.ProcessRequest{
+	err = runner.worker.Scan(context.Background(), work.ProcessRequest{
 		File:       fileRelativePath,
 		ReportPath: detectorsReportPath,
 		Repository: work.Repository{

--- a/new/detector/detection/detection.go
+++ b/new/detector/detection/detection.go
@@ -1,0 +1,9 @@
+package detection
+
+import "github.com/bearer/bearer/new/language/tree"
+
+type Detection struct {
+	DetectorType string
+	MatchNode    *tree.Node
+	Data         interface{}
+}

--- a/new/detector/evaluator/cache/cache.go
+++ b/new/detector/evaluator/cache/cache.go
@@ -1,0 +1,75 @@
+package cache
+
+import (
+	"github.com/bearer/bearer/new/detector/detection"
+	"github.com/bearer/bearer/new/language/tree"
+	"github.com/bearer/bearer/pkg/commands/process/settings"
+	"github.com/bearer/bearer/pkg/util/set"
+)
+
+type Key struct {
+	rootNodeID tree.NodeID
+	ruleID     string
+	scope      settings.RuleReferenceScope
+	followFlow bool
+}
+
+func NewKey(
+	rootNode *tree.Node,
+	ruleID string,
+	scope settings.RuleReferenceScope,
+	followFlow bool,
+) Key {
+	return Key{
+		rootNodeID: rootNode.ID(),
+		ruleID:     ruleID,
+		scope:      scope,
+		followFlow: followFlow,
+	}
+}
+
+type cacheMap map[Key][]*detection.Detection
+
+type Shared struct {
+	ruleIDs set.Set[string]
+	data    cacheMap
+}
+
+func NewShared(ruleIDs []string) *Shared {
+	idSet := set.New[string]()
+	idSet.AddAll(ruleIDs)
+
+	return &Shared{
+		ruleIDs: idSet,
+		data:    make(cacheMap),
+	}
+}
+
+type Cache struct {
+	shared *Shared
+	data   cacheMap
+}
+
+func NewCache(sharedCache *Shared) *Cache {
+	return &Cache{
+		shared: sharedCache,
+		data:   make(cacheMap),
+	}
+}
+
+func (cache *Cache) Get(key Key) ([]*detection.Detection, bool) {
+	detections, cached := cache.dataFor(key)[key]
+	return detections, cached
+}
+
+func (cache *Cache) Put(key Key, detections []*detection.Detection) {
+	cache.dataFor(key)[key] = detections
+}
+
+func (cache *Cache) dataFor(key Key) cacheMap {
+	if cache.shared.ruleIDs.Has(key.ruleID) {
+		return cache.shared.data
+	}
+
+	return cache.data
+}

--- a/new/detector/evaluator/evaluator.go
+++ b/new/detector/evaluator/evaluator.go
@@ -1,6 +1,7 @@
 package evaluator
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -19,6 +20,7 @@ import (
 )
 
 type Evaluator struct {
+	ctx                   context.Context
 	langImplementation    implementation.Implementation
 	lang                  languagetypes.Language
 	detectorSet           types.DetectorSet
@@ -29,6 +31,7 @@ type Evaluator struct {
 }
 
 func New(
+	ctx context.Context,
 	langImplementation implementation.Implementation,
 	lang languagetypes.Language,
 	detectorSet types.DetectorSet,
@@ -37,6 +40,7 @@ func New(
 	stats *stats.Stats,
 ) *Evaluator {
 	return &Evaluator{
+		ctx:                   ctx,
 		langImplementation:    langImplementation,
 		lang:                  lang,
 		fileName:              fileName,
@@ -98,6 +102,10 @@ func (evaluator *Evaluator) Evaluate(
 	var nestedMode bool
 
 	if err := rootNode.Walk(func(node *langtree.Node, visitChildren func() error) error {
+		if evaluator.ctx.Err() != nil {
+			return evaluator.ctx.Err()
+		}
+
 		if scope == settings.RESULT_SCOPE && !evaluator.langImplementation.ContributesToResult(node) {
 			return nil
 		}

--- a/new/detector/evaluator/stats/stats.go
+++ b/new/detector/evaluator/stats/stats.go
@@ -1,0 +1,42 @@
+package stats
+
+import (
+	"strings"
+	"time"
+
+	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
+)
+
+type Stats struct {
+	timings map[string]time.Duration
+}
+
+func New() *Stats {
+	return &Stats{timings: make(map[string]time.Duration)}
+}
+
+func (stats *Stats) Record(ruleID string, startTime time.Time) {
+	duration := time.Since(startTime)
+	stats.timings[ruleID] += duration
+}
+
+func (stats *Stats) String() string {
+	sortedRuleIDs := maps.Keys(stats.timings)
+	slices.SortFunc(sortedRuleIDs, func(a, b string) bool {
+		return stats.timings[a] > stats.timings[b]
+	})
+
+	var s strings.Builder
+	for i, ruleID := range sortedRuleIDs {
+		if i != 0 {
+			s.WriteString("\n")
+		}
+
+		s.WriteString(ruleID)
+		s.WriteString(": ")
+		s.WriteString(stats.timings[ruleID].String())
+	}
+
+	return s.String()
+}

--- a/new/detector/implementation/custom/custom.go
+++ b/new/detector/implementation/custom/custom.go
@@ -3,6 +3,7 @@ package custom
 import (
 	"fmt"
 
+	"github.com/bearer/bearer/new/detector/detection"
 	"github.com/bearer/bearer/new/detector/types"
 	"github.com/bearer/bearer/new/language/tree"
 	languagetypes "github.com/bearer/bearer/new/language/types"
@@ -11,7 +12,7 @@ import (
 
 type Data struct {
 	Pattern       string
-	Datatypes     []*types.Detection
+	Datatypes     []*detection.Detection
 	VariableNodes map[string]*tree.Node
 }
 
@@ -62,8 +63,7 @@ func (detector *customDetector) Name() string {
 
 func (detector *customDetector) DetectAt(
 	node *tree.Node,
-	scope settings.RuleReferenceScope,
-	evaluator types.Evaluator,
+	evaluationState types.EvaluationState,
 ) ([]interface{}, error) {
 	var detectionsData []interface{}
 
@@ -75,9 +75,8 @@ func (detector *customDetector) DetectAt(
 
 		for _, result := range results {
 			filtersMatch, datatypeDetections, variableNodes, err := matchAllFilters(
-				scope,
+				evaluationState,
 				result,
-				evaluator,
 				pattern.Filters,
 				detector.rules,
 			)

--- a/new/detector/implementation/custom/custom.go
+++ b/new/detector/implementation/custom/custom.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bearer/bearer/new/language/tree"
 	languagetypes "github.com/bearer/bearer/new/language/types"
 	"github.com/bearer/bearer/pkg/commands/process/settings"
+	"golang.org/x/exp/slices"
 )
 
 type Data struct {
@@ -41,6 +42,9 @@ func New(
 		if err != nil {
 			return nil, fmt.Errorf("error compiling pattern: %s", err)
 		}
+
+		sortFilters(pattern.Filters)
+
 		compiledPatterns = append(compiledPatterns, Pattern{
 			Pattern: pattern.Pattern,
 			Query:   patternQuery,
@@ -103,4 +107,71 @@ func (detector *customDetector) Close() {
 	for _, pattern := range detector.patterns {
 		pattern.Query.Close()
 	}
+}
+
+func sortFilters(filters []settings.PatternFilter) {
+	slices.SortFunc(filters, func(a, b settings.PatternFilter) bool {
+		return scoreFilter(a) < scoreFilter(b)
+	})
+
+	for i := range filters {
+		sortFilter(&filters[i])
+	}
+}
+
+func sortFilter(filter *settings.PatternFilter) {
+	switch {
+	case len(filter.Either) != 0:
+		sortFilters(filter.Either)
+	case filter.Not != nil:
+		sortFilter(filter.Not)
+	}
+}
+
+func scoreFilter(filter settings.PatternFilter) int {
+	if filter.Regex != nil ||
+		len(filter.Values) != 0 ||
+		filter.LengthLessThan != nil ||
+		filter.LessThan != nil ||
+		filter.LessThanOrEqual != nil ||
+		filter.GreaterThan != nil ||
+		filter.GreaterThanOrEqual != nil ||
+		filter.FilenameRegex != nil {
+		return 1
+	}
+
+	if filter.Detection == "datatype" {
+		return 5
+	}
+
+	if filter.StringRegex != nil ||
+		filter.Detection != "" && filter.Scope == settings.CURSOR_SCOPE {
+		return 2
+	}
+
+	if filter.Detection != "" && filter.Scope == settings.RESULT_SCOPE {
+		return 3
+	}
+
+	if filter.Detection != "" && filter.Scope == settings.NESTED_SCOPE {
+		return 4
+	}
+
+	if filter.Not != nil {
+		return scoreFilter(*filter.Not)
+	}
+
+	if len(filter.Either) != 0 {
+		max := 0
+
+		for _, subFilter := range filter.Either {
+			if subScore := scoreFilter(subFilter); subScore > max {
+				max = subScore
+			}
+		}
+
+		return max
+	}
+
+	panic(fmt.Sprintf("unknown filter %#v", filter))
 }

--- a/new/detector/implementation/generic/insecureurl/insecureurl.go
+++ b/new/detector/implementation/generic/insecureurl/insecureurl.go
@@ -28,10 +28,9 @@ func (detector *insecureURLDetector) Name() string {
 
 func (detector *insecureURLDetector) DetectAt(
 	node *tree.Node,
-	_ settings.RuleReferenceScope,
-	evaluator types.Evaluator,
+	evaluationState types.EvaluationState,
 ) ([]interface{}, error) {
-	detections, err := evaluator.Evaluate(node, "string", "", settings.CURSOR_SCOPE, false)
+	detections, err := evaluationState.Evaluate(node, "string", "", settings.CURSOR_SCOPE, false)
 	if err != nil {
 		return nil, err
 	}

--- a/new/detector/implementation/generic/stringliteral/stringliteral.go
+++ b/new/detector/implementation/generic/stringliteral/stringliteral.go
@@ -23,10 +23,9 @@ func (detector *stringLiteralDetector) Name() string {
 
 func (detector *stringLiteralDetector) DetectAt(
 	node *tree.Node,
-	_ settings.RuleReferenceScope,
-	evaluator types.Evaluator,
+	evaluationState types.EvaluationState,
 ) ([]interface{}, error) {
-	detections, err := evaluator.Evaluate(node, "string", "", settings.CURSOR_SCOPE, false)
+	detections, err := evaluationState.Evaluate(node, "string", "", settings.CURSOR_SCOPE, false)
 	if err != nil {
 		return nil, err
 	}

--- a/new/detector/implementation/generic/types/types.go
+++ b/new/detector/implementation/generic/types/types.go
@@ -1,7 +1,7 @@
 package types
 
 import (
-	"github.com/bearer/bearer/new/detector/types"
+	"github.com/bearer/bearer/new/detector/detection"
 	"github.com/bearer/bearer/new/language/tree"
 )
 
@@ -15,7 +15,7 @@ type Object struct {
 type Property struct {
 	Name   string
 	Node   *tree.Node
-	Object *types.Detection
+	Object *detection.Detection
 }
 
 type String struct {

--- a/new/detector/implementation/java/object/projection.go
+++ b/new/detector/implementation/java/object/projection.go
@@ -8,7 +8,7 @@ import (
 
 func (detector *objectDetector) getProjections(
 	node *tree.Node,
-	evaluator types.Evaluator,
+	evaluationState types.EvaluationState,
 ) ([]interface{}, error) {
 	result, err := detector.fieldAccessQuery.MatchOnceAt(node)
 	if err != nil {
@@ -20,7 +20,7 @@ func (detector *objectDetector) getProjections(
 
 		objects, err := generic.ProjectObject(
 			node,
-			evaluator,
+			evaluationState,
 			objectNode,
 			getObjectName(objectNode),
 			result["field"].Content(),

--- a/new/detector/implementation/java/string/string.go
+++ b/new/detector/implementation/java/string/string.go
@@ -3,7 +3,6 @@ package string
 import (
 	"github.com/bearer/bearer/new/detector/types"
 	"github.com/bearer/bearer/new/language/tree"
-	"github.com/bearer/bearer/pkg/commands/process/settings"
 	"github.com/bearer/bearer/pkg/util/stringutil"
 
 	"github.com/bearer/bearer/new/detector/implementation/generic"
@@ -25,8 +24,7 @@ func (detector *stringDetector) Name() string {
 
 func (detector *stringDetector) DetectAt(
 	node *tree.Node,
-	ruleReferenceType settings.RuleReferenceScope,
-	evaluator types.Evaluator,
+	evaluationState types.EvaluationState,
 ) ([]interface{}, error) {
 	switch node.Type() {
 	case "string_literal":
@@ -36,7 +34,7 @@ func (detector *stringDetector) DetectAt(
 		}}, nil
 	case "binary_expression":
 		if node.AnonymousChild(0).Content() == "+" {
-			return generic.ConcatenateChildStrings(node, evaluator)
+			return generic.ConcatenateChildStrings(node, evaluationState)
 		}
 	}
 

--- a/new/detector/implementation/javascript/object/projection.go
+++ b/new/detector/implementation/javascript/object/projection.go
@@ -11,29 +11,29 @@ import (
 
 func (detector *objectDetector) getProjections(
 	node *tree.Node,
-	evaluator types.Evaluator,
+	evaluationState types.EvaluationState,
 ) ([]interface{}, error) {
-	objects, err := detector.getMemberExpressionProjections(node, evaluator)
+	objects, err := detector.getMemberExpressionProjections(node, evaluationState)
 	if len(objects) != 0 || err != nil {
 		return objects, err
 	}
 
-	objects, err = detector.getSubscriptExpressionProjections(node, evaluator)
+	objects, err = detector.getSubscriptExpressionProjections(node, evaluationState)
 	if len(objects) != 0 || err != nil {
 		return objects, err
 	}
 
-	objects, err = detector.getCallProjections(node, evaluator)
+	objects, err = detector.getCallProjections(node, evaluationState)
 	if len(objects) != 0 || err != nil {
 		return objects, err
 	}
 
-	return detector.getObjectDeconstructionProjections(node, evaluator)
+	return detector.getObjectDeconstructionProjections(node, evaluationState)
 }
 
 func (detector *objectDetector) getMemberExpressionProjections(
 	node *tree.Node,
-	evaluator types.Evaluator,
+	evaluationState types.EvaluationState,
 ) ([]interface{}, error) {
 	result, err := detector.memberExpressionQuery.MatchOnceAt(node)
 	if result == nil || err != nil {
@@ -44,7 +44,7 @@ func (detector *objectDetector) getMemberExpressionProjections(
 
 	objects, err := generic.ProjectObject(
 		node,
-		evaluator,
+		evaluationState,
 		objectNode,
 		getObjectName(objectNode),
 		result["property"].Content(),
@@ -59,7 +59,7 @@ func (detector *objectDetector) getMemberExpressionProjections(
 
 func (detector *objectDetector) getSubscriptExpressionProjections(
 	node *tree.Node,
-	evaluator types.Evaluator,
+	evaluationState types.EvaluationState,
 ) ([]interface{}, error) {
 	result, err := detector.subscriptExpressionQuery.MatchOnceAt(node)
 	if result == nil || err != nil {
@@ -74,7 +74,7 @@ func (detector *objectDetector) getSubscriptExpressionProjections(
 
 	objects, err := generic.ProjectObject(
 		node,
-		evaluator,
+		evaluationState,
 		objectNode,
 		getObjectName(objectNode),
 		propertyName,
@@ -89,7 +89,7 @@ func (detector *objectDetector) getSubscriptExpressionProjections(
 
 func (detector *objectDetector) getCallProjections(
 	node *tree.Node,
-	evaluator types.Evaluator,
+	evaluationState types.EvaluationState,
 ) ([]interface{}, error) {
 	result, err := detector.callQuery.MatchOnceAt(node)
 	if result == nil || err != nil {
@@ -98,7 +98,7 @@ func (detector *objectDetector) getCallProjections(
 
 	var properties []generictypes.Property
 
-	functionDetections, err := evaluator.Evaluate(result["function"], "object", "", settings.NESTED_SCOPE, true)
+	functionDetections, err := evaluationState.Evaluate(result["function"], "object", "", settings.NESTED_SCOPE, true)
 	if len(functionDetections) == 0 || err != nil {
 		return nil, err
 	}
@@ -112,7 +112,7 @@ func (detector *objectDetector) getCallProjections(
 
 func (detector *objectDetector) getObjectDeconstructionProjections(
 	node *tree.Node,
-	evaluator types.Evaluator,
+	evaluationState types.EvaluationState,
 ) ([]interface{}, error) {
 	result, err := detector.objectDeconstructionQuery.MatchOnceAt(node)
 	if result == nil || err != nil {
@@ -127,7 +127,7 @@ func (detector *objectDetector) getObjectDeconstructionProjections(
 
 	objects, err := generic.ProjectObject(
 		node,
-		evaluator,
+		evaluationState,
 		objectNode,
 		getObjectName(objectNode),
 		propertyName,

--- a/new/detector/implementation/javascript/string/string.go
+++ b/new/detector/implementation/javascript/string/string.go
@@ -3,7 +3,6 @@ package string
 import (
 	"github.com/bearer/bearer/new/detector/types"
 	"github.com/bearer/bearer/new/language/tree"
-	"github.com/bearer/bearer/pkg/commands/process/settings"
 	"github.com/bearer/bearer/pkg/util/stringutil"
 
 	"github.com/bearer/bearer/new/detector/implementation/generic"
@@ -25,8 +24,7 @@ func (detector *stringDetector) Name() string {
 
 func (detector *stringDetector) DetectAt(
 	node *tree.Node,
-	ruleReferenceType settings.RuleReferenceScope,
-	evaluator types.Evaluator,
+	evaluationState types.EvaluationState,
 ) ([]interface{}, error) {
 	switch node.Type() {
 	case "string":
@@ -35,17 +33,17 @@ func (detector *stringDetector) DetectAt(
 			IsLiteral: true,
 		}}, nil
 	case "template_string":
-		return handleTemplateString(node, evaluator)
+		return handleTemplateString(node, evaluationState)
 	case "binary_expression":
 		if node.AnonymousChild(0).Content() == "+" {
-			return generic.ConcatenateChildStrings(node, evaluator)
+			return generic.ConcatenateChildStrings(node, evaluationState)
 		}
 	}
 
 	return nil, nil
 }
 
-func handleTemplateString(node *tree.Node, evaluator types.Evaluator) ([]interface{}, error) {
+func handleTemplateString(node *tree.Node, evaluationState types.EvaluationState) ([]interface{}, error) {
 	text := ""
 	isLiteral := true
 
@@ -53,7 +51,7 @@ func handleTemplateString(node *tree.Node, evaluator types.Evaluator) ([]interfa
 		text += partText
 		return nil
 	}, func(child *tree.Node) error {
-		childValue, childIsLiteral, err := generic.GetStringValue(child.Child(1), evaluator)
+		childValue, childIsLiteral, err := generic.GetStringValue(child.Child(1), evaluationState)
 		if err != nil {
 			return err
 		}

--- a/new/detector/implementation/ruby/object/projection.go
+++ b/new/detector/implementation/ruby/object/projection.go
@@ -9,7 +9,7 @@ import (
 
 func (detector *objectDetector) getProjections(
 	node *tree.Node,
-	evaluator types.Evaluator,
+	evaluationState types.EvaluationState,
 ) ([]interface{}, error) {
 	result, err := detector.callsQuery.MatchOnceAt(node)
 	if err != nil {
@@ -21,7 +21,7 @@ func (detector *objectDetector) getProjections(
 
 		objects, err := generic.ProjectObject(
 			node,
-			evaluator,
+			evaluationState,
 			receiverNode,
 			getObjectName(receiverNode),
 			result["method"].Content(),
@@ -48,7 +48,7 @@ func (detector *objectDetector) getProjections(
 
 		objects, err := generic.ProjectObject(
 			node,
-			evaluator,
+			evaluationState,
 			objectNode,
 			getObjectName(objectNode),
 			propertyName,

--- a/new/detector/implementation/ruby/string/string.go
+++ b/new/detector/implementation/ruby/string/string.go
@@ -3,7 +3,6 @@ package string
 import (
 	"github.com/bearer/bearer/new/detector/types"
 	"github.com/bearer/bearer/new/language/tree"
-	"github.com/bearer/bearer/pkg/commands/process/settings"
 
 	"github.com/bearer/bearer/new/detector/implementation/generic"
 	generictypes "github.com/bearer/bearer/new/detector/implementation/generic/types"
@@ -24,8 +23,7 @@ func (detector *stringDetector) Name() string {
 
 func (detector *stringDetector) DetectAt(
 	node *tree.Node,
-	_ settings.RuleReferenceScope,
-	evaluator types.Evaluator,
+	evaluationState types.EvaluationState,
 ) ([]interface{}, error) {
 	switch node.Type() {
 	case "string_content":
@@ -34,10 +32,10 @@ func (detector *stringDetector) DetectAt(
 			IsLiteral: true,
 		}}, nil
 	case "interpolation", "string":
-		return generic.ConcatenateChildStrings(node, evaluator)
+		return generic.ConcatenateChildStrings(node, evaluationState)
 	case "binary":
 		if node.AnonymousChild(0).Content() == "+" {
-			return generic.ConcatenateChildStrings(node, evaluator)
+			return generic.ConcatenateChildStrings(node, evaluationState)
 		}
 	}
 

--- a/new/detector/implementation/testhelper/testhelper.go
+++ b/new/detector/implementation/testhelper/testhelper.go
@@ -1,6 +1,7 @@
 package testhelper
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -51,7 +52,7 @@ func RunTest(
 			tt.Fatalf("failed to create file info for %s: %s", fileName, err)
 		}
 
-		detections, err := composition.DetectFromFileWithTypes(fileInfo, []string{detectorType}, nil)
+		detections, err := composition.DetectFromFileWithTypes(context.Background(), fileInfo, []string{detectorType}, nil)
 		if err != nil {
 			tt.Fatalf("failed to detect: %s", err)
 		}

--- a/new/detector/implementation/testhelper/testhelper.go
+++ b/new/detector/implementation/testhelper/testhelper.go
@@ -22,7 +22,7 @@ type result struct {
 func RunTest(
 	t *testing.T,
 	name string,
-	compositionInstantiator func(map[string]*settings.Rule, *classification.Classifier) (types.Composition, error),
+	compositionInstantiator func(bool, map[string]*settings.Rule, *classification.Classifier) (types.Composition, error),
 	detectorType string,
 	fileName string,
 ) {
@@ -40,7 +40,7 @@ func RunTest(
 			tt.Fatalf("failed to create classifier: %s", err)
 		}
 
-		composition, err := compositionInstantiator(make(map[string]*settings.Rule), classifier)
+		composition, err := compositionInstantiator(false, make(map[string]*settings.Rule), classifier)
 		if err != nil {
 			tt.Fatalf("failed to create composition: %s", err)
 		}

--- a/new/detector/implementation/testhelper/testhelper.go
+++ b/new/detector/implementation/testhelper/testhelper.go
@@ -51,7 +51,7 @@ func RunTest(
 			tt.Fatalf("failed to create file info for %s: %s", fileName, err)
 		}
 
-		detections, err := composition.DetectFromFileWithTypes(fileInfo, []string{detectorType})
+		detections, err := composition.DetectFromFileWithTypes(fileInfo, []string{detectorType}, nil)
 		if err != nil {
 			tt.Fatalf("failed to detect: %s", err)
 		}

--- a/new/detector/set/set.go
+++ b/new/detector/set/set.go
@@ -3,9 +3,9 @@ package set
 import (
 	"fmt"
 
+	"github.com/bearer/bearer/new/detector/detection"
 	"github.com/bearer/bearer/new/detector/types"
 	"github.com/bearer/bearer/new/language/tree"
-	"github.com/bearer/bearer/pkg/commands/process/settings"
 )
 
 type set struct {
@@ -42,22 +42,21 @@ func (set *set) NestedDetections(detectorType string) (bool, error) {
 func (set *set) DetectAt(
 	node *tree.Node,
 	detectorType string,
-	ruleReferenceType settings.RuleReferenceScope,
-	evaluator types.Evaluator,
-) ([]*types.Detection, error) {
+	evaluationState types.EvaluationState,
+) ([]*detection.Detection, error) {
 	detector, err := set.lookupDetector(detectorType)
 	if err != nil {
 		return nil, err
 	}
 
-	detectionsData, err := detector.DetectAt(node, ruleReferenceType, evaluator)
+	detectionsData, err := detector.DetectAt(node, evaluationState)
 	if err != nil {
 		return nil, err
 	}
 
-	detections := make([]*types.Detection, len(detectionsData))
+	detections := make([]*detection.Detection, len(detectionsData))
 	for i, data := range detectionsData {
-		detections[i] = &types.Detection{
+		detections[i] = &detection.Detection{
 			DetectorType: detectorType,
 			MatchNode:    node,
 			Data:         data,

--- a/new/detector/types/types.go
+++ b/new/detector/types/types.go
@@ -1,25 +1,20 @@
 package types
 
 import (
+	"github.com/bearer/bearer/new/detector/detection"
 	"github.com/bearer/bearer/new/language/tree"
 	"github.com/bearer/bearer/pkg/commands/process/settings"
 	"github.com/bearer/bearer/pkg/util/file"
 )
 
-type Detection struct {
-	DetectorType string
-	MatchNode    *tree.Node
-	Data         interface{}
-}
-
-type Evaluator interface {
+type EvaluationState interface {
 	Evaluate(
 		rootNode *tree.Node,
 		detectorType,
 		sanitizerDetectorType string,
 		scope settings.RuleReferenceScope,
 		followFlow bool,
-	) ([]*Detection, error)
+	) ([]*detection.Detection, error)
 	FileName() string
 }
 
@@ -28,18 +23,13 @@ type DetectorSet interface {
 	DetectAt(
 		node *tree.Node,
 		detectorType string,
-		ruleReferenceType settings.RuleReferenceScope,
-		evaluator Evaluator,
-	) ([]*Detection, error)
+		evaluationState EvaluationState,
+	) ([]*detection.Detection, error)
 }
 
 type Detector interface {
 	Name() string
-	DetectAt(
-		node *tree.Node,
-		ruleReferenceType settings.RuleReferenceScope,
-		evaluator Evaluator,
-	) ([]interface{}, error)
+	DetectAt(node *tree.Node, evaluationState EvaluationState) ([]interface{}, error)
 	NestedDetections() bool
 	Close()
 }
@@ -51,7 +41,10 @@ func (*DetectorBase) NestedDetections() bool {
 }
 
 type Composition interface {
-	DetectFromFile(file *file.FileInfo) ([]*Detection, error)
-	DetectFromFileWithTypes(file *file.FileInfo, detectorTypes []string) ([]*Detection, error)
+	DetectFromFile(file *file.FileInfo) ([]*detection.Detection, error)
+	DetectFromFileWithTypes(
+		file *file.FileInfo,
+		detectorTypes, sharedDetectorTypes []string,
+	) ([]*detection.Detection, error)
 	Close()
 }

--- a/new/detector/types/types.go
+++ b/new/detector/types/types.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"context"
+
 	"github.com/bearer/bearer/new/detector/detection"
 	"github.com/bearer/bearer/new/language/tree"
 	"github.com/bearer/bearer/pkg/commands/process/settings"
@@ -41,8 +43,9 @@ func (*DetectorBase) NestedDetections() bool {
 }
 
 type Composition interface {
-	DetectFromFile(file *file.FileInfo) ([]*detection.Detection, error)
+	DetectFromFile(ctx context.Context, file *file.FileInfo) ([]*detection.Detection, error)
 	DetectFromFileWithTypes(
+		ctx context.Context,
 		file *file.FileInfo,
 		detectorTypes, sharedDetectorTypes []string,
 	) ([]*detection.Detection, error)

--- a/new/language/base/base.go
+++ b/new/language/base/base.go
@@ -1,6 +1,8 @@
 package base
 
 import (
+	"context"
+
 	"github.com/bearer/bearer/new/language/implementation"
 	"github.com/bearer/bearer/new/language/patternquery"
 	"github.com/bearer/bearer/new/language/tree"
@@ -15,13 +17,13 @@ func New(implementation implementation.Implementation) *Language {
 	return &Language{implementation: implementation}
 }
 
-func (lang *Language) Parse(input string) (*tree.Tree, error) {
-	tree, err := tree.Parse(lang.implementation.SitterLanguage(), input)
+func (lang *Language) Parse(ctx context.Context, input string) (*tree.Tree, error) {
+	tree, err := tree.Parse(ctx, lang.implementation.SitterLanguage(), input)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := lang.implementation.AnalyzeFlow(tree.RootNode()); err != nil {
+	if err := lang.implementation.AnalyzeFlow(ctx, tree.RootNode()); err != nil {
 		return nil, err
 	}
 

--- a/new/language/implementation/implementation.go
+++ b/new/language/implementation/implementation.go
@@ -1,6 +1,8 @@
 package implementation
 
 import (
+	"context"
+
 	sitter "github.com/smacker/go-tree-sitter"
 
 	patternquerytypes "github.com/bearer/bearer/new/language/patternquery/types"
@@ -17,7 +19,7 @@ type Implementation interface {
 	//   user[:first_name]
 	// the `user` identifier node on lines 2 and 3 will be unified with the
 	// assignment node
-	AnalyzeFlow(rootNode *tree.Node) error
+	AnalyzeFlow(ctx context.Context, rootNode *tree.Node) error
 	// ExtractPatternVariables parses variables from a pattern and returns a new
 	// pattern with the variables replaced with a dummy value, along with a list
 	// of the variables. Dummy values are needed to allow Tree Sitter to parse

--- a/new/language/implementation/java/java.go
+++ b/new/language/implementation/java/java.go
@@ -1,6 +1,7 @@
 package java
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"strings"
@@ -53,10 +54,14 @@ func (implementation *javaImplementation) SitterLanguage() *sitter.Language {
 	return java.GetLanguage()
 }
 
-func (*javaImplementation) AnalyzeFlow(rootNode *tree.Node) error {
+func (*javaImplementation) AnalyzeFlow(ctx context.Context, rootNode *tree.Node) error {
 	scope := implementation.NewScope(nil)
 
 	return rootNode.Walk(func(node *tree.Node, visitChildren func() error) error {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
 		switch node.Type() {
 		// public class Main {
 		//

--- a/new/language/implementation/javascript/javascript.go
+++ b/new/language/implementation/javascript/javascript.go
@@ -1,6 +1,7 @@
 package javascript
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"strings"
@@ -53,10 +54,14 @@ func (implementation *javascriptImplementation) SitterLanguage() *sitter.Languag
 	return tsx.GetLanguage()
 }
 
-func (*javascriptImplementation) AnalyzeFlow(rootNode *tree.Node) error {
+func (*javascriptImplementation) AnalyzeFlow(ctx context.Context, rootNode *tree.Node) error {
 	scope := implementation.NewScope(nil)
 
 	return rootNode.Walk(func(node *tree.Node, visitChildren func() error) error {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
 		switch node.Type() {
 		// () => {}
 		// function getName() {}

--- a/new/language/implementation/ruby/ruby.go
+++ b/new/language/implementation/ruby/ruby.go
@@ -1,6 +1,7 @@
 package ruby
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"strings"
@@ -46,10 +47,14 @@ func (*rubyImplementation) SitterLanguage() *sitter.Language {
 	return ruby.GetLanguage()
 }
 
-func (*rubyImplementation) AnalyzeFlow(rootNode *tree.Node) error {
+func (*rubyImplementation) AnalyzeFlow(ctx context.Context, rootNode *tree.Node) error {
 	scope := implementation.NewScope(nil)
 
 	return rootNode.Walk(func(node *tree.Node, visitChildren func() error) error {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
 		switch node.Type() {
 		case "method":
 			scope = implementation.NewScope(nil)

--- a/new/language/patternquery/builder/builder.go
+++ b/new/language/patternquery/builder/builder.go
@@ -1,6 +1,7 @@
 package builder
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -48,7 +49,7 @@ func Build(
 		return nil, err
 	}
 
-	tree, err := lang.Parse(processedInput)
+	tree, err := lang.Parse(context.TODO(), processedInput)
 	if err != nil {
 		return nil, err
 	}

--- a/new/language/patternquery/builder/builder.go
+++ b/new/language/patternquery/builder/builder.go
@@ -22,10 +22,11 @@ type InputParams struct {
 }
 
 type Result struct {
-	Query           string
-	ParamToVariable map[string]string
-	EqualParams     [][]string
-	ParamToContent  map[string]map[string]string
+	Query              string
+	ParamToVariable    map[string]string
+	EqualParams        [][]string
+	ParamToContent     map[string]map[string]string
+	SingleVariableName string
 }
 
 type builder struct {
@@ -97,6 +98,13 @@ func Build(
 }
 
 func (builder *builder) build(rootNode *tree.Node) (*Result, error) {
+	if rootNode.ChildCount() == 0 {
+		variable := builder.getVariableFor(rootNode)
+		if variable != nil {
+			return &Result{SingleVariableName: variable.Name}, nil
+		}
+	}
+
 	builder.write("(")
 
 	if err := builder.compileNode(rootNode, true, false); err != nil {

--- a/new/language/patternquery/patternquery.go
+++ b/new/language/patternquery/patternquery.go
@@ -11,10 +11,11 @@ import (
 )
 
 type Query struct {
-	treeQuery       *tree.Query
-	paramToVariable map[string]string
-	equalParams     [][]string
-	paramToContent  map[string]map[string]string
+	treeQuery          *tree.Query
+	paramToVariable    map[string]string
+	equalParams        [][]string
+	paramToContent     map[string]map[string]string
+	singleVariableName string
 }
 
 func Compile(
@@ -26,6 +27,11 @@ func Compile(
 	builderResult, err := builder.Build(lang, langImplementation, input, focusedVariable)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build: %s", err)
+	}
+
+	if builderResult.Query == "" {
+		log.Trace().Msgf("single variable pattern %s -> %s", input, builderResult.SingleVariableName)
+		return &Query{singleVariableName: builderResult.SingleVariableName}, nil
 	}
 
 	treeQuery, err := lang.CompileQuery(builderResult.Query)
@@ -44,6 +50,16 @@ func Compile(
 }
 
 func (query *Query) MatchAt(node *tree.Node) ([]*languagetypes.PatternQueryResult, error) {
+	if query.singleVariableName != "" {
+		variables := make(tree.QueryResult)
+		variables[query.singleVariableName] = node
+
+		return []*languagetypes.PatternQueryResult{{
+			MatchNode: node,
+			Variables: variables,
+		}}, nil
+	}
+
 	treeResults, err := query.treeQuery.MatchAt(node)
 	if err != nil {
 		return nil, err
@@ -62,6 +78,16 @@ func (query *Query) MatchAt(node *tree.Node) ([]*languagetypes.PatternQueryResul
 }
 
 func (query *Query) MatchOnceAt(node *tree.Node) (*languagetypes.PatternQueryResult, error) {
+	if query.singleVariableName != "" {
+		variables := make(tree.QueryResult)
+		variables[query.singleVariableName] = node
+
+		return &languagetypes.PatternQueryResult{
+			MatchNode: node,
+			Variables: variables,
+		}, nil
+	}
+
 	treeResult, err := query.treeQuery.MatchOnceAt(node)
 	if err != nil {
 		return nil, err
@@ -71,7 +97,9 @@ func (query *Query) MatchOnceAt(node *tree.Node) (*languagetypes.PatternQueryRes
 }
 
 func (query *Query) Close() {
-	query.treeQuery.Close()
+	if query.treeQuery != nil {
+		query.treeQuery.Close()
+	}
 }
 
 func (query *Query) matchAndTranslateTreeResult(treeResult tree.QueryResult, rootNode *tree.Node) *languagetypes.PatternQueryResult {

--- a/new/language/patternquery/patternquery.go
+++ b/new/language/patternquery/patternquery.go
@@ -33,7 +33,7 @@ func Compile(
 		return nil, fmt.Errorf("failed to compile: %s, %s -> %s", err, input, builderResult.Query)
 	}
 
-	log.Debug().Msgf("compiled pattern %s -> %s", input, builderResult.Query)
+	log.Trace().Msgf("compiled pattern %s -> %s", input, builderResult.Query)
 
 	return &Query{
 		treeQuery:       treeQuery,

--- a/new/language/tree/tree.go
+++ b/new/language/tree/tree.go
@@ -13,7 +13,7 @@ type Tree struct {
 	queryCache   map[int]map[NodeID][]QueryResult
 }
 
-func Parse(sitterLanguage *sitter.Language, input string) (*Tree, error) {
+func Parse(ctx context.Context, sitterLanguage *sitter.Language, input string) (*Tree, error) {
 	inputBytes := []byte(input)
 
 	parser := sitter.NewParser()
@@ -21,7 +21,7 @@ func Parse(sitterLanguage *sitter.Language, input string) (*Tree, error) {
 
 	parser.SetLanguage(sitterLanguage)
 
-	sitterTree, err := parser.ParseCtx(context.TODO(), nil, inputBytes)
+	sitterTree, err := parser.ParseCtx(ctx, nil, inputBytes)
 	if err != nil {
 		return nil, err
 	}

--- a/new/language/types/types.go
+++ b/new/language/types/types.go
@@ -1,6 +1,10 @@
 package types
 
-import "github.com/bearer/bearer/new/language/tree"
+import (
+	"context"
+
+	"github.com/bearer/bearer/new/language/tree"
+)
 
 type PatternQueryResult struct {
 	MatchNode *tree.Node
@@ -14,7 +18,7 @@ type PatternQuery interface {
 }
 
 type Language interface {
-	Parse(input string) (*tree.Tree, error)
+	Parse(ctx context.Context, input string) (*tree.Tree, error)
 	CompileQuery(input string) (*tree.Query, error)
 	CompilePatternQuery(input, focusedVariable string) (PatternQuery, error)
 }

--- a/new/scanner/scanner.go
+++ b/new/scanner/scanner.go
@@ -1,6 +1,7 @@
 package scanner
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/bearer/bearer/new/detector/composition"
@@ -63,9 +64,9 @@ func Setup(config *settings.Config, classifier *classification.Classifier) (err 
 	return err
 }
 
-func Detect(report report.Report, file *file.FileInfo) (err error) {
+func Detect(ctx context.Context, report report.Report, file *file.FileInfo) (err error) {
 	for _, language := range scanner {
-		detections, err := language.composition.DetectFromFile(file)
+		detections, err := language.composition.DetectFromFile(ctx, file)
 		if err != nil {
 			return fmt.Errorf("%s failed to detect in file %s: %s", language.name, file.AbsolutePath, err)
 		}

--- a/new/scanner/scanner.go
+++ b/new/scanner/scanner.go
@@ -23,7 +23,7 @@ type scannerType []language
 
 var scanner scannerType
 
-func (scanner scannerType) Close() {
+func Close() {
 	for _, language := range scanner {
 		language.composition.Close()
 	}
@@ -31,7 +31,7 @@ func (scanner scannerType) Close() {
 
 func Setup(config *settings.Config, classifier *classification.Classifier) (err error) {
 	var toInstantiate = []struct {
-		constructor func(map[string]*settings.Rule, *classification.Classifier) (types.Composition, error)
+		constructor func(bool, map[string]*settings.Rule, *classification.Classifier) (types.Composition, error)
 		name        string
 	}{
 		{
@@ -49,7 +49,7 @@ func Setup(config *settings.Config, classifier *classification.Classifier) (err 
 	}
 
 	for _, instantiatior := range toInstantiate {
-		composition, err := instantiatior.constructor(config.Rules, classifier)
+		composition, err := instantiatior.constructor(config.DebugProfile, config.Rules, classifier)
 		if err != nil {
 			return fmt.Errorf("failed to instantiate composition %s:%s", instantiatior.name, err)
 		}

--- a/pkg/commands/debugprofile/debugprofile.go
+++ b/pkg/commands/debugprofile/debugprofile.go
@@ -43,4 +43,6 @@ func Stop() {
 	log.Debug().Msg("stopping cpu profiling")
 	pprof.StopCPUProfile()
 	file.Close()
+
+	file = nil
 }

--- a/pkg/commands/process/settings/settings.go
+++ b/pkg/commands/process/settings/settings.go
@@ -18,6 +18,7 @@ var (
 	TimeoutFileMinimum        = 5 * time.Second   // Minimum timeout assigned for scanning each file. This config superseeds timeout-second-per-bytes
 	TimeoutFileMaximum        = 30 * time.Second  // Maximum timeout assigned for scanning each file. This config superseeds timeout-second-per-bytes
 	TimeoutFileBytesPerSecond = 1 * 1000          // 1 Kb/s minimum number of bytes per second allowed to scan a file
+	TimeoutWorkerFileGrace    = 5 * time.Second   // Grace period to allow a worker to timeout on it's own
 	TimeoutWorkerOnline       = 60 * time.Second  // Maximum time to wait for a worker process to come online
 	TimeoutWorkerShutdown     = 5 * time.Second   // Maximum time to wait for a worker process to shut down cleanly
 	FileSizeMaximum           = 2 * 1000 * 1000   // 2 MB Ignore files larger than the specified value

--- a/pkg/commands/process/worker/pool/pool.go
+++ b/pkg/commands/process/worker/pool/pool.go
@@ -26,10 +26,7 @@ func New(config settings.Config) *Pool {
 		log.Fatal().Msgf("failed to get current command executable %s", err)
 	}
 
-	baseArguments := []string{"processing-worker"}
-	if config.Scan.Debug {
-		baseArguments = append(baseArguments, "--debug")
-	}
+	baseArguments := []string{"processing-worker", "--log-level", config.Scan.LogLevel}
 	if config.DebugProfile {
 		baseArguments = append(baseArguments, "--debug-profile")
 	}

--- a/pkg/commands/process/worker/pool/process.go
+++ b/pkg/commands/process/worker/pool/process.go
@@ -19,14 +19,14 @@ import (
 	"github.com/struCoder/pidusage"
 
 	"github.com/bearer/bearer/pkg/commands/process/settings"
+	"github.com/bearer/bearer/pkg/commands/process/worker"
 	"github.com/bearer/bearer/pkg/commands/process/worker/work"
 )
 
 var (
-	ErrorCrashed        = errors.New("exited unexpectedly")
-	ErrorNotSpawned     = errors.New("didn't start within expected time")
-	ErrorOutOfMemory    = errors.New("exceeded memory limit")
-	ErrorTimeoutReached = errors.New("file processing time exceeded")
+	ErrorCrashed     = errors.New("exited unexpectedly")
+	ErrorNotSpawned  = errors.New("didn't start within expected time")
+	ErrorOutOfMemory = errors.New("exceeded memory limit")
 )
 
 type Process struct {
@@ -241,7 +241,7 @@ func (process *Process) Scan(scanRequest work.ProcessRequest) (*work.ProcessResp
 		scanComplete <- &scanResponse
 	}()
 
-	timeout := time.NewTimer(scanRequest.File.Timeout)
+	timeout := time.NewTimer(scanRequest.File.Timeout + settings.TimeoutWorkerFileGrace)
 	select {
 	case response := <-scanComplete:
 		return response, nil
@@ -250,7 +250,7 @@ func (process *Process) Scan(scanRequest work.ProcessRequest) (*work.ProcessResp
 		return nil, err
 	case <-timeout.C:
 		process.Close()
-		return nil, ErrorTimeoutReached
+		return nil, worker.ErrorTimeoutReached
 	}
 }
 

--- a/pkg/commands/process/worker/worker.go
+++ b/pkg/commands/process/worker/worker.go
@@ -12,6 +12,7 @@ import (
 
 	customdetector "github.com/bearer/bearer/new/scanner"
 	"github.com/bearer/bearer/pkg/classification"
+	"github.com/bearer/bearer/pkg/commands/debugprofile"
 	config "github.com/bearer/bearer/pkg/commands/process/settings"
 	"github.com/bearer/bearer/pkg/commands/process/worker/blamer"
 	"github.com/bearer/bearer/pkg/commands/process/worker/work"
@@ -112,6 +113,8 @@ func Start(port string) error {
 	done := make(chan struct{})
 	go func() {
 		<-ctx.Done()
+
+		debugprofile.Stop()
 
 		if err := server.Shutdown(context.Background()); err != nil {
 			log.Debug().Msgf("error shutting down server: %s", err)

--- a/pkg/commands/process/worker/worker.go
+++ b/pkg/commands/process/worker/worker.go
@@ -120,6 +120,8 @@ func Start(port string) error {
 			log.Debug().Msgf("error shutting down server: %s", err)
 		}
 
+		customdetector.Close()
+
 		close(done)
 	}()
 

--- a/pkg/commands/processing_worker.go
+++ b/pkg/commands/processing_worker.go
@@ -27,7 +27,7 @@ func NewProcessingWorkerCommand() *cobra.Command {
 			}
 
 			output.Setup(cmd, output.SetupRequest{
-				Debug:     viper.GetBool(flag.DebugFlag.ConfigName),
+				LogLevel:  viper.GetString(flag.LogLevelFlag.ConfigName),
 				Quiet:     viper.GetBool(flag.QuietFlag.ConfigName),
 				ProcessID: viper.GetString(flag.WorkerIDFlag.ConfigName),
 			})

--- a/pkg/commands/processing_worker.go
+++ b/pkg/commands/processing_worker.go
@@ -44,7 +44,6 @@ func NewProcessingWorkerCommand() *cobra.Command {
 			log.Debug().Msgf("running scan worker on port `%s`", processOptions.Port)
 
 			err = worker.Start(processOptions.Port)
-			debugprofile.Stop()
 			return err
 		},
 		Hidden:        true,

--- a/pkg/commands/scan.go
+++ b/pkg/commands/scan.go
@@ -56,8 +56,13 @@ func NewScanCommand() *cobra.Command {
 				return xerrors.Errorf("flag bind error: %w", err)
 			}
 
+			logLevel := viper.GetString(flag.LogLevelFlag.ConfigName)
+			if viper.GetBool(flag.DebugFlag.ConfigName) {
+				logLevel = flag.DebugLogLevel
+			}
+
 			output.Setup(cmd, output.SetupRequest{
-				Debug:     viper.GetBool(flag.DebugFlag.ConfigName),
+				LogLevel:  logLevel,
 				Quiet:     viper.GetBool(flag.QuietFlag.ConfigName),
 				ProcessID: "main",
 			})

--- a/pkg/detectors/internal/testhelper/testhelper.go
+++ b/pkg/detectors/internal/testhelper/testhelper.go
@@ -1,6 +1,7 @@
 package testhelper
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -51,7 +52,7 @@ func Extract(
 		t.Errorf("report has errored %s", err)
 	}
 
-	err = detectors.ExtractWithDetectors(path, files, &report, registrations)
+	err = detectors.ExtractWithDetectors(context.Background(), path, files, &report, registrations)
 	if len(report.Errors) > 0 {
 		t.Errorf("report has some errors %#v", report.Errors)
 	}

--- a/pkg/detectors/typescript/.snapshots/TestDetectorReportDatatype
+++ b/pkg/detectors/typescript/.snapshots/TestDetectorReportDatatype
@@ -1,4 +1,4 @@
-([]*detections.Detection) (len=40) {
+([]*detections.Detection) (len=39) {
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=6) "schema",
     DetectorType: (detectors.Type) (len=10) "typescript",
@@ -512,17 +512,45 @@
       FullFilename: (string) "",
       Language: (string) (len=10) "TypeScript",
       LanguageType: (string) (len=11) "programming",
-      StartLineNumber: (*int)(56),
+      StartLineNumber: (*int)(59),
       StartColumnNumber: (*int)(3),
-      EndLineNumber: (*int)(56),
-      EndColumnNumber: (*int)(12),
+      EndLineNumber: (*int)(70),
+      EndColumnNumber: (*int)(4),
+      Text: (*string)(<nil>)
+    },
+    Value: (schema.Schema) {
+      ObjectName: (string) (len=17) "CloudinaryAdapter",
+      ObjectUUID: (string) (len=2) "28",
+      FieldName: (string) (len=11) "constructor",
+      FieldUUID: (string) (len=2) "29",
+      FieldType: (string) (len=8) "function",
+      SimpleFieldType: (string) (len=8) "function",
+      Classification: (interface {}) <nil>,
+      Source: (*schema.Source)(<nil>),
+      NormalizedObjectName: (string) (len=17) "cloudinaryadapter",
+      NormalizedFieldName: (string) (len=11) "constructor"
+    }
+  }),
+  (*detections.Detection)({
+    Type: (detections.DetectionType) (len=6) "schema",
+    DetectorType: (detectors.Type) (len=10) "typescript",
+    CommitSHA: (string) "",
+    Source: (source.Source) {
+      Filename: (string) (len=9) "schema.ts",
+      FullFilename: (string) "",
+      Language: (string) (len=10) "TypeScript",
+      LanguageType: (string) (len=11) "programming",
+      StartLineNumber: (*int)(65),
+      StartColumnNumber: (*int)(5),
+      EndLineNumber: (*int)(65),
+      EndColumnNumber: (*int)(14),
       Text: (*string)(<nil>)
     },
     Value: (schema.Schema) {
       ObjectName: (string) (len=17) "CloudinaryAdapter",
       ObjectUUID: (string) (len=2) "28",
       FieldName: (string) (len=9) "cloudName",
-      FieldUUID: (string) (len=2) "29",
+      FieldUUID: (string) (len=2) "30",
       FieldType: (string) (len=6) "string",
       SimpleFieldType: (string) (len=6) "string",
       Classification: (interface {}) <nil>,
@@ -540,23 +568,79 @@
       FullFilename: (string) "",
       Language: (string) (len=10) "TypeScript",
       LanguageType: (string) (len=11) "programming",
-      StartLineNumber: (*int)(59),
-      StartColumnNumber: (*int)(3),
-      EndLineNumber: (*int)(70),
-      EndColumnNumber: (*int)(4),
+      StartLineNumber: (*int)(66),
+      StartColumnNumber: (*int)(5),
+      EndLineNumber: (*int)(66),
+      EndColumnNumber: (*int)(11),
       Text: (*string)(<nil>)
     },
     Value: (schema.Schema) {
       ObjectName: (string) (len=17) "CloudinaryAdapter",
       ObjectUUID: (string) (len=2) "28",
-      FieldName: (string) (len=11) "constructor",
-      FieldUUID: (string) (len=2) "30",
-      FieldType: (string) (len=8) "function",
-      SimpleFieldType: (string) (len=8) "function",
+      FieldName: (string) (len=6) "apiKey",
+      FieldUUID: (string) (len=2) "31",
+      FieldType: (string) (len=6) "string",
+      SimpleFieldType: (string) (len=6) "string",
       Classification: (interface {}) <nil>,
       Source: (*schema.Source)(<nil>),
       NormalizedObjectName: (string) (len=17) "cloudinaryadapter",
-      NormalizedFieldName: (string) (len=11) "constructor"
+      NormalizedFieldName: (string) (len=6) "apikey"
+    }
+  }),
+  (*detections.Detection)({
+    Type: (detections.DetectionType) (len=6) "schema",
+    DetectorType: (detectors.Type) (len=10) "typescript",
+    CommitSHA: (string) "",
+    Source: (source.Source) {
+      Filename: (string) (len=9) "schema.ts",
+      FullFilename: (string) "",
+      Language: (string) (len=10) "TypeScript",
+      LanguageType: (string) (len=11) "programming",
+      StartLineNumber: (*int)(67),
+      StartColumnNumber: (*int)(5),
+      EndLineNumber: (*int)(67),
+      EndColumnNumber: (*int)(14),
+      Text: (*string)(<nil>)
+    },
+    Value: (schema.Schema) {
+      ObjectName: (string) (len=17) "CloudinaryAdapter",
+      ObjectUUID: (string) (len=2) "28",
+      FieldName: (string) (len=9) "apiSecret",
+      FieldUUID: (string) (len=2) "32",
+      FieldType: (string) (len=6) "string",
+      SimpleFieldType: (string) (len=6) "string",
+      Classification: (interface {}) <nil>,
+      Source: (*schema.Source)(<nil>),
+      NormalizedObjectName: (string) (len=17) "cloudinaryadapter",
+      NormalizedFieldName: (string) (len=9) "apisecret"
+    }
+  }),
+  (*detections.Detection)({
+    Type: (detections.DetectionType) (len=6) "schema",
+    DetectorType: (detectors.Type) (len=10) "typescript",
+    CommitSHA: (string) "",
+    Source: (source.Source) {
+      Filename: (string) (len=9) "schema.ts",
+      FullFilename: (string) "",
+      Language: (string) (len=10) "TypeScript",
+      LanguageType: (string) (len=11) "programming",
+      StartLineNumber: (*int)(68),
+      StartColumnNumber: (*int)(5),
+      EndLineNumber: (*int)(68),
+      EndColumnNumber: (*int)(11),
+      Text: (*string)(<nil>)
+    },
+    Value: (schema.Schema) {
+      ObjectName: (string) (len=17) "CloudinaryAdapter",
+      ObjectUUID: (string) (len=2) "28",
+      FieldName: (string) (len=6) "folder",
+      FieldUUID: (string) (len=2) "33",
+      FieldType: (string) (len=6) "string",
+      SimpleFieldType: (string) (len=6) "string",
+      Classification: (interface {}) <nil>,
+      Source: (*schema.Source)(<nil>),
+      NormalizedObjectName: (string) (len=17) "cloudinaryadapter",
+      NormalizedFieldName: (string) (len=6) "folder"
     }
   }),
   (*detections.Detection)({
@@ -578,125 +662,13 @@
       ObjectName: (string) (len=17) "CloudinaryAdapter",
       ObjectUUID: (string) (len=2) "28",
       FieldName: (string) (len=4) "save",
-      FieldUUID: (string) (len=2) "31",
+      FieldUUID: (string) (len=2) "34",
       FieldType: (string) (len=8) "function",
       SimpleFieldType: (string) (len=8) "function",
       Classification: (interface {}) <nil>,
       Source: (*schema.Source)(<nil>),
       NormalizedObjectName: (string) (len=17) "cloudinaryadapter",
       NormalizedFieldName: (string) (len=4) "save"
-    }
-  }),
-  (*detections.Detection)({
-    Type: (detections.DetectionType) (len=6) "schema",
-    DetectorType: (detectors.Type) (len=10) "typescript",
-    CommitSHA: (string) "",
-    Source: (source.Source) {
-      Filename: (string) (len=9) "schema.ts",
-      FullFilename: (string) "",
-      Language: (string) (len=10) "TypeScript",
-      LanguageType: (string) (len=11) "programming",
-      StartLineNumber: (*int)(65),
-      StartColumnNumber: (*int)(5),
-      EndLineNumber: (*int)(65),
-      EndColumnNumber: (*int)(14),
-      Text: (*string)(<nil>)
-    },
-    Value: (schema.Schema) {
-      ObjectName: (string) (len=59) "{\n    cloudName,\n    apiKey,\n    apiSecret,\n    folder,\n  }",
-      ObjectUUID: (string) (len=2) "32",
-      FieldName: (string) (len=9) "cloudName",
-      FieldUUID: (string) (len=2) "33",
-      FieldType: (string) (len=6) "string",
-      SimpleFieldType: (string) (len=6) "string",
-      Classification: (interface {}) <nil>,
-      Source: (*schema.Source)(<nil>),
-      NormalizedObjectName: (string) (len=59) "{\n    cloudname,\n    apikey,\n    apisecret,\n    folder,\n  }",
-      NormalizedFieldName: (string) (len=9) "cloudname"
-    }
-  }),
-  (*detections.Detection)({
-    Type: (detections.DetectionType) (len=6) "schema",
-    DetectorType: (detectors.Type) (len=10) "typescript",
-    CommitSHA: (string) "",
-    Source: (source.Source) {
-      Filename: (string) (len=9) "schema.ts",
-      FullFilename: (string) "",
-      Language: (string) (len=10) "TypeScript",
-      LanguageType: (string) (len=11) "programming",
-      StartLineNumber: (*int)(66),
-      StartColumnNumber: (*int)(5),
-      EndLineNumber: (*int)(66),
-      EndColumnNumber: (*int)(11),
-      Text: (*string)(<nil>)
-    },
-    Value: (schema.Schema) {
-      ObjectName: (string) (len=59) "{\n    cloudName,\n    apiKey,\n    apiSecret,\n    folder,\n  }",
-      ObjectUUID: (string) (len=2) "32",
-      FieldName: (string) (len=6) "apiKey",
-      FieldUUID: (string) (len=2) "34",
-      FieldType: (string) (len=6) "string",
-      SimpleFieldType: (string) (len=6) "string",
-      Classification: (interface {}) <nil>,
-      Source: (*schema.Source)(<nil>),
-      NormalizedObjectName: (string) (len=59) "{\n    cloudname,\n    apikey,\n    apisecret,\n    folder,\n  }",
-      NormalizedFieldName: (string) (len=6) "apikey"
-    }
-  }),
-  (*detections.Detection)({
-    Type: (detections.DetectionType) (len=6) "schema",
-    DetectorType: (detectors.Type) (len=10) "typescript",
-    CommitSHA: (string) "",
-    Source: (source.Source) {
-      Filename: (string) (len=9) "schema.ts",
-      FullFilename: (string) "",
-      Language: (string) (len=10) "TypeScript",
-      LanguageType: (string) (len=11) "programming",
-      StartLineNumber: (*int)(67),
-      StartColumnNumber: (*int)(5),
-      EndLineNumber: (*int)(67),
-      EndColumnNumber: (*int)(14),
-      Text: (*string)(<nil>)
-    },
-    Value: (schema.Schema) {
-      ObjectName: (string) (len=59) "{\n    cloudName,\n    apiKey,\n    apiSecret,\n    folder,\n  }",
-      ObjectUUID: (string) (len=2) "32",
-      FieldName: (string) (len=9) "apiSecret",
-      FieldUUID: (string) (len=2) "35",
-      FieldType: (string) (len=6) "string",
-      SimpleFieldType: (string) (len=6) "string",
-      Classification: (interface {}) <nil>,
-      Source: (*schema.Source)(<nil>),
-      NormalizedObjectName: (string) (len=59) "{\n    cloudname,\n    apikey,\n    apisecret,\n    folder,\n  }",
-      NormalizedFieldName: (string) (len=9) "apisecret"
-    }
-  }),
-  (*detections.Detection)({
-    Type: (detections.DetectionType) (len=6) "schema",
-    DetectorType: (detectors.Type) (len=10) "typescript",
-    CommitSHA: (string) "",
-    Source: (source.Source) {
-      Filename: (string) (len=9) "schema.ts",
-      FullFilename: (string) "",
-      Language: (string) (len=10) "TypeScript",
-      LanguageType: (string) (len=11) "programming",
-      StartLineNumber: (*int)(68),
-      StartColumnNumber: (*int)(5),
-      EndLineNumber: (*int)(68),
-      EndColumnNumber: (*int)(11),
-      Text: (*string)(<nil>)
-    },
-    Value: (schema.Schema) {
-      ObjectName: (string) (len=59) "{\n    cloudName,\n    apiKey,\n    apiSecret,\n    folder,\n  }",
-      ObjectUUID: (string) (len=2) "32",
-      FieldName: (string) (len=6) "folder",
-      FieldUUID: (string) (len=2) "36",
-      FieldType: (string) (len=6) "string",
-      SimpleFieldType: (string) (len=6) "string",
-      Classification: (interface {}) <nil>,
-      Source: (*schema.Source)(<nil>),
-      NormalizedObjectName: (string) (len=59) "{\n    cloudname,\n    apikey,\n    apisecret,\n    folder,\n  }",
-      NormalizedFieldName: (string) (len=6) "folder"
     }
   }),
   (*detections.Detection)({
@@ -716,9 +688,9 @@
     },
     Value: (schema.Schema) {
       ObjectName: (string) (len=4) "Base",
-      ObjectUUID: (string) (len=2) "38",
+      ObjectUUID: (string) (len=2) "36",
       FieldName: (string) (len=4) "name",
-      FieldUUID: (string) (len=2) "39",
+      FieldUUID: (string) (len=2) "37",
       FieldType: (string) "",
       SimpleFieldType: (string) (len=6) "string",
       Classification: (interface {}) <nil>,
@@ -744,9 +716,9 @@
     },
     Value: (schema.Schema) {
       ObjectName: (string) (len=4) "Base",
-      ObjectUUID: (string) (len=2) "38",
+      ObjectUUID: (string) (len=2) "36",
       FieldName: (string) (len=11) "constructor",
-      FieldUUID: (string) (len=2) "40",
+      FieldUUID: (string) (len=2) "38",
       FieldType: (string) (len=8) "function",
       SimpleFieldType: (string) (len=8) "function",
       Classification: (interface {}) <nil>,
@@ -772,9 +744,9 @@
     },
     Value: (schema.Schema) {
       ObjectName: (string) (len=7) "Derived",
-      ObjectUUID: (string) (len=2) "41",
+      ObjectUUID: (string) (len=2) "39",
       FieldName: (string) (len=4) "name",
-      FieldUUID: (string) (len=2) "42",
+      FieldUUID: (string) (len=2) "40",
       FieldType: (string) "",
       SimpleFieldType: (string) (len=6) "string",
       Classification: (interface {}) <nil>,
@@ -800,9 +772,9 @@
     },
     Value: (schema.Schema) {
       ObjectName: (string) (len=3) "Box",
-      ObjectUUID: (string) (len=2) "43",
+      ObjectUUID: (string) (len=2) "41",
       FieldName: (string) (len=8) "contents",
-      FieldUUID: (string) (len=2) "44",
+      FieldUUID: (string) (len=2) "42",
       FieldType: (string) (len=4) "Type",
       SimpleFieldType: (string) (len=7) "unknown",
       Classification: (interface {}) <nil>,
@@ -828,9 +800,9 @@
     },
     Value: (schema.Schema) {
       ObjectName: (string) (len=3) "Box",
-      ObjectUUID: (string) (len=2) "43",
+      ObjectUUID: (string) (len=2) "41",
       FieldName: (string) (len=11) "constructor",
-      FieldUUID: (string) (len=2) "45",
+      FieldUUID: (string) (len=2) "43",
       FieldType: (string) (len=8) "function",
       SimpleFieldType: (string) (len=8) "function",
       Classification: (interface {}) <nil>,
@@ -856,9 +828,9 @@
     },
     Value: (schema.Schema) {
       ObjectName: (string) (len=3) "Box",
-      ObjectUUID: (string) (len=2) "43",
+      ObjectUUID: (string) (len=2) "41",
       FieldName: (string) (len=4) "save",
-      FieldUUID: (string) (len=2) "46",
+      FieldUUID: (string) (len=2) "44",
       FieldType: (string) (len=8) "function",
       SimpleFieldType: (string) (len=8) "function",
       Classification: (interface {}) <nil>,
@@ -884,9 +856,9 @@
     },
     Value: (schema.Schema) {
       ObjectName: (string) (len=9) "something",
-      ObjectUUID: (string) (len=2) "49",
+      ObjectUUID: (string) (len=2) "47",
       FieldName: (string) (len=6) "parent",
-      FieldUUID: (string) (len=2) "50",
+      FieldUUID: (string) (len=2) "48",
       FieldType: (string) "",
       SimpleFieldType: (string) (len=6) "object",
       Classification: (interface {}) <nil>,
@@ -912,9 +884,9 @@
     },
     Value: (schema.Schema) {
       ObjectName: (string) (len=6) "parent",
-      ObjectUUID: (string) (len=2) "50",
+      ObjectUUID: (string) (len=2) "48",
       FieldName: (string) (len=6) "nested",
-      FieldUUID: (string) (len=2) "51",
+      FieldUUID: (string) (len=2) "49",
       FieldType: (string) (len=6) "string",
       SimpleFieldType: (string) (len=6) "string",
       Classification: (interface {}) <nil>,
@@ -940,9 +912,9 @@
     },
     Value: (schema.Schema) {
       ObjectName: (string) (len=12) "EventManager",
-      ObjectUUID: (string) (len=2) "52",
+      ObjectUUID: (string) (len=2) "50",
       FieldName: (string) (len=11) "RNOneSignal",
-      FieldUUID: (string) (len=2) "53",
+      FieldUUID: (string) (len=2) "51",
       FieldType: (string) (len=12) "NativeModule",
       SimpleFieldType: (string) (len=7) "unknown",
       Classification: (interface {}) <nil>,
@@ -968,9 +940,9 @@
     },
     Value: (schema.Schema) {
       ObjectName: (string) (len=12) "EventManager",
-      ObjectUUID: (string) (len=2) "52",
+      ObjectUUID: (string) (len=2) "50",
       FieldName: (string) (len=21) "oneSignalEventEmitter",
-      FieldUUID: (string) (len=2) "54",
+      FieldUUID: (string) (len=2) "52",
       FieldType: (string) (len=18) "NativeEventEmitter",
       SimpleFieldType: (string) (len=7) "unknown",
       Classification: (interface {}) <nil>,
@@ -996,9 +968,9 @@
     },
     Value: (schema.Schema) {
       ObjectName: (string) (len=12) "EventManager",
-      ObjectUUID: (string) (len=2) "52",
+      ObjectUUID: (string) (len=2) "50",
       FieldName: (string) (len=15) "eventHandlerMap",
-      FieldUUID: (string) (len=2) "55",
+      FieldUUID: (string) (len=2) "53",
       FieldType: (string) "",
       SimpleFieldType: (string) (len=7) "unknown",
       Classification: (interface {}) <nil>,
@@ -1024,9 +996,9 @@
     },
     Value: (schema.Schema) {
       ObjectName: (string) (len=12) "EventManager",
-      ObjectUUID: (string) (len=2) "52",
+      ObjectUUID: (string) (len=2) "50",
       FieldName: (string) (len=20) "eventHandlerArrayMap",
-      FieldUUID: (string) (len=2) "56",
+      FieldUUID: (string) (len=2) "54",
       FieldType: (string) "",
       SimpleFieldType: (string) (len=6) "object",
       Classification: (interface {}) <nil>,
@@ -1052,9 +1024,9 @@
     },
     Value: (schema.Schema) {
       ObjectName: (string) (len=12) "EventManager",
-      ObjectUUID: (string) (len=2) "52",
+      ObjectUUID: (string) (len=2) "50",
       FieldName: (string) (len=9) "listeners",
-      FieldUUID: (string) (len=2) "57",
+      FieldUUID: (string) (len=2) "55",
       FieldType: (string) "",
       SimpleFieldType: (string) (len=6) "object",
       Classification: (interface {}) <nil>,
@@ -1080,9 +1052,9 @@
     },
     Value: (schema.Schema) {
       ObjectName: (string) (len=12) "EventManager",
-      ObjectUUID: (string) (len=2) "52",
+      ObjectUUID: (string) (len=2) "50",
       FieldName: (string) (len=7) "getTags",
-      FieldUUID: (string) (len=2) "58",
+      FieldUUID: (string) (len=2) "56",
       FieldType: (string) (len=8) "function",
       SimpleFieldType: (string) (len=8) "function",
       Classification: (interface {}) <nil>,
@@ -1108,9 +1080,9 @@
     },
     Value: (schema.Schema) {
       ObjectName: (string) (len=12) "EventManager",
-      ObjectUUID: (string) (len=2) "52",
+      ObjectUUID: (string) (len=2) "50",
       FieldName: (string) (len=12) "setSMSNumber",
-      FieldUUID: (string) (len=2) "59",
+      FieldUUID: (string) (len=2) "57",
       FieldType: (string) (len=8) "function",
       SimpleFieldType: (string) (len=8) "function",
       Classification: (interface {}) <nil>,

--- a/pkg/detectors/typescript/datatype/datatype.go
+++ b/pkg/detectors/typescript/datatype/datatype.go
@@ -122,12 +122,13 @@ func annotateDataTypes(finder *datatype.Finder, node *parser.Node, value *schema
 		name := node.ChildByFieldName("pattern")
 		valueType := node.ChildByFieldName("type")
 
+		if name == nil || name.Type() != "identifier" {
+			return false
+		}
+
 		if valueType == nil {
 			name = node.Child(0)
 			valueType = node.Child(1)
-			if name == nil || name.Type() != "identifier" {
-				return false
-			}
 			if valueType == nil {
 				return false
 			}
@@ -141,12 +142,14 @@ func annotateDataTypes(finder *datatype.Finder, node *parser.Node, value *schema
 		name := node.ChildByFieldName("pattern")
 		valueType := node.ChildByFieldName("type")
 
+		if name == nil || name.Type() != "identifier" {
+			return false
+		}
+
 		if valueType == nil {
 			name = node.Child(0)
 			valueType = node.Child(1)
-			if name == nil || name.Type() != "identifier" {
-				return false
-			}
+
 			if valueType == nil {
 				return false
 			}

--- a/pkg/scanner/scan.go
+++ b/pkg/scanner/scan.go
@@ -1,6 +1,7 @@
 package scanner
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -11,6 +12,7 @@ import (
 )
 
 func Scan(
+	ctx context.Context,
 	rootDir string,
 	FilesToScan []string,
 	blamer blamer.Blamer,
@@ -31,7 +33,7 @@ func Scan(
 		File:       file,
 	}
 
-	if err := detectors.Extract(rootDir, FilesToScan, &rep, scanners); err != nil {
+	if err := detectors.Extract(ctx, rootDir, FilesToScan, &rep, scanners); err != nil {
 		return err
 	}
 

--- a/pkg/util/output/output.go
+++ b/pkg/util/output/output.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/bearer/bearer/pkg/flag"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
@@ -19,8 +20,8 @@ var (
 
 type SetupRequest struct {
 	Quiet     bool
-	Debug     bool
 	ProcessID string
+	LogLevel  string
 }
 
 // DefaultLogger returns default output logger
@@ -54,10 +55,15 @@ func Setup(cmd *cobra.Command, options SetupRequest) {
 
 	log.Logger = log.With().Str("process", options.ProcessID).Logger()
 
-	if options.Debug {
-		zerolog.SetGlobalLevel(zerolog.DebugLevel)
-	} else {
+	switch options.LogLevel {
+	case flag.ErrorLogLevel:
+		zerolog.SetGlobalLevel(zerolog.ErrorLevel)
+	case flag.InfoLogLevel:
 		zerolog.SetGlobalLevel(zerolog.InfoLevel)
+	case flag.DebugLogLevel:
+		zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	case flag.TraceLogLevel:
+		zerolog.SetGlobalLevel(zerolog.TraceLevel)
 	}
 }
 

--- a/pkg/util/output/output.go
+++ b/pkg/util/output/output.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"github.com/bearer/bearer/pkg/flag"
 	"github.com/rs/zerolog"
@@ -49,11 +50,24 @@ func PlainLogger(out io.Writer) *zerolog.Event {
 	return logger.Info()
 }
 
+func debugLogger(out io.Writer, processID string) zerolog.Logger {
+	baseLogger := log.Output(zerolog.ConsoleWriter{
+		Out:     out,
+		NoColor: true,
+		FormatTimestamp: func(i interface{}) string {
+			timestamp, _ := time.Parse(time.RFC3339, i.(string))
+			return timestamp.Format("2006-01-02 15:04:05")
+		},
+	})
+
+	return baseLogger.With().Str("process", processID).Logger()
+}
+
 func Setup(cmd *cobra.Command, options SetupRequest) {
 	outputWriter = cmd.OutOrStdout()
 	ErrorWriter = cmd.ErrOrStderr()
 
-	log.Logger = log.With().Str("process", options.ProcessID).Logger()
+	log.Logger = debugLogger(ErrorWriter, options.ProcessID)
 
 	switch options.LogLevel {
 	case flag.ErrorLogLevel:


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Improves performance by:
- Caching detections at the evaluation level rather than just the node level. This avoids repeated walking of the same part of the tree
- When a file times out, try to gracefully stop the scan in the worker rather than having to kill the process. This avoids reloading the rules in this case.
- Don't create a tree sitter query for patterns that are just a single variable. These match any node anyway.
- Sort filters in order of likely complexity before evaluation. This helps to throw away invalid matches before running the more expensive filters.

Benchmark:

|Project|Before|After|Speedup|
|-|-|-|-|
|Rocket Chat|2min 11sec|1min 36sec|1.4x|
|Juice Shop|1min 27sec|1min 13sec|1.2x|

_(numbers are from the file progress bar, not entire program execution time)_

Also:
- Fixes an issue where a debug profile would not be written if the worker was interrupted
- Adds `--log-level` option and adds some trace logging for rule evaluation.
- Adds rule timing to debug output when `--debug-profile` is set
- Changes log messages to pure text rather than JSON. This is much better when there are newlines in the output.
- Fixes a panic in the typescript global data types detector.

## Related
- Close #1065
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
