### PR TITLE
docs: explain cloud ignores

### DIFF
--- a/docs/_data/bearer_ignore_pull.yaml
+++ b/docs/_data/bearer_ignore_pull.yaml
@@ -1,0 +1,40 @@
+name: ' ignore pull'
+synopsis: Pull ignored fingerprints from Cloud
+usage: ' ignore pull [flags]'
+options:
+    - name: api-key
+      usage: Use your Bearer API Key to send the report to Bearer.
+    - name: config-file
+      default_value: bearer.yml
+      usage: Load configuration from the specified path.
+    - name: debug
+      default_value: "false"
+      usage: Enable debug logs. Equivalent to --log-level=debug
+    - name: debug-profile
+      default_value: "false"
+      usage: Generate profiling data for debugging
+    - name: disable-version-check
+      default_value: "false"
+      usage: Disable Bearer version checking
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for pull
+    - name: host
+      default_value: my.bearer.sh
+      usage: Specify the Host for sending the report.
+    - name: ignore-file
+      default_value: bearer.ignore
+      usage: Load bearer.ignore file from the specified path.
+    - name: log-level
+      default_value: info
+      usage: Set log level (error, info, debug, trace)
+    - name: no-color
+      default_value: "false"
+      usage: Disable color in output
+example: |-
+    # Pull ignored fingerprints from the Cloud (requires API key)
+    $ bearer ignore pull /path/to/your_project --api-key=XXXXX
+see_also:
+    - ' ignore - Manage ignored fingerprints'
+aliases: 

--- a/docs/guides/bearer-cloud.md
+++ b/docs/guides/bearer-cloud.md
@@ -95,9 +95,19 @@ Bearer Cloud automatically captures any scans run with a valid `api-key`. Subseq
 
 ### Ignored findings in Bearer Cloud
 
-When a valid `api-key` is present, the very first scan of a project reads ignored fingerprints from the bearer.ignore file and subsequently create ignored findings for these in the Cloud. A finding has "False Positive" status in the Cloud if its corresponding bearer.ignore entry is a false positive (`false_positive: true`); otherwise, it has the status "Allowed".
+When a valid `api-key` is present, the very first scan of a project reads ignored fingerprints from the bearer.ignore file and subsequently creates ignored findings for these in the Cloud, including status and comments (if present). A finding has "False Positive" status in the Cloud if its corresponding bearer.ignore entry is a false positive (`false_positive: true`); otherwise, it has the status "Allowed".
 
-After this initial scan, the Cloud is taken as the source of truth for ignored fingerprints. This means that, when a valid `api-key` is present, subsequent scans of the project read ignored fingerprints from the Cloud and not the bearer.ignore file.
+After the initial scan, the Cloud is taken as the source of truth for ignored fingerprints. If there are new entries added to the bearer.ignore file, in most cases, these are sent to the Cloud on subsequent scans, and the corresponding Cloud findings are updated to "False Positive" or "Allowed" status accordingly.
+
+However, it is important to note that the Cloud state is always prioritized over the contents of the bearer.ignore file. If a finding is already ignored in the Cloud, and then added to the bearer.ignore file, its Cloud status and comments are unchanged by subsequent scans. Similarly, if an ignored finding is re-opened in the Cloud, and then added to the bearer.ignore file, its Cloud status remains "Open". That is, re-opened findings can only be re-ignored again from the Cloud.
+
+Furthermore, if an ignored finding is later re-opened in the Cloud, any corresponding bearer.ignore entry is not automatically removed. Over time, then, the bearer.ignore file may become out-of-sync with the Cloud state. To remedy this, and align the bearer.ignore file with what is in the Cloud, use the following action:
+
+```bash
+bearer ignore pull project-folder --api-key=XXXXXXXX
+```
+
+This action overwrites the current bearer.ignore file (including any new additions not yet sent to the Cloud) with all ignored findings from the Cloud, including status, comments, and author information.
 
 ## Jira integration
 

--- a/docs/guides/bearer-cloud.md
+++ b/docs/guides/bearer-cloud.md
@@ -93,6 +93,12 @@ Bearer Cloud automatically captures any scans run with a valid `api-key`. Subseq
 
 ![Cloud dashboard](/assets/img/cloud-dashboard.jpg)
 
+### Ignored findings in Bearer Cloud
+
+When a valid `api-key` is present, the very first scan of a project reads ignored fingerprints from the bearer.ignore file and subsequently create ignored findings for these in the Cloud. A finding has "False Positive" status in the Cloud if its corresponding bearer.ignore entry is a false positive (`false_positive: true`); otherwise, it has the status "Allowed".
+
+After this initial scan, the Cloud is taken as the source of truth for ignored fingerprints. This means that, when a valid `api-key` is present, subsequent scans of the project read ignored fingerprints from the Cloud and not the bearer.ignore file.
+
 ## Jira integration
 
 The Jira integration is available on the *Settings > Integrations* page.

--- a/docs/guides/configure-scan.md
+++ b/docs/guides/configure-scan.md
@@ -65,6 +65,7 @@ If a finding is not relevant, you can ignore it automatically from future scans 
 bearer ignore add 4b0883d52334dfd9a4acce2fcf810121_0 \
   --author="Mish Bear" \
   --comment="Ignore this finding"
+  --false-positive
 ```
 
 <br/>

--- a/docs/guides/configure-scan.md
+++ b/docs/guides/configure-scan.md
@@ -68,7 +68,7 @@ bearer ignore add 4b0883d52334dfd9a4acce2fcf810121_0 \
 ```
 
 <br/>
-{% callout "info" %} If you're looking for more options when it comes to managing findings, take a look at <a href="/guides/bearer-cloud">Bearer Cloud</a>. {% endcallout %}
+{% callout "info" %} If you're looking for more options when it comes to managing findings, take a look at <a href="/guides/bearer-cloud">Bearer Cloud</a>. For ignored findings in particular, see <a href="/guides/bearer-cloud/#ignored-findings-in-bearer-cloud">Ignored findings in Bearer Cloud</a>. {% endcallout %}
 
 ## Skip or ignore specific rules
 

--- a/docs/reference/commands.njk
+++ b/docs/reference/commands.njk
@@ -6,7 +6,7 @@ layout: layouts/doc.njk
 They can be found here: https://github.com/Bearer/bearer/tree/main/pkg/commands
  #}
 
-{% set items = [bearer_scan, bearer_init, bearer_ignore_add, bearer_ignore_show, bearer_ignore_remove, bearer_ignore_migrate, bearer_version] %}
+{% set items = [bearer_scan, bearer_init, bearer_ignore_add, bearer_ignore_show, bearer_ignore_remove, bearer_ignore_pull, bearer_ignore_migrate, bearer_version] %}
 {% renderTemplate "md" %}
 # Commands
 


### PR DESCRIPTION
## Description

Add small section to explain from where ignores are read during initial and subsequent project scans, when api-key is set

Closes #1234 

## Cloud page

![Screenshot 2023-09-11 at 13 47 28](https://github.com/Bearer/bearer/assets/4560746/139671d9-2c38-41ed-98a2-bbdbe0c8b44f)

## Configure the Scan page
![Screenshot 2023-09-01 at 12 58 15](https://github.com/Bearer/bearer/assets/4560746/2fc937ac-ae33-4447-a552-bf9225d36768)

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [x] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
