### PR TITLE
fix: hashing of scanners in scan id

### DIFF
--- a/pkg/commands/artifact/scanid/scanid.go
+++ b/pkg/commands/artifact/scanid/scanid.go
@@ -104,7 +104,7 @@ func hashRules(rules map[string]*settings.Rule) ([]byte, error) {
 func hashScanners(scanners []string) ([]byte, error) {
 	hashBuilder := md5.New()
 
-	var sortedScanners []string
+	sortedScanners := make([]string, len(scanners))
 	copy(sortedScanners, scanners)
 	sort.Strings(sortedScanners)
 


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Fixes hashing of scanners (eg. `sast`, `secrets`) when building a scan id. The scan id is the key used for caching reports.

Previously, we were including an empty list of scanners each time. This meant that cached reports for one scanner option were being used when a different option was given.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
