### PR TITLE
fix: listing of files in sass report

### DIFF
--- a/new/detector/composition/testhelper/testhelper.go
+++ b/new/detector/composition/testhelper/testhelper.go
@@ -148,6 +148,7 @@ func (runner *Runner) scanSingleFile(t *testing.T, testDataPath string, fileRela
 			Path: detectorsReportPath,
 		},
 		runner.config,
+		[]files.File{fileRelativePath},
 		nil,
 	)
 

--- a/pkg/report/output/output.go
+++ b/pkg/report/output/output.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/bearer/bearer/pkg/commands/process/filelist/files"
 	"github.com/bearer/bearer/pkg/commands/process/settings"
 	"github.com/bearer/bearer/pkg/flag"
 	"github.com/bearer/bearer/pkg/report/basebranchfindings"
@@ -24,6 +25,7 @@ var ErrUndefinedFormat = errors.New("undefined output format")
 func GetOutput(
 	report types.Report,
 	config settings.Config,
+	files []files.File,
 	baseBranchFindings *basebranchfindings.Findings,
 ) (any, *dataflow.DataFlow, error) {
 	switch config.Report.Report {
@@ -32,14 +34,14 @@ func GetOutput(
 	case flag.ReportDataFlow:
 		return GetDataflow(report, config, false)
 	case flag.ReportSecurity:
-		return reportSecurity(report, config, baseBranchFindings)
+		return reportSecurity(report, config, files, baseBranchFindings)
 	case flag.ReportSaaS:
-		securityResults, dataflow, err := reportSecurity(report, config, baseBranchFindings)
+		securityResults, dataflow, err := reportSecurity(report, config, files, baseBranchFindings)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		return saas.GetReport(config, securityResults, dataflow, report.Inputgocloc)
+		return saas.GetReport(config, securityResults, dataflow, files)
 	case flag.ReportPrivacy:
 		return getPrivacyReportOutput(report, config)
 	case flag.ReportStats:
@@ -94,6 +96,7 @@ func reportStats(report types.Report, config settings.Config) (*stats.Stats, *da
 func reportSecurity(
 	report types.Report,
 	config settings.Config,
+	files []files.File,
 	baseBranchFindings *basebranchfindings.Findings,
 ) (
 	securityResults *security.Results,
@@ -113,7 +116,7 @@ func reportSecurity(
 	}
 
 	if config.Client != nil && config.Client.Error == nil {
-		saas.SendReport(config, securityResults, report.Inputgocloc, dataflow)
+		saas.SendReport(config, securityResults, files, dataflow)
 	}
 
 	return


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Generate the list of files in one place and pass it down. This avoids unnecessary work and ensures consistency.

Following the changes to add support for diff scanning, the `full_filename` and list of files in the saas report were incorrect.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
