### PR TITLE
feat(java): better catch support

### DIFF
--- a/new/language/implementation/java/java.go
+++ b/new/language/implementation/java/java.go
@@ -157,7 +157,7 @@ func (*javaImplementation) AnalyzeFlow(ctx context.Context, rootNode *tree.Node)
 				}
 			}
 
-			if parent.Type() == "formal_parameter" {
+			if parent.Type() == "formal_parameter" || parent.Type() == "catch_formal_parameter" {
 				scope.Assign(node.Content(), node)
 			}
 
@@ -261,7 +261,7 @@ func (implementation *javaImplementation) PatternIsAnchored(node *tree.Node) (bo
 	// function block
 	// lambda () -> {} block
 	// try {} catch () {}
-	unAnchored := []string{"class_body", "block", "try_statement"}
+	unAnchored := []string{"class_body", "block", "try_statement", "catch_type"}
 
 	isUnanchored := !slices.Contains(unAnchored, parent.Type())
 	return isUnanchored, isUnanchored


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Improve support for `catch` in Java:
- Insert variables into the scope to allow patterns to match usages of it
- Make `catch_type` unanchored to allow a pattern `catch (Foo e)` to match code `catch(Foo|Bar e)`

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
