### PR TITLE
feat: add false positive status to bearer ignores

### DIFF
--- a/bearer.ignore
+++ b/bearer.ignore
@@ -1,0 +1,42 @@
+{
+  "123": {
+    "author": "elsapet",
+    "false_positive": true,
+    "ignored_at": "2023-08-31T10:50:33Z"
+  },
+  "234": {
+    "author": "elsapet",
+    "comment": "hello world",
+    "false_positive": false,
+    "ignored_at": "2023-08-31T10:50:33Z"
+  },
+  "345": {
+    "author": "elsapet",
+    "false_positive": false,
+    "ignored_at": "2023-08-31T10:50:33Z"
+  },
+  "456": {
+    "author": "elsapet",
+    "comment": "hello true world",
+    "false_positive": true,
+    "ignored_at": "2023-08-31T10:50:33Z"
+  },
+  "789": {
+    "author": "elsapet",
+    "comment": "hello",
+    "false_positive": true,
+    "ignored_at": "2023-08-31T11:25:22Z"
+  },
+  "890": {
+    "author": "elsapet",
+    "comment": "hello there",
+    "false_positive": true,
+    "ignored_at": "2023-08-31T11:25:51Z"
+  },
+  "8901": {
+    "author": "elsapet",
+    "comment": "asd",
+    "false_positive": false,
+    "ignored_at": "2023-08-31T11:26:50Z"
+  }
+}

--- a/docs/_data/bearer_ignore_add.yaml
+++ b/docs/_data/bearer_ignore_add.yaml
@@ -22,6 +22,9 @@ options:
     - name: disable-version-check
       default_value: "false"
       usage: Disable Bearer version checking
+    - name: false-positive
+      default_value: "false"
+      usage: Mark an this ignored finding as false positive.
     - name: force
       default_value: "false"
       usage: Overwrite an existing ignored finding.

--- a/pkg/commands/ignore.go
+++ b/pkg/commands/ignore.go
@@ -147,14 +147,42 @@ $ bearer ignore add <fingerprint> --author Mish --comment "Possible false positi
 			if err != nil {
 				return fmt.Errorf("flag error: %s", err)
 			}
+
+			// create initial entry
 			fingerprintId := args[0]
 			var fingerprintEntry ignore.IgnoredFingerprint
+			fingerprintsToIgnore := map[string]ignore.IgnoredFingerprint{
+				fingerprintId: fingerprintEntry,
+			}
+
+			ignoredFingerprints, fileExists, err := ignore.GetIgnoredFingerprints(options.GeneralOptions.BearerIgnoreFile, nil)
+			if err != nil {
+				return fmt.Errorf("error retrieving existing ignores: %s", err)
+			}
+
+			// check for merge conflicts
+			if mergeErr := ignore.MergeIgnoredFingerprints(fingerprintsToIgnore, ignoredFingerprints, options.IgnoreAddOptions.Force); mergeErr != nil {
+				// handle expected error (duplicate entry in bearer.ignore)
+				cmd.Printf("Error: %s\n", mergeErr.Error())
+				return nil
+			}
+
+			// ensure ignored at is set
+			fingerprintEntry = ignoredFingerprints[fingerprintId]
+
+			// add additional information to entry
 			if options.IgnoreAddOptions.Author != "" {
 				fingerprintEntry.Author = &options.IgnoreAddOptions.Author
 			} else {
 				if author, err := ignore.GetAuthor(); err == nil {
 					fingerprintEntry.Author = author
 				}
+			}
+			if options.IgnoreAddOptions.FalsePositive {
+				fingerprintEntry.FalsePositive = options.IgnoreAddOptions.FalsePositive
+			} else {
+				fingerprintEntry.FalsePositive = requestConfirmation("Is this finding a false positive?")
+				cmd.Printf("\n")
 			}
 			if options.IgnoreAddOptions.Comment != "" {
 				fingerprintEntry.Comment = &options.IgnoreAddOptions.Comment
@@ -169,23 +197,11 @@ $ bearer ignore add <fingerprint> --author Mish --comment "Possible false positi
 				cmd.Printf("\n")
 			}
 
-			fingerprintsToIgnore := map[string]ignore.IgnoredFingerprint{
-				fingerprintId: fingerprintEntry,
-			}
-
-			ignoredFingerprints, fileExists, err := ignore.GetIgnoredFingerprints(options.GeneralOptions.BearerIgnoreFile, nil)
-			if err != nil {
-				return fmt.Errorf("error retrieving existing ignores: %s", err)
-			}
+			// update entry to include additional information
+			ignoredFingerprints[fingerprintId] = fingerprintEntry
 
 			if !fileExists {
 				cmd.Printf("\nCreating bearer.ignore file...\n")
-			}
-
-			if mergeErr := ignore.MergeIgnoredFingerprints(fingerprintsToIgnore, ignoredFingerprints, options.IgnoreAddOptions.Force); mergeErr != nil {
-				// handle expected error (duplicate entry in bearer.ignore)
-				cmd.Printf("Error: %s\n", mergeErr.Error())
-				return nil
 			}
 
 			if err := writeIgnoreFile(ignoredFingerprints, options.GeneralOptions.BearerIgnoreFile); err != nil {
@@ -354,4 +370,30 @@ func getIgnoredFingerprintsFromConfig(configPath string) (ignoredFingerprintsFro
 	}
 
 	return ignoredFingerprintsFromConfig
+}
+
+func requestConfirmation(s string) bool {
+	r := bufio.NewReader(os.Stdin)
+
+	for i := 0; true; i++ {
+		if i > 0 {
+			fmt.Printf("Please enter y or n\n")
+		}
+		fmt.Printf("%s [y/n]: ", s)
+
+		response, _ := r.ReadString('\n')
+		response = strings.ToLower(strings.TrimSpace(response))
+
+		if response == "y" || response == "yes" {
+			return true
+		}
+
+		if response == "n" || response == "no" {
+			return false
+		}
+
+		continue
+	}
+
+	return false
 }

--- a/pkg/commands/ignore.go
+++ b/pkg/commands/ignore.go
@@ -379,12 +379,17 @@ func requestConfirmation(s string) bool {
 		if i > 0 {
 			fmt.Printf("Please enter y or n\n")
 		}
-		fmt.Printf("%s [y/n]: ", s)
+		fmt.Printf("%s [Y/n]: ", s)
 
 		response, _ := r.ReadString('\n')
 		response = strings.ToLower(strings.TrimSpace(response))
 
 		if response == "y" || response == "yes" {
+			return true
+		}
+
+		if response == "" {
+			// Enter key defaults to Y
 			return true
 		}
 

--- a/pkg/flag/ignore_add_flags.go
+++ b/pkg/flag/ignore_add_flags.go
@@ -14,6 +14,12 @@ var (
 		Value:      FormatEmpty,
 		Usage:      "Add a comment to this ignored finding.",
 	}
+	FalsePositiveFlag = Flag{
+		Name:       "false-positive",
+		ConfigName: "ignore_add.false-positive",
+		Value:      false,
+		Usage:      "Mark an this ignored finding as false positive.",
+	}
 	IgnoreAddForceFlag = Flag{
 		Name:       "force",
 		ConfigName: "ignore_add.force",
@@ -25,19 +31,22 @@ var (
 type IgnoreAddFlagGroup struct {
 	AuthorFlag         *Flag
 	CommentFlag        *Flag
+	FalsePositiveFlag  *Flag
 	IgnoreAddForceFlag *Flag
 }
 
 type IgnoreAddOptions struct {
-	Author  string `mapstructure:"author" json:"author" yaml:"author"`
-	Comment string `mapstructure:"comment" json:"comment" yaml:"comment"`
-	Force   bool   `mapstructure:"ignore_add_force" json:"ignore_add_force" yaml:"ignore_add_force"`
+	Author        string `mapstructure:"author" json:"author" yaml:"author"`
+	Comment       string `mapstructure:"comment" json:"comment" yaml:"comment"`
+	FalsePositive bool   `mapstructure:"false_positive" json:"false_positive" yaml:"false_positive"`
+	Force         bool   `mapstructure:"ignore_add_force" json:"ignore_add_force" yaml:"ignore_add_force"`
 }
 
 func NewIgnoreAddFlagGroup() *IgnoreAddFlagGroup {
 	return &IgnoreAddFlagGroup{
 		AuthorFlag:         &AuthorFlag,
 		CommentFlag:        &CommentFlag,
+		FalsePositiveFlag:  &FalsePositiveFlag,
 		IgnoreAddForceFlag: &IgnoreAddForceFlag,
 	}
 }
@@ -50,14 +59,16 @@ func (f *IgnoreAddFlagGroup) Flags() []*Flag {
 	return []*Flag{
 		f.AuthorFlag,
 		f.CommentFlag,
+		f.FalsePositiveFlag,
 		f.IgnoreAddForceFlag,
 	}
 }
 
 func (f *IgnoreAddFlagGroup) ToOptions() IgnoreAddOptions {
 	return IgnoreAddOptions{
-		Author:  getString(f.AuthorFlag),
-		Comment: getString(f.CommentFlag),
-		Force:   getBool(f.IgnoreAddForceFlag),
+		Author:        getString(f.AuthorFlag),
+		Comment:       getString(f.CommentFlag),
+		FalsePositive: getBool(f.FalsePositiveFlag),
+		Force:         getBool(f.IgnoreAddForceFlag),
 	}
 }

--- a/pkg/util/ignore/ignore.go
+++ b/pkg/util/ignore/ignore.go
@@ -14,9 +14,10 @@ import (
 )
 
 type IgnoredFingerprint struct {
-	Author    *string `json:"author,omitempty"`
-	Comment   *string `json:"comment,omitempty"`
-	IgnoredAt string  `json:"ignored_at"`
+	Author        *string `json:"author,omitempty"`
+	Comment       *string `json:"comment,omitempty"`
+	FalsePositive bool    `json:"false_positive"`
+	IgnoredAt     string  `json:"ignored_at"`
 }
 
 func GetIgnoredFingerprints(bearerIgnoreFilePath string, target *string) (ignoredFingerprints map[string]IgnoredFingerprint, fileExists bool, err error) {
@@ -88,12 +89,19 @@ func DisplayIgnoredEntryTextString(fingerprintId string, entry IgnoredFingerprin
 	result += fmt.Sprintf("%sIgnored At: %s", prefix, bold(entry.IgnoredAt))
 
 	if entry.Author != nil {
-		if entry.Comment == nil {
-			prefix = lastPrefix
-		}
-
 		result += fmt.Sprintf("\n%sAuthor: %s", prefix, bold(*entry.Author))
 	}
+
+	if entry.Comment == nil {
+		prefix = lastPrefix
+	}
+	var falsePositiveStr string
+	if entry.FalsePositive {
+		falsePositiveStr = "Yes"
+	} else {
+		falsePositiveStr = "No"
+	}
+	result += fmt.Sprintf("\n%sFalse positive? %s", prefix, bold(falsePositiveStr))
 
 	if entry.Comment != nil {
 		result += fmt.Sprintf("\n%sComment: %s", lastPrefix, bold(*entry.Comment))


### PR DESCRIPTION
## Description

Add false positive flag to bearer.ignore entries so we can mark findings as false positives. 

Also re-order `ignore add` functionality so we fail fast if there is a duplicate entry for the given fingerprint.

We'll send this to Cloud so we can distinguish these "False Positive" findings from "Allowed" ignores, and keep things consistent between Cloud and CLI

Closes #1232

![Screenshot 2023-08-31 at 13 29 34](https://github.com/Bearer/bearer/assets/4560746/d12fd778-664f-4804-ae54-32b2f3caf331)

## `ignore add`

With flags

![Screenshot 2023-08-31 at 13 25 27](https://github.com/Bearer/bearer/assets/4560746/778708c9-0617-4cf2-a835-a4397aad8e4f)

With prompt

![Screenshot 2023-08-31 at 13 26 04](https://github.com/Bearer/bearer/assets/4560746/ab876513-fbeb-4bd9-92cf-c150f090838a)

## `ignore show`

![Screenshot 2023-08-31 at 13 24 20](https://github.com/Bearer/bearer/assets/4560746/fc85bca6-e1df-4365-b9f4-73abe89f0999)

![Screenshot 2023-08-31 at 13 24 53](https://github.com/Bearer/bearer/assets/4560746/4615abb8-f7d6-4a72-9eb8-5003a01034ca)


<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
