### PR TITLE
feat: add flag to ignore report failures

### DIFF
--- a/docs/_data/bearer_scan.yaml
+++ b/docs/_data/bearer_scan.yaml
@@ -1,103 +1,107 @@
-name: ' scan'
+name: " scan"
 synopsis: Scan a directory or file
-usage: ' scan [flags] <path>'
+usage: " scan [flags] <path>"
 options:
-    - name: api-key
-      usage: Use your Bearer API Key to send the report to Bearer.
-    - name: config-file
-      default_value: bearer.yml
-      usage: Load configuration from the specified path.
-    - name: context
-      usage: |
-        Expand context of schema classification e.g., --context=health, to include data types particular to health
-    - name: data-subject-mapping
-      usage: |
-        Override default data subject mapping by providing a path to a custom mapping JSON file
-    - name: debug
-      default_value: "false"
-      usage: Enable debug logs. Equivalent to --log-level=debug
-    - name: debug-profile
-      default_value: "false"
-      usage: Generate profiling data for debugging
-    - name: disable-default-rules
-      default_value: "false"
-      usage: Disables all default and built-in rules.
-    - name: disable-domain-resolution
-      default_value: "true"
-      usage: |
-        Do not attempt to resolve detected domains during classification
-    - name: disable-version-check
-      default_value: "false"
-      usage: Disable Bearer version checking
-    - name: domain-resolution-timeout
-      default_value: 3s
-      usage: |
-        Set timeout when attempting to resolve detected domains during classification, e.g. --domain-resolution-timeout=3s
-    - name: exclude-fingerprint
-      default_value: '[]'
-      usage: |
-        Specify the comma-separated fingerprints of the findings you would like to exclude from the report.
-    - name: external-rule-dir
-      default_value: '[]'
-      usage: |
-        Specify directories paths that contain .yaml files with external rules configuration
-    - name: force
-      default_value: "false"
-      usage: Disable the cache and runs the detections again
-    - name: format
-      shorthand: f
-      usage: |
-        Specify report format (json, yaml, sarif, gitlab-sast, rdjson, html)
-    - name: help
-      shorthand: h
-      default_value: "false"
-      usage: help for scan
-    - name: host
-      default_value: my.bearer.sh
-      usage: Specify the Host for sending the report.
-    - name: internal-domains
-      default_value: '[]'
-      usage: |
-        Define regular expressions for better classification of private or unreachable domains e.g. --internal-domains=".*.my-company.com,private.sh"
-    - name: log-level
-      default_value: info
-      usage: Set log level (error, info, debug, trace)
-    - name: no-color
-      default_value: "false"
-      usage: Disable color in output
-    - name: only-rule
-      default_value: '[]'
-      usage: |
-        Specify the comma-separated ids of the rules you would like to run. Skips all other rules.
-    - name: output
-      usage: Specify the output path for the report.
-    - name: parallel
-      default_value: "0"
-      usage: Specify the amount of parallelism to use during the scan
-    - name: quiet
-      default_value: "false"
-      usage: Suppress non-essential messages
-    - name: report
-      default_value: security
-      usage: Specify the type of report (security, privacy, dataflow).
-    - name: scanner
-      default_value: '[sast]'
-      usage: |
-        Specify which scanner to use e.g. --scanner=secrets, --scanner=secrets,sast
-    - name: severity
-      default_value: critical,high,medium,low,warning
-      usage: Specify which severities are included in the report.
-    - name: skip-path
-      default_value: '[]'
-      usage: |
-        Specify the comma separated files and directories to skip. Supports * syntax, e.g. --skip-path users/*.go,users/admin.sql
-    - name: skip-rule
-      default_value: '[]'
-      usage: |
-        Specify the comma-separated ids of the rules you would like to skip. Runs all other rules.
+  - name: api-key
+    usage: Use your Bearer API Key to send the report to Bearer.
+  - name: config-file
+    default_value: bearer.yml
+    usage: Load configuration from the specified path.
+  - name: context
+    usage: |
+      Expand context of schema classification e.g., --context=health, to include data types particular to health
+  - name: data-subject-mapping
+    usage: |
+      Override default data subject mapping by providing a path to a custom mapping JSON file
+  - name: debug
+    default_value: "false"
+    usage: Enable debug logs. Equivalent to --log-level=debug
+  - name: debug-profile
+    default_value: "false"
+    usage: Generate profiling data for debugging
+  - name: disable-default-rules
+    default_value: "false"
+    usage: Disables all default and built-in rules.
+  - name: disable-domain-resolution
+    default_value: "true"
+    usage: |
+      Do not attempt to resolve detected domains during classification
+  - name: disable-version-check
+    default_value: "false"
+    usage: Disable Bearer version checking
+  - name: domain-resolution-timeout
+    default_value: 3s
+    usage: |
+      Set timeout when attempting to resolve detected domains during classification, e.g. --domain-resolution-timeout=3s
+  - name: exclude-fingerprint
+    default_value: "[]"
+    usage: |
+      Specify the comma-separated fingerprints of the findings you would like to exclude from the report.
+  - name: exit-code
+    default_value: "-1"
+    usage: |
+      Force a given exit code for the scan command. Set this to 0 (success) to always return a success exit code despite any findings from the scan.
+  - name: external-rule-dir
+    default_value: "[]"
+    usage: |
+      Specify directories paths that contain .yaml files with external rules configuration
+  - name: force
+    default_value: "false"
+    usage: Disable the cache and runs the detections again
+  - name: format
+    shorthand: f
+    usage: |
+      Specify report format (json, yaml, sarif, gitlab-sast, rdjson, html)
+  - name: help
+    shorthand: h
+    default_value: "false"
+    usage: help for scan
+  - name: host
+    default_value: my.bearer.sh
+    usage: Specify the Host for sending the report.
+  - name: internal-domains
+    default_value: "[]"
+    usage: |
+      Define regular expressions for better classification of private or unreachable domains e.g. --internal-domains=".*.my-company.com,private.sh"
+  - name: log-level
+    default_value: info
+    usage: Set log level (error, info, debug, trace)
+  - name: no-color
+    default_value: "false"
+    usage: Disable color in output
+  - name: only-rule
+    default_value: "[]"
+    usage: |
+      Specify the comma-separated ids of the rules you would like to run. Skips all other rules.
+  - name: output
+    usage: Specify the output path for the report.
+  - name: parallel
+    default_value: "0"
+    usage: Specify the amount of parallelism to use during the scan
+  - name: quiet
+    default_value: "false"
+    usage: Suppress non-essential messages
+  - name: report
+    default_value: security
+    usage: Specify the type of report (security, privacy, dataflow).
+  - name: scanner
+    default_value: "[sast]"
+    usage: |
+      Specify which scanner to use e.g. --scanner=secrets, --scanner=secrets,sast
+  - name: severity
+    default_value: critical,high,medium,low,warning
+    usage: Specify which severities are included in the report.
+  - name: skip-path
+    default_value: "[]"
+    usage: |
+      Specify the comma separated files and directories to skip. Supports * syntax, e.g. --skip-path users/*.go,users/admin.sql
+  - name: skip-rule
+    default_value: "[]"
+    usage: |
+      Specify the comma-separated ids of the rules you would like to skip. Runs all other rules.
 example: |4-
       # Scan a local project, including language-specific files
       $ bearer scan /path/to/your_project
 see_also:
-    - ' - '
+  - " - "
 aliases: s

--- a/e2e/flags/.snapshots/TestInitCommand
+++ b/e2e/flags/.snapshots/TestInitCommand
@@ -15,6 +15,7 @@ scan:
     data_subject_mapping: ""
     disable-domain-resolution: true
     domain-resolution-timeout: 3s
+    exit-code: -1
     external-rule-dir: []
     force: false
     internal-domains: []

--- a/e2e/flags/.snapshots/TestMetadataFlags-help-scan
+++ b/e2e/flags/.snapshots/TestMetadataFlags-help-scan
@@ -27,6 +27,7 @@ Scan Flags
       --debug                                Enable debug logs. Equivalent to --log-level=debug
       --disable-domain-resolution            Do not attempt to resolve detected domains during classification (default true)
       --domain-resolution-timeout duration   Set timeout when attempting to resolve detected domains during classification, e.g. --domain-resolution-timeout=3s (default 3s)
+      --exit-code int                        Force a given exit code for the scan command. Set this to 0 (success) to always return a success exit code despite any findings from the scan. (default -1)
       --external-rule-dir strings            Specify directories paths that contain .yaml files with external rules configuration
       --force                                Disable the cache and runs the detections again
       --internal-domains strings             Define regular expressions for better classification of private or unreachable domains e.g. --internal-domains=".*.my-company.com,private.sh"

--- a/e2e/flags/.snapshots/TestMetadataFlags-scan-help
+++ b/e2e/flags/.snapshots/TestMetadataFlags-scan-help
@@ -27,6 +27,7 @@ Scan Flags
       --debug                                Enable debug logs. Equivalent to --log-level=debug
       --disable-domain-resolution            Do not attempt to resolve detected domains during classification (default true)
       --domain-resolution-timeout duration   Set timeout when attempting to resolve detected domains during classification, e.g. --domain-resolution-timeout=3s (default 3s)
+      --exit-code int                        Force a given exit code for the scan command. Set this to 0 (success) to always return a success exit code despite any findings from the scan. (default -1)
       --external-rule-dir strings            Specify directories paths that contain .yaml files with external rules configuration
       --force                                Disable the cache and runs the detections again
       --internal-domains strings             Define regular expressions for better classification of private or unreachable domains e.g. --internal-domains=".*.my-company.com,private.sh"

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-context-flag
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-context-flag
@@ -28,6 +28,7 @@ Scan Flags
       --debug                                Enable debug logs. Equivalent to --log-level=debug
       --disable-domain-resolution            Do not attempt to resolve detected domains during classification (default true)
       --domain-resolution-timeout duration   Set timeout when attempting to resolve detected domains during classification, e.g. --domain-resolution-timeout=3s (default 3s)
+      --exit-code int                        Force a given exit code for the scan command. Set this to 0 (success) to always return a success exit code despite any findings from the scan. (default -1)
       --external-rule-dir strings            Specify directories paths that contain .yaml files with external rules configuration
       --force                                Disable the cache and runs the detections again
       --internal-domains strings             Define regular expressions for better classification of private or unreachable domains e.g. --internal-domains=".*.my-company.com,private.sh"

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag-privacy
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag-privacy
@@ -28,6 +28,7 @@ Scan Flags
       --debug                                Enable debug logs. Equivalent to --log-level=debug
       --disable-domain-resolution            Do not attempt to resolve detected domains during classification (default true)
       --domain-resolution-timeout duration   Set timeout when attempting to resolve detected domains during classification, e.g. --domain-resolution-timeout=3s (default 3s)
+      --exit-code int                        Force a given exit code for the scan command. Set this to 0 (success) to always return a success exit code despite any findings from the scan. (default -1)
       --external-rule-dir strings            Specify directories paths that contain .yaml files with external rules configuration
       --force                                Disable the cache and runs the detections again
       --internal-domains strings             Define regular expressions for better classification of private or unreachable domains e.g. --internal-domains=".*.my-company.com,private.sh"

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag-security
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag-security
@@ -28,6 +28,7 @@ Scan Flags
       --debug                                Enable debug logs. Equivalent to --log-level=debug
       --disable-domain-resolution            Do not attempt to resolve detected domains during classification (default true)
       --domain-resolution-timeout duration   Set timeout when attempting to resolve detected domains during classification, e.g. --domain-resolution-timeout=3s (default 3s)
+      --exit-code int                        Force a given exit code for the scan command. Set this to 0 (success) to always return a success exit code despite any findings from the scan. (default -1)
       --external-rule-dir strings            Specify directories paths that contain .yaml files with external rules configuration
       --force                                Disable the cache and runs the detections again
       --internal-domains strings             Define regular expressions for better classification of private or unreachable domains e.g. --internal-domains=".*.my-company.com,private.sh"

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-report-flag
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-report-flag
@@ -28,6 +28,7 @@ Scan Flags
       --debug                                Enable debug logs. Equivalent to --log-level=debug
       --disable-domain-resolution            Do not attempt to resolve detected domains during classification (default true)
       --domain-resolution-timeout duration   Set timeout when attempting to resolve detected domains during classification, e.g. --domain-resolution-timeout=3s (default 3s)
+      --exit-code int                        Force a given exit code for the scan command. Set this to 0 (success) to always return a success exit code despite any findings from the scan. (default -1)
       --external-rule-dir strings            Specify directories paths that contain .yaml files with external rules configuration
       --force                                Disable the cache and runs the detections again
       --internal-domains strings             Define regular expressions for better classification of private or unreachable domains e.g. --internal-domains=".*.my-company.com,private.sh"

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -309,7 +309,11 @@ func Run(ctx context.Context, opts flag.Options, targetKind TargetKind) (err err
 	}
 
 	if !reportPassed {
-		defer os.Exit(1)
+		if scanSettings.Scan.ExitCode == -1 {
+			defer os.Exit(1)
+		} else {
+			defer os.Exit(scanSettings.Scan.ExitCode)
+		}
 	}
 
 	return nil

--- a/pkg/flag/scan_flags.go
+++ b/pkg/flag/scan_flags.go
@@ -108,6 +108,12 @@ var (
 		Value:      0,
 		Usage:      "Specify the amount of parallelism to use during the scan",
 	}
+	ExitCodeFlag = Flag{
+		Name:       "exit-code",
+		ConfigName: "scan.exit-code",
+		Value:      -1,
+		Usage:      "Force a given exit code for the scan command. Set this to 0 (success) to always return a success exit code despite any findings from the scan.",
+	}
 )
 
 type ScanFlagGroup struct {
@@ -124,6 +130,7 @@ type ScanFlagGroup struct {
 	ForceFlag                   *Flag
 	ExternalRuleDirFlag         *Flag
 	ParallelFlag                *Flag
+	ExitCodeFlag                *Flag
 }
 
 type ScanOptions struct {
@@ -141,6 +148,7 @@ type ScanOptions struct {
 	ExternalRuleDir         []string      `mapstructure:"external-rule-dir" json:"external-rule-dir" yaml:"external-rule-dir"`
 	Scanner                 []string      `mapstructure:"scanner" json:"scanner" yaml:"scanner"`
 	Parallel                int           `mapstructure:"parallel" json:"parallel" yaml:"parallel"`
+	ExitCode                int           `mapstructure:"exit-code" json:"exit-code" yaml:"exit-code"`
 }
 
 func NewScanFlagGroup() *ScanFlagGroup {
@@ -158,6 +166,7 @@ func NewScanFlagGroup() *ScanFlagGroup {
 		ExternalRuleDirFlag:         &ExternalRuleDirFlag,
 		ScannerFlag:                 &ScannerFlag,
 		ParallelFlag:                &ParallelFlag,
+		ExitCodeFlag:                &ExitCodeFlag,
 	}
 }
 
@@ -180,6 +189,7 @@ func (f *ScanFlagGroup) Flags() []*Flag {
 		f.ExternalRuleDirFlag,
 		f.ScannerFlag,
 		f.ParallelFlag,
+		f.ExitCodeFlag,
 	}
 }
 
@@ -227,6 +237,7 @@ func (f *ScanFlagGroup) ToOptions(args []string) (ScanOptions, error) {
 		ExternalRuleDir:         getStringSlice(f.ExternalRuleDirFlag),
 		Scanner:                 scanners,
 		Parallel:                viper.GetInt(f.ParallelFlag.ConfigName),
+		ExitCode:                viper.GetInt(f.ExitCodeFlag.ConfigName),
 	}, nil
 }
 


### PR DESCRIPTION
## Description
Adds a new flag that when used will not set the failure exit code dispite any errors from the scan. The tool will still fail on any other unrelated issues like misconfiguration etc.

## Related
- Close #1119

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
