### PR TITLE
fix: issue where in some cases messages where written as part of output

### DIFF
--- a/internal/commands/artifact/run.go
+++ b/internal/commands/artifact/run.go
@@ -402,7 +402,6 @@ func (r *runner) Report(
 	formatStr, err := reportoutput.FormatOutput(
 		reportData,
 		r.scanSettings,
-		cacheUsed,
 		report.Inputgocloc,
 		startTime,
 		endTime,
@@ -412,6 +411,22 @@ func (r *runner) Report(
 	}
 
 	logger(formatStr)
+
+	if !r.scanSettings.Scan.Quiet {
+		// add cached data warning message
+		if cacheUsed {
+			outputhandler.StdErrLog("Cached data used (no code changes detected). Unexpected? Use --force to force a re-scan.\n")
+		}
+		// add cloud info message
+		if r.scanSettings.Client != nil {
+			if r.scanSettings.Client.Error == nil {
+				outputhandler.StdErrLog("Data successfully sent to Bearer Cloud.")
+			} else {
+				// client error
+				outputhandler.StdErrLog(fmt.Sprintf("Failed to send data to Bearer Cloud. %s ", *r.scanSettings.Client.Error))
+			}
+		}
+	}
 
 	return reportData.ReportFailed, nil
 }

--- a/internal/report/output/output.go
+++ b/internal/report/output/output.go
@@ -88,7 +88,6 @@ func GetDataflow(reportData *types.ReportData, report globaltypes.Report, config
 func FormatOutput(
 	reportData *types.ReportData,
 	config settings.Config,
-	cacheUsed bool,
 	goclocResult *gocloc.Result,
 	startTime time.Time,
 	endTime time.Time,
@@ -117,25 +116,6 @@ func FormatOutput(
 	}
 	if formatStr == "" {
 		return "", fmt.Errorf(`--report flag "%s" does not support --format flag "%s"`, config.Report.Report, config.Report.Format)
-	}
-
-	if !config.Scan.Quiet && (reportData.SendToCloud || cacheUsed) {
-		// add cached data warning message
-		if cacheUsed {
-			formatStr += "\n\nCached data used (no code changes detected). Unexpected? Use --force to force a re-scan."
-		}
-
-		// add cloud info message
-		if reportData.SendToCloud {
-			if config.Client.Error == nil {
-				formatStr += "\n\nData successfully sent to Bearer Cloud."
-			} else {
-				// client error
-				formatStr += fmt.Sprintf("\n\nFailed to send data to Bearer Cloud. %s ", *config.Client.Error)
-			}
-		}
-
-		formatStr += "\n"
 	}
 
 	return formatStr, err


### PR DESCRIPTION
## Description
Some messages in report output where mistakenly written to stdout instead of stderr

## Related
- Close #1278

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
