### PR TITLE
fix: fetching and checkout of base branch

### DIFF
--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -163,7 +163,7 @@ func (r *runner) Scan(ctx context.Context, opts flag.Options) (*basebranchfindin
 	}
 
 	if err := repository.FetchBaseIfNotPresent(); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error fetching base branch: %w", err)
 	}
 
 	fileList, err := filelist.Discover(repository, targetPath, r.goclocResult, r.scanSettings)


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Fixes the checkout of the base branch by checking out the remote ref rather than the local one. The existing logic didn't work correctly with the way Github checks out repositories.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
