### PR TITLE
fix: include target in scan id

### DIFF
--- a/pkg/commands/artifact/scanid/scanid.go
+++ b/pkg/commands/artifact/scanid/scanid.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -49,9 +50,18 @@ func hashConfig(scanSettings settings.Config) (string, error) {
 		return "", fmt.Errorf("error building scanners hash: %w", err)
 	}
 
+	absTarget, err := filepath.Abs(scanSettings.Scan.Target)
+	if err != nil {
+		return "", fmt.Errorf("error getting absolute path to target: %w", err)
+	}
+
+	targetHash := md5.Sum([]byte(absTarget))
 	baseBranchHash := md5.Sum([]byte(scanSettings.Scan.DiffBaseBranch))
 
 	hashBuilder := md5.New()
+	if _, err := hashBuilder.Write(targetHash[:]); err != nil {
+		return "", err
+	}
 	if _, err := hashBuilder.Write(ruleHash); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Include the absolute path to the scan target in the scan id (scan id is used for report filenames/caching). 

Currently, if you scan any subfolder or file individually in a git repo, they will share the same report filename. This leads to incorrect data being returned when using the cache, or race conditions between concurrent CLI processes scanning files in the same repo.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
