### PR TITLE
feat: show warnings in html summary

### DIFF
--- a/pkg/report/output/html/.snapshots/TestJuiceShopSecurityHtml.html
+++ b/pkg/report/output/html/.snapshots/TestJuiceShopSecurityHtml.html
@@ -7,6 +7,8 @@
     <span class="medium">32</span>
     <span class="badge low low-bg">L</span>
     <span class="low">0</span>
+    <span class="badge warning warning-bg">W</span>
+    <span class="warning">0</span>
 	</div>
 		
 		

--- a/pkg/report/output/html/security.tmpl
+++ b/pkg/report/output/html/security.tmpl
@@ -7,6 +7,8 @@
     <span class="medium">{{.medium | count }}</span>
     <span class="badge low low-bg">L</span>
     <span class="low">{{.low | count }}</span>
+    <span class="badge warning warning-bg">W</span>
+    <span class="warning">{{.warning | count }}</span>
 	</div>
 		{{range $severity, $results := .}}
 		{{range $index, $result := $results}}


### PR DESCRIPTION
## Description
Show warnings in html summary

<img width="451" alt="Screenshot 2023-07-24 at 11 56 41" src="https://github.com/Bearer/bearer/assets/699436/ce2138f4-a1df-4978-84b4-1a4646974751">


## Related
closes #1136

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
