### PR TITLE
fix: bearer ignore path when target is a file

### DIFF
--- a/docs/_data/bearer_ignore_add.yaml
+++ b/docs/_data/bearer_ignore_add.yaml
@@ -36,8 +36,7 @@ options:
       default_value: my.bearer.sh
       usage: Specify the Host for sending the report.
     - name: ignore-file
-      default_value: bearer.ignore
-      usage: Load bearer.ignore file from the specified path.
+      usage: Load ignore file from the specified path.
     - name: log-level
       default_value: info
       usage: Set log level (error, info, debug, trace)

--- a/docs/_data/bearer_ignore_migrate.yaml
+++ b/docs/_data/bearer_ignore_migrate.yaml
@@ -28,8 +28,7 @@ options:
       default_value: my.bearer.sh
       usage: Specify the Host for sending the report.
     - name: ignore-file
-      default_value: bearer.ignore
-      usage: Load bearer.ignore file from the specified path.
+      usage: Load ignore file from the specified path.
     - name: log-level
       default_value: info
       usage: Set log level (error, info, debug, trace)

--- a/docs/_data/bearer_ignore_pull.yaml
+++ b/docs/_data/bearer_ignore_pull.yaml
@@ -24,8 +24,7 @@ options:
       default_value: my.bearer.sh
       usage: Specify the Host for sending the report.
     - name: ignore-file
-      default_value: bearer.ignore
-      usage: Load bearer.ignore file from the specified path.
+      usage: Load ignore file from the specified path.
     - name: log-level
       default_value: info
       usage: Set log level (error, info, debug, trace)

--- a/docs/_data/bearer_ignore_remove.yaml
+++ b/docs/_data/bearer_ignore_remove.yaml
@@ -24,8 +24,7 @@ options:
       default_value: my.bearer.sh
       usage: Specify the Host for sending the report.
     - name: ignore-file
-      default_value: bearer.ignore
-      usage: Load bearer.ignore file from the specified path.
+      usage: Load ignore file from the specified path.
     - name: log-level
       default_value: info
       usage: Set log level (error, info, debug, trace)

--- a/docs/_data/bearer_ignore_show.yaml
+++ b/docs/_data/bearer_ignore_show.yaml
@@ -27,8 +27,7 @@ options:
       default_value: my.bearer.sh
       usage: Specify the Host for sending the report.
     - name: ignore-file
-      default_value: bearer.ignore
-      usage: Load bearer.ignore file from the specified path.
+      usage: Load ignore file from the specified path.
     - name: log-level
       default_value: info
       usage: Set log level (error, info, debug, trace)

--- a/docs/_data/bearer_scan.yaml
+++ b/docs/_data/bearer_scan.yaml
@@ -60,8 +60,7 @@ options:
       default_value: my.bearer.sh
       usage: Specify the Host for sending the report.
     - name: ignore-file
-      default_value: bearer.ignore
-      usage: Load bearer.ignore file from the specified path.
+      usage: Load ignore file from the specified path.
     - name: internal-domains
       default_value: '[]'
       usage: |

--- a/docs/_data/bearer_version.yaml
+++ b/docs/_data/bearer_version.yaml
@@ -24,8 +24,7 @@ options:
       default_value: my.bearer.sh
       usage: Specify the Host for sending the report.
     - name: ignore-file
-      default_value: bearer.ignore
-      usage: Load bearer.ignore file from the specified path.
+      usage: Load ignore file from the specified path.
     - name: log-level
       default_value: info
       usage: Set log level (error, info, debug, trace)

--- a/e2e/flags/.snapshots/TestMetadataFlags-help-scan
+++ b/e2e/flags/.snapshots/TestMetadataFlags-help-scan
@@ -38,7 +38,7 @@ General Flags
       --config-file string      Load configuration from the specified path. (default "bearer.yml")
       --debug                   Enable debug logs. Equivalent to --log-level=debug
       --disable-version-check   Disable Bearer version checking
-      --ignore-file string      Load bearer.ignore file from the specified path. (default "bearer.ignore")
+      --ignore-file string      Load ignore file from the specified path.
       --log-level string        Set log level (error, info, debug, trace) (default "info")
       --no-color                Disable color in output
 

--- a/e2e/flags/.snapshots/TestMetadataFlags-scan-help
+++ b/e2e/flags/.snapshots/TestMetadataFlags-scan-help
@@ -38,7 +38,7 @@ General Flags
       --config-file string      Load configuration from the specified path. (default "bearer.yml")
       --debug                   Enable debug logs. Equivalent to --log-level=debug
       --disable-version-check   Disable Bearer version checking
-      --ignore-file string      Load bearer.ignore file from the specified path. (default "bearer.ignore")
+      --ignore-file string      Load ignore file from the specified path.
       --log-level string        Set log level (error, info, debug, trace) (default "info")
       --no-color                Disable color in output
 

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-context-flag
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-context-flag
@@ -39,7 +39,7 @@ General Flags
       --config-file string      Load configuration from the specified path. (default "bearer.yml")
       --debug                   Enable debug logs. Equivalent to --log-level=debug
       --disable-version-check   Disable Bearer version checking
-      --ignore-file string      Load bearer.ignore file from the specified path. (default "bearer.ignore")
+      --ignore-file string      Load ignore file from the specified path.
       --log-level string        Set log level (error, info, debug, trace) (default "info")
       --no-color                Disable color in output
 

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag-privacy
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag-privacy
@@ -39,7 +39,7 @@ General Flags
       --config-file string      Load configuration from the specified path. (default "bearer.yml")
       --debug                   Enable debug logs. Equivalent to --log-level=debug
       --disable-version-check   Disable Bearer version checking
-      --ignore-file string      Load bearer.ignore file from the specified path. (default "bearer.ignore")
+      --ignore-file string      Load ignore file from the specified path.
       --log-level string        Set log level (error, info, debug, trace) (default "info")
       --no-color                Disable color in output
 

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag-security
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag-security
@@ -39,7 +39,7 @@ General Flags
       --config-file string      Load configuration from the specified path. (default "bearer.yml")
       --debug                   Enable debug logs. Equivalent to --log-level=debug
       --disable-version-check   Disable Bearer version checking
-      --ignore-file string      Load bearer.ignore file from the specified path. (default "bearer.ignore")
+      --ignore-file string      Load ignore file from the specified path.
       --log-level string        Set log level (error, info, debug, trace) (default "info")
       --no-color                Disable color in output
 

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-report-flag
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-report-flag
@@ -39,7 +39,7 @@ General Flags
       --config-file string      Load configuration from the specified path. (default "bearer.yml")
       --debug                   Enable debug logs. Equivalent to --log-level=debug
       --disable-version-check   Disable Bearer version checking
-      --ignore-file string      Load bearer.ignore file from the specified path. (default "bearer.ignore")
+      --ignore-file string      Load ignore file from the specified path.
       --log-level string        Set log level (error, info, debug, trace) (default "info")
       --no-color                Disable color in output
 

--- a/internal/flag/general_flags.go
+++ b/internal/flag/general_flags.go
@@ -54,8 +54,8 @@ var (
 	IgnoreFileFlag = Flag{
 		Name:            "ignore-file",
 		ConfigName:      "ignore-file",
-		Value:           "bearer.ignore",
-		Usage:           "Load bearer.ignore file from the specified path.",
+		Value:           "",
+		Usage:           "Load ignore file from the specified path.",
 		DisableInConfig: true,
 	}
 	DebugFlag = Flag{

--- a/internal/util/ignore/ignore.go
+++ b/internal/util/ignore/ignore.go
@@ -18,35 +18,21 @@ import (
 	pointer "github.com/bearer/bearer/internal/util/pointers"
 )
 
-func GetIgnoredFingerprints(bearerIgnoreFilePath string, target *string) (ignoredFingerprints map[string]types.IgnoredFingerprint, fileExists bool, err error) {
-	if bearerIgnoreFilePath == "" {
-		// nothing to do here
-		return ignoredFingerprints, false, err
-	}
+const DefaultIgnoreFilepath = "bearer.ignore"
 
-	if target != nil {
-		targetPath := ""
-		if targetPath, err = filepath.Abs(*target); err != nil {
-			return ignoredFingerprints, fileExists, err
-		}
-		bearerIgnoreFilePath = filepath.Join(targetPath, bearerIgnoreFilePath)
-	}
-
-	info, err := os.Stat(bearerIgnoreFilePath)
+func GetIgnoredFingerprints(ignoreFilePath string, target *string) (ignoredFingerprints map[string]types.IgnoredFingerprint, fileExists bool, err error) {
+	ignorePath, err := getIgnoreFilePath(ignoreFilePath, target)
 	if err != nil {
-		if os.IsNotExist(err) {
-			// file does not exist : expected scenario
-			err = nil
+		if ignoreFilePath == "" && os.IsNotExist(err) {
+			// bearer.ignore file does not exist: expected scenario
+			return map[string]types.IgnoredFingerprint{}, false, nil
 		}
-		return make(map[string]types.IgnoredFingerprint), false, err
-	}
 
-	if info.IsDir() {
-		return ignoredFingerprints, false, fmt.Errorf("bearer-ignore-file path %s is a dir not a file", bearerIgnoreFilePath)
+		return ignoredFingerprints, fileExists, err
 	}
 
 	// file exists
-	content, err := os.ReadFile(bearerIgnoreFilePath)
+	content, err := os.ReadFile(ignorePath)
 	if err != nil {
 		return ignoredFingerprints, true, err
 	}
@@ -144,4 +130,61 @@ func GetAuthor() (*string, error) {
 	}
 
 	return pointer.String(strings.TrimSuffix(string(nameBytes), "\n")), nil
+}
+
+func getIgnoreFilePath(ignoreFilePath string, target *string) (string, error) {
+	if ignoreFilePath == "" {
+		// use default ignore file path
+		ignoreFilePath = DefaultIgnoreFilepath
+	}
+
+	_, err := os.Stat(ignoreFilePath)
+	if err == nil || !os.IsNotExist(err) {
+		// either file is found (all good) or we've hit an unexpected error
+		return ignoreFilePath, err
+	}
+
+	// file not found
+
+	// append filepath to target path and try again
+	targetPath, targetErr := targetPath(target)
+	if targetErr != nil {
+		return "", targetErr
+	}
+
+	ignoreFilePath = filepath.Join(targetPath, ignoreFilePath)
+	info, err := os.Stat(ignoreFilePath)
+	if err != nil {
+		return "", err
+	}
+
+	if info.IsDir() {
+		return "", fmt.Errorf("ignore file path %s is a dir not a file", ignoreFilePath)
+	}
+
+	return ignoreFilePath, nil
+}
+
+// returns target directory from target
+func targetPath(target *string) (string, error) {
+	if target == nil {
+		return "", nil
+	}
+
+	targetPath, err := filepath.Abs(*target)
+	if err != nil {
+		return "", err
+	}
+
+	info, err := os.Stat(targetPath)
+	if err != nil {
+		return "", err
+	}
+
+	if info.IsDir() {
+		return targetPath, nil
+	}
+
+	// not a directory
+	return filepath.Dir(targetPath), nil
 }

--- a/internal/util/ignore/ignore_test.go
+++ b/internal/util/ignore/ignore_test.go
@@ -12,11 +12,18 @@ import (
 )
 
 func TestGetIgnoredFingerprints(t *testing.T) {
-	t.Run("bearer.ignore does not exist", func(t *testing.T) {
-		ignoredFingerprints, fileExists, err := ignore.GetIgnoredFingerprints("some_path.ignore", nil)
+	t.Run("Default bearer.ignore does not exist", func(t *testing.T) {
+		ignoredFingerprints, fileExists, err := ignore.GetIgnoredFingerprints("", nil)
 		assert.Equal(t, map[string]types.IgnoredFingerprint{}, ignoredFingerprints)
 		assert.Equal(t, false, fileExists)
 		assert.Equal(t, nil, err)
+	})
+
+	t.Run("Custom ignore file does not exist", func(t *testing.T) {
+		ignoredFingerprints, fileExists, err := ignore.GetIgnoredFingerprints("my-own-ignore-file.ignore", nil)
+		assert.Equal(t, map[string]types.IgnoredFingerprint(nil), ignoredFingerprints)
+		assert.Equal(t, false, fileExists)
+		assert.NotEqual(t, nil, err)
 	})
 }
 


### PR DESCRIPTION
## Description

Rule repo test failures tell us that more sophistication is needed when constructing ignore path. 

Updated flow is the following: 

If the user has passed a value to `--ignore-file`, we try this path first. If no file is found, we append the target directory path and try again. If still, no file is found, we return an error. 

If no value is passed to `--ignore-file`, we try `bearer.ignore` first. If no file is found, we append the target directory path and try again. If still no file is found, we assume it cannot be found. Depending on the action (e.g. `bearer ignore add`), a new file is then created in this location. 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
