### PR TITLE
fix: disabling of rules using comments

### DIFF
--- a/e2e/rules/.snapshots/TestDisabledRules-testdata-data-disabled_rules
+++ b/e2e/rules/.snapshots/TestDisabledRules-testdata-data-disabled_rules
@@ -1,0 +1,35 @@
+low:
+    - rule:
+        cwe_ids:
+            - "319"
+        id: match_sink
+        title: ""
+        description: ""
+        documentation_url: ""
+      line_number: 7
+      full_filename: e2e/rules/testdata/data/disabled_rules/main.rb
+      filename: main.rb
+      source:
+        location:
+            start: 7
+            end: 7
+            column:
+                start: 3
+                end: 7
+      sink:
+        location:
+            start: 7
+            end: 7
+            column:
+                start: 3
+                end: 7
+        content: sink
+      parent_line_number: 7
+      snippet: sink
+      fingerprint: eb59f129d5424fb58e3bfcb5bfa83159_0
+      old_fingerprint: e94b7fee5e58e735f107aa1cb3cfb75b_0
+      code_extract: '  sink'
+
+
+--
+

--- a/e2e/rules/rules_test.go
+++ b/e2e/rules/rules_test.go
@@ -31,6 +31,10 @@ func TestAuxilary(t *testing.T) {
 	runRulesTest("auxilary", "javascript_third_parties_datadog_test", t)
 }
 
+func TestDisabledRules(t *testing.T) {
+	runRulesTest("disabled_rules", "match_sink", t)
+}
+
 func TestReferenceFilters(t *testing.T) {
 	runRulesTest("reference_filters", "reference_filters_test", t)
 }

--- a/e2e/rules/testdata/data/disabled_rules/main.rb
+++ b/e2e/rules/testdata/data/disabled_rules/main.rb
@@ -1,0 +1,8 @@
+# bearer:disable match_sink
+def m
+  sink
+end
+
+def n
+  sink
+end

--- a/e2e/rules/testdata/rules/match_sink.yml
+++ b/e2e/rules/testdata/rules/match_sink.yml
@@ -1,0 +1,9 @@
+patterns:
+  - sink
+languages:
+  - ruby
+severity: low
+metadata:
+  cwe_id:
+    - 319
+  id: match_sink

--- a/internal/scanner/ast/.snapshots/TestDisabledRules
+++ b/internal/scanner/ast/.snapshots/TestDisabledRules
@@ -75,6 +75,9 @@ children:
     - type: method
       id: 3
       range: 4:3 - 8:6
+      disabledrules:
+        - 5
+        - 6
       children:
         - type: '"def"'
           id: 4
@@ -108,6 +111,8 @@ children:
         - type: call
           id: 11
           range: 6:4 - 6:9
+          disabledrules:
+            - 7
           children:
             - type: identifier
               id: 12

--- a/internal/scanner/ast/.snapshots/TestDisabledRules
+++ b/internal/scanner/ast/.snapshots/TestDisabledRules
@@ -1,0 +1,143 @@
+([]*ruleset.Rule) (len=8) {
+  (*ruleset.Rule)({
+    index: (int) 0,
+    id: (string) (len=6) "object",
+    ruleType: (ruleset.RuleType) 2,
+    sanitizerRule: (*ruleset.Rule)(<nil>),
+    patterns: ([]settings.RulePattern) <nil>
+  }),
+  (*ruleset.Rule)({
+    index: (int) 1,
+    id: (string) (len=6) "string",
+    ruleType: (ruleset.RuleType) 2,
+    sanitizerRule: (*ruleset.Rule)(<nil>),
+    patterns: ([]settings.RulePattern) <nil>
+  }),
+  (*ruleset.Rule)({
+    index: (int) 2,
+    id: (string) (len=8) "datatype",
+    ruleType: (ruleset.RuleType) 2,
+    sanitizerRule: (*ruleset.Rule)(<nil>),
+    patterns: ([]settings.RulePattern) <nil>
+  }),
+  (*ruleset.Rule)({
+    index: (int) 3,
+    id: (string) (len=12) "insecure_url",
+    ruleType: (ruleset.RuleType) 2,
+    sanitizerRule: (*ruleset.Rule)(<nil>),
+    patterns: ([]settings.RulePattern) <nil>
+  }),
+  (*ruleset.Rule)({
+    index: (int) 4,
+    id: (string) (len=14) "string_literal",
+    ruleType: (ruleset.RuleType) 2,
+    sanitizerRule: (*ruleset.Rule)(<nil>),
+    patterns: ([]settings.RulePattern) <nil>
+  }),
+  (*ruleset.Rule)({
+    index: (int) 5,
+    id: (string) (len=5) "rule1",
+    ruleType: (ruleset.RuleType) 0,
+    sanitizerRule: (*ruleset.Rule)(<nil>),
+    patterns: ([]settings.RulePattern) <nil>
+  }),
+  (*ruleset.Rule)({
+    index: (int) 6,
+    id: (string) (len=5) "rule2",
+    ruleType: (ruleset.RuleType) 0,
+    sanitizerRule: (*ruleset.Rule)(<nil>),
+    patterns: ([]settings.RulePattern) <nil>
+  }),
+  (*ruleset.Rule)({
+    index: (int) 7,
+    id: (string) (len=5) "rule3",
+    ruleType: (ruleset.RuleType) 0,
+    sanitizerRule: (*ruleset.Rule)(<nil>),
+    patterns: ([]settings.RulePattern) <nil>
+  })
+}
+type: program
+id: 0
+range: 2:3 - 9:2
+dataflow_sources:
+    - 1
+    - 2
+    - 3
+children:
+    - type: comment
+      id: 1
+      range: 2:3 - 2:25
+      content: '# bearer:disable rule1'
+    - type: comment
+      id: 2
+      range: 3:3 - 3:25
+      content: '# bearer:disable rule2'
+    - type: method
+      id: 3
+      range: 4:3 - 8:6
+      children:
+        - type: '"def"'
+          id: 4
+          range: 4:3 - 4:6
+        - type: identifier
+          id: 5
+          range: 4:7 - 4:8
+          content: m
+        - type: method_parameters
+          id: 6
+          range: 4:8 - 4:11
+          dataflow_sources:
+            - 7
+            - 8
+            - 9
+          children:
+            - type: '"("'
+              id: 7
+              range: 4:8 - 4:9
+            - type: identifier
+              id: 8
+              range: 4:9 - 4:10
+              content: a
+            - type: '")"'
+              id: 9
+              range: 4:10 - 4:11
+        - type: comment
+          id: 10
+          range: 5:4 - 5:26
+          content: '# bearer:disable rule3'
+        - type: call
+          id: 11
+          range: 6:4 - 6:9
+          children:
+            - type: identifier
+              id: 12
+              range: 6:4 - 6:5
+              content: a
+              alias_of:
+                - 8
+            - type: '"."'
+              id: 13
+              range: 6:5 - 6:6
+            - type: identifier
+              id: 14
+              range: 6:6 - 6:9
+              content: foo
+        - type: call
+          id: 15
+          range: 7:4 - 7:9
+          children:
+            - type: identifier
+              id: 16
+              range: 7:4 - 7:5
+              content: b
+            - type: '"."'
+              id: 17
+              range: 7:5 - 7:6
+            - type: identifier
+              id: 18
+              range: 7:6 - 7:9
+              content: bar
+        - type: '"end"'
+          id: 19
+          range: 8:3 - 8:6
+

--- a/internal/scanner/ast/.snapshots/TestDisabledRules
+++ b/internal/scanner/ast/.snapshots/TestDisabledRules
@@ -36,21 +36,21 @@
   }),
   (*ruleset.Rule)({
     index: (int) 5,
-    id: (string) (len=5) "rule1",
+    id: (string) (len=5) "rule3",
     ruleType: (ruleset.RuleType) 0,
     sanitizerRule: (*ruleset.Rule)(<nil>),
     patterns: ([]settings.RulePattern) <nil>
   }),
   (*ruleset.Rule)({
     index: (int) 6,
-    id: (string) (len=5) "rule2",
+    id: (string) (len=5) "rule1",
     ruleType: (ruleset.RuleType) 0,
     sanitizerRule: (*ruleset.Rule)(<nil>),
     patterns: ([]settings.RulePattern) <nil>
   }),
   (*ruleset.Rule)({
     index: (int) 7,
-    id: (string) (len=5) "rule3",
+    id: (string) (len=5) "rule2",
     ruleType: (ruleset.RuleType) 0,
     sanitizerRule: (*ruleset.Rule)(<nil>),
     patterns: ([]settings.RulePattern) <nil>
@@ -76,16 +76,22 @@ children:
       id: 3
       range: 4:3 - 8:6
       disabledrules:
-        - 5
         - 6
+        - 7
       children:
         - type: '"def"'
           id: 4
           range: 4:3 - 4:6
+          disabledrules:
+            - 6
+            - 7
         - type: identifier
           id: 5
           range: 4:7 - 4:8
           content: m
+          disabledrules:
+            - 6
+            - 7
         - type: method_parameters
           id: 6
           range: 4:8 - 4:11
@@ -93,25 +99,42 @@ children:
             - 7
             - 8
             - 9
+          disabledrules:
+            - 6
+            - 7
           children:
             - type: '"("'
               id: 7
               range: 4:8 - 4:9
+              disabledrules:
+                - 6
+                - 7
             - type: identifier
               id: 8
               range: 4:9 - 4:10
               content: a
+              disabledrules:
+                - 6
+                - 7
             - type: '")"'
               id: 9
               range: 4:10 - 4:11
+              disabledrules:
+                - 6
+                - 7
         - type: comment
           id: 10
           range: 5:4 - 5:26
           content: '# bearer:disable rule3'
+          disabledrules:
+            - 6
+            - 7
         - type: call
           id: 11
           range: 6:4 - 6:9
           disabledrules:
+            - 5
+            - 6
             - 7
           children:
             - type: identifier
@@ -120,29 +143,56 @@ children:
               content: a
               alias_of:
                 - 8
+              disabledrules:
+                - 5
+                - 6
+                - 7
             - type: '"."'
               id: 13
               range: 6:5 - 6:6
+              disabledrules:
+                - 5
+                - 6
+                - 7
             - type: identifier
               id: 14
               range: 6:6 - 6:9
               content: foo
+              disabledrules:
+                - 5
+                - 6
+                - 7
         - type: call
           id: 15
           range: 7:4 - 7:9
+          disabledrules:
+            - 6
+            - 7
           children:
             - type: identifier
               id: 16
               range: 7:4 - 7:5
               content: b
+              disabledrules:
+                - 6
+                - 7
             - type: '"."'
               id: 17
               range: 7:5 - 7:6
+              disabledrules:
+                - 6
+                - 7
             - type: identifier
               id: 18
               range: 7:6 - 7:9
               content: bar
+              disabledrules:
+                - 6
+                - 7
         - type: '"end"'
           id: 19
           range: 8:3 - 8:6
+          disabledrules:
+            - 6
+            - 7
 

--- a/internal/scanner/ast/.snapshots/TestDisabledRules
+++ b/internal/scanner/ast/.snapshots/TestDisabledRules
@@ -1,60 +1,20 @@
-([]*ruleset.Rule) (len=8) {
-  (*ruleset.Rule)({
-    index: (int) 0,
-    id: (string) (len=6) "object",
-    ruleType: (ruleset.RuleType) 2,
-    sanitizerRule: (*ruleset.Rule)(<nil>),
-    patterns: ([]settings.RulePattern) <nil>
-  }),
-  (*ruleset.Rule)({
-    index: (int) 1,
-    id: (string) (len=6) "string",
-    ruleType: (ruleset.RuleType) 2,
-    sanitizerRule: (*ruleset.Rule)(<nil>),
-    patterns: ([]settings.RulePattern) <nil>
-  }),
-  (*ruleset.Rule)({
-    index: (int) 2,
-    id: (string) (len=8) "datatype",
-    ruleType: (ruleset.RuleType) 2,
-    sanitizerRule: (*ruleset.Rule)(<nil>),
-    patterns: ([]settings.RulePattern) <nil>
-  }),
-  (*ruleset.Rule)({
-    index: (int) 3,
-    id: (string) (len=12) "insecure_url",
-    ruleType: (ruleset.RuleType) 2,
-    sanitizerRule: (*ruleset.Rule)(<nil>),
-    patterns: ([]settings.RulePattern) <nil>
-  }),
-  (*ruleset.Rule)({
-    index: (int) 4,
-    id: (string) (len=14) "string_literal",
-    ruleType: (ruleset.RuleType) 2,
-    sanitizerRule: (*ruleset.Rule)(<nil>),
-    patterns: ([]settings.RulePattern) <nil>
-  }),
-  (*ruleset.Rule)({
-    index: (int) 5,
-    id: (string) (len=5) "rule3",
-    ruleType: (ruleset.RuleType) 0,
-    sanitizerRule: (*ruleset.Rule)(<nil>),
-    patterns: ([]settings.RulePattern) <nil>
-  }),
-  (*ruleset.Rule)({
-    index: (int) 6,
-    id: (string) (len=5) "rule1",
-    ruleType: (ruleset.RuleType) 0,
-    sanitizerRule: (*ruleset.Rule)(<nil>),
-    patterns: ([]settings.RulePattern) <nil>
-  }),
-  (*ruleset.Rule)({
-    index: (int) 7,
-    id: (string) (len=5) "rule2",
-    ruleType: (ruleset.RuleType) 0,
-    sanitizerRule: (*ruleset.Rule)(<nil>),
-    patterns: ([]settings.RulePattern) <nil>
-  })
+([]ast_test.ruleInfo) (len=4) {
+  (ast_test.ruleInfo) {
+    ID: (string) (len=5) "rule1",
+    Index: (int) 5
+  },
+  (ast_test.ruleInfo) {
+    ID: (string) (len=5) "rule2",
+    Index: (int) 6
+  },
+  (ast_test.ruleInfo) {
+    ID: (string) (len=5) "rule3",
+    Index: (int) 7
+  },
+  (ast_test.ruleInfo) {
+    ID: (string) (len=5) "rule4",
+    Index: (int) 8
+  }
 }
 type: program
 id: 0
@@ -66,16 +26,17 @@ dataflow_sources:
 children:
     - type: comment
       id: 1
-      range: 2:3 - 2:25
-      content: '# bearer:disable rule1'
+      range: 2:3 - 2:31
+      content: '# bearer:disable rule1,rule2'
     - type: comment
       id: 2
       range: 3:3 - 3:25
-      content: '# bearer:disable rule2'
+      content: '# bearer:disable rule3'
     - type: method
       id: 3
       range: 4:3 - 8:6
       disabledrules:
+        - 5
         - 6
         - 7
       children:
@@ -83,6 +44,7 @@ children:
           id: 4
           range: 4:3 - 4:6
           disabledrules:
+            - 5
             - 6
             - 7
         - type: identifier
@@ -90,6 +52,7 @@ children:
           range: 4:7 - 4:8
           content: m
           disabledrules:
+            - 5
             - 6
             - 7
         - type: method_parameters
@@ -100,6 +63,7 @@ children:
             - 8
             - 9
           disabledrules:
+            - 5
             - 6
             - 7
           children:
@@ -107,6 +71,7 @@ children:
               id: 7
               range: 4:8 - 4:9
               disabledrules:
+                - 5
                 - 6
                 - 7
             - type: identifier
@@ -114,19 +79,22 @@ children:
               range: 4:9 - 4:10
               content: a
               disabledrules:
+                - 5
                 - 6
                 - 7
             - type: '")"'
               id: 9
               range: 4:10 - 4:11
               disabledrules:
+                - 5
                 - 6
                 - 7
         - type: comment
           id: 10
           range: 5:4 - 5:26
-          content: '# bearer:disable rule3'
+          content: '# bearer:disable rule4'
           disabledrules:
+            - 5
             - 6
             - 7
         - type: call
@@ -136,6 +104,7 @@ children:
             - 5
             - 6
             - 7
+            - 8
           children:
             - type: identifier
               id: 12
@@ -147,6 +116,7 @@ children:
                 - 5
                 - 6
                 - 7
+                - 8
             - type: '"."'
               id: 13
               range: 6:5 - 6:6
@@ -154,6 +124,7 @@ children:
                 - 5
                 - 6
                 - 7
+                - 8
             - type: identifier
               id: 14
               range: 6:6 - 6:9
@@ -162,10 +133,12 @@ children:
                 - 5
                 - 6
                 - 7
+                - 8
         - type: call
           id: 15
           range: 7:4 - 7:9
           disabledrules:
+            - 5
             - 6
             - 7
           children:
@@ -174,12 +147,14 @@ children:
               range: 7:4 - 7:5
               content: b
               disabledrules:
+                - 5
                 - 6
                 - 7
             - type: '"."'
               id: 17
               range: 7:5 - 7:6
               disabledrules:
+                - 5
                 - 6
                 - 7
             - type: identifier
@@ -187,12 +162,14 @@ children:
               range: 7:6 - 7:9
               content: bar
               disabledrules:
+                - 5
                 - 6
                 - 7
         - type: '"end"'
           id: 19
           range: 8:3 - 8:6
           disabledrules:
+            - 5
             - 6
             - 7
 

--- a/internal/scanner/ast/ast.go
+++ b/internal/scanner/ast/ast.go
@@ -20,7 +20,7 @@ func Parse(
 	language language.Language,
 	contentBytes []byte,
 ) (*tree.Tree, error) {
-	builder, err := parseBuilder(ctx, language, contentBytes)
+	builder, err := parseBuilder(ctx, language, contentBytes, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -35,7 +35,7 @@ func ParseAndAnalyze(
 	querySet *query.Set,
 	contentBytes []byte,
 ) (*tree.Tree, error) {
-	builder, err := parseBuilder(ctx, language, contentBytes)
+	builder, err := parseBuilder(ctx, language, contentBytes, len(ruleSet.Rules()))
 	if err != nil {
 		return nil, err
 	}
@@ -56,6 +56,7 @@ func parseBuilder(
 	ctx context.Context,
 	language language.Language,
 	contentBytes []byte,
+	ruleCount int,
 ) (*tree.Builder, error) {
 	parser := sitter.NewParser()
 	defer parser.Close()
@@ -67,7 +68,7 @@ func parseBuilder(
 		return nil, err
 	}
 
-	return tree.NewBuilder(contentBytes, sitterTree.RootNode()), nil
+	return tree.NewBuilder(contentBytes, sitterTree.RootNode(), ruleCount), nil
 }
 
 func analyzeNode(

--- a/internal/scanner/ast/ast.go
+++ b/internal/scanner/ast/ast.go
@@ -91,7 +91,7 @@ func analyzeNode(
 				continue
 			}
 
-			disabledRules = addDisabledRules(ruleSet, builder, disabledRules, node)
+			disabledRules = addDisabledRules(ruleSet, builder, disabledRules, child)
 			if err := analyzeNode(ctx, ruleSet, builder, analyzer, child); err != nil {
 				return err
 			}

--- a/internal/scanner/ast/ast_test.go
+++ b/internal/scanner/ast/ast_test.go
@@ -1,0 +1,64 @@
+package ast_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bradleyjkemp/cupaloy"
+
+	"github.com/bearer/bearer/internal/commands/process/settings"
+	"github.com/bearer/bearer/internal/languages/ruby"
+	"github.com/bearer/bearer/internal/scanner/ast"
+	"github.com/bearer/bearer/internal/scanner/ast/query"
+	"github.com/bearer/bearer/internal/scanner/ruleset"
+)
+
+func TestDisabledRules(t *testing.T) {
+	content := `
+		# bearer:disable rule1
+		# bearer:disable rule2
+		def m(a)
+			# bearer:disable rule3
+			a.foo
+			b.bar
+		end
+	`
+
+	language := ruby.Get()
+	languageIDs := []string{language.ID()}
+
+	ruleSet, err := ruleset.New(
+		language.ID(),
+		map[string]*settings.Rule{
+			"rule1": {Id: "rule1", Languages: languageIDs},
+			"rule2": {Id: "rule2", Languages: languageIDs},
+			"rule3": {Id: "rule3", Languages: languageIDs},
+		},
+	)
+	if err != nil {
+		t.Fatalf("failed to create rule set: %s", err)
+	}
+
+	querySet := query.NewSet(language.ID(), language.SitterLanguage())
+	if err := querySet.Compile(); err != nil {
+		t.Fatalf("failed to compile query set: %s", err)
+	}
+
+	tree, err := ast.ParseAndAnalyze(
+		context.Background(),
+		language,
+		ruleSet,
+		querySet,
+		[]byte(content),
+	)
+
+	if err != nil {
+		t.Fatalf("failed to parse and analyze input: %s", err)
+	}
+
+	cupaloy.SnapshotT(
+		t,
+		ruleSet.Rules(),
+		tree.RootNode().Dump(),
+	)
+}

--- a/internal/scanner/ast/ast_test.go
+++ b/internal/scanner/ast/ast_test.go
@@ -13,12 +13,17 @@ import (
 	"github.com/bearer/bearer/internal/scanner/ruleset"
 )
 
+type ruleInfo struct {
+	ID    string
+	Index int
+}
+
 func TestDisabledRules(t *testing.T) {
 	content := `
-		# bearer:disable rule1
-		# bearer:disable rule2
+		# bearer:disable rule1,rule2
+		# bearer:disable rule3
 		def m(a)
-			# bearer:disable rule3
+			# bearer:disable rule4
 			a.foo
 			b.bar
 		end
@@ -33,10 +38,18 @@ func TestDisabledRules(t *testing.T) {
 			"rule1": {Id: "rule1", Languages: languageIDs},
 			"rule2": {Id: "rule2", Languages: languageIDs},
 			"rule3": {Id: "rule3", Languages: languageIDs},
+			"rule4": {Id: "rule4", Languages: languageIDs},
 		},
 	)
 	if err != nil {
 		t.Fatalf("failed to create rule set: %s", err)
+	}
+
+	var ruleDump []ruleInfo
+	for _, rule := range ruleSet.Rules() {
+		if rule.Type() != ruleset.RuleTypeBuiltin {
+			ruleDump = append(ruleDump, ruleInfo{ID: rule.ID(), Index: rule.Index()})
+		}
 	}
 
 	querySet := query.NewSet(language.ID(), language.SitterLanguage())
@@ -58,7 +71,7 @@ func TestDisabledRules(t *testing.T) {
 
 	cupaloy.SnapshotT(
 		t,
-		ruleSet.Rules(),
+		ruleDump,
 		tree.RootNode().Dump(),
 	)
 }

--- a/internal/scanner/ast/tree/builder.go
+++ b/internal/scanner/ast/tree/builder.go
@@ -101,13 +101,21 @@ func (builder *Builder) AddDisabledRules(sitterNode *sitter.Node, rules []*rules
 		return
 	}
 
-	node := &builder.nodes[builder.sitterToNodeID[sitterNode]]
+	builder.addDisabledRulesForNode(builder.sitterToNodeID[sitterNode], rules)
+}
+
+func (builder *Builder) addDisabledRulesForNode(nodeID int, rules []*ruleset.Rule) {
+	node := &builder.nodes[nodeID]
 	if node.disabledRuleIndices == nil {
 		node.disabledRuleIndices = bitset.New(uint(builder.ruleCount))
 	}
 
 	for _, rule := range rules {
 		node.disabledRuleIndices.Set(uint(rule.Index()))
+	}
+
+	for _, childID := range builder.children[nodeID] {
+		builder.addDisabledRulesForNode(childID, rules)
 	}
 }
 

--- a/internal/scanner/ast/tree/tree.go
+++ b/internal/scanner/ast/tree/tree.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	sitter "github.com/smacker/go-tree-sitter"
+	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v3"
 )
@@ -143,6 +144,7 @@ type nodeDump struct {
 	DataflowSources []int      `yaml:"dataflow_sources,omitempty"`
 	AliasOf         []int      `yaml:"alias_of,omitempty"`
 	Queries         []int      `yaml:",omitempty"`
+	DisabledRules   []int      `yaml:",omitempty"`
 	Children        []nodeDump `yaml:",omitempty"`
 }
 
@@ -162,11 +164,12 @@ func (node *Node) dumpValue() nodeDump {
 		childDump[i] = child.dumpValue()
 	}
 
-	var queries []int
-	for queryID := range node.queryResults {
-		queries = append(queries, queryID)
-	}
+	queries := maps.Keys(node.queryResults)
 	slices.Sort(queries)
+
+	disabledRules := make([]int, len(node.disabledRuleIndices))
+	copy(disabledRules, node.disabledRuleIndices)
+	slices.Sort(disabledRules)
 
 	contentRange := fmt.Sprintf(
 		"%d:%d - %d:%d",
@@ -190,6 +193,7 @@ func (node *Node) dumpValue() nodeDump {
 		AliasOf:         nodeListToID(node.aliasOf),
 		Children:        childDump,
 		Queries:         queries,
+		DisabledRules:   disabledRules,
 	}
 }
 

--- a/internal/scanner/ast/tree/tree.go
+++ b/internal/scanner/ast/tree/tree.go
@@ -173,9 +173,11 @@ func (node *Node) dumpValue() nodeDump {
 	slices.Sort(queries)
 
 	var disabledRules []int
-	for i := 0; i < int(node.disabledRuleIndices.Len()); i++ {
-		if node.disabledRuleIndices.Test(uint(i)) {
-			disabledRules = append(disabledRules, i)
+	if node.disabledRuleIndices != nil {
+		for i := 0; i < int(node.disabledRuleIndices.Len()); i++ {
+			if node.disabledRuleIndices.Test(uint(i)) {
+				disabledRules = append(disabledRules, i)
+			}
 		}
 	}
 

--- a/internal/scanner/ast/tree/tree_test.go
+++ b/internal/scanner/ast/tree/tree_test.go
@@ -20,7 +20,7 @@ func parseTree(t *testing.T, content string) *tree.Tree {
 		t.Fatalf("failed to parse input: %s", err)
 	}
 
-	return tree.NewBuilder(contentBytes, sitterRootNode).Build()
+	return tree.NewBuilder(contentBytes, sitterRootNode, 0).Build()
 }
 
 func TestTree(t *testing.T) {

--- a/internal/scanner/rulescanner/rulescanner.go
+++ b/internal/scanner/rulescanner/rulescanner.go
@@ -148,7 +148,7 @@ func (scanner *Scanner) detectAtNode(rule *ruleset.Rule, node *tree.Node) (*dete
 
 func (scanner *Scanner) ruleDisabledForNode(rule *ruleset.Rule, node *tree.Node) bool {
 	for current := node; current != nil; current = current.Parent() {
-		if slices.Contains(node.DisabledRuleIndices(), rule.Index()) {
+		if slices.Contains(current.DisabledRuleIndices(), rule.Index()) {
 			return true
 		}
 	}

--- a/internal/scanner/rulescanner/rulescanner.go
+++ b/internal/scanner/rulescanner/rulescanner.go
@@ -3,7 +3,6 @@ package rulescanner
 import (
 	"context"
 	"fmt"
-	"slices"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -148,7 +147,7 @@ func (scanner *Scanner) detectAtNode(rule *ruleset.Rule, node *tree.Node) (*dete
 
 func (scanner *Scanner) ruleDisabledForNode(rule *ruleset.Rule, node *tree.Node) bool {
 	for current := node; current != nil; current = current.Parent() {
-		if slices.Contains(current.DisabledRuleIndices(), rule.Index()) {
+		if current.RuleDisabled(rule.Index()) {
 			return true
 		}
 	}

--- a/internal/scanner/rulescanner/rulescanner.go
+++ b/internal/scanner/rulescanner/rulescanner.go
@@ -114,7 +114,7 @@ func (scanner *Scanner) detectAtNode(rule *ruleset.Rule, node *tree.Node) (*dete
 		return result, nil
 	}
 
-	if scanner.ruleDisabledForNode(rule, node) {
+	if node.RuleDisabled(rule.Index()) {
 		if log.Trace().Enabled() {
 			log.Trace().Msgf(
 				"detect at node end: %s at %s: rule disabled",
@@ -143,16 +143,6 @@ func (scanner *Scanner) detectAtNode(rule *ruleset.Rule, node *tree.Node) (*dete
 
 	scanner.cache.Put(node, rule, result)
 	return result, nil
-}
-
-func (scanner *Scanner) ruleDisabledForNode(rule *ruleset.Rule, node *tree.Node) bool {
-	for current := node; current != nil; current = current.Parent() {
-		if current.RuleDisabled(rule.Index()) {
-			return true
-		}
-	}
-
-	return false
 }
 
 func traceResultText(result *detectorset.Result) string {


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Fixes disabling of rules with comments, which was broken by https://github.com/Bearer/bearer/pull/1206.

The issue was that we weren't adding the disabled rules to the correct node, and we also weren't looking up using the correct node!

As part of the fix, we now store the transitive disabled rules for a node. ie. when a disabled rule is added, we add it to all of the node's descendants. This avoids looking at all of the ancestors for each node we visit during rule evaluation.

Also improves test coverage in this area.


## Related
- Close #1280
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
