### PR TITLE
fix: add toString to js reflexive calls

### DIFF
--- a/internal/languages/javascript/analyzer/analyzer.go
+++ b/internal/languages/javascript/analyzer/analyzer.go
@@ -12,6 +12,7 @@ import (
 
 // methods that use `this` in their result
 var reflexiveMethods = []string{
+	"toString",
 	// String
 	"replace",
 	"replaceAll",


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Adds `toString` to the list of reflexive methods for JS.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
