### PR TITLE
docs: update nav format

### DIFF
--- a/docs/_data/nav.js
+++ b/docs/_data/nav.js
@@ -1,10 +1,12 @@
 module.exports = [
   {
     name: "Get Started",
+    open: true,
     items: [{ name: "Quick Start", url: "/quickstart/" }],
   },
   {
     name: "Guides",
+    open: true,
     items: [
       { name: "Configure the scan", url: "/guides/configure-scan/" },
       {
@@ -32,6 +34,7 @@ module.exports = [
   },
   {
     name: "Explanations",
+    open: true,
     items: [
       {
         name: "How Bearer CLI works",
@@ -57,6 +60,7 @@ module.exports = [
   },
   {
     name: "Reference",
+    open: false,
     items: [
       { name: "Installation", url: "/reference/installation/" },
       { name: "Configuration", url: "/reference/config/" },
@@ -69,6 +73,7 @@ module.exports = [
   },
   {
     name: "Contributing",
+    open: false,
     items: [
       { name: "Overview", url: "/contributing/" },
       { name: "Contribute code", url: "/contributing/code/" },

--- a/docs/_src/_includes/layouts/doc.njk
+++ b/docs/_src/_includes/layouts/doc.njk
@@ -3,18 +3,21 @@ layout: layouts/base.njk
 ---
 {% set currentUrl = page.url %}
 <main class="wrap mx-auto flex flex-col sm:grid grid-cols-5 text-black dark:text-neutral-100 px-8 relative gap-4 pt-4">
-	<nav class="hidden self-stretch top-heading-offset sm:revert sm:self-start sticky  col-span-1  bg-white dark:bg-neutral-600 z-10 pb-4 text-sm lg:text-base" id="doc-nav" >
+	<nav class="hidden self-stretch overflow-y-scroll max-h-[85vh] top-heading-offset sm:revert sm:self-start sticky  col-span-1  bg-white dark:bg-neutral-600 z-10 pb-4 text-sm lg:text-base" id="doc-nav" >
 		<ul>
 			{% for heading in nav %}
 				<li class="mb-4">
-					<h2 class="font-bold text-md">{{heading.name}}</h2>
-					<ul class="ml-2">
-						{% for item in heading.items %}
-							<li>
-								<a class="hover:underline block" {% if navHighlight(item.url, page.url) %}aria-current="page" {% endif %} href="{{item.url}}">{{item.name}}</a>
-							</li>
-						{% endfor %}
-					</ul>
+					<details {{"open" if heading.open }} >
+						<summary class="font-bold text-md cursor-pointer leading-8 flex items-center">{{heading.name}}
+							<span class="transition-transform -rotate-90">{%include 'icon-chevron.njk' %}</span></summary>
+						<ul class="ml-2">
+							{% for item in heading.items %}
+								<li>
+									<a class="hover:underline block" {% if navHighlight(item.url, page.url) %}aria-current="page" {% endif %} href="{{item.url}}">{{item.name}}</a>
+								</li>
+							{% endfor %}
+						</ul>
+					</details>
 				</li>
 			{% endfor %}
 		</ul>

--- a/docs/_src/styles/tailwind.css
+++ b/docs/_src/styles/tailwind.css
@@ -109,6 +109,12 @@
   [aria-current="page"] {
     @apply text-main dark:text-main-300 font-semibold;
   }
+  details summary::-webkit-details-marker {
+    display: none;
+  }
+  details[open] span {
+    @apply rotate-0;
+  }
 
   .start-self {
     align-self: start;


### PR DESCRIPTION
## Description
Updates the styling of the side-nav to handle the growing number of pages. Switches to toggle sections, with the first three sections defaulting to open.
<img width="429" alt="CleanShot 2023-06-26 at 22 13 56@2x" src="https://github.com/Bearer/bearer/assets/1649672/7ce0ac89-9612-4e16-b93e-bc5951de7ed8">



## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
