### PR TITLE
feat: add sign-up link to report output

### DIFF
--- a/pkg/report/output/security/.snapshots/TestBuildReportString
+++ b/pkg/report/output/security/.snapshots/TestBuildReportString
@@ -37,5 +37,5 @@ WARNING: 0
 
 Need help or want to discuss the output? Join the Community https://discord.gg/eaHZBJUXRF
 
-Ready to take the next step, learn more about Bearer Cloud https://www.bearer.com/bearer-cloud
+Manage your findings directly on Bearer Cloud. Start now for free https://www.bearer.com/signup or learn more https://docs.bearer.com/guides/bearer-cloud/
 

--- a/pkg/report/output/security/security.go
+++ b/pkg/report/output/security/security.go
@@ -365,7 +365,7 @@ func BuildReportString(config settings.Config, results *Results, lineOfCodeOutpu
 	reportStr.WriteString("\nNeed help or want to discuss the output? Join the Community https://discord.gg/eaHZBJUXRF\n")
 
 	if config.Client == nil {
-		reportStr.WriteString("\nReady to take the next step, learn more about Bearer Cloud https://www.bearer.com/bearer-cloud\n")
+		reportStr.WriteString("\nManage your findings directly on Bearer Cloud. Start now for free https://www.bearer.com/signup or learn more https://docs.bearer.com/guides/bearer-cloud/\n")
 	}
 
 	color.NoColor = initialColorSetting


### PR DESCRIPTION
## Description

Update copy at the end of the security report to include a link to the cloud sign up page and cloud documentation

<img width="1005" alt="Screenshot 2023-08-01 at 11 09 05" src="https://github.com/Bearer/bearer/assets/4560746/a4874125-8823-4672-b7bd-d34299f37323">

## Checklist

- [x] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
