### PR TITLE
fix: ignore command CLI interface

### DIFF
--- a/e2e/flags/.snapshots/TestMetadataFlags-help
+++ b/e2e/flags/.snapshots/TestMetadataFlags-help
@@ -12,6 +12,7 @@ Usage: bearer <command> [flags]
 Available Commands:
 	scan              Scan a directory or file
 	init              Write the default config to bearer.yml
+	ignore            Manage ignored fingerprints
 	version           Print the version
 
 Examples:

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -42,6 +42,7 @@ Usage: bearer <command> [flags]
 Available Commands:
 	scan              Scan a directory or file
 	init              Write the default config to bearer.yml
+	ignore            Manage ignored fingerprints
 	version           Print the version
 
 Examples:

--- a/pkg/commands/ignore.go
+++ b/pkg/commands/ignore.go
@@ -12,6 +12,27 @@ import (
 )
 
 func NewIgnoreCommand() *cobra.Command {
+	usageTemplate := `
+Usage: bearer ignore <command> [flags]
+
+Available Commands:
+    add              Add an ignored fingerprint
+    show             Show an ignored fingerprint
+    migrate          Migrate ignored fingerprints
+
+Examples:
+    # Add an ignored fingerprint to your bearer.ignore file
+    $ bearer ignore add <fingerprint> --author Mish --comment "investigate this"
+
+    # Show the details of an ignored fingerprint from your bearer.ignore file
+    $ bearer ignore show <fingerprint>
+
+    # Migrate existing ignored (excluded) fingerprints from bearer.yml file
+    # to bearer.ignore
+    $ bearer ignore migrate
+
+`
+
 	cmd := &cobra.Command{
 		Use:           "ignore [subcommand] <fingerprint>",
 		Short:         "Manage ignored fingerprints",
@@ -25,6 +46,8 @@ func NewIgnoreCommand() *cobra.Command {
 		newIgnoreAddCommand(),
 		newIgnoreMigrateCommand(),
 	)
+
+	cmd.SetUsageTemplate(usageTemplate)
 
 	return cmd
 }

--- a/pkg/commands/ignore.go
+++ b/pkg/commands/ignore.go
@@ -60,8 +60,7 @@ func newIgnoreShowCommand() *cobra.Command {
 $ bearer ignore show <fingerprint>`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				cmd.Printf("No fingerprint given. Please provide a fingerprint with the command: $ bearer ignore show <fingerprint>\n")
-				return nil
+				return cmd.Help()
 			}
 
 			ignoredFingerprints, err := ignore.GetIgnoredFingerprints(nil)
@@ -101,8 +100,7 @@ $ bearer ignore add <fingerprint> --author Mish --comment "Possible false positi
 			}
 
 			if len(args) == 0 {
-				cmd.Printf("No fingerprint given. Please provide a fingerprint with the command: $ bearer ignore add <fingerprint>\n")
-				return nil
+				return cmd.Help()
 			}
 
 			options, err := IgnoreAddFlags.ToOptions(args)

--- a/pkg/flag/ignore_add_flags.go
+++ b/pkg/flag/ignore_add_flags.go
@@ -6,7 +6,7 @@ var (
 		ConfigName: "ignore_add.author",
 		Shorthand:  "a",
 		Value:      FormatEmpty,
-		Usage:      "Specify report format (json, yaml, sarif, gitlab-sast, rdjson, html)",
+		Usage:      "Add author information to this ignored finding.",
 	}
 	CommentFlag = Flag{
 		Name:       "comment",


### PR DESCRIPTION
## Description

Some fixes around CLI interface for new `ignore` command

Fixes include: 

* Add usage template for `ignore` command, detailing its subcommands
* Display usage template when no fingerprint is given (previously error message shown)
* Include `ignore` in "Available Commands" list
* Fix bad copy-pasta for `author` flag description (`ignore add` subcommand)

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
