### PR TITLE
feat: add path flag for ignore file

### DIFF
--- a/docs/_data/bearer_ignore_add.yaml
+++ b/docs/_data/bearer_ignore_add.yaml
@@ -22,4 +22,4 @@ example: |-
     $ bearer ignore add <fingerprint> --author Mish --comment "Possible false positive"
 see_also:
     - ' ignore - Manage ignored fingerprints'
-aliases:
+aliases: 

--- a/docs/_data/bearer_ignore_add.yaml
+++ b/docs/_data/bearer_ignore_add.yaml
@@ -5,6 +5,9 @@ options:
     - name: author
       shorthand: a
       usage: Add author information to this ignored finding.
+    - name: bearer-ignore-file
+      default_value: bearer.ignore
+      usage: Load bearer.ignore file from the specified path.
     - name: comment
       usage: Add a comment to this ignored finding.
     - name: force
@@ -19,4 +22,4 @@ example: |-
     $ bearer ignore add <fingerprint> --author Mish --comment "Possible false positive"
 see_also:
     - ' ignore - Manage ignored fingerprints'
-aliases: 
+aliases:

--- a/docs/_data/bearer_ignore_migrate.yaml
+++ b/docs/_data/bearer_ignore_migrate.yaml
@@ -3,6 +3,9 @@ synopsis: |
     Migrate ignored fingerprints from bearer.yml to bearer.ignore
 usage: ' ignore migrate [flags]'
 options:
+    - name: bearer-ignore-file
+      default_value: bearer.ignore
+      usage: Load bearer.ignore file from the specified path.
     - name: config-file
       default_value: bearer.yml
       usage: Load configuration from the specified path.

--- a/docs/_data/bearer_ignore_show.yaml
+++ b/docs/_data/bearer_ignore_show.yaml
@@ -2,6 +2,9 @@ name: ' ignore show'
 synopsis: Show an ignored fingerprint
 usage: ' ignore show <fingerprint> [flags]'
 options:
+    - name: bearer-ignore-file
+      default_value: bearer.ignore
+      usage: Load bearer.ignore file from the specified path.
     - name: help
       shorthand: h
       default_value: "false"

--- a/pkg/commands/ignore.go
+++ b/pkg/commands/ignore.go
@@ -67,6 +67,10 @@ func newIgnoreShowCommand() *cobra.Command {
 		Example: `# Show the details of an ignored fingerprint from your bearer.ignore file
 $ bearer ignore show <fingerprint>`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := IgnoreShowFlags.Bind(cmd); err != nil {
+				return fmt.Errorf("flag bind error: %w", err)
+			}
+
 			if len(args) == 0 {
 				return cmd.Help()
 			}
@@ -79,6 +83,10 @@ $ bearer ignore show <fingerprint>`,
 			ignoredFingerprints, fileExists, err := ignore.GetIgnoredFingerprints(options.IgnoreOptions.BearerIgnoreFile)
 			if err != nil {
 				cmd.Printf("Issue loading ignored fingerprints from bearer.ignore file: %s", err)
+				return nil
+			}
+			if !fileExists {
+				cmd.Printf("bearer.ignore file not found. Perhaps you need to use --bearer-ignore-file to specify the path to bearer.ignore?\n")
 				return nil
 			}
 			fingerprintId := args[0]
@@ -139,7 +147,7 @@ $ bearer ignore add <fingerprint> --author Mish --comment "Possible false positi
 			}
 
 			if !fileExists {
-				cmd.Printf("\nCreating bearer.ignore file...")
+				cmd.Printf("\nCreating bearer.ignore file...\n")
 			}
 
 			if mergeErr := ignore.MergeIgnoredFingerprints(fingerprintsToIgnore, ignoredFingerprints, options.IgnoreAddOptions.Force); mergeErr != nil {

--- a/pkg/commands/process/settings/settings.go
+++ b/pkg/commands/process/settings/settings.go
@@ -311,7 +311,7 @@ func FromOptions(opts flag.Options, foundLanguages []string) (Config, error) {
 		}
 	}
 
-	ignoredFingerprints, err := ignore.GetIgnoredFingerprints(&opts.ScanOptions.Target)
+	ignoredFingerprints, err := ignore.GetIgnoredFingerprints(opts.IgnoreOptions.BearerIgnoreFile)
 	if err != nil {
 		return Config{}, err
 	}

--- a/pkg/commands/process/settings/settings.go
+++ b/pkg/commands/process/settings/settings.go
@@ -311,7 +311,7 @@ func FromOptions(opts flag.Options, foundLanguages []string) (Config, error) {
 		}
 	}
 
-	ignoredFingerprints, err := ignore.GetIgnoredFingerprints(opts.IgnoreOptions.BearerIgnoreFile)
+	ignoredFingerprints, _, err := ignore.GetIgnoredFingerprints(opts.IgnoreOptions.BearerIgnoreFile)
 	if err != nil {
 		return Config{}, err
 	}

--- a/pkg/flag/general_flags.go
+++ b/pkg/flag/general_flags.go
@@ -56,6 +56,7 @@ var (
 
 type GeneralFlagGroup struct {
 	ConfigFile          *Flag
+	BearerIgnoreFile    *Flag
 	APIKey              *Flag
 	Host                *Flag
 	DisableVersionCheck *Flag

--- a/pkg/flag/ignore_flags.go
+++ b/pkg/flag/ignore_flags.go
@@ -1,0 +1,41 @@
+package flag
+
+var (
+	BearerIgnoreFileFlag = Flag{
+		Name:            "bearer-ignore-file",
+		ConfigName:      "bearer-ignore-file",
+		Value:           "bearer.ignore",
+		Usage:           "Load bearer.ignore file from the specified path.",
+		DisableInConfig: true,
+	}
+)
+
+type IgnoreFlagGroup struct {
+	BearerIgnoreFileFlag *Flag
+}
+
+type IgnoreOptions struct {
+	BearerIgnoreFile string `mapstructure:"ignore_bearer_ignore_file" json:"ignore_bearer_ignore_file" yaml:"ignore_bearer_ignore_file"`
+}
+
+func NewIgnoreFlagGroup() *IgnoreFlagGroup {
+	return &IgnoreFlagGroup{
+		BearerIgnoreFileFlag: &BearerIgnoreFileFlag,
+	}
+}
+
+func (f *IgnoreFlagGroup) Name() string {
+	return "Ignore"
+}
+
+func (f *IgnoreFlagGroup) Flags() []*Flag {
+	return []*Flag{
+		f.BearerIgnoreFileFlag,
+	}
+}
+
+func (f *IgnoreFlagGroup) ToOptions() IgnoreOptions {
+	return IgnoreOptions{
+		BearerIgnoreFile: getString(f.BearerIgnoreFileFlag),
+	}
+}

--- a/pkg/flag/ignore_migrate_flags.go
+++ b/pkg/flag/ignore_migrate_flags.go
@@ -7,6 +7,13 @@ var (
 		Value:      false,
 		Usage:      "Overwrite an existing ignored finding.",
 	}
+	IgnoreMigrateBearerIgnoreFileFlag = Flag{
+		Name:            "config-file",
+		ConfigName:      "config-file",
+		Value:           "bearer.yml",
+		Usage:           "Load configuration from the specified path.",
+		DisableInConfig: true,
+	}
 	IgnoreMigrateConfigFileFlag = Flag{
 		Name:            "config-file",
 		ConfigName:      "config-file",
@@ -17,8 +24,9 @@ var (
 )
 
 type IgnoreMigrateFlagGroup struct {
-	IgnoreMigrateForceFlag      *Flag
-	IgnoreMigrateConfigFileFlag *Flag
+	IgnoreMigrateForceFlag            *Flag
+	IgnoreMigrateConfigFileFlag       *Flag
+	IgnoreMigrateBearerIgnoreFileFlag *Flag
 }
 
 type IgnoreMigrateOptions struct {
@@ -28,8 +36,9 @@ type IgnoreMigrateOptions struct {
 
 func NewIgnoreMigrateFlagGroup() *IgnoreMigrateFlagGroup {
 	return &IgnoreMigrateFlagGroup{
-		IgnoreMigrateForceFlag:      &IgnoreMigrateForceFlag,
-		IgnoreMigrateConfigFileFlag: &IgnoreMigrateConfigFileFlag,
+		IgnoreMigrateForceFlag:            &IgnoreMigrateForceFlag,
+		IgnoreMigrateBearerIgnoreFileFlag: &IgnoreMigrateBearerIgnoreFileFlag,
+		IgnoreMigrateConfigFileFlag:       &IgnoreMigrateConfigFileFlag,
 	}
 }
 

--- a/pkg/flag/options.go
+++ b/pkg/flag/options.go
@@ -53,6 +53,7 @@ type Flags struct {
 	ProcessFlagGroup       *ProcessFlagGroup
 	ScanFlagGroup          *ScanFlagGroup
 	GeneralFlagGroup       *GeneralFlagGroup
+	IgnoreFlagGroup        *IgnoreFlagGroup
 	IgnoreAddFlagGroup     *IgnoreAddFlagGroup
 	IgnoreMigrateFlagGroup *IgnoreMigrateFlagGroup
 }
@@ -64,6 +65,7 @@ type Options struct {
 	RuleOptions
 	ScanOptions
 	GeneralOptions
+	IgnoreOptions
 	IgnoreAddOptions
 	IgnoreMigrateOptions
 }
@@ -180,6 +182,9 @@ func (f *Flags) groups() []FlagGroup {
 	if f.RepoFlagGroup != nil {
 		groups = append(groups, f.RepoFlagGroup)
 	}
+	if f.IgnoreFlagGroup != nil {
+		groups = append(groups, f.IgnoreFlagGroup)
+	}
 	if f.IgnoreAddFlagGroup != nil {
 		groups = append(groups, f.IgnoreAddFlagGroup)
 	}
@@ -282,6 +287,10 @@ func (f *Flags) ToOptions(args []string) (Options, error) {
 
 	if f.GeneralFlagGroup != nil {
 		opts.GeneralOptions = f.GeneralFlagGroup.ToOptions()
+	}
+
+	if f.IgnoreFlagGroup != nil {
+		opts.IgnoreOptions = f.IgnoreFlagGroup.ToOptions()
 	}
 
 	if f.IgnoreAddFlagGroup != nil {

--- a/pkg/util/ignore/ignore.go
+++ b/pkg/util/ignore/ignore.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"os"
 	"time"
-
-	"github.com/fatih/color"
 )
 
 type IgnoredFingerprint struct {
@@ -15,102 +13,36 @@ type IgnoredFingerprint struct {
 	IgnoredAt string
 }
 
-type DuplicateIgnoredFingerprintError struct {
-	Err error
-}
-
-func (f *DuplicateIgnoredFingerprintError) Error() string {
-	return f.Err.Error()
-}
-
-var bold = color.New(color.Bold).SprintFunc()
-var morePrefix = color.HiBlackString("├─ ")
-var lastPrefix = color.HiBlackString("└─ ")
-
-func DisplayIgnoredEntryTextString(fingerprintId string, entry IgnoredFingerprint) string {
-	prefix := morePrefix
-	result := fmt.Sprintf(bold(color.HiBlueString("%s \n")), fingerprintId)
-
-	if entry.Author == "" && entry.Comment == "" {
-		prefix = lastPrefix
-	}
-	result += fmt.Sprintf("%sIgnored At: %s\n", prefix, bold(entry.IgnoredAt))
-
-	if entry.Author != "" {
-		if entry.Comment == "" {
-			prefix = lastPrefix
-		}
-
-		result += fmt.Sprintf("%sAuthor: %s\n", prefix, bold(entry.Author))
-	}
-
-	if entry.Comment != "" {
-		result += fmt.Sprintf("%sComment: %s\n", lastPrefix, bold(entry.Comment))
-	}
-
-	return result
-}
-
-func GetIgnoredFingerprints(bearerIgnoreFilePath string) (ignoredFingerprints map[string]IgnoredFingerprint, err error) {
-	fingerprints, err := readIgnoreFile(bearerIgnoreFilePath)
-	if err != nil {
-		return map[string]IgnoredFingerprint{}, err
-	}
-
-	return fingerprints, nil
-}
-
-func GetExistingIgnoredFingerprints(bearerIgnoreFilePath string) (existingIgnoredFingerprints map[string]IgnoredFingerprint, fileExists bool, err error) {
+func GetIgnoredFingerprints(bearerIgnoreFilePath string) (ignoredFingerprints map[string]IgnoredFingerprint, fileExists bool, err error) {
 	if _, noFileErr := os.Stat(bearerIgnoreFilePath); noFileErr != nil {
-		existingIgnoredFingerprints = make(map[string]IgnoredFingerprint)
-	} else {
-		fileExists = true
-		existingIgnoredFingerprints, err = readIgnoreFile(bearerIgnoreFilePath)
+		ignoredFingerprints = make(map[string]IgnoredFingerprint)
+		return ignoredFingerprints, false, err
 	}
 
-	return existingIgnoredFingerprints, fileExists, err
+	// file exists
+	content, err := os.ReadFile(bearerIgnoreFilePath)
+	if err != nil {
+		return ignoredFingerprints, true, err
+	}
+
+	err = json.Unmarshal(content, &ignoredFingerprints)
+	return ignoredFingerprints, true, err
 }
 
-func AddToIgnoreFile(fingerprintsToIgnore map[string]IgnoredFingerprint, existingIgnoredFingerprints map[string]IgnoredFingerprint, bearerIgnoreFilePath string, force bool) error {
+func MergeIgnoredFingerprints(fingerprintsToIgnore map[string]IgnoredFingerprint, ignoredFingerprints map[string]IgnoredFingerprint, force bool) error {
 	for key, value := range fingerprintsToIgnore {
 		if !force {
-			if _, ok := existingIgnoredFingerprints[key]; ok {
-				error := fmt.Errorf(
-					"fingerprint '%s' already exists in bearer.ignore file. To view this entry run:\n\n$ bearer ignore show %s\n\nTo overwrite this entry, use --force",
+			if _, ok := ignoredFingerprints[key]; ok {
+				return fmt.Errorf(
+					"fingerprint '%s' already exists in the bearer.ignore file. To view this entry run:\n\n$ bearer ignore show %s\n\nTo overwrite this entry, use --force",
 					key,
 					key,
 				)
-				return &DuplicateIgnoredFingerprintError{
-					Err: error,
-				}
 			}
 		}
 		ignoredAt := time.Now().UTC()
 		value.IgnoredAt = ignoredAt.Format(time.RFC3339)
-		existingIgnoredFingerprints[key] = value
+		ignoredFingerprints[key] = value
 	}
-
-	data, err := json.MarshalIndent(existingIgnoredFingerprints, "", "  ")
-	if err != nil {
-		// failed to marshall data
-		return err
-	}
-
-	return os.WriteFile(bearerIgnoreFilePath, data, 0644)
-}
-
-func readIgnoreFile(bearerIgnoreFilePath string) (payload map[string]IgnoredFingerprint, err error) {
-	if _, err := os.Stat(bearerIgnoreFilePath); err != nil {
-		// bearer.ignore file does not exist
-		// return blank payload
-		return map[string]IgnoredFingerprint{}, nil
-	}
-
-	content, err := os.ReadFile(bearerIgnoreFilePath)
-	if err != nil {
-		return payload, err
-	}
-
-	err = json.Unmarshal(content, &payload)
-	return payload, err
+	return nil
 }

--- a/pkg/util/ignore/ignore.go
+++ b/pkg/util/ignore/ignore.go
@@ -61,7 +61,7 @@ func GetIgnoredFingerprints(bearerIgnoreFilePath string) (ignoredFingerprints ma
 }
 
 func GetExistingIgnoredFingerprints(bearerIgnoreFilePath string) (existingIgnoredFingerprints map[string]IgnoredFingerprint, fileExists bool, err error) {
-	if _, err = os.Stat(bearerIgnoreFilePath); err != nil {
+	if _, noFileErr := os.Stat(bearerIgnoreFilePath); noFileErr != nil {
 		existingIgnoredFingerprints = make(map[string]IgnoredFingerprint)
 	} else {
 		fileExists = true

--- a/pkg/util/ignore/ignore.go
+++ b/pkg/util/ignore/ignore.go
@@ -8,9 +8,9 @@ import (
 )
 
 type IgnoredFingerprint struct {
-	Author    string
-	Comment   string
-	IgnoredAt string
+	Author    *string `json:"author,omitempty"`
+	Comment   *string `json:"comment,omitempty"`
+	IgnoredAt string  `json:"ignored_at"`
 }
 
 func GetIgnoredFingerprints(bearerIgnoreFilePath string) (ignoredFingerprints map[string]IgnoredFingerprint, fileExists bool, err error) {

--- a/pkg/util/ignore/ignore_test.go
+++ b/pkg/util/ignore/ignore_test.go
@@ -1,0 +1,102 @@
+package ignore_test
+
+import (
+	"testing"
+
+	"github.com/bearer/bearer/pkg/util/ignore"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/exp/maps"
+)
+
+func TestGetIgnoredFingerprints(t *testing.T) {
+	t.Run("bearer.ignore does not exist", func(t *testing.T) {
+		ignoredFingerprints, fileExists, err := ignore.GetIgnoredFingerprints("some_path.ignore")
+		assert.Equal(t, map[string]ignore.IgnoredFingerprint{}, ignoredFingerprints)
+		assert.Equal(t, false, fileExists)
+		assert.Equal(t, nil, err)
+	})
+}
+
+func TestMergeIgnoredFingerprints(t *testing.T) {
+	tests := []struct {
+		Name                 string
+		FingerprintsToIgnore map[string]ignore.IgnoredFingerprint
+		IgnoredFingerprints  map[string]ignore.IgnoredFingerprint
+		Force                bool
+		Want                 []string
+		ShouldSucceed        bool
+	}{
+		{
+			Name: "Happy path - no duplicates",
+			FingerprintsToIgnore: map[string]ignore.IgnoredFingerprint{
+				"123": {
+					IgnoredAt: "2",
+				},
+			},
+			IgnoredFingerprints: map[string]ignore.IgnoredFingerprint{
+				"456": {
+					IgnoredAt: "2",
+				},
+			},
+			Force:         false,
+			Want:          []string{"123", "456"},
+			ShouldSucceed: true,
+		},
+		{
+			Name: "Duplicate entries",
+			FingerprintsToIgnore: map[string]ignore.IgnoredFingerprint{
+				"123": {
+					IgnoredAt: "2",
+				},
+			},
+			IgnoredFingerprints: map[string]ignore.IgnoredFingerprint{
+				"123": {
+					IgnoredAt: "2",
+				},
+				"456": {
+					IgnoredAt: "2",
+				},
+			},
+			Force:         false,
+			Want:          []string{"123", "456"},
+			ShouldSucceed: false,
+		},
+		{
+			Name: "Duplicate entries with force flag set",
+			FingerprintsToIgnore: map[string]ignore.IgnoredFingerprint{
+				"123": {
+					IgnoredAt: "2",
+				},
+			},
+			IgnoredFingerprints: map[string]ignore.IgnoredFingerprint{
+				"123": {
+					IgnoredAt: "2",
+				},
+				"456": {
+					IgnoredAt: "2",
+				},
+			},
+			Force:         true,
+			Want:          []string{"123", "456"},
+			ShouldSucceed: true,
+		},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.Name, func(t *testing.T) {
+			ignores := testCase.IgnoredFingerprints
+			err := ignore.MergeIgnoredFingerprints(
+				testCase.FingerprintsToIgnore, ignores, testCase.Force,
+			)
+
+			if err != nil && testCase.ShouldSucceed {
+				t.Errorf("ignore returned error %s", err)
+			}
+
+			if err == nil && !testCase.ShouldSucceed {
+				t.Errorf("expected error for test case %s but none was returned", testCase.Name)
+			}
+
+			assert.ElementsMatch(t, testCase.Want, maps.Keys(ignores))
+		})
+	}
+}

--- a/pkg/util/ignore/ignore_test.go
+++ b/pkg/util/ignore/ignore_test.go
@@ -30,12 +30,12 @@ func TestMergeIgnoredFingerprints(t *testing.T) {
 			Name: "Happy path - no duplicates",
 			FingerprintsToIgnore: map[string]ignore.IgnoredFingerprint{
 				"123": {
-					IgnoredAt: "2",
+					IgnoredAt: "2023-08-28T09:30:01Z",
 				},
 			},
 			IgnoredFingerprints: map[string]ignore.IgnoredFingerprint{
 				"456": {
-					IgnoredAt: "2",
+					IgnoredAt: "2023-08-28T09:30:01Z",
 				},
 			},
 			Force:         false,
@@ -46,15 +46,15 @@ func TestMergeIgnoredFingerprints(t *testing.T) {
 			Name: "Duplicate entries",
 			FingerprintsToIgnore: map[string]ignore.IgnoredFingerprint{
 				"123": {
-					IgnoredAt: "2",
+					IgnoredAt: "2023-08-28T09:30:01Z",
 				},
 			},
 			IgnoredFingerprints: map[string]ignore.IgnoredFingerprint{
 				"123": {
-					IgnoredAt: "2",
+					IgnoredAt: "2023-08-28T09:30:01Z",
 				},
 				"456": {
-					IgnoredAt: "2",
+					IgnoredAt: "2023-08-28T09:30:01Z",
 				},
 			},
 			Force:         false,


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Add `--bearer-ignore-file` flag to ignore commands, so that we can specify a path to our bearer.ignore file. Defaults to `bearer.ignore`

Also some refactoring and adding tests around ignore methods and util

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [x] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
