### PR TITLE
feat: add more helpful rule validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -99,6 +99,7 @@ require (
 	github.com/sirupsen/logrus v1.9.2 // indirect
 	github.com/skeema/knownhosts v1.1.1 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
+	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	go.opentelemetry.io/otel v1.14.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.14.0 // indirect
 	go.opentelemetry.io/otel/trace v1.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -385,10 +385,13 @@ github.com/weppos/publicsuffix-go v0.30.0/go.mod h1:kBi8zwYnR0zrbm8RcuN1o9Fzgpnn
 github.com/weppos/publicsuffix-go/publicsuffix/generator v0.0.0-20220927085643-dc0d00c92642/go.mod h1:GHfoeIdZLdZmLjMlzBftbTDntahTttUMWjxZwQJhULE=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
+github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
+github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/yashtewari/glob-intersection v0.1.0 h1:6gJvMYQlTDOL3dMsPF6J0+26vwX9MB8/1q3uAdhmTrg=
 github.com/yashtewari/glob-intersection v0.1.0/go.mod h1:LK7pIC3piUjovexikBbJ26Yml7g8xa5bsjfx2v1fwok=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/commands/process/settings/ruleValidator.go
+++ b/pkg/commands/process/settings/ruleValidator.go
@@ -1,0 +1,68 @@
+package settings
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/ghodss/yaml"
+	"github.com/xeipuuv/gojsonschema"
+)
+
+const SCHEMA_URL = "https://raw.githubusercontent.com/Bearer/bearer-rules/main/scripts/rule_schema.json"
+
+func ValidateRule(entry []byte, filename string) string {
+	validationStr := &strings.Builder{}
+	validationStr.WriteString(fmt.Sprintf("Failed to load %s\nValidating against %s\n\n", filename, SCHEMA_URL))
+	schema, err := loadSchema(SCHEMA_URL)
+	if err != nil {
+		validationStr.WriteString("Could not load schema to validate")
+		return validationStr.String()
+	}
+
+	jsonData, err := yaml.YAMLToJSON(entry)
+	if err != nil {
+		validationStr.WriteString("File fdormat is invalid")
+		return validationStr.String()
+	}
+
+	result, err := validateData(jsonData, schema)
+	if err != nil {
+		validationStr.WriteString("Could not apply validation")
+		return validationStr.String()
+	}
+
+	if result.Valid() {
+		validationStr.WriteString("Format of appears valid but could not be loaded")
+	} else {
+		validationStr.WriteString(fmt.Sprintf("%s validation issues found:\n", filename))
+		for _, desc := range result.Errors() {
+			validationStr.WriteString(fmt.Sprintf("- %s\n", desc))
+		}
+		fmt.Print("\n")
+	}
+	return validationStr.String()
+}
+
+func loadSchema(url string) (*gojsonschema.Schema, error) {
+	response, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	var buf bytes.Buffer
+	_, err = buf.ReadFrom(response.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	loader := gojsonschema.NewStringLoader(buf.String())
+	return gojsonschema.NewSchema(loader)
+}
+
+func validateData(data []byte, schema *gojsonschema.Schema) (*gojsonschema.Result, error) {
+	loader := gojsonschema.NewStringLoader(string(data))
+	return schema.Validate(loader)
+}

--- a/pkg/commands/process/settings/rules.go
+++ b/pkg/commands/process/settings/rules.go
@@ -126,7 +126,7 @@ func loadRules(
 		}
 		log.Debug().Msgf("loading external rules from: %s", dir)
 		if err := loadRuleDefinitionsFromDir(definitions, os.DirFS(dir)); err != nil {
-			return result, fmt.Errorf("error loading external rules from %s: %w", dir, err)
+			return result, fmt.Errorf("external rules %w", err)
 		}
 	}
 
@@ -145,7 +145,6 @@ func loadRules(
 
 func loadRuleDefinitionsFromDir(definitions map[string]RuleDefinition, dir fs.FS) error {
 	loadedDefinitions := make(map[string]RuleDefinition)
-
 	if err := fs.WalkDir(dir, ".", func(path string, dirEntry fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -170,7 +169,8 @@ func loadRuleDefinitionsFromDir(definitions map[string]RuleDefinition, dir fs.FS
 		var ruleDefinition RuleDefinition
 		err = yaml.Unmarshal(entry, &ruleDefinition)
 		if err != nil {
-			return fmt.Errorf("failed to unmarshal rule %s: %w", path, err)
+			output.StdErrLog(ValidateRule(entry, filename))
+			return fmt.Errorf("rule file was invalid")
 		}
 
 		if ruleDefinition.Metadata == nil {


### PR DESCRIPTION
## Description
Currently when creating a rule if the rule is invlaid the feedback is very poor. Here is an example with a very old version of `airbrake.yml:`:
```
Loading rules
Error: error loading external rules from /Users/phil/bearer-rule2: failed to unmarshal rule airbrake.yml: yaml: unmarshal errors:
  line 52: cannot unmarshal !!str `local` into settings.RuleDefinitionTrigger
  line 54: cannot unmarshal !!map into string
```
With this change we get the following:
```
Loading rules

Failed to load airbrake.yml
Validating against https://raw.githubusercontent.com/Bearer/bearer-rules/main/scripts/rule_schema.json

airbrake.yml validation issues found:
- (root): Must validate "else" as "if" was not valid
- metadata: documentation_url is required
- metadata: Additional property dsr_id is not allowed
- trigger: Invalid type. Expected: object, given: string
- severity: Invalid type. Expected: string, given: object

Error: external rules rule file was invalid
```

## Related
closes #429

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
