### PR TITLE
feat: add ignore remove command

### DIFF
--- a/docs/_data/bearer_ignore_remove.yaml
+++ b/docs/_data/bearer_ignore_remove.yaml
@@ -1,0 +1,17 @@
+name: ' ignore remove'
+synopsis: Remove an ignored fingerprint
+usage: ' ignore remove <fingerprint> [flags]'
+options:
+    - name: bearer-ignore-file
+      default_value: bearer.ignore
+      usage: Load bearer.ignore file from the specified path.
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for remove
+example: |-
+    # Remove an ignored fingerprint from your bearer.ignore file
+    $ bearer ignore remove <fingerprint>
+see_also:
+    - ' ignore - Manage ignored fingerprints'
+aliases: 

--- a/pkg/commands/ignore.go
+++ b/pkg/commands/ignore.go
@@ -7,16 +7,11 @@ import (
 
 	"github.com/bearer/bearer/pkg/flag"
 	"github.com/bearer/bearer/pkg/util/ignore"
-	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
 var migratedIgnoreComment = "migrated from bearer.yml"
-
-var bold = color.New(color.Bold).SprintFunc()
-var morePrefix = color.HiBlackString("├─ ")
-var lastPrefix = color.HiBlackString("└─ ")
 
 func NewIgnoreCommand() *cobra.Command {
 	usageTemplate := `
@@ -98,7 +93,7 @@ $ bearer ignore show <fingerprint>`,
 			if options.IgnoreShowOptions.All {
 				// show all fingerprints
 				for fingerprintId, fingerprint := range ignoredFingerprints {
-					cmd.Print(displayIgnoredEntryTextString(fingerprintId, fingerprint))
+					cmd.Print(ignore.DisplayIgnoredEntryTextString(fingerprintId, fingerprint))
 				}
 			} else {
 				// show a specific fingerprint
@@ -108,9 +103,9 @@ $ bearer ignore show <fingerprint>`,
 					cmd.Printf("Ignored fingerprint '%s' was not found in bearer.ignore file\n", fingerprintId)
 					return nil
 				}
-				cmd.Print(displayIgnoredEntryTextString(fingerprintId, selectedIgnoredFingerprint))
+				cmd.Print(ignore.DisplayIgnoredEntryTextString(fingerprintId, selectedIgnoredFingerprint))
 			}
-			cmd.Print("\n")
+			cmd.Print("\n\n")
 			return nil
 		},
 		SilenceErrors: false,
@@ -178,8 +173,8 @@ $ bearer ignore add <fingerprint> --author Mish --comment "Possible false positi
 			}
 
 			cmd.Print("Fingerprint added to bearer.ignore:\n\n")
-			cmd.Print(displayIgnoredEntryTextString(fingerprintId, ignoredFingerprints[fingerprintId]))
-			cmd.Print("\n")
+			cmd.Print(ignore.DisplayIgnoredEntryTextString(fingerprintId, ignoredFingerprints[fingerprintId]))
+			cmd.Print("\n\n")
 			return nil
 		},
 		SilenceErrors: false,
@@ -236,8 +231,8 @@ $ bearer ignore remove <fingerprint>`,
 			}
 
 			cmd.Print("Fingerprint successfully removed from bearer.ignore:\n\n")
-			cmd.Print(displayIgnoredEntryTextString(fingerprintId, removedFingerprint))
-			cmd.Print("\n")
+			cmd.Print(ignore.DisplayIgnoredEntryTextString(fingerprintId, removedFingerprint))
+			cmd.Print("\n\n")
 			return nil
 		},
 		SilenceErrors: false,
@@ -342,28 +337,4 @@ func getIgnoredFingerprintsFromConfig(configPath string) (ignoredFingerprintsFro
 	}
 
 	return ignoredFingerprintsFromConfig, nil
-}
-
-func displayIgnoredEntryTextString(fingerprintId string, entry ignore.IgnoredFingerprint) string {
-	prefix := morePrefix
-	result := fmt.Sprintf(bold(color.HiBlueString("%s \n")), fingerprintId)
-
-	if entry.Author == nil && entry.Comment == nil {
-		prefix = lastPrefix
-	}
-	result += fmt.Sprintf("%sIgnored At: %s\n", prefix, bold(entry.IgnoredAt))
-
-	if entry.Author != nil {
-		if entry.Comment == nil {
-			prefix = lastPrefix
-		}
-
-		result += fmt.Sprintf("%sAuthor: %s\n", prefix, bold(*entry.Author))
-	}
-
-	if entry.Comment != nil {
-		result += fmt.Sprintf("%sComment: %s\n", lastPrefix, bold(*entry.Comment))
-	}
-
-	return result
 }

--- a/pkg/report/output/security/security.go
+++ b/pkg/report/output/security/security.go
@@ -313,7 +313,7 @@ func fingerprintOutput(fingerprints []string, legacyExcludedFingerprints map[str
 		output.StdErrLog("\n=====================================\n")
 		// legacy
 		if len(legacyExcludedFingerprints) > 0 {
-			output.StdErrLog("\nNote: exclude_fingerprints is legacy. To use new ignore functionality, run bearer ignore migrate. See https://docs.bearer.com/reference/commands/#ignore_migrate.\n\n")
+			output.StdErrLog("Note: exclude-fingerprints is being replaced by bearer.ignore. To use the new ignore functionality, run bearer ignore migrate. See https://docs.bearer.com/reference/commands/#ignore_migrate.\n")
 		}
 
 		if len(unusedLegacyFingerprints) > 0 {
@@ -326,8 +326,19 @@ func fingerprintOutput(fingerprints []string, legacyExcludedFingerprints map[str
 
 		if len(unusedFingerprints) > 0 {
 			output.StdErrLog(fmt.Sprintf("%d ignored fingerprints present in your bearer.ignore file are no longer detected:", len(unusedFingerprints)))
-			for _, fingerprint := range unusedFingerprints {
-				output.StdErrLog(fmt.Sprintf("  - %s", fingerprint))
+			for _, fingerprintId := range unusedFingerprints {
+				fingerprint, ok := ignoredFingerprints[fingerprintId]
+				if !ok {
+					// fingerprint will always be found, but if not let's not blow up the scan
+					continue
+				}
+
+				if fingerprint.Comment == nil {
+					output.StdErrLog(fmt.Sprintf("  - %s", fingerprintId))
+				} else {
+					output.StdErrLog(fmt.Sprintf("  - %s (%s)", fingerprintId, *fingerprint.Comment))
+				}
+				output.StdErrLog(color.HiBlackString("\tTo remove this fingerprint from your bearer.ignore file, run: bearer ignore remove " + fingerprintId))
 			}
 		}
 		output.StdErrLog("\n=====================================")

--- a/pkg/util/ignore/ignore.go
+++ b/pkg/util/ignore/ignore.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"time"
+
+	"github.com/fatih/color"
 )
 
 type IgnoredFingerprint struct {
@@ -45,4 +47,32 @@ func MergeIgnoredFingerprints(fingerprintsToIgnore map[string]IgnoredFingerprint
 		ignoredFingerprints[key] = value
 	}
 	return nil
+}
+
+var bold = color.New(color.Bold).SprintFunc()
+var morePrefix = color.HiBlackString("├─ ")
+var lastPrefix = color.HiBlackString("└─ ")
+
+func DisplayIgnoredEntryTextString(fingerprintId string, entry IgnoredFingerprint) string {
+	prefix := morePrefix
+	result := fmt.Sprintf(bold(color.HiBlueString("%s \n")), fingerprintId)
+
+	if entry.Author == nil && entry.Comment == nil {
+		prefix = lastPrefix
+	}
+	result += fmt.Sprintf("%sIgnored At: %s", prefix, bold(entry.IgnoredAt))
+
+	if entry.Author != nil {
+		if entry.Comment == nil {
+			prefix = lastPrefix
+		}
+
+		result += fmt.Sprintf("\n%sAuthor: %s", prefix, bold(*entry.Author))
+	}
+
+	if entry.Comment != nil {
+		result += fmt.Sprintf("\n%sComment: %s", lastPrefix, bold(*entry.Comment))
+	}
+
+	return result
 }


### PR DESCRIPTION
## Description
Add `bearer ignore remove <fingerprint>` command
Use display method for scan warning about stale ignored fingerprints and include reference to ignore remove command

### Visual changes

`bearer ignore remove 111`

<img width="617" alt="Screenshot 2023-08-28 at 13 57 06" src="https://github.com/Bearer/bearer/assets/4560746/1e943b5f-a388-4430-83a2-eb6a9bfdb107">

Scan message: 
<img width="1196" alt="Screenshot 2023-08-28 at 14 45 02" src="https://github.com/Bearer/bearer/assets/4560746/0bc20ca6-8e67-48f6-8896-c5005257cb27">

Scan message when exclude-fingerprints is still used: 

<img width="1492" alt="Screenshot 2023-08-28 at 14 52 28" src="https://github.com/Bearer/bearer/assets/4560746/c55cd20e-eb4f-4e32-a8eb-fa6dd3d05cfd">

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
