### PR TITLE
fix: use correct base in diff

### DIFF
--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -159,11 +159,7 @@ func (r *runner) Scan(ctx context.Context, opts flag.Options) ([]files.File, *ba
 
 	repository, err := gitrepository.New(ctx, r.scanSettings, targetPath, opts.DiffBaseBranch)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error opening git repository: %w", err)
-	}
-
-	if err := repository.FetchBaseIfNotPresent(); err != nil {
-		return nil, nil, fmt.Errorf("error fetching base branch: %w", err)
+		return nil, nil, fmt.Errorf("git repository error: %w", err)
 	}
 
 	fileList, err := filelist.Discover(repository, targetPath, r.goclocResult, r.scanSettings)


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Use the correct base branch commit for diffing. ie. the latest common ancestor between the base branch and current commit.

Previously we were using the latest commit of the base branch to compare, which is incorrect.

We use the Github API or a passed in SHA (for Gitlab) as a preference, and fall back to computing the merge base commit. If not enough history is present to compute the merge base, an error is raised. This could be extended in future to try and fetch the history.

## Related

- #1144


## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
