### PR TITLE
fix: report failure data was incorrect

### DIFF
--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -270,7 +270,7 @@ func Run(ctx context.Context, opts flag.Options) (err error) {
 		return fmt.Errorf("scan error: %w", err)
 	}
 
-	reportPassed, err := r.Report(files, baseBranchFindings)
+	reportFailed, err := r.Report(files, baseBranchFindings)
 	if err != nil {
 		return fmt.Errorf("report error: %w", err)
 	} else {
@@ -289,7 +289,7 @@ func Run(ctx context.Context, opts flag.Options) (err error) {
 		outputhandler.StdErrLog(fmt.Sprintf("=====================================\n\nProfile\n\n%s", stats.String()))
 	}
 
-	if !reportPassed {
+	if reportFailed {
 		if scanSettings.Scan.ExitCode == -1 {
 			defer os.Exit(1)
 		} else {
@@ -306,7 +306,6 @@ func (r *runner) Report(
 ) (bool, error) {
 	startTime := time.Now()
 	cacheUsed := r.CacheUsed()
-	reportPassed := true
 
 	report := types.Report{Path: r.reportPath, Inputgocloc: r.goclocResult}
 
@@ -363,7 +362,7 @@ func (r *runner) Report(
 
 	outputCachedDataWarning(cacheUsed, r.scanSettings.Scan.Quiet)
 
-	return reportPassed, nil
+	return reportData.ReportFailed, nil
 }
 
 func (r *runner) ReportPath() string {


### PR DESCRIPTION
## Description
When the internal data structures where changed in https://github.com/Bearer/bearer/pull/1202 exit code was not piped in correctly

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
