### PR TITLE
fix: stale ignores json key

### DIFF
--- a/api/fetch_ignores.go
+++ b/api/fetch_ignores.go
@@ -9,7 +9,7 @@ import (
 type CloudIgnoreData struct {
 	ProjectFound             bool                                      `json:"project_found"`
 	Ignores                  []string                                  `json:"ignores"`
-	StaleIgnores             []string                                  `json:"stale_ignores"`
+	StaleIgnores             []string                                  `json:"stale_local_ignores"`
 	CloudIgnoredFingerprints map[string]ignoretypes.IgnoredFingerprint `json:"detailed_cloud_ignores"`
 }
 


### PR DESCRIPTION
## Description

Fix typo in json key; stale ignores were not being set and therefore not displayed in security output

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
