### PR TITLE
fix: default ignore file value

### DIFF
--- a/docs/_data/bearer_ignore_add.yaml
+++ b/docs/_data/bearer_ignore_add.yaml
@@ -36,6 +36,7 @@ options:
       default_value: my.bearer.sh
       usage: Specify the Host for sending the report.
     - name: ignore-file
+      default_value: bearer.ignore
       usage: Load ignore file from the specified path.
     - name: log-level
       default_value: info
@@ -44,7 +45,7 @@ options:
       default_value: "false"
       usage: Disable color in output
 example: |-
-    # Add an ignored fingerprint to your bearer.ignore file
+    # Add an ignored fingerprint to your ignore file
     $ bearer ignore add <fingerprint> --author Mish --comment "Possible false positive"
 see_also:
     - ' ignore - Manage ignored fingerprints'

--- a/docs/_data/bearer_ignore_migrate.yaml
+++ b/docs/_data/bearer_ignore_migrate.yaml
@@ -1,6 +1,5 @@
 name: ' ignore migrate'
-synopsis: |
-    Migrate ignored fingerprints from bearer.yml to bearer.ignore
+synopsis: Migrate ignored fingerprints from bearer.yml to ignore file
 usage: ' ignore migrate [flags]'
 options:
     - name: api-key
@@ -28,6 +27,7 @@ options:
       default_value: my.bearer.sh
       usage: Specify the Host for sending the report.
     - name: ignore-file
+      default_value: bearer.ignore
       usage: Load ignore file from the specified path.
     - name: log-level
       default_value: info
@@ -36,7 +36,7 @@ options:
       default_value: "false"
       usage: Disable color in output
 example: |-
-    # Migrate existing ignored (excluded) fingerprints from bearer.yml file to bearer.ignore
+    # Migrate existing ignored (excluded) fingerprints from bearer.yml file to ignore file
     $ bearer ignore migrate
 see_also:
     - ' ignore - Manage ignored fingerprints'

--- a/docs/_data/bearer_ignore_pull.yaml
+++ b/docs/_data/bearer_ignore_pull.yaml
@@ -24,6 +24,7 @@ options:
       default_value: my.bearer.sh
       usage: Specify the Host for sending the report.
     - name: ignore-file
+      default_value: bearer.ignore
       usage: Load ignore file from the specified path.
     - name: log-level
       default_value: info

--- a/docs/_data/bearer_ignore_remove.yaml
+++ b/docs/_data/bearer_ignore_remove.yaml
@@ -24,6 +24,7 @@ options:
       default_value: my.bearer.sh
       usage: Specify the Host for sending the report.
     - name: ignore-file
+      default_value: bearer.ignore
       usage: Load ignore file from the specified path.
     - name: log-level
       default_value: info
@@ -32,7 +33,7 @@ options:
       default_value: "false"
       usage: Disable color in output
 example: |-
-    # Remove an ignored fingerprint from your bearer.ignore file
+    # Remove an ignored fingerprint from your ignore file
     $ bearer ignore remove <fingerprint>
 see_also:
     - ' ignore - Manage ignored fingerprints'

--- a/docs/_data/bearer_ignore_show.yaml
+++ b/docs/_data/bearer_ignore_show.yaml
@@ -27,6 +27,7 @@ options:
       default_value: my.bearer.sh
       usage: Specify the Host for sending the report.
     - name: ignore-file
+      default_value: bearer.ignore
       usage: Load ignore file from the specified path.
     - name: log-level
       default_value: info
@@ -35,7 +36,7 @@ options:
       default_value: "false"
       usage: Disable color in output
 example: |-
-    # Show the details of an ignored fingerprint from your bearer.ignore file
+    # Show the details of an ignored fingerprint from your ignore file
     $ bearer ignore show <fingerprint>
 see_also:
     - ' ignore - Manage ignored fingerprints'

--- a/docs/_data/bearer_scan.yaml
+++ b/docs/_data/bearer_scan.yaml
@@ -60,6 +60,7 @@ options:
       default_value: my.bearer.sh
       usage: Specify the Host for sending the report.
     - name: ignore-file
+      default_value: bearer.ignore
       usage: Load ignore file from the specified path.
     - name: internal-domains
       default_value: '[]'

--- a/docs/_data/bearer_version.yaml
+++ b/docs/_data/bearer_version.yaml
@@ -24,6 +24,7 @@ options:
       default_value: my.bearer.sh
       usage: Specify the Host for sending the report.
     - name: ignore-file
+      default_value: bearer.ignore
       usage: Load ignore file from the specified path.
     - name: log-level
       default_value: info

--- a/docs/guides/bearer-cloud.md
+++ b/docs/guides/bearer-cloud.md
@@ -95,19 +95,19 @@ Bearer Cloud automatically captures any scans run with a valid `api-key`. Subseq
 
 ### Ignored findings in Bearer Cloud
 
-When a valid `api-key` is present, the very first scan of a project reads ignored fingerprints from the bearer.ignore file and subsequently creates ignored findings for these in the Cloud, including status and comments (if present). A finding has "False Positive" status in the Cloud if its corresponding bearer.ignore entry is a false positive (`false_positive: true`); otherwise, it has the status "Allowed".
+When a valid `api-key` is present, the very first scan of a project reads ignored fingerprints from the ignore file and subsequently creates ignored findings for these in the Cloud, including status and comments (if present). A finding has "False Positive" status in the Cloud if its corresponding ignore file entry is a false positive (`false_positive: true`); otherwise, it has the status "Allowed".
 
-After the initial scan, the Cloud is taken as the source of truth for ignored fingerprints. If there are new entries added to the bearer.ignore file, in most cases, these are sent to the Cloud on subsequent scans, and the corresponding Cloud findings are updated to "False Positive" or "Allowed" status accordingly.
+After the initial scan, the Cloud is taken as the source of truth for ignored fingerprints. If there are new entries added to the ignore file, in most cases, these are sent to the Cloud on subsequent scans, and the corresponding Cloud findings are updated to "False Positive" or "Allowed" status accordingly.
 
-However, it is important to note that the Cloud state is always prioritized over the contents of the bearer.ignore file. If a finding is already ignored in the Cloud, and then added to the bearer.ignore file, its Cloud status and comments are unchanged by subsequent scans. Similarly, if an ignored finding is re-opened in the Cloud, and then added to the bearer.ignore file, its Cloud status remains "Open". That is, re-opened findings can only be re-ignored again from the Cloud.
+However, it is important to note that the Cloud state is always prioritized over the contents of the ignore file. If a finding is already ignored in the Cloud, and then added to the ignore file, its Cloud status and comments are unchanged by subsequent scans. Similarly, if an ignored finding is re-opened in the Cloud, and then added to the ignore file, its Cloud status remains "Open". That is, re-opened findings can only be re-ignored again from the Cloud.
 
-Furthermore, if an ignored finding is later re-opened in the Cloud, any corresponding bearer.ignore entry is not automatically removed. Over time, then, the bearer.ignore file may become out-of-sync with the Cloud state. To remedy this, and align the bearer.ignore file with what is in the Cloud, use the following action:
+Furthermore, if an ignored finding is later re-opened in the Cloud, any corresponding ignore entry is not automatically removed. Over time, then, the ignore file may become out-of-sync with the Cloud state. To remedy this, and align the ignore file with what is in the Cloud, use the following action:
 
 ```bash
 bearer ignore pull project-folder --api-key=XXXXXXXX
 ```
 
-This action overwrites the current bearer.ignore file (including any new additions not yet sent to the Cloud) with all ignored findings from the Cloud, including status, comments, and author information.
+This action overwrites the current ignore file (including any new additions not yet sent to the Cloud) with all ignored findings from the Cloud, including status, comments, and author information.
 
 ## Jira integration
 
@@ -124,7 +124,7 @@ You have two ways to use the Jira Integration:
 2. Link a finding to an existing Jira ticket.
 ![Link Jira Ticket](/assets/img/jira-integration/link.png)
 
-Once a finding is associated with a Jira ticket, you can quickly see it in the interface, view the ticket status and go to the ticket. 
+Once a finding is associated with a Jira ticket, you can quickly see it in the interface, view the ticket status and go to the ticket.
 
 ![View Jira Ticket](/assets/img/jira-integration/view.png)
 

--- a/docs/guides/configure-scan.md
+++ b/docs/guides/configure-scan.md
@@ -59,7 +59,7 @@ To ignore this finding, run: bearer ignore add 4b0883d52334dfd9a4acce2fcf810121_
 ...
 ```
 
-If a finding is not relevant, you can ignore it automatically from future scans using the ```bearer ignore add``` command. This adds the finding's fingerprint to your bearer.ignore file. You can also provide optional author information or a comment:
+If a finding is not relevant, you can ignore it automatically from future scans using the ```bearer ignore add``` command. This adds the finding's fingerprint to your ignore file. You can also provide optional author information or a comment:
 
 ```bash
 bearer ignore add 4b0883d52334dfd9a4acce2fcf810121_0 \

--- a/e2e/flags/.snapshots/TestMetadataFlags-help-scan
+++ b/e2e/flags/.snapshots/TestMetadataFlags-help-scan
@@ -38,7 +38,7 @@ General Flags
       --config-file string      Load configuration from the specified path. (default "bearer.yml")
       --debug                   Enable debug logs. Equivalent to --log-level=debug
       --disable-version-check   Disable Bearer version checking
-      --ignore-file string      Load ignore file from the specified path.
+      --ignore-file string      Load ignore file from the specified path. (default "bearer.ignore")
       --log-level string        Set log level (error, info, debug, trace) (default "info")
       --no-color                Disable color in output
 

--- a/e2e/flags/.snapshots/TestMetadataFlags-scan-help
+++ b/e2e/flags/.snapshots/TestMetadataFlags-scan-help
@@ -38,7 +38,7 @@ General Flags
       --config-file string      Load configuration from the specified path. (default "bearer.yml")
       --debug                   Enable debug logs. Equivalent to --log-level=debug
       --disable-version-check   Disable Bearer version checking
-      --ignore-file string      Load ignore file from the specified path.
+      --ignore-file string      Load ignore file from the specified path. (default "bearer.ignore")
       --log-level string        Set log level (error, info, debug, trace) (default "info")
       --no-color                Disable color in output
 

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-context-flag
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-context-flag
@@ -39,7 +39,7 @@ General Flags
       --config-file string      Load configuration from the specified path. (default "bearer.yml")
       --debug                   Enable debug logs. Equivalent to --log-level=debug
       --disable-version-check   Disable Bearer version checking
-      --ignore-file string      Load ignore file from the specified path.
+      --ignore-file string      Load ignore file from the specified path. (default "bearer.ignore")
       --log-level string        Set log level (error, info, debug, trace) (default "info")
       --no-color                Disable color in output
 

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag-privacy
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag-privacy
@@ -39,7 +39,7 @@ General Flags
       --config-file string      Load configuration from the specified path. (default "bearer.yml")
       --debug                   Enable debug logs. Equivalent to --log-level=debug
       --disable-version-check   Disable Bearer version checking
-      --ignore-file string      Load ignore file from the specified path.
+      --ignore-file string      Load ignore file from the specified path. (default "bearer.ignore")
       --log-level string        Set log level (error, info, debug, trace) (default "info")
       --no-color                Disable color in output
 

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag-security
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag-security
@@ -39,7 +39,7 @@ General Flags
       --config-file string      Load configuration from the specified path. (default "bearer.yml")
       --debug                   Enable debug logs. Equivalent to --log-level=debug
       --disable-version-check   Disable Bearer version checking
-      --ignore-file string      Load ignore file from the specified path.
+      --ignore-file string      Load ignore file from the specified path. (default "bearer.ignore")
       --log-level string        Set log level (error, info, debug, trace) (default "info")
       --no-color                Disable color in output
 

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-report-flag
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-report-flag
@@ -39,7 +39,7 @@ General Flags
       --config-file string      Load configuration from the specified path. (default "bearer.yml")
       --debug                   Enable debug logs. Equivalent to --log-level=debug
       --disable-version-check   Disable Bearer version checking
-      --ignore-file string      Load ignore file from the specified path.
+      --ignore-file string      Load ignore file from the specified path. (default "bearer.ignore")
       --log-level string        Set log level (error, info, debug, trace) (default "info")
       --no-color                Disable color in output
 

--- a/internal/commands/artifact/run.go
+++ b/internal/commands/artifact/run.go
@@ -219,7 +219,7 @@ func getIgnoredFingerprints(client *api.API, settings settings.Config) (
 	staleIgnoredFingerprintIds []string,
 	err error,
 ) {
-	localIgnoredFingerprints, _, err := ignore.GetIgnoredFingerprints(settings.IgnoreFile, &settings.Target)
+	localIgnoredFingerprints, _, _, err := ignore.GetIgnoredFingerprints(settings.IgnoreFile, &settings.Target)
 	if err != nil {
 		return useCloudIgnores, ignoredFingerprints, staleIgnoredFingerprintIds, err
 	}

--- a/internal/commands/process/settings/settings.go
+++ b/internal/commands/process/settings/settings.go
@@ -336,7 +336,7 @@ func FromOptions(opts flag.Options, versionMeta *version_check.VersionMeta) (Con
 		}
 	}
 
-	ignoredFingerprints, _, err := ignore.GetIgnoredFingerprints(opts.GeneralOptions.IgnoreFile, &opts.ScanOptions.Target)
+	ignoredFingerprints, _, _, err := ignore.GetIgnoredFingerprints(opts.GeneralOptions.IgnoreFile, &opts.ScanOptions.Target)
 	if err != nil {
 		return Config{}, err
 	}

--- a/internal/flag/general_flags.go
+++ b/internal/flag/general_flags.go
@@ -54,7 +54,7 @@ var (
 	IgnoreFileFlag = Flag{
 		Name:            "ignore-file",
 		ConfigName:      "ignore-file",
-		Value:           "",
+		Value:           "bearer.ignore",
 		Usage:           "Load ignore file from the specified path.",
 		DisableInConfig: true,
 	}

--- a/internal/report/output/security/security.go
+++ b/internal/report/output/security/security.go
@@ -278,11 +278,11 @@ func fingerprintOutput(
 			}
 
 			if len(staleFingerprints) > 0 {
-				// bearer.ignore entries that have been e.g. re-opened in the Cloud
-				output.StdErrLog(fmt.Sprintf("%d fingerprints present in your bearer.ignore are stale and have not been applied", len(staleFingerprints)))
+				// ignore file entries that have been e.g. re-opened in the Cloud
+				output.StdErrLog(fmt.Sprintf("%d fingerprints present in your ignore file are stale and have not been applied", len(staleFingerprints)))
 				for _, fingerprintId := range staleFingerprints {
 					output.StdErrLog(fmt.Sprintf("  - %s", fingerprintId))
-					output.StdErrLog(color.HiBlackString("\tTo remove this fingerprint from your bearer.ignore file, run: bearer ignore remove " + fingerprintId))
+					output.StdErrLog(color.HiBlackString("\tTo remove this fingerprint from your ignore file, run: bearer ignore remove " + fingerprintId))
 				}
 			}
 			output.StdErrLog("\n=====================================\n")
@@ -298,7 +298,7 @@ func fingerprintOutput(
 		output.StdErrLog("\n=====================================\n")
 		// legacy
 		if len(legacyExcludedFingerprints) > 0 {
-			output.StdErrLog(color.HiYellowString("Note: exclude-fingerprints is being replaced by bearer.ignore. To use the new ignore functionality, run bearer ignore migrate. See https://docs.bearer.com/reference/commands/#ignore_migrate."))
+			output.StdErrLog(color.HiYellowString("Note: exclude-fingerprints is being replaced by bearer ignore. To use the new ignore functionality, run bearer ignore migrate. See https://docs.bearer.com/reference/commands/#ignore_migrate."))
 		}
 
 		if !diffScan { // stale ignored fingerprint warning is misleading for diff scans
@@ -312,7 +312,7 @@ func fingerprintOutput(
 			// end legacy
 
 			if len(unusedFingerprints) > 0 {
-				output.StdErrLog(fmt.Sprintf("%d ignored fingerprints present in your bearer.ignore file are no longer detected:", len(unusedFingerprints)))
+				output.StdErrLog(fmt.Sprintf("%d ignored fingerprints present in your ignore file are no longer detected:", len(unusedFingerprints)))
 				for _, fingerprintId := range unusedFingerprints {
 					fingerprint, ok := ignoredFingerprints[fingerprintId]
 					if !ok {
@@ -325,7 +325,7 @@ func fingerprintOutput(
 					} else {
 						output.StdErrLog(fmt.Sprintf("  - %s (%s)", fingerprintId, *fingerprint.Comment))
 					}
-					output.StdErrLog(color.HiBlackString("\tTo remove this fingerprint from your bearer.ignore file, run: bearer ignore remove " + fingerprintId))
+					output.StdErrLog(color.HiBlackString("\tTo remove this fingerprint from your ignore file, run: bearer ignore remove " + fingerprintId))
 				}
 			}
 		}

--- a/internal/util/ignore/ignore.go
+++ b/internal/util/ignore/ignore.go
@@ -21,6 +21,11 @@ import (
 const DefaultIgnoreFilepath = "bearer.ignore"
 
 func GetIgnoredFingerprints(filePath string, target *string) (ignoredFingerprints map[string]types.IgnoredFingerprint, ignoreFilePath string, fileExists bool, err error) {
+	if filePath == "" {
+		// nothing to do here
+		return map[string]types.IgnoredFingerprint{}, filePath, false, nil
+	}
+
 	ignoreFilePath, isDefaultPath, fileExists, err := GetIgnoreFilePath(filePath, target)
 	if err != nil {
 		if isDefaultPath && !fileExists {

--- a/internal/util/ignore/ignore_test.go
+++ b/internal/util/ignore/ignore_test.go
@@ -13,15 +13,17 @@ import (
 
 func TestGetIgnoredFingerprints(t *testing.T) {
 	t.Run("Default bearer.ignore does not exist", func(t *testing.T) {
-		ignoredFingerprints, fileExists, err := ignore.GetIgnoredFingerprints("", nil)
+		ignoredFingerprints, ignoreFilePath, fileExists, err := ignore.GetIgnoredFingerprints("bearer.ignore", nil)
 		assert.Equal(t, map[string]types.IgnoredFingerprint{}, ignoredFingerprints)
+		assert.Equal(t, "bearer.ignore", ignoreFilePath)
 		assert.Equal(t, false, fileExists)
 		assert.Equal(t, nil, err)
 	})
 
 	t.Run("Custom ignore file does not exist", func(t *testing.T) {
-		ignoredFingerprints, fileExists, err := ignore.GetIgnoredFingerprints("my-own-ignore-file.ignore", nil)
+		ignoredFingerprints, ignoreFilePath, fileExists, err := ignore.GetIgnoredFingerprints("my-own-ignore-file.ignore", nil)
 		assert.Equal(t, map[string]types.IgnoredFingerprint(nil), ignoredFingerprints)
+		assert.Equal(t, "my-own-ignore-file.ignore", ignoreFilePath)
 		assert.Equal(t, false, fileExists)
 		assert.NotEqual(t, nil, err)
 	})


### PR DESCRIPTION
## Description

Updates to the recent changes around `--ignore file` flag: 

* Add default value back for flag
* Return actual path to ignore file and use this in console messages
* Fix migrate and pull commands (which weren't using `ignore-file` value)
* In copy, prefer more general "ignore file" (similar to e.g. "config file") to "`bearer.ignore` file"
* Update docs accordingly

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
