### PR TITLE
fix(java): counting of rules in security report

### DIFF
--- a/pkg/commands/process/settings/settings.go
+++ b/pkg/commands/process/settings/settings.go
@@ -255,6 +255,8 @@ func (rule *Rule) Language() string {
 	}
 
 	switch rule.Languages[0] {
+	case "java":
+		return "Java"
 	case "javascript":
 		return "JavaScript"
 	case "ruby":


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Fixes an issue where Java rules were not counted. 

In some situations this resulted in a "Zero rules found" message with no findings, despite their being findings to report.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
