### PR TITLE
fix: typo in sign up url in security report message

### DIFF
--- a/pkg/report/output/security/.snapshots/TestBuildReportString
+++ b/pkg/report/output/security/.snapshots/TestBuildReportString
@@ -37,5 +37,5 @@ WARNING: 0
 
 Need help or want to discuss the output? Join the Community https://discord.gg/eaHZBJUXRF
 
-Manage your findings directly on Bearer Cloud. Start now for free https://www.bearer.com/signup or learn more https://docs.bearer.com/guides/bearer-cloud/
+Manage your findings directly on Bearer Cloud. Start now for free https://my.bearer.sh/users/sign_up or learn more https://docs.bearer.com/guides/bearer-cloud/
 

--- a/pkg/report/output/security/security.go
+++ b/pkg/report/output/security/security.go
@@ -376,7 +376,7 @@ func BuildReportString(config settings.Config, results *Results, lineOfCodeOutpu
 	reportStr.WriteString("\nNeed help or want to discuss the output? Join the Community https://discord.gg/eaHZBJUXRF\n")
 
 	if config.Client == nil {
-		reportStr.WriteString("\nManage your findings directly on Bearer Cloud. Start now for free https://www.bearer.com/signup or learn more https://docs.bearer.com/guides/bearer-cloud/\n")
+		reportStr.WriteString("\nManage your findings directly on Bearer Cloud. Start now for free https://my.bearer.sh/users/sign_up or learn more https://docs.bearer.com/guides/bearer-cloud/\n")
 	}
 
 	color.NoColor = initialColorSetting


### PR DESCRIPTION
## Description

Fixes typo in sign up URL that is shown at the end of the security report

<img width="1003" alt="Screenshot 2023-08-01 at 13 41 02" src="https://github.com/Bearer/bearer/assets/4560746/7d0b5d0f-5dfc-426a-af71-b032cc73dc11">


## Checklist

- [x] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
