### PR TITLE
fix(java): allow variable lookup in ternary

### DIFF
--- a/new/language/implementation/java/java.go
+++ b/new/language/implementation/java/java.go
@@ -20,11 +20,12 @@ import (
 
 var (
 	variableLookupParents = []string{
-		"field_declaration",
 		"argument_list",
-		"binary_expression",
 		"array_access",
 		"array_initializer",
+		"binary_expression",
+		"field_declaration",
+		"ternary_expression",
 	}
 
 	anonymousPatternNodeParentTypes = []string{}


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Allow variable lookups in ternary expressions in Java.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
