### PR TITLE
docs: add diff scan

### DIFF
--- a/docs/guides/ci-setup.md
+++ b/docs/guides/ci-setup.md
@@ -35,7 +35,7 @@ This tells GitLab to use the `bearer/bearer` docker image. You can adjust the `s
 
 GitLab's guide on [Running CI/CD jobs in Docker containers](https://docs.gitlab.com/ee/ci/docker/using_docker_images.html) provides additional context on configuring the CI in this way.
 
-For more details and additional configuration, see our [guide to using the GitLab](/guides/gitlab/).
+For more details and additional configuration, see our [guide to using GitLab](/guides/gitlab/).
 
 ## Universal setup
 

--- a/docs/guides/configure-scan.md
+++ b/docs/guides/configure-scan.md
@@ -32,7 +32,7 @@ Use the `DIFF_BASE_BRANCH` environment variable to enable differential scanning,
 and to specify the base branch to use for comparison.
 
 ```bash
-git co my-feature
+git checkout my-feature
 DIFF_BASE_BRANCH=main bearer scan .
 ```
 

--- a/docs/guides/configure-scan.md
+++ b/docs/guides/configure-scan.md
@@ -22,6 +22,23 @@ Did you know that Bearer CLI can also detect hard-coded secrets in your code? In
 bearer scan . --scanner secrets
 ```
 
+## Only report new findings on a branch
+
+When scanning a Git repository, you can choose to only report new findings that
+have been introduced, relative to a base branch. Any findings that already
+existed in the base branch will not be reported.
+
+Use the `DIFF_BASE_BRANCH` environment variable to enable differential scanning,
+and to specify the base branch to use for comparison.
+
+```bash
+git co my-feature
+DIFF_BASE_BRANCH=main bearer scan .
+```
+
+If the base branch is not available in the git repository, it's head will be
+fetched by Bearer CLI (a shallow fetch of depth 1).
+
 ## Exclude specific findings
 
 Every finding is associated with a unique fingerprint visible directly in the CLI output, for example:
@@ -170,7 +187,7 @@ bearer scan . --format html --output path/to/security-scan.html
 
 ## Send report to Bearer Cloud
 
-If you're looking to manage product and application code security at scale, [Bearer Cloud](https://www.bearer.com/bearer-cloud) offers a platform for teams that syncs with Bearer CLI's output. 
+If you're looking to manage product and application code security at scale, [Bearer Cloud](https://www.bearer.com/bearer-cloud) offers a platform for teams that syncs with Bearer CLI's output.
 
 Learn how to [send your report](/guides/bearer-cloud) to Bearer Cloud.
 

--- a/docs/guides/configure-scan.md
+++ b/docs/guides/configure-scan.md
@@ -24,6 +24,11 @@ bearer scan . --scanner secrets
 
 ## Only report new findings on a branch
 
+{% callout %}
+  Differential scanning avoids scanning your entire codebase and drastically
+  reduces scan times. We recommended that you use this feature when possible.
+{% endcallout %}
+
 When scanning a Git repository, you can choose to only report new findings that
 have been introduced, relative to a base branch. Any findings that already
 existed in the base branch will not be reported.
@@ -38,6 +43,10 @@ DIFF_BASE_BRANCH=main bearer scan .
 
 If the base branch is not available in the git repository, it's head will be
 fetched by Bearer CLI (a shallow fetch of depth 1).
+
+See our [guide to using the GitHub action](/guides/github-action/#pull-request-diff) and
+[guide to using GitLab](/guides/gitlab/#gitlab-merge-request-diff) for
+information on using this feature with those services.
 
 ## Exclude specific findings
 

--- a/docs/guides/github-action.njk
+++ b/docs/guides/github-action.njk
@@ -129,10 +129,11 @@ When the Bearer action is being used to check a pull request, you can tell the
 action to only report findings introduced within the pull request by setting
 the `diff` input parameter to `true`.
 
-```yaml
+```diff-yaml
 name: Bearer PR Check
 
 on:
++ # Diff can only be used with pull_request events
   pull_request:
     types: [opened, synchronize, reopened]
 
@@ -149,6 +150,7 @@ jobs:
         id: report
         uses: bearer/bearer-action@v2
         with:
++         # Add diff option
           diff: true
 ```
 
@@ -169,6 +171,8 @@ on:
 
 permissions:
   contents: read
++ # Add the pull-requests permission
+  pull-requests: write
 
 jobs:
   rule_check:
@@ -180,23 +184,20 @@ jobs:
         id: report
         uses: bearer/bearer-action@v2
         with:
++         # use rdjson output, and only report changes from your PR
           format: rdjson
           output: rd.json
           diff: true
++     # add steps to setup and run reviewdog
       - uses: reviewdog/action-setup@v1
         with:
           reviewdog_version: latest
       - name: Run reviewdog
         env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.REVIEWDOG_GITHUB_API_TOKEN }}
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cat rd.json | reviewdog -f=rdjson -reporter=github-pr-review
 ```
-Remember to set a personal access [token](https://github.com/settings/personal-access-tokens/new) with read and write access to your repository.
-- If you choose a "classic" personal access token, it will need full repo permissions (scope: repo)
-- If you choose a "fine-grained" personal access token, it will need read and write access to pull requests for your repo
-
-Save this token to your repo secrets as `REVIEWDOG_GITHUB_API_TOKEN` and you should be good to go.
 
 ## Integrate with Defect Dojo
 

--- a/docs/guides/github-action.njk
+++ b/docs/guides/github-action.njk
@@ -123,6 +123,38 @@ jobs:
 
 By setting the format and output path, and adding a new upload step, the action will upload SARIF-formatted findings to GitHub's code scanner.
 
+## Pull Request Diff
+
+When the Bearer action is being used to check a pull request, you can tell the
+action to only report findings introduced within the pull request by setting
+the `diff` input parameter to `true`.
+
+```yaml
+name: Bearer PR Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  rule_check:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run Report
+        id: report
+        uses: bearer/bearer-action@v2
+        with:
+          diff: true
+```
+
+See our guide on [configuring a scan](/guides/configure-scan#only-report-new-findings-on-a-branch)
+for more information on differential scans.
+
 ## Code Review Comments
 Bearer CLI supports [Reviewdog](https://github.com/reviewdog/reviewdog) rdjson format so you can use any of the reviewdog reporters to quickly add bearer feedback directly to your pull requests.
 
@@ -150,6 +182,7 @@ jobs:
         with:
           format: rdjson
           output: rd.json
+          diff: true
       - uses: reviewdog/action-setup@v1
         with:
           reviewdog_version: latest

--- a/docs/guides/gitlab.md
+++ b/docs/guides/gitlab.md
@@ -61,6 +61,7 @@ bearer:
     entrypoint: [ "" ]
   variables:
     DIFF_BASE_BRANCH: $CI_MERGE_REQUEST_TARGET_BRANCH_NAME
+    DIFF_BASE_COMMIT: $CI_MERGE_REQUEST_DIFF_BASE_SHA
   script: bearer scan .
 ```
 
@@ -82,6 +83,7 @@ pr_check:
     CURRENT_BRANCH: $CI_COMMIT_REF_NAME
     DEFAULT_BRANCH: $CI_DEFAULT_BRANCH
     DIFF_BASE_BRANCH: $CI_MERGE_REQUEST_TARGET_BRANCH_NAME
+    DIFF_BASE_COMMIT: $CI_MERGE_REQUEST_DIFF_BASE_SHA
   script:
     - curl -sfL https://raw.githubusercontent.com/Bearer/bearer/main/contrib/install.sh | sh -s -- -b /usr/local/bin
     - curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b /usr/local/bin

--- a/docs/guides/gitlab.md
+++ b/docs/guides/gitlab.md
@@ -48,6 +48,25 @@ bearer:
 
 These changes set the format to `gitlab-sast` and write an artifact that GitLab can use. Once run, the results of the security scan will display in the Security and Compliance section of the repository.
 
+### Gitlab Merge Request Diff
+
+When Bearer CLI is being used to check a merge request, you can tell the Bearer
+CLI to only report findings introduced within the merge request by setting the
+`DIFF_BASE_BRANCH` variable.
+
+```yml
+bearer:
+  image:
+    name: bearer/bearer
+    entrypoint: [ "" ]
+  variables:
+    DIFF_BASE_BRANCH: $CI_MERGE_REQUEST_TARGET_BRANCH_NAME
+  script: bearer scan .
+```
+
+See our guide on [configuring a scan](/guides/configure-scan#only-report-new-findings-on-a-branch)
+for more information on differential scans.
+
 ### Gitlab Merge Request Comments
 
 Bearer CLI supports [Reviewdog](https://github.com/reviewdog/reviewdog) rdjson format so you can get direct feedback on your merge requests.
@@ -62,6 +81,7 @@ pr_check:
     SHA: $CI_COMMIT_SHA
     CURRENT_BRANCH: $CI_COMMIT_REF_NAME
     DEFAULT_BRANCH: $CI_DEFAULT_BRANCH
+    DIFF_BASE_BRANCH: $CI_MERGE_REQUEST_TARGET_BRANCH_NAME
   script:
     - curl -sfL https://raw.githubusercontent.com/Bearer/bearer/main/contrib/install.sh | sh -s -- -b /usr/local/bin
     - curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b /usr/local/bin


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Adds documentation for diff scanning, and simplifies reviewdog instructions for Github.


## Related

- #1144


## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
