### PR TITLE
feat: support filters when referencing rules

### DIFF
--- a/e2e/rules/.snapshots/TestReferenceFilters-testdata-data-reference_filters
+++ b/e2e/rules/.snapshots/TestReferenceFilters-testdata-data-reference_filters
@@ -1,0 +1,34 @@
+high:
+    - rule:
+        cwe_ids:
+            - "42"
+        id: reference_filters_test
+        title: Test rule reference filters
+        description: Test rule reference filters
+        documentation_url: ""
+      line_number: 1
+      full_filename: e2e/rules/testdata/data/reference_filters/main.rb
+      filename: main.rb
+      source:
+        location:
+            start: 1
+            end: 1
+            column:
+                start: 1
+                end: 6
+      sink:
+        location:
+            start: 1
+            end: 1
+            column:
+                start: 1
+                end: 6
+        content: x.foo
+      parent_line_number: 1
+      snippet: x.foo
+      fingerprint: df1f6d9ee9f4ee60085d0046163b3701_0
+      old_fingerprint: 52f7dcd9f1ba09f3a9f8c1ad305c8a89_0
+
+
+--
+

--- a/e2e/rules/rules_test.go
+++ b/e2e/rules/rules_test.go
@@ -30,6 +30,10 @@ func TestAuxilary(t *testing.T) {
 	runRulesTest("auxilary", "javascript_third_parties_datadog_test", t)
 }
 
+func TestReferenceFilters(t *testing.T) {
+	runRulesTest("reference_filters", "reference_filters_test", t)
+}
+
 func TestSanitizer(t *testing.T) {
 	runRulesTest("sanitizer", "sanitizer_test", t)
 }

--- a/e2e/rules/testdata/data/reference_filters/main.rb
+++ b/e2e/rules/testdata/data/reference_filters/main.rb
@@ -1,0 +1,2 @@
+x.foo
+y.foo

--- a/e2e/rules/testdata/rules/reference_filters.yml
+++ b/e2e/rules/testdata/rules/reference_filters.yml
@@ -1,0 +1,23 @@
+languages:
+  - ruby
+patterns:
+  - pattern: $<AUX>
+    filters:
+      - variable: AUX
+        detection: reference_filters_test_foo
+        scope: cursor
+        filters:
+          - variable: RECEIVER
+            values:
+              - x
+auxiliary:
+  - id: reference_filters_test_foo
+    patterns:
+      - $<RECEIVER>.foo
+severity: high
+metadata:
+  description: Test rule reference filters
+  remediation_message: Test rule reference filters
+  cwe_id:
+    - 42
+  id: reference_filters_test

--- a/new/detector/implementation/custom/custom.go
+++ b/new/detector/implementation/custom/custom.go
@@ -80,7 +80,7 @@ func (detector *customDetector) DetectAt(
 		for _, result := range results {
 			filtersMatch, datatypeDetections, variableNodes, err := matchAllFilters(
 				evaluationState,
-				result,
+				result.Variables,
 				pattern.Filters,
 				detector.rules,
 			)

--- a/pkg/commands/process/settings/settings.go
+++ b/pkg/commands/process/settings/settings.go
@@ -202,6 +202,7 @@ type PatternFilter struct {
 	Variable  string             `mapstructure:"variable" json:"variable" yaml:"variable"`
 	Detection string             `mapstructure:"detection" json:"detection" yaml:"detection"`
 	Scope     RuleReferenceScope `mapstructure:"scope" json:"scope" yaml:"scope"`
+	Filters   []PatternFilter    `mapstructure:"filters" json:"filters" yaml:"filters"`
 	// Contains is deprecated in favour of Scope
 	Contains           *bool    `mapstructure:"contains" json:"contains" yaml:"contains"`
 	Regex              *Regexp  `mapstructure:"regex" json:"regex" yaml:"regex"`


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Adds support for specifying filters when using a rule reference (`detection`) filter. 

This will allow us to write shared rules that are then further filtered in rules that use them. eg. we can write a shared rule to match all Java variable definitions, and then filter on the type in rules that use it.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [x] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
