### PR TITLE
docs(rules): fix broken source link

### DIFF
--- a/docs/reference/rule-pages.njk
+++ b/docs/reference/rule-pages.njk
@@ -26,7 +26,7 @@ eleventyComputed:
   {% endif %}
   <li>
     <strong>Source:</strong>
-    <a class="text-main dark:text-main-300 hover:underline" href="https://github.com/bearer/bearer-rules/blob/main/{{rule.location}}.yml">{{rule.name}}.yml</a>
+    <a class="text-main dark:text-main-300 hover:underline" href="https://github.com/bearer/bearer-rules/blob/main/rules/{{rule.location}}.yml">{{rule.name}}.yml</a>
   </li>
 </ul>
 {% renderTemplate 'liquid,md',


### PR DESCRIPTION
## Description
Broke link to source files when we made the change to put rules in a rules subfolder https://github.com/Bearer/bearer-rules/pull/143

This PR fixes that issue
## Related
- https://github.com/Bearer/bearer-rules/pull/143


## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
