### PR TITLE
fix: use local ignores for first scan

### DIFF
--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -233,7 +233,11 @@ func getIgnoredFingerprints(client *api.API, settings settings.Config) (
 			return useCloudIgnores, ignoredFingerprints, staleIgnoredFingerprintIds, err
 		}
 
-		useCloudIgnores, ignoredFingerprints, staleIgnoredFingerprintIds, err = ignore.GetIgnoredFingerprintsFromCloud(client, vcsInfo.FullName, ignoredFingerprints)
+		useCloudIgnores, ignoredFingerprints, staleIgnoredFingerprintIds, err = ignore.GetIgnoredFingerprintsFromCloud(
+			client,
+			vcsInfo.FullName,
+			localIgnoredFingerprints,
+		)
 		if err != nil {
 			return useCloudIgnores, ignoredFingerprints, staleIgnoredFingerprintIds, err
 		}

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -221,7 +221,7 @@ func getIgnoredFingerprints(client *api.API, settings settings.Config) (
 	staleIgnoredFingerprintIds []string,
 	err error,
 ) {
-	ignoredFingerprints, _, err = ignore.GetIgnoredFingerprints(settings.IgnoreFile, &settings.Target)
+	localIgnoredFingerprints, _, err := ignore.GetIgnoredFingerprints(settings.IgnoreFile, &settings.Target)
 	if err != nil {
 		return useCloudIgnores, ignoredFingerprints, staleIgnoredFingerprintIds, err
 	}
@@ -243,7 +243,7 @@ func getIgnoredFingerprints(client *api.API, settings settings.Config) (
 		return useCloudIgnores, ignoredFingerprints, staleIgnoredFingerprintIds, nil
 	}
 
-	return useCloudIgnores, ignoredFingerprints, staleIgnoredFingerprintIds, nil
+	return false, localIgnoredFingerprints, []string{}, nil
 }
 
 // Run performs artifact scanning


### PR DESCRIPTION
## Description

For initial scan, any local fingerprints in the `ignoreFingerprints` were being overwritten unintentionally. 

Here we rename the local fingerprint var to something unique and return this var when we are not using cloud ignores.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
