### PR TITLE
fix: fatal logging

### DIFF
--- a/cmd/bearer/main.go
+++ b/cmd/bearer/main.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"os"
-
 	"github.com/bearer/bearer/cmd/bearer/build"
 
 	"github.com/bearer/bearer/pkg/commands"
@@ -11,8 +9,7 @@ import (
 
 func main() {
 	if err := run(); err != nil {
-		output.StdErrLogger().Msgf("%s", err)
-		os.Exit(1)
+		output.Fatal(err.Error())
 	}
 }
 

--- a/pkg/commands/process/orchestrator/orchestrator.go
+++ b/pkg/commands/process/orchestrator/orchestrator.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path"
@@ -179,7 +180,7 @@ func (orchestrator *orchestrator) writeFileError(file work.File, fileErr error) 
 
 func Scan(repository work.Repository, config settings.Config, goclogResult *gocloc.Result, reportPath string) error {
 	if !config.Scan.Quiet {
-		output.StdErrLogger().Msgf("Scanning target %s", config.Scan.Target)
+		output.StdErrLog(fmt.Sprintf("Scanning target %s", config.Scan.Target))
 	}
 
 	orchestrator, err := newOrchestrator(repository, config, goclogResult, reportPath)

--- a/pkg/commands/process/settings/settings.go
+++ b/pkg/commands/process/settings/settings.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/rs/zerolog/log"
 	"gopkg.in/yaml.v3"
 
 	"github.com/bearer/bearer/api"
 	"github.com/bearer/bearer/pkg/flag"
+	"github.com/bearer/bearer/pkg/util/output"
 	"github.com/bearer/bearer/pkg/util/rego"
 )
 
@@ -367,7 +367,7 @@ func DefaultPolicies() map[string]*Policy {
 
 	err := yaml.Unmarshal(defaultPolicies, &policy)
 	if err != nil {
-		log.Fatal().Msgf("failed to unmarshal policy file %s", err)
+		output.Fatal(fmt.Sprintf("failed to unmarshal policy file %s", err))
 	}
 
 	for _, policy := range policy {

--- a/pkg/commands/process/worker/pool/pool.go
+++ b/pkg/commands/process/worker/pool/pool.go
@@ -6,10 +6,9 @@ import (
 	"os"
 	"sync"
 
-	"github.com/rs/zerolog/log"
-
 	"github.com/bearer/bearer/pkg/commands/process/settings"
 	"github.com/bearer/bearer/pkg/commands/process/worker/work"
+	"github.com/bearer/bearer/pkg/util/output"
 )
 
 type Pool struct {
@@ -23,7 +22,7 @@ type Pool struct {
 func New(config settings.Config) *Pool {
 	executable, err := os.Executable()
 	if err != nil {
-		log.Fatal().Msgf("failed to get current command executable %s", err)
+		output.Fatal(fmt.Sprintf("failed to get current command executable %s", err))
 	}
 
 	baseArguments := []string{"processing-worker", "--log-level", config.Scan.LogLevel}

--- a/pkg/github_api/version_check.go
+++ b/pkg/github_api/version_check.go
@@ -2,6 +2,7 @@ package github_api
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/bearer/bearer/cmd/bearer/build"
@@ -21,7 +22,7 @@ func VersionCheck(ctx context.Context, disableVersionCheck bool, Quiet bool) {
 		} else {
 			version := strings.TrimPrefix(*release.Name, "v")
 			if version != build.Version && build.Version != "dev" && !Quiet {
-				output.StdErrLogger().Msgf("You are running an outdated version of Bearer CLI, %s is now available. You can find update instructions at https://docs.bearer.com/reference/installation/#updating-bearer", *release.Name)
+				output.StdErrLog(fmt.Sprintf("You are running an outdated version of Bearer CLI, %s is now available. You can find update instructions at https://docs.bearer.com/reference/installation/#updating-bearer", *release.Name))
 			}
 		}
 	}

--- a/pkg/report/output/dataflow/dataflow.go
+++ b/pkg/report/output/dataflow/dataflow.go
@@ -188,7 +188,7 @@ func GetOutput(input []interface{}, config settings.Config, isInternal bool) (*D
 	}
 
 	if !config.Scan.Quiet {
-		output.StdErrLogger().Msgf("Generating dataflow")
+		output.StdErrLog("Generating dataflow")
 	}
 	dataflow := &DataFlow{
 		Datatypes:    dataTypesHolder.ToDataFlow(),

--- a/pkg/report/output/detectors/detectors.go
+++ b/pkg/report/output/detectors/detectors.go
@@ -14,7 +14,7 @@ import (
 
 func GetOutput(report types.Report, config settings.Config) ([]interface{}, *dataflow.DataFlow, error) {
 	if !config.Scan.Quiet {
-		output.StdErrLogger().Msgf("Running Detectors")
+		output.StdErrLog("Running Detectors")
 	}
 
 	var detections []interface{}

--- a/pkg/report/output/privacy/privacy.go
+++ b/pkg/report/output/privacy/privacy.go
@@ -134,7 +134,7 @@ func BuildCsvString(dataflow *dataflow.DataFlow, config settings.Config) (*strin
 
 func GetOutput(dataflow *dataflow.DataFlow, config settings.Config) (*Report, *dataflow.DataFlow, error) {
 	if !config.Scan.Quiet {
-		output.StdErrLogger().Msgf("Evaluating rules")
+		output.StdErrLog("Evaluating rules")
 	}
 
 	bar := progressbar.GetProgressBar(len(config.Rules), config, "rules")
@@ -168,7 +168,7 @@ func GetOutput(dataflow *dataflow.DataFlow, config settings.Config) (*Report, *d
 
 		err := bar.Add(1)
 		if err != nil {
-			output.StdErrLogger().Msgf("Policy %s failed to write progress bar %s", rule.Id, err)
+			output.StdErrLog(fmt.Sprintf("Policy %s failed to write progress bar %s", rule.Id, err))
 		}
 
 		if !rule.PolicyType() {
@@ -286,7 +286,7 @@ func GetOutput(dataflow *dataflow.DataFlow, config settings.Config) (*Report, *d
 	}
 
 	if !config.Scan.Quiet {
-		output.StdErrLogger().Msgf("Compiling privacy report")
+		output.StdErrLog("Compiling privacy report")
 	}
 
 	// get inventory result

--- a/pkg/report/output/security/security.go
+++ b/pkg/report/output/security/security.go
@@ -119,7 +119,7 @@ type Rule struct {
 func GetOutput(dataflow *dataflow.DataFlow, config settings.Config) (*Results, error) {
 	summaryResults := make(Results)
 	if !config.Scan.Quiet {
-		output.StdErrLogger().Msgf("Evaluating rules")
+		output.StdErrLog("Evaluating rules")
 	}
 
 	err := evaluateRules(summaryResults, config.BuiltInRules, config, dataflow, true)
@@ -152,7 +152,7 @@ func evaluateRules(
 		if !builtIn {
 			err := bar.Add(1)
 			if err != nil {
-				output.StdErrLogger().Msgf("Rule %s failed to write progress bar %s", rule.Id, err)
+				output.StdErrLog(fmt.Sprintf("Rule %s failed to write progress bar %s", rule.Id, err))
 			}
 		}
 

--- a/pkg/util/progressbar/progressbar.go
+++ b/pkg/util/progressbar/progressbar.go
@@ -10,13 +10,13 @@ func GetProgressBar(filesLength int, config settings.Config, display_type string
 	hideProgress := config.Scan.Quiet || config.Scan.Debug
 	return progressbar.NewOptions(filesLength,
 		progressbar.OptionSetVisibility(!hideProgress),
-		progressbar.OptionSetWriter(output.ErrorWriter),
+		progressbar.OptionSetWriter(output.ErrorWriter()),
 		progressbar.OptionShowCount(),
 		progressbar.OptionSetWidth(15),
 		progressbar.OptionEnableColorCodes(false),
 		progressbar.OptionShowElapsedTimeOnFinish(),
 		progressbar.OptionOnCompletion(func() {
-			output.ErrorWriter.Write([]byte("\n")) //nolint:all,errcheck
+			output.ErrorWriter().Write([]byte("\n")) //nolint:all,errcheck
 		}),
 		progressbar.OptionShowIts(),
 		progressbar.OptionSetItsString(display_type),

--- a/pkg/util/tmpfile/tmpfile.go
+++ b/pkg/util/tmpfile/tmpfile.go
@@ -2,9 +2,10 @@ package tmpfile
 
 import (
 	"errors"
+	"fmt"
 	"os"
 
-	"github.com/rs/zerolog/log"
+	"github.com/bearer/bearer/pkg/util/output"
 )
 
 var ErrCreateFailed = errors.New("failed to create file")
@@ -12,7 +13,7 @@ var ErrCreateFailed = errors.New("failed to create file")
 func Create(ext string) string {
 	outputFile, err := os.CreateTemp("", "*"+ext)
 	if err != nil {
-		log.Fatal().Msgf("got create fail error %s %s", err, ErrCreateFailed)
+		output.Fatal(fmt.Sprintf("got create fail error %s %s", err, ErrCreateFailed))
 	}
 	outputFile.Close()
 


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Fixes logging of fatal errors. These are now logged in plain text.

Previously, fatal errors were using the debug logger and were output with timestamps, log level and process id.

Also fixes an issue where we were calling `logger.Info()` and retaining that event object for multiple messages. This is not supported by zerolog.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
