### PR TITLE
chore: generate stable rule indices

### DIFF
--- a/internal/scanner/ruleset/ruleset.go
+++ b/internal/scanner/ruleset/ruleset.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"slices"
 
+	"golang.org/x/exp/maps"
+
 	"github.com/bearer/bearer/internal/commands/process/settings"
 	"github.com/bearer/bearer/internal/report/customdetectors"
 	"github.com/bearer/bearer/internal/util/set"
@@ -90,7 +92,11 @@ func New(languageID string, settingsRules map[string]*settings.Rule) (*Set, erro
 func getLanguageRules(settingsRules map[string]*settings.Rule, languageID string) []*settings.Rule {
 	var result []*settings.Rule
 
-	for _, settingsRule := range settingsRules {
+	ruleIDs := maps.Keys(settingsRules)
+	slices.Sort(ruleIDs)
+
+	for _, ruleID := range ruleIDs {
+		settingsRule := settingsRules[ruleID]
 		if slices.Contains(settingsRule.Languages, languageID) {
 			result = append(result, settingsRule)
 		}


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Ensure rules are added to a rule set in a consistent order each time. 

This aids in debugging when running the CLI multiple times, and allows tests to see a consistent rule index order.

Fixes a flakey test in `internal/scanner/ast/ast_test.go`

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
