### PR TITLE
docs: add path to pull command usage

### DIFF
--- a/docs/_data/bearer_ignore_pull.yaml
+++ b/docs/_data/bearer_ignore_pull.yaml
@@ -1,6 +1,6 @@
 name: ' ignore pull'
 synopsis: Pull ignored fingerprints from Cloud
-usage: ' ignore pull [flags]'
+usage: ' ignore pull <path> [flags]'
 options:
     - name: api-key
       usage: Use your Bearer API Key to send the report to Bearer.

--- a/internal/commands/ignore.go
+++ b/internal/commands/ignore.go
@@ -299,7 +299,7 @@ func newIgnorePullCommand() *cobra.Command {
 		GeneralFlagGroup: flag.NewGeneralFlagGroup(),
 	}
 	cmd := &cobra.Command{
-		Use:   "pull",
+		Use:   "pull <path>",
 		Short: "Pull ignored fingerprints from Cloud",
 		Example: `# Pull ignored fingerprints from the Cloud (requires API key)
 $ bearer ignore pull /path/to/your_project --api-key=XXXXX`,


### PR DESCRIPTION
## Description

Add `<path>` to ignore pull command usage

<img width="1131" alt="Screenshot 2023-09-18 at 11 36 40" src="https://github.com/Bearer/bearer/assets/4560746/55866418-b230-43a0-8789-0e7fc586ea60">

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
