### PR TITLE
feat: move log level and debug flags to General

### DIFF
--- a/docs/_data/bearer_ignore_add.yaml
+++ b/docs/_data/bearer_ignore_add.yaml
@@ -16,6 +16,9 @@ options:
     - name: config-file
       default_value: bearer.yml
       usage: Load configuration from the specified path.
+    - name: debug
+      default_value: "false"
+      usage: Enable debug logs. Equivalent to --log-level=debug
     - name: debug-profile
       default_value: "false"
       usage: Generate profiling data for debugging
@@ -35,6 +38,9 @@ options:
     - name: host
       default_value: my.bearer.sh
       usage: Specify the Host for sending the report.
+    - name: log-level
+      default_value: info
+      usage: Set log level (error, info, debug, trace)
     - name: no-color
       default_value: "false"
       usage: Disable color in output

--- a/docs/_data/bearer_ignore_migrate.yaml
+++ b/docs/_data/bearer_ignore_migrate.yaml
@@ -11,6 +11,9 @@ options:
     - name: config-file
       default_value: bearer.yml
       usage: Load configuration from the specified path.
+    - name: debug
+      default_value: "false"
+      usage: Enable debug logs. Equivalent to --log-level=debug
     - name: debug-profile
       default_value: "false"
       usage: Generate profiling data for debugging
@@ -27,6 +30,9 @@ options:
     - name: host
       default_value: my.bearer.sh
       usage: Specify the Host for sending the report.
+    - name: log-level
+      default_value: info
+      usage: Set log level (error, info, debug, trace)
     - name: no-color
       default_value: "false"
       usage: Disable color in output

--- a/docs/_data/bearer_ignore_remove.yaml
+++ b/docs/_data/bearer_ignore_remove.yaml
@@ -10,6 +10,9 @@ options:
     - name: config-file
       default_value: bearer.yml
       usage: Load configuration from the specified path.
+    - name: debug
+      default_value: "false"
+      usage: Enable debug logs. Equivalent to --log-level=debug
     - name: debug-profile
       default_value: "false"
       usage: Generate profiling data for debugging
@@ -23,6 +26,9 @@ options:
     - name: host
       default_value: my.bearer.sh
       usage: Specify the Host for sending the report.
+    - name: log-level
+      default_value: info
+      usage: Set log level (error, info, debug, trace)
     - name: no-color
       default_value: "false"
       usage: Disable color in output

--- a/docs/_data/bearer_ignore_show.yaml
+++ b/docs/_data/bearer_ignore_show.yaml
@@ -13,6 +13,9 @@ options:
     - name: config-file
       default_value: bearer.yml
       usage: Load configuration from the specified path.
+    - name: debug
+      default_value: "false"
+      usage: Enable debug logs. Equivalent to --log-level=debug
     - name: debug-profile
       default_value: "false"
       usage: Generate profiling data for debugging
@@ -26,6 +29,9 @@ options:
     - name: host
       default_value: my.bearer.sh
       usage: Specify the Host for sending the report.
+    - name: log-level
+      default_value: info
+      usage: Set log level (error, info, debug, trace)
     - name: no-color
       default_value: "false"
       usage: Disable color in output

--- a/e2e/flags/.snapshots/TestInitCommand
+++ b/e2e/flags/.snapshots/TestInitCommand
@@ -1,4 +1,5 @@
 disable-version-check: false
+log-level: info
 report:
     format: ""
     no-color: false
@@ -18,7 +19,6 @@ scan:
     external-rule-dir: []
     force: false
     internal-domains: []
-    log-level: info
     parallel: 0
     quiet: false
     scanner:

--- a/e2e/flags/.snapshots/TestMetadataFlags-help-scan
+++ b/e2e/flags/.snapshots/TestMetadataFlags-help-scan
@@ -23,14 +23,12 @@ Rule Flags
 Scan Flags
       --context string                       Expand context of schema classification e.g., --context=health, to include data types particular to health
       --data-subject-mapping string          Override default data subject mapping by providing a path to a custom mapping JSON file
-      --debug                                Enable debug logs. Equivalent to --log-level=debug
       --disable-domain-resolution            Do not attempt to resolve detected domains during classification (default true)
       --domain-resolution-timeout duration   Set timeout when attempting to resolve detected domains during classification, e.g. --domain-resolution-timeout=3s (default 3s)
       --exit-code int                        Force a given exit code for the scan command. Set this to 0 (success) to always return a success exit code despite any findings from the scan. (default -1)
       --external-rule-dir strings            Specify directories paths that contain .yaml files with external rules configuration
       --force                                Disable the cache and runs the detections again
       --internal-domains strings             Define regular expressions for better classification of private or unreachable domains e.g. --internal-domains=".*.my-company.com,private.sh"
-      --log-level string                     Set log level (error, info, debug, trace) (default "info")
       --parallel int                         Specify the amount of parallelism to use during the scan
       --quiet                                Suppress non-essential messages
       --scanner strings                      Specify which scanner to use e.g. --scanner=secrets, --scanner=secrets,sast (default [sast])
@@ -39,7 +37,9 @@ Scan Flags
 General Flags
       --bearer-ignore-file string   Load bearer.ignore file from the specified path. (default "bearer.ignore")
       --config-file string          Load configuration from the specified path. (default "bearer.yml")
+      --debug                       Enable debug logs. Equivalent to --log-level=debug
       --disable-version-check       Disable Bearer version checking
+      --log-level string            Set log level (error, info, debug, trace) (default "info")
       --no-color                    Disable color in output
 
 

--- a/e2e/flags/.snapshots/TestMetadataFlags-scan-help
+++ b/e2e/flags/.snapshots/TestMetadataFlags-scan-help
@@ -23,14 +23,12 @@ Rule Flags
 Scan Flags
       --context string                       Expand context of schema classification e.g., --context=health, to include data types particular to health
       --data-subject-mapping string          Override default data subject mapping by providing a path to a custom mapping JSON file
-      --debug                                Enable debug logs. Equivalent to --log-level=debug
       --disable-domain-resolution            Do not attempt to resolve detected domains during classification (default true)
       --domain-resolution-timeout duration   Set timeout when attempting to resolve detected domains during classification, e.g. --domain-resolution-timeout=3s (default 3s)
       --exit-code int                        Force a given exit code for the scan command. Set this to 0 (success) to always return a success exit code despite any findings from the scan. (default -1)
       --external-rule-dir strings            Specify directories paths that contain .yaml files with external rules configuration
       --force                                Disable the cache and runs the detections again
       --internal-domains strings             Define regular expressions for better classification of private or unreachable domains e.g. --internal-domains=".*.my-company.com,private.sh"
-      --log-level string                     Set log level (error, info, debug, trace) (default "info")
       --parallel int                         Specify the amount of parallelism to use during the scan
       --quiet                                Suppress non-essential messages
       --scanner strings                      Specify which scanner to use e.g. --scanner=secrets, --scanner=secrets,sast (default [sast])
@@ -39,7 +37,9 @@ Scan Flags
 General Flags
       --bearer-ignore-file string   Load bearer.ignore file from the specified path. (default "bearer.ignore")
       --config-file string          Load configuration from the specified path. (default "bearer.yml")
+      --debug                       Enable debug logs. Equivalent to --log-level=debug
       --disable-version-check       Disable Bearer version checking
+      --log-level string            Set log level (error, info, debug, trace) (default "info")
       --no-color                    Disable color in output
 
 

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-context-flag
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-context-flag
@@ -24,14 +24,12 @@ Rule Flags
 Scan Flags
       --context string                       Expand context of schema classification e.g., --context=health, to include data types particular to health
       --data-subject-mapping string          Override default data subject mapping by providing a path to a custom mapping JSON file
-      --debug                                Enable debug logs. Equivalent to --log-level=debug
       --disable-domain-resolution            Do not attempt to resolve detected domains during classification (default true)
       --domain-resolution-timeout duration   Set timeout when attempting to resolve detected domains during classification, e.g. --domain-resolution-timeout=3s (default 3s)
       --exit-code int                        Force a given exit code for the scan command. Set this to 0 (success) to always return a success exit code despite any findings from the scan. (default -1)
       --external-rule-dir strings            Specify directories paths that contain .yaml files with external rules configuration
       --force                                Disable the cache and runs the detections again
       --internal-domains strings             Define regular expressions for better classification of private or unreachable domains e.g. --internal-domains=".*.my-company.com,private.sh"
-      --log-level string                     Set log level (error, info, debug, trace) (default "info")
       --parallel int                         Specify the amount of parallelism to use during the scan
       --quiet                                Suppress non-essential messages
       --scanner strings                      Specify which scanner to use e.g. --scanner=secrets, --scanner=secrets,sast (default [sast])
@@ -40,7 +38,9 @@ Scan Flags
 General Flags
       --bearer-ignore-file string   Load bearer.ignore file from the specified path. (default "bearer.ignore")
       --config-file string          Load configuration from the specified path. (default "bearer.yml")
+      --debug                       Enable debug logs. Equivalent to --log-level=debug
       --disable-version-check       Disable Bearer version checking
+      --log-level string            Set log level (error, info, debug, trace) (default "info")
       --no-color                    Disable color in output
 
 

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag-privacy
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag-privacy
@@ -24,14 +24,12 @@ Rule Flags
 Scan Flags
       --context string                       Expand context of schema classification e.g., --context=health, to include data types particular to health
       --data-subject-mapping string          Override default data subject mapping by providing a path to a custom mapping JSON file
-      --debug                                Enable debug logs. Equivalent to --log-level=debug
       --disable-domain-resolution            Do not attempt to resolve detected domains during classification (default true)
       --domain-resolution-timeout duration   Set timeout when attempting to resolve detected domains during classification, e.g. --domain-resolution-timeout=3s (default 3s)
       --exit-code int                        Force a given exit code for the scan command. Set this to 0 (success) to always return a success exit code despite any findings from the scan. (default -1)
       --external-rule-dir strings            Specify directories paths that contain .yaml files with external rules configuration
       --force                                Disable the cache and runs the detections again
       --internal-domains strings             Define regular expressions for better classification of private or unreachable domains e.g. --internal-domains=".*.my-company.com,private.sh"
-      --log-level string                     Set log level (error, info, debug, trace) (default "info")
       --parallel int                         Specify the amount of parallelism to use during the scan
       --quiet                                Suppress non-essential messages
       --scanner strings                      Specify which scanner to use e.g. --scanner=secrets, --scanner=secrets,sast (default [sast])
@@ -40,7 +38,9 @@ Scan Flags
 General Flags
       --bearer-ignore-file string   Load bearer.ignore file from the specified path. (default "bearer.ignore")
       --config-file string          Load configuration from the specified path. (default "bearer.yml")
+      --debug                       Enable debug logs. Equivalent to --log-level=debug
       --disable-version-check       Disable Bearer version checking
+      --log-level string            Set log level (error, info, debug, trace) (default "info")
       --no-color                    Disable color in output
 
 

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag-security
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag-security
@@ -24,14 +24,12 @@ Rule Flags
 Scan Flags
       --context string                       Expand context of schema classification e.g., --context=health, to include data types particular to health
       --data-subject-mapping string          Override default data subject mapping by providing a path to a custom mapping JSON file
-      --debug                                Enable debug logs. Equivalent to --log-level=debug
       --disable-domain-resolution            Do not attempt to resolve detected domains during classification (default true)
       --domain-resolution-timeout duration   Set timeout when attempting to resolve detected domains during classification, e.g. --domain-resolution-timeout=3s (default 3s)
       --exit-code int                        Force a given exit code for the scan command. Set this to 0 (success) to always return a success exit code despite any findings from the scan. (default -1)
       --external-rule-dir strings            Specify directories paths that contain .yaml files with external rules configuration
       --force                                Disable the cache and runs the detections again
       --internal-domains strings             Define regular expressions for better classification of private or unreachable domains e.g. --internal-domains=".*.my-company.com,private.sh"
-      --log-level string                     Set log level (error, info, debug, trace) (default "info")
       --parallel int                         Specify the amount of parallelism to use during the scan
       --quiet                                Suppress non-essential messages
       --scanner strings                      Specify which scanner to use e.g. --scanner=secrets, --scanner=secrets,sast (default [sast])
@@ -40,7 +38,9 @@ Scan Flags
 General Flags
       --bearer-ignore-file string   Load bearer.ignore file from the specified path. (default "bearer.ignore")
       --config-file string          Load configuration from the specified path. (default "bearer.yml")
+      --debug                       Enable debug logs. Equivalent to --log-level=debug
       --disable-version-check       Disable Bearer version checking
+      --log-level string            Set log level (error, info, debug, trace) (default "info")
       --no-color                    Disable color in output
 
 

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-report-flag
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-report-flag
@@ -24,14 +24,12 @@ Rule Flags
 Scan Flags
       --context string                       Expand context of schema classification e.g., --context=health, to include data types particular to health
       --data-subject-mapping string          Override default data subject mapping by providing a path to a custom mapping JSON file
-      --debug                                Enable debug logs. Equivalent to --log-level=debug
       --disable-domain-resolution            Do not attempt to resolve detected domains during classification (default true)
       --domain-resolution-timeout duration   Set timeout when attempting to resolve detected domains during classification, e.g. --domain-resolution-timeout=3s (default 3s)
       --exit-code int                        Force a given exit code for the scan command. Set this to 0 (success) to always return a success exit code despite any findings from the scan. (default -1)
       --external-rule-dir strings            Specify directories paths that contain .yaml files with external rules configuration
       --force                                Disable the cache and runs the detections again
       --internal-domains strings             Define regular expressions for better classification of private or unreachable domains e.g. --internal-domains=".*.my-company.com,private.sh"
-      --log-level string                     Set log level (error, info, debug, trace) (default "info")
       --parallel int                         Specify the amount of parallelism to use during the scan
       --quiet                                Suppress non-essential messages
       --scanner strings                      Specify which scanner to use e.g. --scanner=secrets, --scanner=secrets,sast (default [sast])
@@ -40,7 +38,9 @@ Scan Flags
 General Flags
       --bearer-ignore-file string   Load bearer.ignore file from the specified path. (default "bearer.ignore")
       --config-file string          Load configuration from the specified path. (default "bearer.yml")
+      --debug                       Enable debug logs. Equivalent to --log-level=debug
       --disable-version-check       Disable Bearer version checking
+      --log-level string            Set log level (error, info, debug, trace) (default "info")
       --no-color                    Disable color in output
 
 

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -240,7 +240,7 @@ func Run(ctx context.Context, opts flag.Options) (err error) {
 	}()
 
 	var stats *evalstats.Stats
-	if scanSettings.Scan.Debug {
+	if scanSettings.Debug {
 		stats = evalstats.New()
 	}
 

--- a/pkg/commands/process/orchestrator/pool/pool.go
+++ b/pkg/commands/process/orchestrator/pool/pool.go
@@ -30,7 +30,7 @@ func New(config settings.Config, stats *stats.Stats) *Pool {
 		output.Fatal(fmt.Sprintf("failed to get current command executable %s", err))
 	}
 
-	baseArguments := []string{"processing-worker", "--log-level", config.Scan.LogLevel}
+	baseArguments := []string{"processing-worker", "--log-level", config.LogLevel}
 	if config.DebugProfile {
 		baseArguments = append(baseArguments, "--debug-profile")
 	}

--- a/pkg/commands/process/orchestrator/worker/worker.go
+++ b/pkg/commands/process/orchestrator/worker/worker.go
@@ -33,7 +33,7 @@ type Worker struct {
 }
 
 func (worker *Worker) Setup(config config.Config) error {
-	worker.debug = config.Scan.Debug
+	worker.debug = config.Debug
 	worker.scanners = config.Scan.Scanner
 
 	if slices.Contains(worker.scanners, "sast") {

--- a/pkg/commands/process/settings/settings.go
+++ b/pkg/commands/process/settings/settings.go
@@ -336,6 +336,8 @@ func FromOptions(opts flag.Options, foundLanguages []string) (Config, error) {
 		IgnoredFingerprints: ignoredFingerprints,
 		NoColor:             opts.GeneralOptions.NoColor || opts.ReportOptions.Output != "",
 		DebugProfile:        opts.GeneralOptions.DebugProfile,
+		Debug:               opts.GeneralOptions.Debug,
+		LogLevel:            opts.GeneralOptions.LogLevel,
 		Policies:            policies,
 		Rules:               result.Rules,
 		BuiltInRules:        result.BuiltInRules,

--- a/pkg/commands/process/settings/settings.go
+++ b/pkg/commands/process/settings/settings.go
@@ -56,6 +56,8 @@ type Config struct {
 	CacheUsed           bool                                 `mapstructure:"cache_used" json:"cache_used" yaml:"cache_used"`
 	BearerRulesVersion  string                               `mapstructure:"bearer_rules_version" json:"bearer_rules_version" yaml:"bearer_rules_version"`
 	NoColor             bool                                 `mapstructure:"no_color" json:"no_color" yaml:"no_color"`
+	Debug               bool                                 `mapstructure:"debug" json:"debug" yaml:"debug"`
+	LogLevel            string                               `mapstructure:"string" json:"string" yaml:"string"`
 	DebugProfile        bool                                 `mapstructure:"debug_profile" json:"debug_profile" yaml:"debug_profile"`
 }
 

--- a/pkg/commands/processing_worker.go
+++ b/pkg/commands/processing_worker.go
@@ -15,6 +15,7 @@ import (
 func NewProcessingWorkerCommand() *cobra.Command {
 	flags := &flag.Flags{
 		ProcessFlagGroup: flag.NewProcessGroup(),
+		GeneralFlagGroup: flag.NewGeneralFlagGroup(),
 		ScanFlagGroup:    flag.NewScanFlagGroup(),
 	}
 
@@ -32,7 +33,7 @@ func NewProcessingWorkerCommand() *cobra.Command {
 				ProcessID: viper.GetString(flag.WorkerIDFlag.ConfigName),
 			})
 
-			if viper.GetBool(flag.WorkerDebugProfileFlag.ConfigName) {
+			if viper.GetBool(flag.DebugProfileFlag.ConfigName) {
 				debugprofile.Start()
 			}
 

--- a/pkg/flag/general_flags.go
+++ b/pkg/flag/general_flags.go
@@ -8,6 +8,13 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+const (
+	ErrorLogLevel = "error"
+	InfoLogLevel  = "info"
+	DebugLogLevel = "debug"
+	TraceLogLevel = "trace"
+)
+
 var (
 	HostFlag = Flag{
 		Name:            "host",
@@ -51,6 +58,19 @@ var (
 		Usage:           "Load bearer.ignore file from the specified path.",
 		DisableInConfig: true,
 	}
+	DebugFlag = Flag{
+		Name:            "debug",
+		ConfigName:      "scan.debug",
+		Value:           false,
+		Usage:           "Enable debug logs. Equivalent to --log-level=debug",
+		DisableInConfig: true,
+	}
+	LogLevelFlag = Flag{
+		Name:       "log-level",
+		ConfigName: "scan.log-level",
+		Value:      "info",
+		Usage:      "Set log level (error, info, debug, trace)",
+	}
 	DebugProfileFlag = Flag{
 		Name:            "debug-profile",
 		ConfigName:      "debug-profile",
@@ -68,6 +88,8 @@ type GeneralFlagGroup struct {
 	Host                *Flag
 	DisableVersionCheck *Flag
 	NoColor             *Flag
+	DebugFlag           *Flag
+	LogLevelFlag        *Flag
 	DebugProfile        *Flag
 }
 
@@ -78,6 +100,8 @@ type GeneralOptions struct {
 	DisableVersionCheck bool
 	NoColor             bool   `mapstructure:"no_color" json:"no_color" yaml:"no_color"`
 	BearerIgnoreFile    string `mapstructure:"bearer_ignore_file" json:"bearer_ignore_file" yaml:"bearer_ignore_file"`
+	Debug               bool   `mapstructure:"debug" json:"debug" yaml:"debug"`
+	LogLevel            string `mapstructure:"log-level" json:"log-level" yaml:"log-level"`
 	DebugProfile        bool
 }
 
@@ -89,6 +113,8 @@ func NewGeneralFlagGroup() *GeneralFlagGroup {
 		DisableVersionCheck: &DisableVersionCheckFlag,
 		NoColor:             &NoColorFlag,
 		BearerIgnoreFile:    &BearerIgnoreFileFlag,
+		DebugFlag:           &DebugFlag,
+		LogLevelFlag:        &LogLevelFlag,
 		DebugProfile:        &DebugProfileFlag,
 	}
 }
@@ -105,6 +131,8 @@ func (f *GeneralFlagGroup) Flags() []*Flag {
 		f.DisableVersionCheck,
 		f.NoColor,
 		f.BearerIgnoreFile,
+		f.DebugFlag,
+		f.LogLevelFlag,
 		f.DebugProfile,
 	}
 }
@@ -127,12 +155,20 @@ func (f *GeneralFlagGroup) ToOptions() GeneralOptions {
 		}
 	}
 
+	debug := getBool(f.DebugFlag)
+	logLevel := getString(f.LogLevelFlag)
+	if debug {
+		logLevel = DebugLogLevel
+	}
+
 	return GeneralOptions{
 		Client:              client,
 		ConfigFile:          getString(f.ConfigFile),
 		DisableVersionCheck: getBool(f.DisableVersionCheck),
 		NoColor:             getBool(f.NoColor),
 		BearerIgnoreFile:    getString(f.BearerIgnoreFile),
+		Debug:               debug,
+		LogLevel:            logLevel,
 		DebugProfile:        getBool(f.DebugProfile),
 	}
 }

--- a/pkg/flag/general_flags.go
+++ b/pkg/flag/general_flags.go
@@ -60,14 +60,14 @@ var (
 	}
 	DebugFlag = Flag{
 		Name:            "debug",
-		ConfigName:      "scan.debug",
+		ConfigName:      "debug",
 		Value:           false,
 		Usage:           "Enable debug logs. Equivalent to --log-level=debug",
 		DisableInConfig: true,
 	}
 	LogLevelFlag = Flag{
 		Name:       "log-level",
-		ConfigName: "scan.log-level",
+		ConfigName: "log-level",
 		Value:      "info",
 		Usage:      "Set log level (error, info, debug, trace)",
 	}

--- a/pkg/flag/process_flags.go
+++ b/pkg/flag/process_flags.go
@@ -15,13 +15,6 @@ var (
 		Value:      "",
 		Usage:      "Set the worker's identifier.",
 	}
-
-	WorkerDebugProfileFlag = Flag{
-		Name:       "debug-profile",
-		ConfigName: "process.debug-profile",
-		Value:      false,
-		Usage:      "Generate profiling data for debugging",
-	}
 )
 
 type ProcessFlagGroup struct {
@@ -31,16 +24,14 @@ type ProcessFlagGroup struct {
 }
 
 type ProcessOptions struct {
-	WorkerID     string `mapstructure:"worker-id" json:"worker-id" yaml:"worker-id"`
-	Port         string `mapstructure:"port" json:"port" yaml:"port"`
-	DebugProfile bool   `mapstructure:"debug_profile" json:"debug_profile" yaml:"debug_profile"`
+	WorkerID string `mapstructure:"worker-id" json:"worker-id" yaml:"worker-id"`
+	Port     string `mapstructure:"port" json:"port" yaml:"port"`
 }
 
 func NewProcessGroup() *ProcessFlagGroup {
 	return &ProcessFlagGroup{
-		PortFlag:               &PortFlag,
-		WorkerIDFlag:           &WorkerIDFlag,
-		WorkerDebugProfileFlag: &WorkerDebugProfileFlag,
+		PortFlag:     &PortFlag,
+		WorkerIDFlag: &WorkerIDFlag,
 	}
 }
 
@@ -52,7 +43,6 @@ func (f *ProcessFlagGroup) Flags() []*Flag {
 	return []*Flag{
 		f.PortFlag,
 		f.WorkerIDFlag,
-		f.WorkerDebugProfileFlag,
 	}
 }
 
@@ -61,8 +51,7 @@ func (f *ProcessFlagGroup) ToOptions() (ProcessOptions, error) {
 	workerID := getString(f.WorkerIDFlag)
 
 	return ProcessOptions{
-		Port:         port,
-		WorkerID:     workerID,
-		DebugProfile: getBool(f.WorkerDebugProfileFlag),
+		Port:     port,
+		WorkerID: workerID,
 	}, nil
 }

--- a/pkg/flag/scan_flags.go
+++ b/pkg/flag/scan_flags.go
@@ -17,11 +17,6 @@ const (
 
 	ScannerSAST    = "sast"
 	ScannerSecrets = "secrets"
-
-	ErrorLogLevel = "error"
-	InfoLogLevel  = "info"
-	DebugLogLevel = "debug"
-	TraceLogLevel = "trace"
 )
 
 var (
@@ -35,19 +30,6 @@ var (
 		ConfigName: "scan.skip-path",
 		Value:      []string{},
 		Usage:      "Specify the comma separated files and directories to skip. Supports * syntax, e.g. --skip-path users/*.go,users/admin.sql",
-	}
-	DebugFlag = Flag{
-		Name:            "debug",
-		ConfigName:      "scan.debug",
-		Value:           false,
-		Usage:           "Enable debug logs. Equivalent to --log-level=debug",
-		DisableInConfig: true,
-	}
-	LogLevelFlag = Flag{
-		Name:       "log-level",
-		ConfigName: "scan.log-level",
-		Value:      "info",
-		Usage:      "Set log level (error, info, debug, trace)",
 	}
 	DisableDomainResolutionFlag = Flag{
 		Name:       "disable-domain-resolution",
@@ -120,8 +102,6 @@ var (
 type ScanFlagGroup struct {
 	ScannerFlag                 *Flag
 	SkipPathFlag                *Flag
-	DebugFlag                   *Flag
-	LogLevelFlag                *Flag
 	DisableDomainResolutionFlag *Flag
 	DomainResolutionTimeoutFlag *Flag
 	InternalDomainsFlag         *Flag
@@ -137,8 +117,6 @@ type ScanFlagGroup struct {
 type ScanOptions struct {
 	Target                  string        `mapstructure:"target" json:"target" yaml:"target"`
 	SkipPath                []string      `mapstructure:"skip-path" json:"skip-path" yaml:"skip-path"`
-	Debug                   bool          `mapstructure:"debug" json:"debug" yaml:"debug"`
-	LogLevel                string        `mapstructure:"log-level" json:"log-level" yaml:"log-level"`
 	DisableDomainResolution bool          `mapstructure:"disable-domain-resolution" json:"disable-domain-resolution" yaml:"disable-domain-resolution"`
 	DomainResolutionTimeout time.Duration `mapstructure:"domain-resolution-timeout" json:"domain-resolution-timeout" yaml:"domain-resolution-timeout"`
 	InternalDomains         []string      `mapstructure:"internal-domains" json:"internal-domains" yaml:"internal-domains"`
@@ -157,8 +135,6 @@ type ScanOptions struct {
 func NewScanFlagGroup() *ScanFlagGroup {
 	return &ScanFlagGroup{
 		SkipPathFlag:                &SkipPathFlag,
-		DebugFlag:                   &DebugFlag,
-		LogLevelFlag:                &LogLevelFlag,
 		DisableDomainResolutionFlag: &DisableDomainResolutionFlag,
 		DomainResolutionTimeoutFlag: &DomainResolutionTimeoutFlag,
 		InternalDomainsFlag:         &InternalDomainsFlag,
@@ -180,8 +156,6 @@ func (f *ScanFlagGroup) Name() string {
 func (f *ScanFlagGroup) Flags() []*Flag {
 	return []*Flag{
 		f.SkipPathFlag,
-		f.DebugFlag,
-		f.LogLevelFlag,
 		f.DisableDomainResolutionFlag,
 		f.DomainResolutionTimeoutFlag,
 		f.InternalDomainsFlag,
@@ -219,16 +193,8 @@ func (f *ScanFlagGroup) ToOptions(args []string) (ScanOptions, error) {
 		}
 	}
 
-	debug := getBool(f.DebugFlag)
-	logLevel := getString(f.LogLevelFlag)
-	if debug {
-		logLevel = DebugLogLevel
-	}
-
 	return ScanOptions{
 		SkipPath:                getStringSlice(f.SkipPathFlag),
-		Debug:                   debug,
-		LogLevel:                logLevel,
 		DisableDomainResolution: getBool(f.DisableDomainResolutionFlag),
 		DomainResolutionTimeout: getDuration(f.DomainResolutionTimeoutFlag),
 		InternalDomains:         getStringSlice(f.InternalDomainsFlag),

--- a/pkg/util/progressbar/progressbar.go
+++ b/pkg/util/progressbar/progressbar.go
@@ -7,7 +7,7 @@ import (
 )
 
 func GetProgressBar(filesLength int, config settings.Config, display_type string) *progressbar.ProgressBar {
-	hideProgress := config.Scan.Quiet || config.Scan.Debug
+	hideProgress := config.Scan.Quiet || config.Debug
 	return progressbar.NewOptions(filesLength,
 		progressbar.OptionSetVisibility(!hideProgress),
 		progressbar.OptionSetWriter(output.ErrorWriter()),


### PR DESCRIPTION
## Description

Debug and Log Level flags were Scan flags but we would like to use them in other contexts too (e.g. bearer ignore actions) and so we move them to General flags. 

The related docs are also updated. 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
