### PR TITLE
fix: respect gitignore syntax in skip-path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/hhatto/gocloc v0.5.0
 	github.com/jessevdk/go-flags v1.5.0
-	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00
 	github.com/open-policy-agent/opa v0.54.0
 	github.com/rs/zerolog v1.29.1
 	github.com/russross/blackfriday v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -288,8 +288,6 @@ github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2Em
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
-github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 h1:n6/2gBQ3RWajuToeY6ZtZTIKv2v7ThUy5KKusIT0yc0=
-github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00/go.mod h1:Pm3mSP3c5uWn86xMLZ5Sa7JB9GsEZySvHYXCTK4E9q4=
 github.com/muesli/reflow v0.2.1-0.20210115123740-9e1d0d53df68/go.mod h1:Xk+z4oIWdQqJzsxyjgl3P22oYZnHdZ8FFTHAQQt5BMQ=
 github.com/muesli/reflow v0.3.0 h1:IFsN6K9NfGtjeggFP+68I4chLZV2yIKsXJFNZ+eWh6s=
 github.com/muesli/reflow v0.3.0/go.mod h1:pbwTDkVPibjO2kyvBQRBxTWEEGDGq0FlB1BIKtnHY/8=

--- a/pkg/commands/process/orchestrator/fileignore/fileignore.go
+++ b/pkg/commands/process/orchestrator/fileignore/fileignore.go
@@ -1,7 +1,6 @@
 package fileignore
 
 import (
-	"bytes"
 	"fmt"
 	"io/fs"
 	"os"
@@ -9,12 +8,12 @@ import (
 
 	"github.com/bearer/bearer/pkg/commands/process/settings"
 	"github.com/hhatto/gocloc"
-	"github.com/monochromegane/go-gitignore"
 	"github.com/rs/zerolog/log"
+	ignore "github.com/sabhiram/go-gitignore"
 )
 
 type FileIgnore struct {
-	ignorer gitignore.IgnoreMatcher
+	ignorer *ignore.GitIgnore
 
 	config settings.Config
 }
@@ -43,8 +42,8 @@ func (fileignore *FileIgnore) Ignore(projectPath string, filePath string, gocloc
 		return true
 	}
 
-	if fileignore.ignorer.Match(trimmedPath, fileInfo.IsDir()) {
-		log.Error().Msgf("file ignore match err: %s %s", projectPath, relativePath)
+	if fileignore.ignorer.MatchesPath(trimmedPath) {
+		log.Debug().Msgf("file ignore match err: %s %s", projectPath, relativePath)
 		return true
 	}
 
@@ -97,11 +96,6 @@ func isSymlink(path string) (bool, error) {
 	return fileInfo.Mode()&os.ModeSymlink == os.ModeSymlink, nil
 }
 
-func ignorerFromStrings(paths []string) gitignore.IgnoreMatcher {
-	buffer := bytes.NewBuffer([]byte{})
-	for _, path := range paths {
-		buffer.Write([]byte(path + "\n"))
-	}
-
-	return gitignore.NewGitIgnoreFromReader(".", buffer)
+func ignorerFromStrings(paths []string) *ignore.GitIgnore {
+	return ignore.CompileIgnoreLines(paths...)
 }


### PR DESCRIPTION
## Description

We should support full gitignore syntax with the `skip-path` flag. 

Our current library did not support ignoring subdirectories, so the following skip-path pattern would not skip subdirectories e.g. `public/static/temp/1.js`

```
  skip-path: [public]
```

I propose a different library that does not have the limitations of `filepath.Match`. Note: this may carry some performance considerations. 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
