### PR TITLE
docs: add reference to PHP support coming next

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   Bearer CLI is a static application security testing (SAST) tool that scans your source code and analyzes your data flows to discover, filter and prioritize security and privacy risks.
   <br /><br />
   Currently supporting <strong>JavaScript</strong>, <strong>TypeScript</strong>, <strong>Ruby</strong>, and <strong>Java</strong> stacks.<br />
+  🚧 <strong>PHP</strong> Beta support is <a href="https://github.com/Bearer/bearer/issues/1242">coming next</a> 🚧 
   <br /><br />
 
   [Getting Started](#rocket-getting-started) - [FAQ](#question-faqs) - [Documentation](https://docs.bearer.com) - [Report a Bug](https://github.com/Bearer/bearer/issues/new/choose) - [Discord Community][discord]

--- a/docs/reference/supported-languages.njk
+++ b/docs/reference/supported-languages.njk
@@ -124,7 +124,7 @@ When you scan a codebase, Bearer will automatically select the appropriate langu
         </td>
         <td>
           {{ data.status }}<br/>
-          <small><i>{{ data.comment }}</i> </small>
+          <span class="italic text-xs">{{ data.comment }}</span>
         </td>
       </tr>
     {% endfor %}

--- a/docs/reference/supported-languages.njk
+++ b/docs/reference/supported-languages.njk
@@ -39,16 +39,6 @@ supportChart:
     searchName: lang-java
     searchTerm: java_
     status: Beta
-  csharp:
-    name: C#
-    support:
-      - Privacy
-      - Data Flow
-    frameworks: []
-    rules: false
-    searchName: lang-csharp
-    searchTerm: csharp_
-    status: Alpha
   php:
     name: PHP
     support:
@@ -58,6 +48,17 @@ supportChart:
     rules: false
     searchName: lang-php
     searchTerm: php_
+    status: Alpha
+    comment: Beta coming soon
+  csharp:
+    name: C#
+    support:
+      - Privacy
+      - Data Flow
+    frameworks: []
+    rules: false
+    searchName: lang-csharp
+    searchTerm: csharp_
     status: Alpha
   python:
     name: Python
@@ -122,7 +123,8 @@ When you scan a codebase, Bearer will automatically select the appropriate langu
           {% endif %}
         </td>
         <td>
-          {{ data.status }}
+          {{ data.status }}<br/>
+          <small><i>{{ data.comment }}</i> </small>
         </td>
       </tr>
     {% endfor %}


### PR DESCRIPTION
## Description
Add reference to PHP support coming next:
- Top of GH README
- In the language support doc page 

<img width="1129" alt="image" src="https://github.com/Bearer/bearer/assets/380564/0dbdd4ed-14e9-4064-bfc8-d940628b2461">

<img width="273" alt="image" src="https://github.com/Bearer/bearer/assets/380564/e3a97e66-a26c-4a6b-ad79-aa860e1eb17b">

