### PR TITLE
fix: repository lookup errors and diff git file scanning

### DIFF
--- a/new/detector/composition/testhelper/testhelper.go
+++ b/new/detector/composition/testhelper/testhelper.go
@@ -93,7 +93,13 @@ func (runner *Runner) RunTest(t *testing.T, testdataPath string, snapshotPath st
 		Languages:     map[string]*gocloc.Language{},
 		MaxPathLength: 0,
 	}
-	fileList, err := filelist.Discover(nil, testdataPath, &dummyGoclocResult, runner.config)
+
+	absTestdataPath, err := filepath.Abs(testdataPath)
+	if err != nil {
+		t.Fatalf("failed to get absolute target: %s", err)
+	}
+
+	fileList, err := filelist.Discover(nil, absTestdataPath, &dummyGoclocResult, runner.config)
 	if err != nil {
 		t.Fatalf("failed to discover files: %s", err)
 	}
@@ -105,7 +111,7 @@ func (runner *Runner) RunTest(t *testing.T, testdataPath string, snapshotPath st
 	for _, file := range fileList.Files {
 		myfile := file
 		ext := filepath.Ext(file.FilePath)
-		testName := strings.TrimSuffix(file.FilePath, ext) + ".yml"
+		testName := "/" + strings.TrimSuffix(file.FilePath, ext) + ".yml"
 		t.Run(testName, func(t *testing.T) {
 			runner.scanSingleFile(t, testdataPath, myfile, snapshotPath)
 		})

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -151,7 +152,12 @@ func (r *runner) Scan(ctx context.Context, opts flag.Options) (*basebranchfindin
 		output.StdErrLog(fmt.Sprintf("Scanning target %s", opts.Target))
 	}
 
-	repository, err := gitrepository.New(ctx, r.scanSettings, opts.Target, opts.DiffBaseBranch)
+	targetPath, err := filepath.Abs(opts.Target)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get absolute target: %w", err)
+	}
+
+	repository, err := gitrepository.New(ctx, r.scanSettings, targetPath, opts.DiffBaseBranch)
 	if err != nil {
 		return nil, fmt.Errorf("error opening git repository: %w", err)
 	}
@@ -160,7 +166,7 @@ func (r *runner) Scan(ctx context.Context, opts flag.Options) (*basebranchfindin
 		return nil, err
 	}
 
-	fileList, err := filelist.Discover(repository, opts.Target, r.goclocResult, r.scanSettings)
+	fileList, err := filelist.Discover(repository, targetPath, r.goclocResult, r.scanSettings)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/commands/process/filelist/filelist_test.go
+++ b/pkg/commands/process/filelist/filelist_test.go
@@ -40,7 +40,27 @@ func TestFileList(t *testing.T) {
 			Want: &files.List{
 				Files: []files.File{
 					{
-						FilePath: "/user.go",
+						FilePath: "user.go",
+						Timeout:  0,
+					},
+				},
+			},
+		},
+		{
+			Name: "Find files - standard single file - happy path",
+			Input: input{
+				projectPath: filepath.Join("testdata", "happy_path", "standard", "user.go"),
+				config: settings.Config{
+					Worker: settings.WorkerOptions{
+						FileSizeMaximum:           100000,
+						TimeoutFileBytesPerSecond: 1,
+					},
+				},
+			},
+			Want: &files.List{
+				Files: []files.File{
+					{
+						FilePath: ".",
 						Timeout:  0,
 					},
 				},
@@ -64,7 +84,7 @@ func TestFileList(t *testing.T) {
 				Files: []files.File{
 					{
 						Timeout:  0,
-						FilePath: "/users/users.go",
+						FilePath: "users/users.go",
 					},
 				},
 			},


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Makes the following fixes to changes introduced in https://github.com/Bearer/bearer/pull/1158 :
- Fix error trying to lookup git repo when scanning a single non-git file
- Allow diff scans to scan files/folders within the repo, rather than only the entire repo

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
