### PR TITLE
build(notarization): fix macos build failures

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -64,7 +64,7 @@ jobs:
   build-darwin:
     needs: [tag]
     name: build-darwin
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
   build-darwin:
     needs: [tag]
     name: build-darwin
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.goreleaser/common.yaml
+++ b/.goreleaser/common.yaml
@@ -43,7 +43,8 @@ builds:
           }
           EOF
           '
-        - "gon -log-level DEBUG 'dist/darwin/darwin_{{.Target}}/gon.hcl'"
+        - cmd: "gon -log-level DEBUG 'dist/darwin/darwin_{{.Target}}/gon.hcl'"
+          output: true
 
   - id: linux
     main: ./cmd/bearer


### PR DESCRIPTION
## Description
- We encountered build issues when trying to use macos 11 for signing & notarization this pins to macos 12.
- Show output from gon during build.

## Related
- Opens #1247

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
