### PR TITLE
fix: ignore commands no default file value

### DIFF
--- a/internal/commands/ignore.go
+++ b/internal/commands/ignore.go
@@ -480,6 +480,10 @@ func setLogLevel(cmd *cobra.Command) {
 }
 
 func writeIgnoreFile(ignoredFingerprints map[string]ignoretypes.IgnoredFingerprint, bearerIgnoreFilePath string) error {
+	if bearerIgnoreFilePath == "" {
+		bearerIgnoreFilePath = ignore.DefaultIgnoreFilepath
+	}
+
 	data, err := json.MarshalIndent(ignoredFingerprints, "", "  ")
 	if err != nil {
 		// failed to marshall data


### PR DESCRIPTION
## Description

Since we have removed the default ignore-file value, we add a catch for the `""` case when writing to the ignore file

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
