### PR TITLE
build: target macos 11 for builds

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -64,7 +64,7 @@ jobs:
   build-darwin:
     needs: [tag]
     name: build-darwin
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
   build-darwin:
     needs: [tag]
     name: build-darwin
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Description
MacOS 11 is still supported by Apple so lower our build target to make sure it runs in this environment


## Related
- Close #1247

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
