### PR TITLE
fix: improve memory usage

### DIFF
--- a/new/detector/composition/composition.go
+++ b/new/detector/composition/composition.go
@@ -3,8 +3,6 @@ package composition
 import (
 	"strings"
 
-	"github.com/gertd/go-pluralize"
-
 	"github.com/bearer/bearer/new/detector/detection"
 	"github.com/bearer/bearer/new/detector/implementation/custom"
 	"github.com/bearer/bearer/new/detector/implementation/generic/datatype"
@@ -13,11 +11,10 @@ import (
 	"github.com/bearer/bearer/pkg/report/schema"
 	"github.com/bearer/bearer/pkg/report/source"
 	"github.com/bearer/bearer/pkg/util/file"
+	"github.com/bearer/bearer/pkg/util/pluralize"
 )
 
 func ReportDetections(report reportdetections.ReportDetection, file *file.FileInfo, detections []*detection.Detection) {
-	pluralizer := pluralize.NewClient()
-
 	for _, detection := range detections {
 		detectorType := detectors.Type(detection.DetectorType)
 		data := detection.Data.(custom.Data)
@@ -46,7 +43,6 @@ func ReportDetections(report reportdetections.ReportDetection, file *file.FileIn
 		for _, datatypeDetection := range data.Datatypes {
 			reportDatatypeDetection(
 				report,
-				pluralizer,
 				file,
 				detectorType,
 				detection,
@@ -59,7 +55,6 @@ func ReportDetections(report reportdetections.ReportDetection, file *file.FileIn
 
 func reportDatatypeDetection(
 	report reportdetections.ReportDetection,
-	pluralizer *pluralize.Client,
 	file *file.FileInfo,
 	detectorType detectors.Type,
 	detection,
@@ -83,9 +78,9 @@ func reportDatatypeDetection(
 			),
 			schema.Schema{
 				ObjectName:           objectName,
-				NormalizedObjectName: pluralizer.Singular(strings.ToLower(objectName)),
+				NormalizedObjectName: pluralize.Singular(strings.ToLower(objectName)),
 				FieldName:            property.Name,
-				NormalizedFieldName:  pluralizer.Singular(strings.ToLower(property.Name)),
+				NormalizedFieldName:  pluralize.Singular(strings.ToLower(property.Name)),
 				Classification:       property.Classification,
 				Source: &schema.Source{
 					StartLineNumber:   detection.MatchNode.StartLineNumber(),
@@ -100,7 +95,6 @@ func reportDatatypeDetection(
 		if property.Datatype != nil {
 			reportDatatypeDetection(
 				report,
-				pluralizer,
 				file,
 				detectorType,
 				detection,

--- a/pkg/commands/debugprofile/debugprofile.go
+++ b/pkg/commands/debugprofile/debugprofile.go
@@ -10,39 +10,55 @@ import (
 	"github.com/bearer/bearer/pkg/flag"
 )
 
-var file *os.File
+var cpuFile *os.File
 
 func Start() {
 	log.Debug().Msgf("starting cpu profiling")
 
-	processID := viper.GetString(flag.WorkerIDFlag.ConfigName)
-	if processID == "" {
-		processID = "main"
-	}
-
 	var err error
-	file, err = os.Create(processID + ".pprof")
+	cpuFile, err = os.Create(getProcessID() + "-cpu.pprof")
 	if err != nil {
-		log.Err(err).Msg("failed to create profiling file")
+		log.Err(err).Msg("failed to create cpu profiling file")
 		return
 	}
 
-	if err := pprof.StartCPUProfile(file); err != nil {
+	if err := pprof.StartCPUProfile(cpuFile); err != nil {
 		log.Err(err).Msg("failed to start cpu profile")
-		file.Close()
-		file = nil
+		cpuFile.Close()
+		cpuFile = nil
 		return
 	}
 }
 
 func Stop() {
-	if file == nil {
+	if cpuFile == nil {
 		return
 	}
 
 	log.Debug().Msg("stopping cpu profiling")
 	pprof.StopCPUProfile()
-	file.Close()
+	cpuFile.Close()
+	cpuFile = nil
 
-	file = nil
+	log.Debug().Msgf("writing memory profile")
+	memFile, err := os.Create(getProcessID() + "-mem.pprof")
+	if err != nil {
+		log.Err(err).Msg("failed to create memory profiling file")
+		return
+	}
+
+	if err = pprof.Lookup("allocs").WriteTo(memFile, 0); err != nil {
+		log.Err(err).Msg("failed to write memory profile")
+	}
+
+	memFile.Close()
+}
+
+func getProcessID() string {
+	processID := viper.GetString(flag.WorkerIDFlag.ConfigName)
+	if processID != "" {
+		return processID
+	}
+
+	return "main"
 }

--- a/pkg/detectors/custom/custom.go
+++ b/pkg/detectors/custom/custom.go
@@ -20,7 +20,6 @@ import (
 	schemadatatype "github.com/bearer/bearer/pkg/report/schema/datatype"
 	"github.com/bearer/bearer/pkg/report/source"
 	"github.com/bearer/bearer/pkg/util/file"
-	pluralize "github.com/gertd/go-pluralize"
 	"golang.org/x/exp/slices"
 
 	"github.com/bearer/bearer/pkg/parser/nodeid"
@@ -39,7 +38,6 @@ type Detector struct {
 	idGenerator        nodeid.Generator
 	paramIdGenerator   nodeid.Generator
 	rulesGroupedByLang map[string][]config.CompiledRule
-	pluralize          *pluralize.Client
 
 	Sql language.Detector
 }
@@ -51,7 +49,6 @@ func New(idGenerator nodeid.Generator) types.Detector {
 	}
 
 	detector.Sql = &sqldetector.Detector{}
-	detector.pluralize = pluralize.NewClient()
 
 	return detector
 }
@@ -366,18 +363,6 @@ func shouldIgnoreCaptures(captures parser.Captures, rule config.CompiledRule) bo
 
 	return false
 }
-
-// func (detector *Detector) applyDatatypeTransformations(rule config.CompiledRule, datatypes map[parser.NodeID]*schemadatatype.DataType) {
-// 	for _, datatype := range datatypes {
-// 		if rule.RootSingularize {
-// 			datatype.Name = detector.pluralize.Singular(datatype.Name)
-// 		}
-
-// 		if rule.RootLowercase {
-// 			datatype.Name = strings.ToLower(datatype.Name)
-// 		}
-// 	}
-// }
 
 func filterCaptures(params []config.Param, captures []parser.Captures) (filtered []parser.Captures, err error) {
 	for _, capture := range captures {

--- a/pkg/detectors/graphql/graphql.go
+++ b/pkg/detectors/graphql/graphql.go
@@ -11,7 +11,7 @@ import (
 	"github.com/bearer/bearer/pkg/report/detectors"
 	"github.com/bearer/bearer/pkg/report/schema"
 	"github.com/bearer/bearer/pkg/util/file"
-	"github.com/gertd/go-pluralize"
+	"github.com/bearer/bearer/pkg/util/pluralize"
 
 	reporttypes "github.com/bearer/bearer/pkg/report"
 )
@@ -81,9 +81,8 @@ func (detector *detector) ExtractFromSchema(
 
 		normalizedObjectName := ""
 		normalizedFieldName := ""
-		pluralizer := pluralize.NewClient()
-		normalizedObjectName = pluralizer.Singular(strings.ToLower(objectName))
-		normalizedFieldName = pluralizer.Singular(strings.ToLower(fieldName))
+		normalizedObjectName = pluralize.Singular(strings.ToLower(objectName))
+		normalizedFieldName = pluralize.Singular(strings.ToLower(fieldName))
 
 		currentSchema := schema.Schema{
 			ObjectName:           objectName,

--- a/pkg/detectors/proto/proto.go
+++ b/pkg/detectors/proto/proto.go
@@ -9,7 +9,7 @@ import (
 	"github.com/bearer/bearer/pkg/report/detectors"
 	"github.com/bearer/bearer/pkg/report/schema"
 	"github.com/bearer/bearer/pkg/util/file"
-	"github.com/gertd/go-pluralize"
+	"github.com/bearer/bearer/pkg/util/pluralize"
 
 	"github.com/bearer/bearer/pkg/parser/nodeid"
 	parserschema "github.com/bearer/bearer/pkg/parser/schema"
@@ -84,9 +84,8 @@ func (detector *detector) ExtractFromSchema(
 
 		normalizedObjectName := ""
 		normalizedFieldName := ""
-		pluralizer := pluralize.NewClient()
-		normalizedObjectName = pluralizer.Singular(strings.ToLower(objectName))
-		normalizedFieldName = pluralizer.Singular(strings.ToLower(fieldName))
+		normalizedObjectName = pluralize.Singular(strings.ToLower(objectName))
+		normalizedFieldName = pluralize.Singular(strings.ToLower(fieldName))
 
 		currentSchema := schema.Schema{
 			ObjectName:           objectName,

--- a/pkg/detectors/rails/schema_rb/schema_rb.go
+++ b/pkg/detectors/rails/schema_rb/schema_rb.go
@@ -12,7 +12,7 @@ import (
 	"github.com/bearer/bearer/pkg/report/detectors"
 	"github.com/bearer/bearer/pkg/report/schema"
 	"github.com/bearer/bearer/pkg/util/file"
-	pluralize "github.com/gertd/go-pluralize"
+	"github.com/bearer/bearer/pkg/util/pluralize"
 )
 
 var (
@@ -65,9 +65,8 @@ func ExtractFromDatabaseSchema(
 
 		normalizedObjectName := ""
 		normalizedFieldName := ""
-		pluralizer := pluralize.NewClient()
-		normalizedObjectName = pluralizer.Singular(strings.ToLower(tableName))
-		normalizedFieldName = pluralizer.Singular(strings.ToLower(columnName))
+		normalizedObjectName = pluralize.Singular(strings.ToLower(tableName))
+		normalizedFieldName = pluralize.Singular(strings.ToLower(columnName))
 
 		currentSchema := schema.Schema{
 			ObjectName:           tableName,

--- a/pkg/report/schema/datatype/datatype.go
+++ b/pkg/report/schema/datatype/datatype.go
@@ -11,7 +11,7 @@ import (
 	"github.com/bearer/bearer/pkg/report/detectors"
 	"github.com/bearer/bearer/pkg/report/schema"
 	"github.com/bearer/bearer/pkg/util/normalize_key"
-	pluralize "github.com/gertd/go-pluralize"
+	"github.com/bearer/bearer/pkg/util/pluralize"
 )
 
 type ReportDataType interface {
@@ -216,9 +216,8 @@ func dataTypeToSchema[D DataTypable](report detections.ReportDetection, detectio
 		}
 		normalizedObjectName := ""
 		normalizedFieldName := ""
-		pluralizer := pluralize.NewClient()
-		normalizedObjectName = pluralizer.Singular(strings.ToLower(parentName))
-		normalizedFieldName = pluralizer.Singular(strings.ToLower(selfName))
+		normalizedObjectName = pluralize.Singular(strings.ToLower(parentName))
+		normalizedFieldName = pluralize.Singular(strings.ToLower(selfName))
 
 		report.AddDetection(
 			detectionType,

--- a/pkg/util/pluralize/pluralize.go
+++ b/pkg/util/pluralize/pluralize.go
@@ -1,0 +1,9 @@
+package pluralize
+
+import "github.com/gertd/go-pluralize"
+
+var pluralizer = pluralize.NewClient()
+
+func Singular(word string) string {
+	return pluralizer.Singular(word)
+}


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Adds Go memory profiling when using `--debug-profile` and makes the following improvements:
- limit detections cache size
- use a single instance of the pluralizer

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
