### PR TITLE
fix: report passed not being calculated correctly

### DIFF
--- a/e2e/rules/helper.go
+++ b/e2e/rules/helper.go
@@ -15,6 +15,7 @@ func buildRulesTestCase(testName, path, ruleID string) testhelper.TestCase {
 		"--only-rule=" + ruleID,
 		"--format=yaml",
 		"--disable-default-rules",
+		"--exit-code=0",
 		"--external-rule-dir=" + filepath.Join("e2e", "rules", "testdata", "rules"),
 	}
 

--- a/e2e/rules/rules_test.go
+++ b/e2e/rules/rules_test.go
@@ -18,6 +18,7 @@ func TestSecrets(t *testing.T) {
 				"--only-rule=gitleaks",
 				"--format=yaml",
 				"--disable-default-rules",
+				"--exit-code=0",
 			},
 			testhelper.TestCaseOptions{},
 		),

--- a/new/detector/composition/testhelper/testhelper.go
+++ b/new/detector/composition/testhelper/testhelper.go
@@ -143,7 +143,7 @@ func (runner *Runner) scanSingleFile(t *testing.T, testDataPath string, fileRela
 	}
 
 	runner.config.Scan.Target = testDataPath
-	detections, _, _ := output.GetOutput(
+	detections, _, _, _ := output.GetOutput(
 		types.Report{
 			Path: detectorsReportPath,
 		},

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -193,7 +193,8 @@ func (r *runner) Scan(ctx context.Context, opts flag.Options) ([]files.File, *ba
 		}
 
 		report := types.Report{Path: r.reportPath + ".base", Inputgocloc: r.goclocResult}
-		detections, _, err := reportoutput.GetOutput(report, r.scanSettings, fileList.BaseFiles, nil)
+
+		detections, _, _, err := reportoutput.GetOutput(report, r.scanSettings, fileList.BaseFiles, nil)
 		if err != nil {
 			return err
 		}
@@ -330,7 +331,7 @@ func (r *runner) Report(
 		outputhandler.StdErrLog("Using cached data")
 	}
 
-	detections, dataflow, err := reportoutput.GetOutput(report, r.scanSettings, files, baseBranchFindings)
+	detections, dataflow, reportPassed, err := reportoutput.GetOutput(report, r.scanSettings, files, baseBranchFindings)
 	if err != nil {
 		return false, err
 	}
@@ -359,8 +360,7 @@ func (r *runner) Report(
 		if r.scanSettings.Report.Report == flag.ReportSecurity {
 			// for security report, default report format is Table
 			detectionReport := detections.(*security.Results)
-			var reportStr *strings.Builder
-			reportStr, reportPassed = security.BuildReportString(r.scanSettings, detectionReport, report.Inputgocloc, dataflow)
+			reportStr := security.BuildReportString(r.scanSettings, detectionReport, report.Inputgocloc, dataflow, reportPassed)
 
 			logger(reportStr.String())
 		} else if r.scanSettings.Report.Report == flag.ReportPrivacy {

--- a/pkg/report/output/security/security_test.go
+++ b/pkg/report/output/security/security_test.go
@@ -51,7 +51,7 @@ func TestBuildReportString(t *testing.T) {
 
 	dataflow := dummyDataflow()
 
-	results, err := security.GetOutput(&dataflow, config, nil)
+	results, reportPassed, err := security.GetOutput(&dataflow, config, nil)
 	if err != nil {
 		t.Fatalf("failed to generate security output err:%s", err)
 	}
@@ -66,7 +66,7 @@ func TestBuildReportString(t *testing.T) {
 		MaxPathLength: 0,
 	}
 
-	stringBuilder, _ := security.BuildReportString(config, results, &dummyGoclocResult, &dataflow)
+	stringBuilder := security.BuildReportString(config, results, &dummyGoclocResult, &dataflow, reportPassed)
 	cupaloy.SnapshotT(t, stringBuilder.String())
 }
 
@@ -91,7 +91,7 @@ func TestNoRulesBuildReportString(t *testing.T) {
 
 	dataflow := dummyDataflow()
 
-	results, err := security.GetOutput(&dataflow, config, nil)
+	results, reportPassed, err := security.GetOutput(&dataflow, config, nil)
 	if err != nil {
 		t.Fatalf("failed to generate security output err:%s", err)
 	}
@@ -106,7 +106,7 @@ func TestNoRulesBuildReportString(t *testing.T) {
 		MaxPathLength: 0,
 	}
 
-	stringBuilder, _ := security.BuildReportString(config, results, &dummyGoclocResult, &dataflow)
+	stringBuilder := security.BuildReportString(config, results, &dummyGoclocResult, &dataflow, reportPassed)
 	cupaloy.SnapshotT(t, stringBuilder.String())
 }
 
@@ -128,7 +128,7 @@ func TestGetOutput(t *testing.T) {
 
 	dataflow := dummyDataflow()
 
-	res, err := security.GetOutput(&dataflow, config, nil)
+	res, _, err := security.GetOutput(&dataflow, config, nil)
 	if err != nil {
 		t.Fatalf("failed to generate security output err:%s", err)
 	}
@@ -154,7 +154,7 @@ func TestTestGetOutputWithSeverity(t *testing.T) {
 
 	dataflow := dummyDataflow()
 
-	res, err := security.GetOutput(&dataflow, config, nil)
+	res, _, err := security.GetOutput(&dataflow, config, nil)
 	if err != nil {
 		t.Fatalf("failed to generate security output err:%s", err)
 	}


### PR DESCRIPTION
## Description
For formats other than default the security report would not set the exit code correctly. This meant when using rdjson for PR reviews runs would be shown as a pass. 

NB: Old behvaiour can be replicated using `--exit-code=0`.

## Related


## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
