### PR TITLE
docs: elaborate reviewdog token permissions

### DIFF
--- a/docs/guides/github-action.njk
+++ b/docs/guides/github-action.njk
@@ -158,7 +158,11 @@ jobs:
         run: |
           cat rd.json | reviewdog -f=rdjson -reporter=github-pr-review
 ```
-Remember to set a personal access [token](https://github.com/settings/personal-access-tokens/new) with read and write permissions and save it to your repo secrets as `REVIEWDOG_GITHUB_API_TOKEN` and you should be good to go.
+Remember to set a personal access [token](https://github.com/settings/personal-access-tokens/new) with read and write access to your repository.
+- If you choose a "classic" personal access token, it will need full repo permissions (scope: repo)
+- If you choose a "fine-grained" personal access token, it will need read and write access to pull requests for your repo
+
+Save this token to your repo secrets as `REVIEWDOG_GITHUB_API_TOKEN` and you should be good to go.
 
 ## Integrate with Defect Dojo
 


### PR DESCRIPTION
## Description

Elaborate what permissions are needed for the Reviewdog GitHub API token

![Screenshot 2023-07-18 at 18 07 49](https://github.com/Bearer/bearer/assets/4560746/a40f6e28-ba03-4b83-98ec-b0b69c00cc37)

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
