### PR TITLE
fix: handle empty list to scan for orchestrator

### DIFF
--- a/pkg/commands/process/orchestrator/orchestrator.go
+++ b/pkg/commands/process/orchestrator/orchestrator.go
@@ -85,6 +85,11 @@ func (orchestrator *Orchestrator) waitForScan(fileComplete chan struct{}, totalC
 		}
 	}()
 
+	if totalCount == 0 {
+		log.Debug().Msgf("no files to scan")
+		return
+	}
+
 	for {
 		select {
 		case <-orchestrator.done:


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

When performing a diff scan, you might end up with a branch that contains only new files. The orchestrator would hang in such circumstances.

closes #1205 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
