### PR TITLE
fix: show cloud notices for any report

### DIFF
--- a/new/detector/composition/testhelper/testhelper.go
+++ b/new/detector/composition/testhelper/testhelper.go
@@ -160,5 +160,5 @@ func (runner *Runner) scanSingleFile(t *testing.T, testDataPath string, fileRela
 	}
 
 	cupaloyCopy := cupaloy.NewDefaultConfig().WithOptions(cupaloy.SnapshotSubdirectory(snapshotsPath))
-	cupaloyCopy.SnapshotT(t, *report)
+	cupaloyCopy.SnapshotT(t, report)
 }

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -15,7 +15,6 @@ import (
 
 	"golang.org/x/exp/maps"
 
-	"github.com/bearer/bearer/api"
 	evalstats "github.com/bearer/bearer/new/detector/evaluator/stats"
 	"github.com/bearer/bearer/pkg/commands/artifact/scanid"
 	"github.com/bearer/bearer/pkg/commands/process/filelist"
@@ -351,6 +350,7 @@ func (r *runner) Report(
 	formatStr, err := reportoutput.FormatOutput(
 		reportData,
 		r.scanSettings,
+		cacheUsed,
 		report.Inputgocloc,
 		startTime,
 		endTime,
@@ -361,36 +361,11 @@ func (r *runner) Report(
 
 	logger(formatStr)
 
-	outputSendToCloudInfo(reportData.SendToCloud, r.scanSettings.Scan.Quiet, r.scanSettings.Client)
-	outputCachedDataWarning(cacheUsed, r.scanSettings.Scan.Quiet)
-
 	return reportData.ReportFailed, nil
 }
 
 func (r *runner) ReportPath() string {
 	return r.reportPath
-}
-
-func outputSendToCloudInfo(sendToCloud bool, quietMode bool, client *api.API) {
-	if quietMode || !sendToCloud {
-		return
-	}
-
-	if client.Error != nil {
-		// client error sending to saas
-		outputhandler.StdErrLog(fmt.Sprintf("Failed to send data to Bearer Cloud. %s \n", *client.Error))
-		return
-	}
-
-	outputhandler.StdErrLog("Data successfully sent to Bearer Cloud.\n")
-}
-
-func outputCachedDataWarning(cacheUsed bool, quietMode bool) {
-	if quietMode || !cacheUsed {
-		return
-	}
-
-	outputhandler.StdErrLog("Cached data used (no code changes detected). Unexpected? Use --force to force a re-scan.\n")
 }
 
 func anySupportedLanguagesPresent(inputgocloc *gocloc.Result, config settings.Config) (bool, error) {

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -15,6 +15,7 @@ import (
 
 	"golang.org/x/exp/maps"
 
+	"github.com/bearer/bearer/api"
 	evalstats "github.com/bearer/bearer/new/detector/evaluator/stats"
 	"github.com/bearer/bearer/pkg/commands/artifact/scanid"
 	"github.com/bearer/bearer/pkg/commands/process/filelist"
@@ -360,6 +361,7 @@ func (r *runner) Report(
 
 	logger(*formatStr)
 
+	outputSendToCloudInfo(reportData.SendToCloud, r.scanSettings.Scan.Quiet, r.scanSettings.Client)
 	outputCachedDataWarning(cacheUsed, r.scanSettings.Scan.Quiet)
 
 	return reportData.ReportFailed, nil
@@ -367,6 +369,20 @@ func (r *runner) Report(
 
 func (r *runner) ReportPath() string {
 	return r.reportPath
+}
+
+func outputSendToCloudInfo(sendToCloud bool, quietMode bool, client *api.API) {
+	if quietMode || !sendToCloud {
+		return
+	}
+
+	if client.Error != nil {
+		// client error sending to saas
+		outputhandler.StdErrLog(fmt.Sprintf("Failed to send data to Bearer Cloud. %s \n", *client.Error))
+		return
+	}
+
+	outputhandler.StdErrLog("Data successfully sent to Bearer Cloud.\n")
 }
 
 func outputCachedDataWarning(cacheUsed bool, quietMode bool) {

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -359,7 +359,7 @@ func (r *runner) Report(
 		return false, fmt.Errorf("error generating report %s", err)
 	}
 
-	logger(*formatStr)
+	logger(formatStr)
 
 	outputSendToCloudInfo(reportData.SendToCloud, r.scanSettings.Scan.Quiet, r.scanSettings.Client)
 	outputCachedDataWarning(cacheUsed, r.scanSettings.Scan.Quiet)

--- a/pkg/report/output/dataflow/formatter.go
+++ b/pkg/report/output/dataflow/formatter.go
@@ -19,7 +19,7 @@ func NewFormatter(reportData *outputtypes.ReportData, config settings.Config) *F
 	}
 }
 
-func (f Formatter) Format(format string) (output *string, err error) {
+func (f Formatter) Format(format string) (output string, err error) {
 	switch format {
 	case flag.FormatEmpty, flag.FormatJSON:
 		return outputhandler.ReportJSON(f.ReportData.Dataflow)

--- a/pkg/report/output/detectors/formatter.go
+++ b/pkg/report/output/detectors/formatter.go
@@ -19,7 +19,7 @@ func NewFormatter(reportData *outputtypes.ReportData, config settings.Config) *F
 	}
 }
 
-func (f Formatter) Format(format string) (output *string, err error) {
+func (f Formatter) Format(format string) (output string, err error) {
 	switch format {
 	case flag.FormatEmpty, flag.FormatJSON:
 		return outputhandler.ReportJSON(f.ReportData.Detectors)

--- a/pkg/report/output/gitlab/gitlab_test.go
+++ b/pkg/report/output/gitlab/gitlab_test.go
@@ -39,7 +39,7 @@ func TestJuiceShopSarif(t *testing.T) {
 	}
 
 	var prettyJSON bytes.Buffer
-	err = json.Indent(&prettyJSON, []byte(*output), "", "\t")
+	err = json.Indent(&prettyJSON, []byte(output), "", "\t")
 	if err != nil {
 		t.Fatalf("error indenting output, err: %s", err)
 	}

--- a/pkg/report/output/html/html.go
+++ b/pkg/report/output/html/html.go
@@ -27,7 +27,7 @@ var wrapperTemplate string
 //go:embed styles.css
 var siteCss string
 
-func ReportHTMLWrapper(title string, body *string) (*string, error) {
+func ReportHTMLWrapper(title string, body *string) (string, error) {
 	htmlContent := &strings.Builder{}
 
 	t := time.Now()
@@ -41,17 +41,16 @@ func ReportHTMLWrapper(title string, body *string) (*string, error) {
 	}
 	pageTemplate, err := template.New("pageTemplate").Parse(wrapperTemplate)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	err = pageTemplate.Execute(htmlContent, wrapperContent)
 
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
-	content := htmlContent.String()
-	return &content, nil
+	return htmlContent.String(), nil
 }
 
 func ReportSecurityHTML(detections map[string][]securitytypes.Finding) (*string, error) {

--- a/pkg/report/output/output.go
+++ b/pkg/report/output/output.go
@@ -29,8 +29,6 @@ func GetData(
 	config settings.Config,
 	baseBranchFindings *basebranchfindings.Findings,
 ) (*types.ReportData, error) {
-	sendToCloud := false
-
 	data := &types.ReportData{}
 	// add detectors
 	err := detectors.AddReportData(data, report, config)
@@ -48,14 +46,14 @@ func GetData(
 	case flag.ReportDataFlow:
 		return data, err
 	case flag.ReportSecurity:
-		sendToCloud = true
+		data.SendToCloud = true
 		err = security.AddReportData(data, config, baseBranchFindings)
 	case flag.ReportSaaS:
 		if err = security.AddReportData(data, config, baseBranchFindings); err != nil {
 			return nil, err
 		}
 
-		sendToCloud = true
+		data.SendToCloud = true
 		err = saas.GetReport(data, config, false)
 	case flag.ReportPrivacy:
 		err = privacy.AddReportData(data, config)
@@ -65,7 +63,7 @@ func GetData(
 		return nil, fmt.Errorf(`--report flag "%s" is not supported`, config.Report.Report)
 	}
 
-	if sendToCloud && config.Client != nil && config.Client.Error == nil {
+	if data.SendToCloud && config.Client != nil && config.Client.Error == nil {
 		// send SaaS report to Cloud
 		saas.SendReport(config, data)
 	}

--- a/pkg/report/output/output.go
+++ b/pkg/report/output/output.go
@@ -86,6 +86,7 @@ func GetDataflow(reportData *types.ReportData, report globaltypes.Report, config
 func FormatOutput(
 	reportData *types.ReportData,
 	config settings.Config,
+	cacheUsed bool,
 	goclocResult *gocloc.Result,
 	startTime time.Time,
 	endTime time.Time,
@@ -114,6 +115,25 @@ func FormatOutput(
 	}
 	if formatStr == "" {
 		return "", fmt.Errorf(`--report flag "%s" does not support --format flag "%s"`, config.Report.Report, config.Report.Format)
+	}
+
+	if !config.Scan.Quiet && (reportData.SendToCloud || cacheUsed) {
+		// add cached data warning message
+		if cacheUsed {
+			formatStr += "\n\nCached data used (no code changes detected). Unexpected? Use --force to force a re-scan."
+		}
+
+		// add cloud info message
+		if reportData.SendToCloud {
+			if config.Client.Error == nil {
+				formatStr += "\n\nData successfully sent to Bearer Cloud."
+			} else {
+				// client error
+				formatStr += fmt.Sprintf("\n\nFailed to send data to Bearer Cloud. %s ", *config.Client.Error)
+			}
+		}
+
+		formatStr += "\n"
 	}
 
 	return formatStr, err

--- a/pkg/report/output/output.go
+++ b/pkg/report/output/output.go
@@ -89,7 +89,7 @@ func FormatOutput(
 	goclocResult *gocloc.Result,
 	startTime time.Time,
 	endTime time.Time,
-) (*string, error) {
+) (string, error) {
 	var formatter types.GenericFormatter
 	switch config.Report.Report {
 	case flag.ReportDetectors:
@@ -105,15 +105,15 @@ func FormatOutput(
 	case flag.ReportStats:
 		formatter = stats.NewFormatter(reportData, config)
 	default:
-		return nil, fmt.Errorf(`--report flag "%s" is not supported`, config.Report.Report)
+		return "", fmt.Errorf(`--report flag "%s" is not supported`, config.Report.Report)
 	}
 
 	formatStr, err := formatter.Format(config.Report.Format)
 	if err != nil {
 		return formatStr, err
 	}
-	if formatStr == nil {
-		return nil, fmt.Errorf(`--report flag "%s" does not support --format flag "%s"`, config.Report.Report, config.Report.Format)
+	if formatStr == "" {
+		return "", fmt.Errorf(`--report flag "%s" does not support --format flag "%s"`, config.Report.Report, config.Report.Format)
 	}
 
 	return formatStr, err

--- a/pkg/report/output/privacy/formatter.go
+++ b/pkg/report/output/privacy/formatter.go
@@ -22,15 +22,14 @@ func NewFormatter(reportData *outputtypes.ReportData, config settings.Config) *F
 	}
 }
 
-func (f Formatter) Format(format string) (output *string, err error) {
+func (f Formatter) Format(format string) (output string, err error) {
 	switch format {
 	case flag.FormatEmpty, flag.FormatCSV:
 		stringBuilder, err := BuildCsvString(f.ReportData, f.Config)
 		if err != nil {
 			return output, err
 		}
-		csvStr := stringBuilder.String()
-		output = &csvStr
+		output = stringBuilder.String()
 	case flag.FormatJSON:
 		return outputhandler.ReportJSON(f.ReportData.PrivacyReport)
 	case flag.FormatYAML:

--- a/pkg/report/output/reviewdog/reviewdog_test.go
+++ b/pkg/report/output/reviewdog/reviewdog_test.go
@@ -36,7 +36,7 @@ func TestRailsGoatReviewdog(t *testing.T) {
 	}
 
 	var prettyJSON bytes.Buffer
-	err = json.Indent(&prettyJSON, []byte(*sarifOutput), "", "\t")
+	err = json.Indent(&prettyJSON, []byte(sarifOutput), "", "\t")
 	if err != nil {
 		t.Fatalf("error indenting output, err: %s", err)
 	}

--- a/pkg/report/output/saas/formatter.go
+++ b/pkg/report/output/saas/formatter.go
@@ -19,7 +19,7 @@ func NewFormatter(reportData *outputtypes.ReportData, config settings.Config) *F
 	}
 }
 
-func (f Formatter) Format(format string) (output *string, err error) {
+func (f Formatter) Format(format string) (output string, err error) {
 	switch format {
 	case flag.FormatEmpty, flag.FormatJSON:
 		return outputhandler.ReportJSON(f.ReportData.SaasReport)

--- a/pkg/report/output/saas/saas.go
+++ b/pkg/report/output/saas/saas.go
@@ -132,7 +132,7 @@ func createBearerGzipFileReport(
 
 	content, _ := util.ReportJSON(reportData.SaasReport)
 	gzWriter := gzip.NewWriter(file)
-	_, err = gzWriter.Write([]byte(*content))
+	_, err = gzWriter.Write([]byte(content))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/report/output/sarif/sarif_test.go
+++ b/pkg/report/output/sarif/sarif_test.go
@@ -65,7 +65,7 @@ func TestJuiceShopSarif(t *testing.T) {
 	}
 
 	var prettyJSON bytes.Buffer
-	err = json.Indent(&prettyJSON, []byte(*sarifOutput), "", "\t")
+	err = json.Indent(&prettyJSON, []byte(sarifOutput), "", "\t")
 	if err != nil {
 		t.Fatalf("error indenting output, err: %s", err)
 	}

--- a/pkg/report/output/security/formatter.go
+++ b/pkg/report/output/security/formatter.go
@@ -33,11 +33,10 @@ func NewFormatter(reportData *outputtypes.ReportData, config settings.Config, go
 	}
 }
 
-func (f Formatter) Format(format string) (output *string, err error) {
+func (f Formatter) Format(format string) (output string, err error) {
 	switch format {
 	case flag.FormatEmpty:
-		reportStr := BuildReportString(f.ReportData, f.Config, f.GoclocResult).String()
-		output = &reportStr
+		output = BuildReportString(f.ReportData, f.Config, f.GoclocResult).String()
 	case flag.FormatSarif:
 		sarifContent, sarifErr := sarif.ReportSarif(f.ReportData.FindingsBySeverity, f.Config.Rules)
 		if sarifErr != nil {

--- a/pkg/report/output/security/security.go
+++ b/pkg/report/output/security/security.go
@@ -392,8 +392,6 @@ func BuildReportString(reportData *outputtypes.ReportData, config settings.Confi
 		writeStatsToString(reportData, reportStr, config, lineOfCodeOutput)
 	}
 
-	writeApiClientResultToString(reportStr, config)
-
 	reportStr.WriteString("\nNeed help or want to discuss the output? Join the Community https://discord.gg/eaHZBJUXRF\n")
 
 	if config.Client == nil {
@@ -528,19 +526,6 @@ func writeRuleListToString(
 	tbl.Print()
 
 	return totalRuleCount
-}
-
-func writeApiClientResultToString(
-	reportStr *strings.Builder,
-	config settings.Config,
-) {
-	if config.Client != nil {
-		if config.Client.Error == nil {
-			reportStr.WriteString("\nData successfully sent to Bearer Cloud.\n")
-		} else {
-			reportStr.WriteString(fmt.Sprintf("\nFailed to send data to Bearer Cloud. %s \n", *config.Client.Error))
-		}
-	}
 }
 
 func countRules(

--- a/pkg/report/output/stats/formatter.go
+++ b/pkg/report/output/stats/formatter.go
@@ -19,7 +19,7 @@ func NewFormatter(reportData *outputtypes.ReportData, config settings.Config) *F
 	}
 }
 
-func (f Formatter) Format(format string) (output *string, err error) {
+func (f Formatter) Format(format string) (output string, err error) {
 	switch format {
 	case flag.FormatEmpty, flag.FormatJSON:
 		return outputhandler.ReportJSON(f.ReportData.Stats)

--- a/pkg/report/output/types/types.go
+++ b/pkg/report/output/types/types.go
@@ -29,5 +29,5 @@ type DataFlow struct {
 }
 
 type GenericFormatter interface {
-	Format(format string) (*string, error) // TODO: ensure format is an expected format (from report flags)
+	Format(format string) (string, error) // TODO: ensure format is an expected format (from report flags)
 }

--- a/pkg/report/output/types/types.go
+++ b/pkg/report/output/types/types.go
@@ -10,6 +10,7 @@ import (
 
 type ReportData struct {
 	ReportFailed       bool
+	SendToCloud        bool
 	Files              []string
 	Detectors          []any
 	Dataflow           *DataFlow

--- a/pkg/util/output/output.go
+++ b/pkg/util/output/output.go
@@ -97,22 +97,20 @@ func Fatal(message string) {
 	os.Exit(1)
 }
 
-func ReportJSON(outputDetections any) (*string, error) {
+func ReportJSON(outputDetections any) (string, error) {
 	jsonBytes, err := json.Marshal(&outputDetections)
 	if err != nil {
-		return nil, fmt.Errorf("failed to json marshal detections: %s", err)
+		return "", fmt.Errorf("failed to json marshal detections: %s", err)
 	}
 
-	content := string(jsonBytes)
-	return &content, nil
+	return string(jsonBytes), nil
 }
 
-func ReportYAML(outputDetections any) (*string, error) {
+func ReportYAML(outputDetections any) (string, error) {
 	yamlBytes, err := yaml.Marshal(&outputDetections)
 	if err != nil {
-		return nil, fmt.Errorf("failed to yaml marshal detections: %s", err)
+		return "", fmt.Errorf("failed to yaml marshal detections: %s", err)
 	}
 
-	content := string(yamlBytes)
-	return &content, nil
+	return string(yamlBytes), nil
 }


### PR DESCRIPTION
## Description

Include info messages in the output whenever we are sending data to the Cloud (successfully or otherwise)

Light refactor to move cached data warning from run file to to output formatter

Closes #1254

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
