### PR TITLE
docs: fix uses of continue-on-error

### DIFF
--- a/docs/guides/github-action.njk
+++ b/docs/guides/github-action.njk
@@ -143,7 +143,6 @@ permissions:
 jobs:
   rule_check:
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v3
       - name: Run Report
@@ -177,9 +176,12 @@ permissions:
 jobs:
   rule_check:
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v3
++     # install reviewdog
+      - uses: reviewdog/action-setup@v1
+        with:
+          reviewdog_version: latest
       - name: Run Report
         id: report
         uses: bearer/bearer-action@v2
@@ -188,11 +190,9 @@ jobs:
           format: rdjson
           output: rd.json
           diff: true
-+     # add steps to setup and run reviewdog
-      - uses: reviewdog/action-setup@v1
-        with:
-          reviewdog_version: latest
++     # always run reviewdog otherwise the step will be skiped by github when a scan fails
       - name: Run reviewdog
+        if: always()
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -217,7 +217,6 @@ permissions:
 jobs:
   rule_check:
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v3
       - name: Run Report
@@ -227,6 +226,7 @@ jobs:
           format: gitlab-sast
           output: gl-sast-report.json
       - name: Defect Dojo
+        if: always()
         env:
           DD_TOKEN: ${{ secrets.DD_TOKEN}}
           DD_APP: ${{ secrets.DD_APP}}


### PR DESCRIPTION
## Description
Continue on error does not always work as expected update the documentation for github actions to use `if: always()` instead.

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
