### PR TITLE
fix: honor quiet flag in diff logic

### DIFF
--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -188,10 +188,10 @@ func (r *runner) Scan(ctx context.Context, opts flag.Options) (*basebranchfindin
 
 	var baseBranchFindings *basebranchfindings.Findings
 	if err := repository.WithBaseBranch(func() error {
-		output.StdErrLog(fmt.Sprintf(
-			"\nScanning base branch %s",
-			opts.DiffBaseBranch,
-		))
+		if !opts.Quiet {
+			output.StdErrLog(fmt.Sprintf("\nScanning base branch %s", opts.DiffBaseBranch))
+		}
+
 		if err := orchestrator.Scan(r.reportPath+".base", fileList.BaseFiles); err != nil {
 			return err
 		}
@@ -204,7 +204,10 @@ func (r *runner) Scan(ctx context.Context, opts flag.Options) (*basebranchfindin
 
 		baseBranchFindings = buildBaseBranchFindings(fileList, detections)
 
-		output.StdErrLog("\nScanning current branch")
+		if !opts.Quiet {
+			output.StdErrLog("\nScanning current branch")
+		}
+
 		return nil
 	}); err != nil {
 		return nil, err


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Honor the `--quiet` flag for the log messages produced when diffing against a base branch.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
