### PR TITLE
feat: memory soft limit

### DIFF
--- a/pkg/commands/process/orchestrator/work/work.go
+++ b/pkg/commands/process/orchestrator/work/work.go
@@ -28,3 +28,4 @@ type ProcessRequest struct {
 
 var RouteInitialize = "/initialize"
 var RouteProcess = "/process"
+var RouteReduceMemory = "/reduce_memory"

--- a/pkg/commands/process/orchestrator/worker/worker.go
+++ b/pkg/commands/process/orchestrator/worker/worker.go
@@ -133,6 +133,9 @@ func Start(port string) error {
 					FileStats: fileStats,
 					Error:     errorString,
 				})
+			case work.RouteReduceMemory:
+				log.Trace().Msgf("attempting to reduce memory usage")
+				runtime.GC()
 			default:
 				rw.WriteHeader(http.StatusNotFound)
 			}

--- a/pkg/commands/process/settings/settings.go
+++ b/pkg/commands/process/settings/settings.go
@@ -25,6 +25,7 @@ var (
 	CodeExtractBuffer                = 3                 // Number of lines allowed before or after the detection
 	FileSizeMaximum                  = 2 * 1000 * 1000   // 2 MB Ignore files larger than the specified value
 	FilesPerWorker                   = 1000              // By default, start a worker per this many files, up to the number of CPUs
+	MemorySoftMaximum         uint64 = 650 * 1000 * 1000 // 650 MB If the memory needed to scan a file surpasses the specified limit, ask the worker to reduce memory usage.
 	MemoryMaximum             uint64 = 800 * 1000 * 1000 // 800 MB If the memory needed to scan a file surpasses the specified limit, skip the file.
 	ExistingWorker                   = ""                // Specify the URL of an existing worker
 )


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Adds a lower "soft" memory limit at 650mb. Once this is reached, the worker is asked to try to reduce its memory usage. Currently this just means running the Go garbage collector, but it could be extended in the future to reduce cache sizes, etc.

This allows some files that currently run out of memory to now succeed.

## Related
- Close #1170 
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
