### PR TITLE
perf: use a single tree sitter query per language

### DIFF
--- a/new/detector/composition/java/java.go
+++ b/new/detector/composition/java/java.go
@@ -29,6 +29,7 @@ import (
 	detectortypes "github.com/bearer/bearer/new/detector/types"
 	"github.com/bearer/bearer/new/language/implementation"
 	java "github.com/bearer/bearer/new/language/implementation/java"
+	"github.com/bearer/bearer/new/language/tree"
 	languagetypes "github.com/bearer/bearer/new/language/types"
 )
 
@@ -38,6 +39,7 @@ type Composition struct {
 	detectorSet         detectortypes.DetectorSet
 	langImplementation  implementation.Implementation
 	lang                languagetypes.Language
+	querySet            *tree.QuerySet
 	closers             []func()
 	rules               map[string]*settings.Rule
 }
@@ -51,13 +53,16 @@ func New(
 		return nil, fmt.Errorf("failed to lookup language: %s", err)
 	}
 
+	querySet := lang.NewQuerySet()
+
 	composition := &Composition{
 		langImplementation: java.Get(),
 		lang:               lang,
+		querySet:           querySet,
 	}
 
 	staticDetectors := []struct {
-		constructor func(languagetypes.Language) (detectortypes.Detector, error)
+		constructor func(*tree.QuerySet) (detectortypes.Detector, error)
 		name        string
 	}{
 		{
@@ -98,7 +103,7 @@ func New(
 		creator := detectorCreator
 
 		go func() {
-			detector, err := creator.constructor(lang)
+			detector, err := creator.constructor(querySet)
 			receiver <- types.DetectorInitResult{
 				Error:        err,
 				Detector:     detector,
@@ -137,6 +142,7 @@ func New(
 		go func() {
 			customDetector, err := custom.New(
 				lang,
+				querySet,
 				localRuleName,
 				patterns,
 				javaRules,
@@ -167,13 +173,15 @@ func New(
 	}
 	composition.detectorSet = detectorSet
 
-	return composition, nil
+	return composition, querySet.Compile()
 }
 
 func (composition *Composition) Close() {
 	for _, closeFunc := range composition.closers {
 		closeFunc()
 	}
+
+	composition.querySet.Close()
 }
 
 func (composition *Composition) DetectFromFile(

--- a/new/detector/composition/javascript/javascript.go
+++ b/new/detector/composition/javascript/javascript.go
@@ -29,6 +29,7 @@ import (
 	detectortypes "github.com/bearer/bearer/new/detector/types"
 	"github.com/bearer/bearer/new/language/implementation"
 	"github.com/bearer/bearer/new/language/implementation/javascript"
+	"github.com/bearer/bearer/new/language/tree"
 	languagetypes "github.com/bearer/bearer/new/language/types"
 )
 
@@ -38,6 +39,7 @@ type Composition struct {
 	detectorSet         detectortypes.DetectorSet
 	langImplementation  implementation.Implementation
 	lang                languagetypes.Language
+	querySet            *tree.QuerySet
 	closers             []func()
 	rules               map[string]*settings.Rule
 }
@@ -51,13 +53,16 @@ func New(
 		return nil, fmt.Errorf("failed to lookup language: %s", err)
 	}
 
+	querySet := lang.NewQuerySet()
+
 	composition := &Composition{
 		langImplementation: javascript.Get(),
 		lang:               lang,
+		querySet:           querySet,
 	}
 
 	staticDetectors := []struct {
-		constructor func(languagetypes.Language) (detectortypes.Detector, error)
+		constructor func(*tree.QuerySet) (detectortypes.Detector, error)
 		name        string
 	}{
 		{
@@ -98,7 +103,7 @@ func New(
 		creator := detectorCreator
 
 		go func() {
-			detector, err := creator.constructor(lang)
+			detector, err := creator.constructor(querySet)
 			receiver <- types.DetectorInitResult{
 				Error:        err,
 				Detector:     detector,
@@ -137,6 +142,7 @@ func New(
 		go func() {
 			customDetector, err := custom.New(
 				lang,
+				querySet,
 				localRuleName,
 				patterns,
 				jsRules,
@@ -167,13 +173,15 @@ func New(
 	}
 	composition.detectorSet = detectorSet
 
-	return composition, nil
+	return composition, querySet.Compile()
 }
 
 func (composition *Composition) Close() {
 	for _, closeFunc := range composition.closers {
 		closeFunc()
 	}
+
+	composition.querySet.Close()
 }
 
 func (composition *Composition) DetectFromFile(

--- a/new/detector/implementation/custom/custom.go
+++ b/new/detector/implementation/custom/custom.go
@@ -32,13 +32,14 @@ type customDetector struct {
 
 func New(
 	lang languagetypes.Language,
+	querySet *tree.QuerySet,
 	detectorType string,
 	patterns []settings.RulePattern,
 	rules map[string]*settings.Rule,
 ) (types.Detector, error) {
 	var compiledPatterns []Pattern
 	for _, pattern := range patterns {
-		patternQuery, err := lang.CompilePatternQuery(pattern.Pattern, pattern.Focus)
+		patternQuery, err := lang.CompilePatternQuery(querySet, pattern.Pattern, pattern.Focus)
 		if err != nil {
 			return nil, fmt.Errorf("error compiling pattern: %s", err)
 		}
@@ -104,9 +105,6 @@ func (detector *customDetector) DetectAt(
 }
 
 func (detector *customDetector) Close() {
-	for _, pattern := range detector.patterns {
-		pattern.Query.Close()
-	}
 }
 
 func sortFilters(filters []settings.PatternFilter) {

--- a/new/detector/implementation/generic/insecureurl/insecureurl.go
+++ b/new/detector/implementation/generic/insecureurl/insecureurl.go
@@ -8,7 +8,6 @@ import (
 	"github.com/bearer/bearer/pkg/commands/process/settings"
 
 	generictypes "github.com/bearer/bearer/new/detector/implementation/generic/types"
-	languagetypes "github.com/bearer/bearer/new/language/types"
 )
 
 type insecureURLDetector struct {
@@ -18,7 +17,7 @@ type insecureURLDetector struct {
 var insecureUrlPattern = regexp.MustCompile(`^http:`)
 var localhostInsecureUrlPattern = regexp.MustCompile(`^http://(localhost|127.0.0.1)`)
 
-func New(lang languagetypes.Language) (types.Detector, error) {
+func New(querySet *tree.QuerySet) (types.Detector, error) {
 	return &insecureURLDetector{}, nil
 }
 

--- a/new/detector/implementation/generic/stringliteral/stringliteral.go
+++ b/new/detector/implementation/generic/stringliteral/stringliteral.go
@@ -6,14 +6,13 @@ import (
 	"github.com/bearer/bearer/pkg/commands/process/settings"
 
 	generictypes "github.com/bearer/bearer/new/detector/implementation/generic/types"
-	languagetypes "github.com/bearer/bearer/new/language/types"
 )
 
 type stringLiteralDetector struct {
 	types.DetectorBase
 }
 
-func New(lang languagetypes.Language) (types.Detector, error) {
+func New(querySet *tree.QuerySet) (types.Detector, error) {
 	return &stringLiteralDetector{}, nil
 }
 

--- a/new/detector/implementation/java/string/string.go
+++ b/new/detector/implementation/java/string/string.go
@@ -7,14 +7,13 @@ import (
 
 	"github.com/bearer/bearer/new/detector/implementation/generic"
 	generictypes "github.com/bearer/bearer/new/detector/implementation/generic/types"
-	languagetypes "github.com/bearer/bearer/new/language/types"
 )
 
 type stringDetector struct {
 	types.DetectorBase
 }
 
-func New(lang languagetypes.Language) (types.Detector, error) {
+func New(querySet *tree.QuerySet) (types.Detector, error) {
 	return &stringDetector{}, nil
 }
 

--- a/new/detector/implementation/javascript/string/string.go
+++ b/new/detector/implementation/javascript/string/string.go
@@ -7,14 +7,13 @@ import (
 
 	"github.com/bearer/bearer/new/detector/implementation/generic"
 	generictypes "github.com/bearer/bearer/new/detector/implementation/generic/types"
-	languagetypes "github.com/bearer/bearer/new/language/types"
 )
 
 type stringDetector struct {
 	types.DetectorBase
 }
 
-func New(lang languagetypes.Language) (types.Detector, error) {
+func New(querySet *tree.QuerySet) (types.Detector, error) {
 	return &stringDetector{}, nil
 }
 

--- a/new/detector/implementation/ruby/string/string.go
+++ b/new/detector/implementation/ruby/string/string.go
@@ -6,14 +6,13 @@ import (
 
 	"github.com/bearer/bearer/new/detector/implementation/generic"
 	generictypes "github.com/bearer/bearer/new/detector/implementation/generic/types"
-	languagetypes "github.com/bearer/bearer/new/language/types"
 )
 
 type stringDetector struct {
 	types.DetectorBase
 }
 
-func New(lang languagetypes.Language) (types.Detector, error) {
+func New(querySet *tree.QuerySet) (types.Detector, error) {
 	return &stringDetector{}, nil
 }
 

--- a/new/language/base/base.go
+++ b/new/language/base/base.go
@@ -30,10 +30,10 @@ func (lang *Language) Parse(ctx context.Context, input string) (*tree.Tree, erro
 	return tree, nil
 }
 
-func (lang *Language) CompileQuery(input string) (*tree.Query, error) {
-	return tree.CompileQuery(lang.implementation.SitterLanguage(), input)
+func (lang *Language) NewQuerySet() *tree.QuerySet {
+	return tree.NewQuerySet(lang.implementation.SitterLanguage())
 }
 
-func (lang *Language) CompilePatternQuery(input, focusedVariable string) (types.PatternQuery, error) {
-	return patternquery.Compile(lang, lang.implementation, input, focusedVariable)
+func (lang *Language) CompilePatternQuery(querySet *tree.QuerySet, input, focusedVariable string) (types.PatternQuery, error) {
+	return patternquery.Compile(lang, lang.implementation, querySet, input, focusedVariable)
 }

--- a/new/language/implementation/implementation.go
+++ b/new/language/implementation/implementation.go
@@ -10,6 +10,7 @@ import (
 )
 
 type Implementation interface {
+	Name() string
 	SitterLanguage() *sitter.Language
 	// AnalyzeFlow unifies nodes that represent the same value in the tree.
 	//

--- a/new/language/implementation/java/java.go
+++ b/new/language/implementation/java/java.go
@@ -52,6 +52,10 @@ func Get() implementation.Implementation {
 	return &javaImplementation{}
 }
 
+func (*javaImplementation) Name() string {
+	return "java"
+}
+
 func (implementation *javaImplementation) SitterLanguage() *sitter.Language {
 	return java.GetLanguage()
 }

--- a/new/language/implementation/javascript/javascript.go
+++ b/new/language/implementation/javascript/javascript.go
@@ -51,6 +51,10 @@ func Get() implementation.Implementation {
 	return &javascriptImplementation{}
 }
 
+func (*javascriptImplementation) Name() string {
+	return "javascript"
+}
+
 func (implementation *javascriptImplementation) SitterLanguage() *sitter.Language {
 	return tsx.GetLanguage()
 }

--- a/new/language/implementation/ruby/ruby.go
+++ b/new/language/implementation/ruby/ruby.go
@@ -45,6 +45,10 @@ func Get() implementation.Implementation {
 	return &rubyImplementation{}
 }
 
+func (*rubyImplementation) Name() string {
+	return "ruby"
+}
+
 func (*rubyImplementation) SitterLanguage() *sitter.Language {
 	return ruby.GetLanguage()
 }

--- a/new/language/patternquery/types/types.go
+++ b/new/language/patternquery/types/types.go
@@ -14,5 +14,4 @@ type Variable struct {
 type PatternQuery interface {
 	MatchAt(node *tree.Node) ([]*languagetypes.PatternQueryResult, error)
 	MatchOnceAt(node *tree.Node) (*languagetypes.PatternQueryResult, error)
-	Close()
 }

--- a/new/language/tree/tree.go
+++ b/new/language/tree/tree.go
@@ -10,7 +10,7 @@ type Tree struct {
 	input        []byte
 	sitterTree   *sitter.Tree
 	unifiedNodes map[NodeID][]*Node
-	queryCache   map[int]map[NodeID][]QueryResult
+	queryCache   QuerySetResults
 }
 
 func Parse(ctx context.Context, sitterLanguage *sitter.Language, input string) (*Tree, error) {
@@ -30,7 +30,6 @@ func Parse(ctx context.Context, sitterLanguage *sitter.Language, input string) (
 		input:        inputBytes,
 		sitterTree:   sitterTree,
 		unifiedNodes: make(map[NodeID][]*Node),
-		queryCache:   make(map[int]map[NodeID][]QueryResult),
 	}, nil
 }
 

--- a/new/language/types/types.go
+++ b/new/language/types/types.go
@@ -14,11 +14,10 @@ type PatternQueryResult struct {
 type PatternQuery interface {
 	MatchAt(node *tree.Node) ([]*PatternQueryResult, error)
 	MatchOnceAt(node *tree.Node) (*PatternQueryResult, error)
-	Close()
 }
 
 type Language interface {
 	Parse(ctx context.Context, input string) (*tree.Tree, error)
-	CompileQuery(input string) (*tree.Query, error)
-	CompilePatternQuery(input, focusedVariable string) (PatternQuery, error)
+	NewQuerySet() *tree.QuerySet
+	CompilePatternQuery(querySet *tree.QuerySet, input, focusedVariable string) (PatternQuery, error)
 }


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Compile all tree sitter queries into a single pattern per language. This gives the following runtime improvements:

|Project|Speedup|
|-|-|
|NodeGoat|1.85x|
|WebGoat|1.10x|
|Rocket.Chat|1.34x|
|Bear Publishing|2.04x|
|Discourse|1.20x|
|BenchmarkJava|1.37x|

Included in this is approximately a halving of the worker startup time.

## Related
- Makes some small progress towards https://github.com/Bearer/bearer-rules/issues/137

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
