### PR TITLE
feat: show rule count per language

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -97,6 +97,7 @@ require (
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.42.0 // indirect
 	github.com/prometheus/procfs v0.10.1 // indirect
+	github.com/rodaine/table v1.1.0 // indirect
 	github.com/sergi/go-diff v1.3.1 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -277,6 +277,7 @@ github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27k
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPng=
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
@@ -328,6 +329,8 @@ github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.4 h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis=
 github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/rodaine/table v1.1.0 h1:/fUlCSdjamMY8VifdQRIu3VWZXYLY7QHFkVorS8NTr4=
+github.com/rodaine/table v1.1.0/go.mod h1:Qu3q5wi1jTQD6B6HsP6szie/S4w1QUQ8pq22pz9iL8g=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=

--- a/pkg/report/output/security/.snapshots/TestBuildReportString
+++ b/pkg/report/output/security/.snapshots/TestBuildReportString
@@ -5,8 +5,11 @@ Security Report
 =====================================
 
 Rules: 
- - 2 default rules applied (https://docs.bearer.com/reference/rules) [TEST]
- - 1 custom rules applied
+https://docs.bearer.com/reference/rules [TEST]
+
+Language  Default Rules  Custom Rules  
+Ruby      2              1             
+
 
 CRITICAL: Sensitive data sent to Rails loggers detected. [CWE-209, CWE-532]
 https://docs.bearer.com/reference/rules/ruby_rails_logger

--- a/pkg/report/output/security/.snapshots/TestBuildReportString
+++ b/pkg/report/output/security/.snapshots/TestBuildReportString
@@ -7,8 +7,7 @@ Security Report
 Rules: 
 https://docs.bearer.com/reference/rules [TEST]
 
-Language  Default Rules  Custom Rules  
-Ruby      2              1             
+Language  Default Rules  Custom Rules  Files  
 
 
 CRITICAL: Sensitive data sent to Rails loggers detected. [CWE-209, CWE-532]

--- a/pkg/report/output/security/security.go
+++ b/pkg/report/output/security/security.go
@@ -130,11 +130,11 @@ func GetOutput(dataflow *dataflow.DataFlow, config settings.Config) (*Results, e
 		output.StdErrLog("Evaluating rules")
 	}
 
-	err, builtInFingerprints := evaluateRules(summaryResults, config.BuiltInRules, config, dataflow, true)
+	builtInFingerprints, err := evaluateRules(summaryResults, config.BuiltInRules, config, dataflow, true)
 	if err != nil {
 		return nil, err
 	}
-	err, fingerprints := evaluateRules(summaryResults, config.Rules, config, dataflow, false)
+	fingerprints, err := evaluateRules(summaryResults, config.Rules, config, dataflow, false)
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +161,7 @@ func evaluateRules(
 	config settings.Config,
 	dataflow *dataflow.DataFlow,
 	builtIn bool,
-) (error, []string) {
+) ([]string, error) {
 	outputResults := map[string][]Result{}
 
 	var bar *progressbar.ProgressBar
@@ -195,19 +195,19 @@ func evaluateRules(
 			// TODO: perf question: can we do this once?
 			policy.Modules.ToRegoModules())
 		if err != nil {
-			return err, fingerprints
+			return fingerprints, err
 		}
 
 		if len(rs) > 0 {
 			jsonRes, err := json.Marshal(rs)
 			if err != nil {
-				return err, fingerprints
+				return fingerprints, err
 			}
 
 			var results map[string][]Output
 			err = json.Unmarshal(jsonRes, &results)
 			if err != nil {
-				return err, fingerprints
+				return fingerprints, err
 			}
 
 			ruleSummary := &Rule{
@@ -275,7 +275,7 @@ func evaluateRules(
 		summaryResults[severity] = append(summaryResults[severity], resultSlice...)
 	}
 
-	return nil, fingerprints
+	return fingerprints, nil
 }
 
 func removeUnusedFingerprints(detectedFingerprints []string, excludeFingerprints map[string]bool) []string {

--- a/pkg/report/output/security/security.go
+++ b/pkg/report/output/security/security.go
@@ -468,10 +468,16 @@ func writeRuleListToString(
 		reportStr.WriteString(color.HiBlackString(fmt.Sprintf("https://docs.bearer.com/reference/rules [%s]\n\n", config.BearerRulesVersion)))
 	}
 
-	tbl := table.New("Language", "Default Rules", "Custom Rules").WithWriter(reportStr)
-	for _, lang := range maputil.SortedStringKeys(ruleCountPerLang) {
-		ruleCount := ruleCountPerLang[lang]
-		tbl.AddRow(lang, ruleCount.DefaultRuleCount, ruleCount.CustomRuleCount)
+	tbl := table.New("Language", "Default Rules", "Custom Rules", "Files").WithWriter(reportStr)
+
+	languageSlice := maps.Values(languages)[:]
+	sort.Slice(languageSlice, func(i, j int) bool {
+		return len(languageSlice[i].Files) > len(languageSlice[j].Files)
+	})
+	for _, lang := range languageSlice {
+		if ruleCount, ok := ruleCountPerLang[lang.Name]; ok {
+			tbl.AddRow(lang.Name, ruleCount.DefaultRuleCount, ruleCount.CustomRuleCount, len(languages[lang.Name].Files))
+		}
 	}
 	tbl.Print()
 


### PR DESCRIPTION
## Description

Instead of total count, break rule counts down per language.
Also, unrelated, fixes the ordering of return args for function in file (error to be returned last)

Closes #782

## Before

![Screenshot 2023-07-31 at 13 57 27](https://github.com/Bearer/bearer/assets/4560746/ff343110-8a2b-4a50-bead-45c471f7c8ab)

## After

![Screenshot 2023-07-31 at 16 03 05](https://github.com/Bearer/bearer/assets/4560746/83f9c727-ffc9-4ebc-8a9a-6dbe0624e4f5)

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [x] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
