### PR TITLE
fix: support variables in js imports

### DIFF
--- a/e2e/flags/report_flags_test.go
+++ b/e2e/flags/report_flags_test.go
@@ -14,6 +14,7 @@ func newScanTest(name string, arguments []string) testhelper.TestCase {
 	arguments = append([]string{
 		"scan",
 		"--disable-version-check",
+		"--disable-default-rules",
 		filepath.Join("e2e", "flags", "testdata", "simple")},
 		arguments...,
 	)

--- a/new/detector/composition/javascript/.snapshots/TestPatternVariables--main.yml
+++ b/new/detector/composition/javascript/.snapshots/TestPatternVariables--main.yml
@@ -1,0 +1,60 @@
+high:
+    - rule:
+        cwe_ids:
+            - "42"
+        id: pattern_variables_test
+        title: Test pattern variable tree sitter node types/fixups
+        description: Test pattern variable tree sitter node types/fixups
+        documentation_url: ""
+      line_number: 1
+      full_filename: main.js
+      filename: main.js
+      source:
+        location:
+            start: 1
+            end: 1
+            column:
+                start: 1
+                end: 27
+      sink:
+        location:
+            start: 1
+            end: 1
+            column:
+                start: 1
+                end: 27
+        content: const matchedVariable = 42
+      parent_line_number: 1
+      snippet: const matchedVariable = 42
+      fingerprint: 5cac1aedf89257ee57d014d2ccc8d328_0
+      old_fingerprint: 5cac1aedf89257ee57d014d2ccc8d328_0
+    - rule:
+        cwe_ids:
+            - "42"
+        id: pattern_variables_test
+        title: Test pattern variable tree sitter node types/fixups
+        description: Test pattern variable tree sitter node types/fixups
+        documentation_url: ""
+      line_number: 4
+      full_filename: main.js
+      filename: main.js
+      source:
+        location:
+            start: 4
+            end: 4
+            column:
+                start: 1
+                end: 32
+      sink:
+        location:
+            start: 4
+            end: 4
+            column:
+                start: 1
+                end: 32
+        content: import x from "matched_package"
+      parent_line_number: 4
+      snippet: import x from "matched_package"
+      fingerprint: 5cac1aedf89257ee57d014d2ccc8d328_1
+      old_fingerprint: 5cac1aedf89257ee57d014d2ccc8d328_1
+

--- a/new/detector/composition/javascript/javascript_test.go
+++ b/new/detector/composition/javascript/javascript_test.go
@@ -19,6 +19,9 @@ var datatypeRule []byte
 //go:embed testdata/deconstructing.yml
 var deconstructingRule []byte
 
+//go:embed testdata/pattern_variables_rule.yml
+var patternVariablesRule []byte
+
 //go:embed testdata/scope_rule.yml
 var scopeRule []byte
 
@@ -36,6 +39,10 @@ func TestImport(t *testing.T) {
 
 func TestString(t *testing.T) {
 	testhelper.GetRunner(t, insecureURLRule, "Javascript").RunTest(t, "./testdata/testcases/string", ".snapshots/string/")
+}
+
+func TestPatternVariables(t *testing.T) {
+	testhelper.GetRunner(t, patternVariablesRule, "Javascript").RunTest(t, "./testdata/pattern_variables", ".snapshots/")
 }
 
 func TestScope(t *testing.T) {

--- a/new/detector/composition/javascript/testdata/pattern_variables/main.js
+++ b/new/detector/composition/javascript/testdata/pattern_variables/main.js
@@ -1,0 +1,5 @@
+const matchedVariable = 42
+const ignored = 42
+
+import x from "matched_package"
+import x from "ignored"

--- a/new/detector/composition/javascript/testdata/pattern_variables_rule.yml
+++ b/new/detector/composition/javascript/testdata/pattern_variables_rule.yml
@@ -1,0 +1,20 @@
+languages:
+  - javascript
+patterns:
+  - pattern: const $<NAME> = $<_>
+    filters:
+      - variable: NAME
+        values:
+          - matchedVariable
+  - pattern: |
+      import x from $<NAME>
+    filters:
+      - variable: NAME
+        string_regex: \Amatched_package\z
+severity: high
+metadata:
+  description: Test pattern variable tree sitter node types/fixups
+  remediation_message: Test pattern variable tree sitter node types/fixups
+  cwe_id:
+    - 42
+  id: pattern_variables_test

--- a/new/detector/composition/ruby/.snapshots/TestPatternVariables--main.yml
+++ b/new/detector/composition/ruby/.snapshots/TestPatternVariables--main.yml
@@ -68,31 +68,31 @@ high:
         title: Test pattern variable tree sitter node types/fixups
         description: Test pattern variable tree sitter node types/fixups
         documentation_url: ""
-      line_number: 8
+      line_number: 7
       full_filename: main.rb
       filename: main.rb
       source:
         location:
-            start: 8
-            end: 10
+            start: 7
+            end: 9
             column:
                 start: 1
                 end: 4
       sink:
         location:
-            start: 8
-            end: 10
+            start: 7
+            end: 9
             column:
                 start: 1
                 end: 4
         content: |-
             class MatchedClass
-              something :foo
+              validates :password, length: { minimum: 2 }
             end
-      parent_line_number: 8
+      parent_line_number: 7
       snippet: |-
         class MatchedClass
-          something :foo
+          validates :password, length: { minimum: 2 }
         end
       fingerprint: 514e95a40b868d7341016d3fa344513d_2
       old_fingerprint: 514e95a40b868d7341016d3fa344513d_2

--- a/new/detector/composition/ruby/.snapshots/TestPatternVariables--main.yml
+++ b/new/detector/composition/ruby/.snapshots/TestPatternVariables--main.yml
@@ -1,0 +1,99 @@
+high:
+    - rule:
+        cwe_ids:
+            - "42"
+        id: pattern_fixup_test
+        title: Test pattern variable tree sitter node types/fixups
+        description: Test pattern variable tree sitter node types/fixups
+        documentation_url: ""
+      line_number: 1
+      full_filename: main.rb
+      filename: main.rb
+      source:
+        location:
+            start: 1
+            end: 1
+            column:
+                start: 1
+                end: 22
+      sink:
+        location:
+            start: 1
+            end: 1
+            column:
+                start: 1
+                end: 22
+        content: matched_variable = 42
+      parent_line_number: 1
+      snippet: matched_variable = 42
+      fingerprint: 514e95a40b868d7341016d3fa344513d_0
+      old_fingerprint: 514e95a40b868d7341016d3fa344513d_0
+    - rule:
+        cwe_ids:
+            - "42"
+        id: pattern_fixup_test
+        title: Test pattern variable tree sitter node types/fixups
+        description: Test pattern variable tree sitter node types/fixups
+        documentation_url: ""
+      line_number: 4
+      full_filename: main.rb
+      filename: main.rb
+      source:
+        location:
+            start: 4
+            end: 5
+            column:
+                start: 1
+                end: 4
+      sink:
+        location:
+            start: 4
+            end: 5
+            column:
+                start: 1
+                end: 4
+        content: |-
+            class MatchedClass
+            end
+      parent_line_number: 4
+      snippet: |-
+        class MatchedClass
+        end
+      fingerprint: 514e95a40b868d7341016d3fa344513d_1
+      old_fingerprint: 514e95a40b868d7341016d3fa344513d_1
+    - rule:
+        cwe_ids:
+            - "42"
+        id: pattern_fixup_test
+        title: Test pattern variable tree sitter node types/fixups
+        description: Test pattern variable tree sitter node types/fixups
+        documentation_url: ""
+      line_number: 8
+      full_filename: main.rb
+      filename: main.rb
+      source:
+        location:
+            start: 8
+            end: 10
+            column:
+                start: 1
+                end: 4
+      sink:
+        location:
+            start: 8
+            end: 10
+            column:
+                start: 1
+                end: 4
+        content: |-
+            class MatchedClass
+              something :foo
+            end
+      parent_line_number: 8
+      snippet: |-
+        class MatchedClass
+          something :foo
+        end
+      fingerprint: 514e95a40b868d7341016d3fa344513d_2
+      old_fingerprint: 514e95a40b868d7341016d3fa344513d_2
+

--- a/new/detector/composition/ruby/ruby_test.go
+++ b/new/detector/composition/ruby/ruby_test.go
@@ -10,11 +10,18 @@ import (
 //go:embed testdata/rule.yml
 var loggerRule []byte
 
+//go:embed testdata/pattern_variables_rule.yml
+var patternVariablesRule []byte
+
 //go:embed testdata/scope_rule.yml
 var scopeRule []byte
 
 func TestRuby(t *testing.T) {
 	testhelper.GetRunner(t, loggerRule, "Ruby").RunTest(t, "./testdata/testcases", ".snapshots/")
+}
+
+func TestPatternVariables(t *testing.T) {
+	testhelper.GetRunner(t, patternVariablesRule, "Ruby").RunTest(t, "./testdata/pattern_variables", ".snapshots/")
 }
 
 func TestScope(t *testing.T) {

--- a/new/detector/composition/ruby/testdata/pattern_variables/main.rb
+++ b/new/detector/composition/ruby/testdata/pattern_variables/main.rb
@@ -1,0 +1,13 @@
+matched_variable = 42
+ignored = 42
+
+class MatchedClass
+end
+
+# the error parsing is different between classes with bodies and without
+class MatchedClass
+  something :foo
+end
+
+class IgnoredClass
+end

--- a/new/detector/composition/ruby/testdata/pattern_variables/main.rb
+++ b/new/detector/composition/ruby/testdata/pattern_variables/main.rb
@@ -4,10 +4,13 @@ ignored = 42
 class MatchedClass
 end
 
-# the error parsing is different between classes with bodies and without
 class MatchedClass
-  something :foo
+  validates :password, length: { minimum: 2 }
 end
 
 class IgnoredClass
+end
+
+class IgnoredClass
+  validates :password, length: { minimum: 2 }
 end

--- a/new/detector/composition/ruby/testdata/pattern_variables_rule.yml
+++ b/new/detector/composition/ruby/testdata/pattern_variables_rule.yml
@@ -13,6 +13,15 @@ patterns:
       - variable: NAME
         values:
           - MatchedClass
+  # the error parsing is different between classes with bodies and without
+  - pattern: |
+      class $<NAME>
+        validates :password, length: { minimum: $<_> }
+      end
+    filters:
+      - variable: NAME
+        values:
+          - MatchedClass
 severity: high
 metadata:
   description: Test pattern variable tree sitter node types/fixups

--- a/new/detector/composition/ruby/testdata/pattern_variables_rule.yml
+++ b/new/detector/composition/ruby/testdata/pattern_variables_rule.yml
@@ -1,0 +1,22 @@
+languages:
+  - ruby
+patterns:
+  - pattern: $<NAME> = $<_>
+    filters:
+      - variable: NAME
+        values:
+          - matched_variable
+  - pattern: |
+      class $<NAME>
+      end
+    filters:
+      - variable: NAME
+        values:
+          - MatchedClass
+severity: high
+metadata:
+  description: Test pattern variable tree sitter node types/fixups
+  remediation_message: Test pattern variable tree sitter node types/fixups
+  cwe_id:
+    - 42
+  id: pattern_fixup_test

--- a/new/detector/composition/testhelper/testhelper.go
+++ b/new/detector/composition/testhelper/testhelper.go
@@ -18,6 +18,7 @@ import (
 	util "github.com/bearer/bearer/pkg/util/output"
 	"github.com/bradleyjkemp/cupaloy"
 	"github.com/hhatto/gocloc"
+	"github.com/rs/zerolog"
 	"gopkg.in/yaml.v3"
 )
 
@@ -27,6 +28,8 @@ type Runner struct {
 }
 
 func GetRunner(t *testing.T, ruleBytes []byte, lang string) *Runner {
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+
 	err := commands.ScanFlags.BindForConfigInit(commands.NewScanCommand())
 	if err != nil {
 		t.Fatalf("failed to bind flags: %s", err)

--- a/new/language/implementation/implementation.go
+++ b/new/language/implementation/implementation.go
@@ -109,7 +109,7 @@ type Implementation interface {
 	// we want to ignore member_expressions as roots.
 	IsRootOfRuleQuery(node *tree.Node) bool
 	PatternLeafContentTypes() []string
-	FixupPatternVariableDummyValue(node *tree.Node, dummyValue string) string
+	FixupPatternVariableDummyValue(input []byte, node *tree.Node, dummyValue string) string
 	// ShouldSkipNode returns wether a node should should be skipped or assigned variable to it
 	// it is useful for cases when you have nested nodes to ignore and want to assign variable to its child
 	//

--- a/new/language/implementation/implementation.go
+++ b/new/language/implementation/implementation.go
@@ -109,6 +109,7 @@ type Implementation interface {
 	// we want to ignore member_expressions as roots.
 	IsRootOfRuleQuery(node *tree.Node) bool
 	PatternLeafContentTypes() []string
+	FixupPatternVariableDummyValue(node *tree.Node, dummyValue string) string
 	// ShouldSkipNode returns wether a node should should be skipped or assigned variable to it
 	// it is useful for cases when you have nested nodes to ignore and want to assign variable to its child
 	//

--- a/new/language/implementation/java/java.go
+++ b/new/language/implementation/java/java.go
@@ -345,3 +345,7 @@ func (*javaImplementation) ContributesToResult(node *tree.Node) bool {
 
 	return true
 }
+
+func (*javaImplementation) FixupPatternVariableDummyValue(node *tree.Node, dummyValue string) string {
+	return dummyValue
+}

--- a/new/language/implementation/java/java.go
+++ b/new/language/implementation/java/java.go
@@ -346,6 +346,6 @@ func (*javaImplementation) ContributesToResult(node *tree.Node) bool {
 	return true
 }
 
-func (*javaImplementation) FixupPatternVariableDummyValue(node *tree.Node, dummyValue string) string {
+func (*javaImplementation) FixupPatternVariableDummyValue(input []byte, node *tree.Node, dummyValue string) string {
 	return dummyValue
 }

--- a/new/language/implementation/javascript/javascript.go
+++ b/new/language/implementation/javascript/javascript.go
@@ -362,3 +362,16 @@ func isImportedIdentifier(node *tree.Node) bool {
 
 	return false
 }
+
+func (*javascriptImplementation) FixupPatternVariableDummyValue(node *tree.Node, dummyValue string) string {
+	parent := node.Parent()
+	if parent == nil {
+		return dummyValue
+	}
+
+	if parent.NamedChild(0).Type() == "import_clause" {
+		return "\"" + dummyValue + "\""
+	}
+
+	return dummyValue
+}

--- a/new/language/implementation/javascript/javascript.go
+++ b/new/language/implementation/javascript/javascript.go
@@ -363,7 +363,7 @@ func isImportedIdentifier(node *tree.Node) bool {
 	return false
 }
 
-func (*javascriptImplementation) FixupPatternVariableDummyValue(node *tree.Node, dummyValue string) string {
+func (*javascriptImplementation) FixupPatternVariableDummyValue(input []byte, node *tree.Node, dummyValue string) string {
 	parent := node.Parent()
 	if parent == nil {
 		return dummyValue

--- a/new/language/patternquery/builder/builder.go
+++ b/new/language/patternquery/builder/builder.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bearer/bearer/new/language/tree"
 	languagetypes "github.com/bearer/bearer/new/language/types"
 	"github.com/bearer/bearer/pkg/parser/nodeid"
+	"github.com/rs/zerolog/log"
 )
 
 type InputParams struct {
@@ -119,6 +120,7 @@ func fixupInput(
 	insideError := false
 	inputOffset := 0
 
+	byteInput := []byte(input)
 	newInput := []byte(input)
 	fixed := false
 
@@ -141,7 +143,21 @@ func fixupInput(
 			return nil
 		}
 
-		newValue := langImplementation.FixupPatternVariableDummyValue(node, variable.DummyValue)
+		if log.Trace().Enabled() {
+			var parentDebug, grandparentDebug string
+			if parent := node.Parent(); parent != nil {
+				parentDebug = parent.Debug(true)
+				if grandparent := parent.Parent(); grandparent != nil {
+					grandparentDebug = grandparent.Debug(true)
+				}
+			}
+
+			log.Trace().Msgf("attempting pattern fixup. node: %s", node.Debug(true))
+			log.Trace().Msgf("fixup parent: %s", parentDebug)
+			log.Trace().Msgf("fixup grandparent: %s", grandparentDebug)
+		}
+
+		newValue := langImplementation.FixupPatternVariableDummyValue(byteInput, node, variable.DummyValue)
 		if newValue == variable.DummyValue {
 			return nil
 		}

--- a/new/language/patternquery/builder/builder.go
+++ b/new/language/patternquery/builder/builder.go
@@ -56,6 +56,19 @@ func Build(
 	}
 	defer tree.Close()
 
+	if fixedInput, fixed := fixupInput(
+		langImplementation,
+		processedInput,
+		inputParams.Variables,
+		tree.RootNode(),
+	); fixed {
+		tree.Close()
+		tree, err = lang.Parse(context.TODO(), fixedInput)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	root := tree.RootNode()
 
 	if root.ChildCount() != 1 {
@@ -95,6 +108,67 @@ func Build(
 	}
 
 	return result, nil
+}
+
+func fixupInput(
+	langImplementation implementation.Implementation,
+	input string,
+	variables []types.Variable,
+	rootNode *tree.Node,
+) (string, bool) {
+	insideError := false
+	inputOffset := 0
+
+	newInput := []byte(input)
+	fixed := false
+
+	err := rootNode.Walk(func(node *tree.Node, visitChildren func() error) error {
+		oldInsideError := insideError
+		if node.Type() == "ERROR" {
+			insideError = true
+		}
+		if err := visitChildren(); err != nil {
+			return err
+		}
+		insideError = oldInsideError
+
+		if !insideError {
+			return nil
+		}
+
+		variable := getVariableFor(node, langImplementation, variables)
+		if variable == nil {
+			return nil
+		}
+
+		newValue := langImplementation.FixupPatternVariableDummyValue(node, variable.DummyValue)
+		if newValue == variable.DummyValue {
+			return nil
+		}
+
+		fixed = true
+		valueOffset := len(newValue) - len(variable.DummyValue)
+		variable.DummyValue = newValue
+
+		newInput = append(
+			append(
+				newInput[:node.StartByte()+inputOffset],
+				newValue...,
+			),
+			newInput[node.EndByte()+inputOffset:]...,
+		)
+
+		inputOffset += valueOffset
+
+		return nil
+	})
+
+	// walk errors are only ones we produce, and we don't make any
+	if err != nil {
+		panic(err)
+	}
+
+	return string(newInput), fixed
 }
 
 func (builder *builder) build(rootNode *tree.Node) (*Result, error) {
@@ -280,13 +354,21 @@ func (builder *builder) processVariableToParams() (map[string]string, [][]string
 }
 
 func (builder *builder) getVariableFor(node *tree.Node) *types.Variable {
-	for _, variable := range builder.inputParams.Variables {
-		if builder.langImplementation.ShouldSkipNode(node) {
+	return getVariableFor(node, builder.langImplementation, builder.inputParams.Variables)
+}
+
+func getVariableFor(
+	node *tree.Node,
+	langImplementation implementation.Implementation,
+	variables []types.Variable,
+) *types.Variable {
+	for i, variable := range variables {
+		if langImplementation.ShouldSkipNode(node) {
 			continue
 		}
 
-		if node.ChildCount() == 0 && node.Content() == variable.DummyValue {
-			return &variable
+		if (node.NamedChildCount() == 0 || langImplementation.IsMatchLeaf(node)) && node.Content() == variable.DummyValue {
+			return &variables[i]
 		}
 	}
 


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Adds support for variables in place of package names in Javascript imports. eg. `import x from $<VARIABLE>`.

This is currently not supported because we always generate a dummy identifier for a variable (eg. `curioVar1`) but the grammar requires a string (eg. `"curioVar1"`).

To cope with this, we introduce a mechanism for fixing up patterns. Firstly the pattern is parsed with the default variable behaviour, then we look for `ERROR` nodes and attempt to fixup the variables. Afterwards, we attempt a parse again.

Support for Ruby classes is also added.

Following this change, node types should no longer need to be specified in rules.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [x] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
