### PR TITLE
fix: ignoring of minified files

### DIFF
--- a/internal/commands/process/filelist/ignore/ignore.go
+++ b/internal/commands/process/filelist/ignore/ignore.go
@@ -50,7 +50,7 @@ func (fileignore *FileIgnore) Ignore(
 			return true
 		}
 		if isMinified(filePath, fileInfo.Size(), goclocResult) {
-			log.Debug().Msgf("skipping file (suspected minified JS): %s %s", projectPath, filePath)
+			log.Debug().Msgf("skipping file (suspected minified JS): %s %s", projectPath, relativePath)
 			return true
 		}
 	}

--- a/internal/report/output/stats/gocloc_detector.go
+++ b/internal/report/output/stats/gocloc_detector.go
@@ -1,77 +1,15 @@
 package stats
 
 import (
-	"regexp"
-	"strings"
-
 	"github.com/hhatto/gocloc"
-	"github.com/jessevdk/go-flags"
 )
 
-type CmdOptions struct {
-	Byfile         bool   `long:"by-file" description:"report results for every encountered source file"`
-	SortTag        string `long:"sort" default:"code" description:"sort based on a certain column"`
-	OutputType     string `long:"output-type" default:"default" description:"output type [values: default,cloc-xml,sloccount,json]"`
-	ExcludeExt     string `long:"exclude-ext" description:"exclude file name extensions (separated commas)"`
-	IncludeLang    string `long:"include-lang" description:"include language name (separated commas)"`
-	Match          string `long:"match" description:"include file name (regex)"`
-	NotMatch       string `long:"not-match" description:"exclude file name (regex)"`
-	MatchDir       string `long:"match-d" description:"include dir name (regex)"`
-	NotMatchDir    string `long:"not-match-d" description:"exclude dir name (regex)"`
-	Debug          bool   `long:"debug" description:"dump debug log for developer"`
-	SkipDuplicated bool   `long:"skip-duplicated" description:"skip duplicated files"`
-	ShowLang       bool   `long:"show-lang" description:"print about all languages and extensions"`
-}
-
 func GoclocDetectorOutput(path string) (*gocloc.Result, error) {
-	var opts CmdOptions
 	clocOpts := gocloc.NewClocOptions()
-	args := []string{
-		"--output-type=json",
-		path,
-	}
-
-	paths, err := flags.ParseArgs(&opts, args)
-	if err != nil {
-		return nil, err
-	}
+	clocOpts.SkipDuplicated = true
 
 	languages := gocloc.NewDefinedLanguages()
-
-	// setup option for exclude extensions
-	for _, ext := range strings.Split(opts.ExcludeExt, ",") {
-		e, ok := gocloc.Exts[ext]
-		if ok {
-			clocOpts.ExcludeExts[e] = struct{}{}
-		} else {
-			clocOpts.ExcludeExts[ext] = struct{}{}
-		}
-	}
-
-	// directory and file matching options
-	if opts.Match != "" {
-		clocOpts.ReMatch = regexp.MustCompile(opts.Match)
-	}
-	if opts.NotMatch != "" {
-		clocOpts.ReNotMatch = regexp.MustCompile(opts.NotMatch)
-	}
-	if opts.MatchDir != "" {
-		clocOpts.ReMatchDir = regexp.MustCompile(opts.MatchDir)
-	}
-	if opts.NotMatchDir != "" {
-		clocOpts.ReNotMatchDir = regexp.MustCompile(opts.NotMatchDir)
-	}
-
-	// setup option for include languages
-	for _, lang := range strings.Split(opts.IncludeLang, ",") {
-		if _, ok := languages.Langs[lang]; ok {
-			clocOpts.IncludeLangs[lang] = struct{}{}
-		}
-	}
-
-	clocOpts.Debug = opts.Debug
-	clocOpts.SkipDuplicated = opts.SkipDuplicated
-
 	processor := gocloc.NewProcessor(languages, clocOpts)
-	return processor.Analyze(paths)
+
+	return processor.Analyze([]string{path})
 }


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Fixes ignoring of minified files when there are duplicate files in the tree. 

The fix is to set Gocloc's `SkipDuplicated` option to `true`. This option causes it to (confusingly!) skip the duplicated check (rather than skipping duplicated files as it would seem). Previously, we were only getting Gocloc results for the first filename of a duplicated file.

A side effect of this change is that duplicated files will be counted in the Gocloc stats.

Also:
- Fixes the log message when a minified file is ignored, we were previously including the target path twice.
- Removes unused code for triggering Gocloc

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
