### PR TITLE
fix: fixes from testing diff scan

### DIFF
--- a/pkg/commands/process/gitrepository/gitrepository.go
+++ b/pkg/commands/process/gitrepository/gitrepository.go
@@ -391,6 +391,10 @@ func (repository *Repository) lookupMergeBaseHash(baseBranch string) (*plumbing.
 
 	ref, err := repository.git.Reference(repository.baseRemoteRefName, true)
 	if err != nil {
+		if err == plumbing.ErrReferenceNotFound {
+			return nil, nil
+		}
+
 		return nil, fmt.Errorf("invalid ref: %w", err)
 	}
 


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

- Cope with the case where the remote base branch is not in the local repo. This still results in an error, but with a more meaningful message.
- Add a trailing slash to the Github API base URL, the client requires this but the value passed by Github Actions lacks the slash.


## Related

- #1144


## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
