### PR TITLE
fix: check node type for root variable patterns

### DIFF
--- a/new/language/patternquery/builder/builder.go
+++ b/new/language/patternquery/builder/builder.go
@@ -23,11 +23,11 @@ type InputParams struct {
 }
 
 type Result struct {
-	Query              string
-	ParamToVariable    map[string]string
-	EqualParams        [][]string
-	ParamToContent     map[string]map[string]string
-	SingleVariableName string
+	Query           string
+	ParamToVariable map[string]string
+	EqualParams     [][]string
+	ParamToContent  map[string]map[string]string
+	RootVariable    *types.Variable
 }
 
 type builder struct {
@@ -191,7 +191,7 @@ func (builder *builder) build(rootNode *tree.Node) (*Result, error) {
 	if rootNode.ChildCount() == 0 {
 		variable := builder.getVariableFor(rootNode)
 		if variable != nil {
-			return &Result{SingleVariableName: variable.Name}, nil
+			return &Result{RootVariable: variable}, nil
 		}
 	}
 

--- a/new/language/patternquery/types/types.go
+++ b/new/language/patternquery/types/types.go
@@ -1,7 +1,18 @@
 package types
 
+import (
+	"github.com/bearer/bearer/new/language/tree"
+	languagetypes "github.com/bearer/bearer/new/language/types"
+)
+
 type Variable struct {
 	NodeTypes  []string
 	DummyValue string
 	Name       string
+}
+
+type PatternQuery interface {
+	MatchAt(node *tree.Node) ([]*languagetypes.PatternQueryResult, error)
+	MatchOnceAt(node *tree.Node) (*languagetypes.PatternQueryResult, error)
+	Close()
 }


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Check the node type for the special case of a single (root) variable pattern. 

https://github.com/Bearer/bearer/pull/1075 added an optimisation that avoids creating a tree sitter query in this case, but we were no longer checking the node type matches.

Also refactors the root variable query into a separate object, to make it easier to follow.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
