### PR TITLE
feat: string assign-equals support

### DIFF
--- a/new/detector/evaluator/evaluator.go
+++ b/new/detector/evaluator/evaluator.go
@@ -65,13 +65,7 @@ func (evaluator *Evaluator) Evaluate(
 	startTime := time.Now()
 
 	if log.Trace().Enabled() {
-		log.Trace().Msgf(
-			"evaluate start: %d:%d:%s:\n%s",
-			rootNode.StartLineNumber(),
-			rootNode.StartColumnNumber(),
-			rootNode.Type(),
-			rootNode.Content(),
-		)
+		log.Trace().Msgf("evaluate start: %s", rootNode.Debug(true))
 	}
 
 	key := cachepkg.NewKey(rootNode, detectorType, scope, followFlow)
@@ -82,10 +76,8 @@ func (evaluator *Evaluator) Evaluate(
 		}
 		if log.Trace().Enabled() {
 			log.Trace().Msgf(
-				"evaluate end: %d:%d:%s: %d detections (cached)",
-				rootNode.StartLineNumber(),
-				rootNode.StartColumnNumber(),
-				rootNode.Type(),
+				"evaluate end: %s: %d detections (cached)",
+				rootNode.Debug(false),
 				len(detections),
 			)
 		}
@@ -155,10 +147,8 @@ func (evaluator *Evaluator) Evaluate(
 	}
 	if log.Trace().Enabled() {
 		log.Trace().Msgf(
-			"evaluate end: %d:%d:%s: %d detections",
-			rootNode.StartLineNumber(),
-			rootNode.StartColumnNumber(),
-			rootNode.Type(),
+			"evaluate end: %s: %d detections",
+			rootNode.Debug(false),
 			len(result),
 		)
 	}
@@ -256,25 +246,17 @@ func (evaluator *Evaluator) detectAtNode(
 	scope settings.RuleReferenceScope,
 ) ([]*detection.Detection, error) {
 	if log.Trace().Enabled() {
-		log.Trace().Msgf(
-			"detect at node start: %s at %d:%d:%s\n%s",
-			detectorType,
-			node.StartLineNumber(),
-			node.StartColumnNumber(),
-			node.Type(),
-			node.Content(),
-		)
+		log.Trace().Msgf("detect at node start: %s at %s", detectorType, node.Debug(true))
 	}
+
 	key := cachepkg.NewKey(node, detectorType, settings.CURSOR_SCOPE, false)
 
 	if detections, cached := cache.Get(key); cached {
 		if log.Trace().Enabled() {
 			log.Trace().Msgf(
-				"detect at node end: %s at %d:%d:%s: %d detections (cached)",
+				"detect at node end: %s at %s: %d detections (cached)",
 				detectorType,
-				node.StartLineNumber(),
-				node.StartColumnNumber(),
-				node.Type(),
+				node.Debug(false),
 				len(detections),
 			)
 		}
@@ -285,11 +267,9 @@ func (evaluator *Evaluator) detectAtNode(
 	if evaluator.ruleDisabledForNode(detectorType, node) {
 		if log.Trace().Enabled() {
 			log.Trace().Msgf(
-				"detect at node end: %s at %d:%d:%s: rule disabled",
+				"detect at node end: %s at %s: rule disabled",
 				detectorType,
-				node.StartLineNumber(),
-				node.StartColumnNumber(),
-				node.Type(),
+				node.Debug(false),
 			)
 		}
 
@@ -313,11 +293,9 @@ func (evaluator *Evaluator) detectAtNode(
 
 	if log.Trace().Enabled() {
 		log.Trace().Msgf(
-			"detect at node end: %s at %d:%d:%s: %d detections",
+			"detect at node end: %s at %s: %d detections",
 			detectorType,
-			node.StartLineNumber(),
-			node.StartColumnNumber(),
-			node.Type(),
+			node.Debug(false),
 			len(detections),
 		)
 	}

--- a/new/detector/implementation/generic/generic.go
+++ b/new/detector/implementation/generic/generic.go
@@ -155,14 +155,21 @@ func ConcatenateAssignEquals(node *tree.Node, evaluationState types.EvaluationSt
 	if err != nil {
 		return nil, err
 	}
-	if left == "" && !leftIsLiteral {
-		left = "*"
-	}
 
 	right, rightIsLiteral, err := GetStringValue(node.ChildByFieldName("right"), evaluationState)
 	if err != nil {
 		return nil, err
 	}
+
+	if left == "" && !leftIsLiteral {
+		left = "*"
+
+		// No detection when neither parts are a string
+		if right == "" && !rightIsLiteral {
+			return nil, nil
+		}
+	}
+
 	if right == "" && !rightIsLiteral {
 		right = "*"
 	}

--- a/new/detector/implementation/generic/generic.go
+++ b/new/detector/implementation/generic/generic.go
@@ -102,7 +102,11 @@ func GetStringValue(node *tree.Node, evaluationState types.EvaluationState) (str
 
 		return childString.Value, childString.IsLiteral, nil
 	default:
-		return "", false, fmt.Errorf("expected single string detection but got %d", len(detections))
+		return "", false, fmt.Errorf(
+			"expected single string detection but got %d for %s",
+			len(detections),
+			node.Debug(true),
+		)
 	}
 }
 

--- a/new/detector/implementation/generic/generic.go
+++ b/new/detector/implementation/generic/generic.go
@@ -137,3 +137,34 @@ func ConcatenateChildStrings(node *tree.Node, evaluationState types.EvaluationSt
 		IsLiteral: isLiteral,
 	}}, nil
 }
+
+func ConcatenateAssignEquals(node *tree.Node, evaluationState types.EvaluationState) ([]interface{}, error) {
+	unifiedNodes := node.ChildByFieldName("left").UnifiedNodes()
+	if len(unifiedNodes) == 0 {
+		return nil, nil
+	}
+	if len(unifiedNodes) != 1 {
+		return nil, fmt.Errorf("expected exactly one unified `+=` node but got %d", len(unifiedNodes))
+	}
+
+	left, leftIsLiteral, err := GetStringValue(unifiedNodes[0], evaluationState)
+	if err != nil {
+		return nil, err
+	}
+	if left == "" && !leftIsLiteral {
+		left = "*"
+	}
+
+	right, rightIsLiteral, err := GetStringValue(node.ChildByFieldName("right"), evaluationState)
+	if err != nil {
+		return nil, err
+	}
+	if right == "" && !rightIsLiteral {
+		right = "*"
+	}
+
+	return []interface{}{generictypes.String{
+		Value:     left + right,
+		IsLiteral: leftIsLiteral && rightIsLiteral,
+	}}, nil
+}

--- a/new/detector/implementation/java/.snapshots/TestJavaString-string
+++ b/new/detector/implementation/java/.snapshots/TestJavaString-string
@@ -8,4 +8,24 @@
   data:
     value: Hello World!
     isliteral: true
+- position: "7:5"
+  content: s += "!!"
+  data:
+    value: Hello World!!!
+    isliteral: true
+- position: "9:17"
+  content: '"hey "'
+  data:
+    value: 'hey '
+    isliteral: true
+- position: "10:5"
+  content: s2 += args[0]
+  data:
+    value: hey *
+    isliteral: false
+- position: "11:5"
+  content: s2 += " there"
+  data:
+    value: hey * there
+    isliteral: false
 

--- a/new/detector/implementation/java/object/object.go
+++ b/new/detector/implementation/java/object/object.go
@@ -6,7 +6,6 @@ import (
 	"github.com/bearer/bearer/new/detector/detection"
 	"github.com/bearer/bearer/new/detector/types"
 	"github.com/bearer/bearer/new/language/tree"
-	"github.com/rs/zerolog/log"
 
 	"github.com/bearer/bearer/new/detector/implementation/generic"
 	generictypes "github.com/bearer/bearer/new/detector/implementation/generic/types"
@@ -72,8 +71,6 @@ func (detector *objectDetector) DetectAt(
 	node *tree.Node,
 	evaluationState types.EvaluationState,
 ) ([]interface{}, error) {
-	log.Debug().Msgf("node is %s", node.Debug())
-
 	detections, err := detector.getAssignment(node, evaluationState)
 	if len(detections) != 0 || err != nil {
 		return detections, err

--- a/new/detector/implementation/java/string/string.go
+++ b/new/detector/implementation/java/string/string.go
@@ -36,8 +36,13 @@ func (detector *stringDetector) DetectAt(
 		if node.AnonymousChild(0).Content() == "+" {
 			return generic.ConcatenateChildStrings(node, evaluationState)
 		}
+	case "assignment_expression":
+		if node.AnonymousChild(0).Content() == "+=" {
+			return generic.ConcatenateAssignEquals(node, evaluationState)
+		}
 	}
 
 	return nil, nil
 }
+
 func (detector *stringDetector) Close() {}

--- a/new/detector/implementation/java/testdata/string.java
+++ b/new/detector/implementation/java/testdata/string.java
@@ -4,5 +4,10 @@ public class Greet {
   public static void main(String[] args)
   {
     var s = Greeting + "!";
+    s += "!!";
+
+    String s2 = "hey ";
+    s2 += args[0];
+    s2 += " there";
   }
 }

--- a/new/detector/implementation/javascript/.snapshots/TestJavascriptStringDetector-string_assign_eq
+++ b/new/detector/implementation/javascript/.snapshots/TestJavascriptStringDetector-string_assign_eq
@@ -1,0 +1,21 @@
+- position: "1:11"
+  content: '"a"'
+  data:
+    value: a
+    isliteral: true
+- position: "2:1"
+  content: x += "b"
+  data:
+    value: ab
+    isliteral: true
+- position: "3:1"
+  content: x += name
+  data:
+    value: ab*
+    isliteral: false
+- position: "6:1"
+  content: y += "c"
+  data:
+    value: '*c'
+    isliteral: false
+

--- a/new/detector/implementation/javascript/javascript_test.go
+++ b/new/detector/implementation/javascript/javascript_test.go
@@ -15,6 +15,7 @@ func TestJavascriptObjectDetector(t *testing.T) {
 }
 
 func TestJavascriptStringDetector(t *testing.T) {
+	runTest(t, "string_assign_eq", "string", "testdata/string_assign_eq.js")
 	runTest(t, "string_literal", "string", "testdata/string_literal.js")
 	runTest(t, "string_non_literal", "string", "testdata/string_non_literal.js")
 }

--- a/new/detector/implementation/javascript/string/string.go
+++ b/new/detector/implementation/javascript/string/string.go
@@ -38,6 +38,10 @@ func (detector *stringDetector) DetectAt(
 		if node.AnonymousChild(0).Content() == "+" {
 			return generic.ConcatenateChildStrings(node, evaluationState)
 		}
+	case "augmented_assignment_expression":
+		if node.AnonymousChild(0).Content() == "+=" {
+			return generic.ConcatenateAssignEquals(node, evaluationState)
+		}
 	}
 
 	return nil, nil

--- a/new/detector/implementation/javascript/testdata/string_assign_eq.js
+++ b/new/detector/implementation/javascript/testdata/string_assign_eq.js
@@ -1,0 +1,6 @@
+const x = "a"
+x += "b"
+x += name
+
+const y = name
+y += "c"

--- a/new/detector/implementation/ruby/.snapshots/TestRubyStringDetector-string_assign_eq
+++ b/new/detector/implementation/ruby/.snapshots/TestRubyStringDetector-string_assign_eq
@@ -1,0 +1,21 @@
+- position: "1:5"
+  content: '"a"'
+  data:
+    value: a
+    isliteral: true
+- position: "2:1"
+  content: x += "b"
+  data:
+    value: ab
+    isliteral: true
+- position: "3:1"
+  content: x += name
+  data:
+    value: ab*
+    isliteral: false
+- position: "6:1"
+  content: y += "c"
+  data:
+    value: '*c'
+    isliteral: false
+

--- a/new/detector/implementation/ruby/ruby_test.go
+++ b/new/detector/implementation/ruby/ruby_test.go
@@ -14,6 +14,7 @@ func TestRubyObjectDetector(t *testing.T) {
 }
 
 func TestRubyStringDetector(t *testing.T) {
+	runTest(t, "string_assign_eq", "string", "testdata/string_assign_eq.rb")
 	runTest(t, "string_literal", "string", "testdata/string_literal.rb")
 	runTest(t, "string_non_literal", "string", "testdata/string_non_literal.rb")
 }

--- a/new/detector/implementation/ruby/string/string.go
+++ b/new/detector/implementation/ruby/string/string.go
@@ -37,6 +37,10 @@ func (detector *stringDetector) DetectAt(
 		if node.AnonymousChild(0).Content() == "+" {
 			return generic.ConcatenateChildStrings(node, evaluationState)
 		}
+	case "operator_assignment":
+		if node.AnonymousChild(0).Content() == "+=" {
+			return generic.ConcatenateAssignEquals(node, evaluationState)
+		}
 	}
 
 	return nil, nil

--- a/new/detector/implementation/ruby/testdata/string_assign_eq.rb
+++ b/new/detector/implementation/ruby/testdata/string_assign_eq.rb
@@ -1,0 +1,6 @@
+x = "a"
+x += "b"
+x += name
+
+y = name
+y += "c"

--- a/new/detector/implementation/testhelper/testhelper.go
+++ b/new/detector/implementation/testhelper/testhelper.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bearer/bearer/pkg/flag"
 	"github.com/bearer/bearer/pkg/util/file"
 	"github.com/bradleyjkemp/cupaloy"
+	"github.com/rs/zerolog"
 	"gopkg.in/yaml.v3"
 )
 
@@ -27,6 +28,8 @@ func RunTest(
 	detectorType string,
 	fileName string,
 ) {
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+
 	t.Run(name, func(tt *testing.T) {
 		classifier, err := classification.NewClassifier(&classification.Config{
 			Config: settings.Config{

--- a/new/language/implementation/javascript/javascript.go
+++ b/new/language/implementation/javascript/javascript.go
@@ -26,6 +26,7 @@ var (
 		"template_substitution",
 		"array",
 		"spread_element",
+		"augmented_assignment_expression",
 	}
 
 	anonymousPatternNodeParentTypes = []string{}
@@ -84,6 +85,16 @@ func (*javascriptImplementation) AnalyzeFlow(ctx context.Context, rootNode *tree
 
 				return err
 			}
+		// x += y
+		case "augmented_assignment_expression":
+			err := visitChildren()
+
+			left := node.ChildByFieldName("left")
+			if left.Type() == "identifier" {
+				scope.Assign(left.Content(), node)
+			}
+
+			return err
 		// const user = ...
 		// var user = ...
 		// let user = ...

--- a/new/language/implementation/ruby/ruby.go
+++ b/new/language/implementation/ruby/ruby.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	variableLookupParents = []string{"pair", "argument_list", "interpolation", "array", "binary"}
+	variableLookupParents = []string{"pair", "argument_list", "interpolation", "array", "binary", "operator_assignment"}
 
 	anonymousPatternNodeParentTypes = []string{"binary"}
 	patternMatchNodeContainerTypes  = []string{"argument_list", "keyword_parameter", "optional_parameter"}
@@ -70,6 +70,16 @@ func (*rubyImplementation) AnalyzeFlow(ctx context.Context, rootNode *tree.Node)
 
 				return err
 			}
+		// x += y
+		case "operator_assignment":
+			err := visitChildren()
+
+			left := node.ChildByFieldName("left")
+			if left.Type() == "identifier" {
+				scope.Assign(left.Content(), node)
+			}
+
+			return err
 		case "identifier":
 			parent := node.Parent()
 			if parent == nil {

--- a/new/language/tree/node.go
+++ b/new/language/tree/node.go
@@ -1,6 +1,8 @@
 package tree
 
 import (
+	"fmt"
+
 	sitter "github.com/smacker/go-tree-sitter"
 )
 
@@ -11,8 +13,19 @@ type Node struct {
 
 type NodeID *sitter.Node
 
-func (node *Node) Debug() string {
-	return node.sitterNode.String()
+func (node *Node) Debug(includeContent bool) string {
+	content := ""
+	if includeContent {
+		content = ":\n" + node.Content()
+	}
+
+	return fmt.Sprintf(
+		"%d:%d:%s%s",
+		node.StartLineNumber(),
+		node.StartColumnNumber(),
+		node.Type(),
+		content,
+	)
 }
 
 func (node *Node) ID() NodeID {


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Adds support for the `+=` operator for strings, in all languages.

## Related
- Close #1064
<!-- References some existing PR
- #CCC
-->

## Checklist

- [x] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
