### PR TITLE
feat: add flag to disable progress bar

### DIFF
--- a/docs/_data/bearer_scan.yaml
+++ b/docs/_data/bearer_scan.yaml
@@ -56,6 +56,9 @@ options:
       shorthand: h
       default_value: "false"
       usage: help for scan
+    - name: hide-progress-bar
+      default_value: "false"
+      usage: Hide progress bar from output
     - name: host
       default_value: my.bearer.sh
       usage: Specify the Host for sending the report.

--- a/e2e/flags/.snapshots/TestApiKeyFlags-bad-api-key-with-stderr
+++ b/e2e/flags/.snapshots/TestApiKeyFlags-bad-api-key-with-stderr
@@ -3,7 +3,6 @@
 --
 Loading rules
 Scanning target e2e/flags/testdata/simple
-
 Running Detectors
 Generating dataflow
 Evaluating rules

--- a/e2e/flags/.snapshots/TestInitCommand
+++ b/e2e/flags/.snapshots/TestInitCommand
@@ -18,6 +18,7 @@ scan:
     exit-code: -1
     external-rule-dir: []
     force: false
+    hide_progress_bar: false
     internal-domains: []
     parallel: 0
     quiet: false

--- a/e2e/flags/.snapshots/TestMetadataFlags-help-scan
+++ b/e2e/flags/.snapshots/TestMetadataFlags-help-scan
@@ -28,6 +28,7 @@ Scan Flags
       --exit-code int                        Force a given exit code for the scan command. Set this to 0 (success) to always return a success exit code despite any findings from the scan. (default -1)
       --external-rule-dir strings            Specify directories paths that contain .yaml files with external rules configuration
       --force                                Disable the cache and runs the detections again
+      --hide-progress-bar                    Hide progress bar from output
       --internal-domains strings             Define regular expressions for better classification of private or unreachable domains e.g. --internal-domains=".*.my-company.com,private.sh"
       --parallel int                         Specify the amount of parallelism to use during the scan
       --quiet                                Suppress non-essential messages

--- a/e2e/flags/.snapshots/TestMetadataFlags-scan-help
+++ b/e2e/flags/.snapshots/TestMetadataFlags-scan-help
@@ -28,6 +28,7 @@ Scan Flags
       --exit-code int                        Force a given exit code for the scan command. Set this to 0 (success) to always return a success exit code despite any findings from the scan. (default -1)
       --external-rule-dir strings            Specify directories paths that contain .yaml files with external rules configuration
       --force                                Disable the cache and runs the detections again
+      --hide-progress-bar                    Hide progress bar from output
       --internal-domains strings             Define regular expressions for better classification of private or unreachable domains e.g. --internal-domains=".*.my-company.com,private.sh"
       --parallel int                         Specify the amount of parallelism to use during the scan
       --quiet                                Suppress non-essential messages

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-context-flag
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-context-flag
@@ -29,6 +29,7 @@ Scan Flags
       --exit-code int                        Force a given exit code for the scan command. Set this to 0 (success) to always return a success exit code despite any findings from the scan. (default -1)
       --external-rule-dir strings            Specify directories paths that contain .yaml files with external rules configuration
       --force                                Disable the cache and runs the detections again
+      --hide-progress-bar                    Hide progress bar from output
       --internal-domains strings             Define regular expressions for better classification of private or unreachable domains e.g. --internal-domains=".*.my-company.com,private.sh"
       --parallel int                         Specify the amount of parallelism to use during the scan
       --quiet                                Suppress non-essential messages

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag-privacy
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag-privacy
@@ -29,6 +29,7 @@ Scan Flags
       --exit-code int                        Force a given exit code for the scan command. Set this to 0 (success) to always return a success exit code despite any findings from the scan. (default -1)
       --external-rule-dir strings            Specify directories paths that contain .yaml files with external rules configuration
       --force                                Disable the cache and runs the detections again
+      --hide-progress-bar                    Hide progress bar from output
       --internal-domains strings             Define regular expressions for better classification of private or unreachable domains e.g. --internal-domains=".*.my-company.com,private.sh"
       --parallel int                         Specify the amount of parallelism to use during the scan
       --quiet                                Suppress non-essential messages

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag-security
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag-security
@@ -29,6 +29,7 @@ Scan Flags
       --exit-code int                        Force a given exit code for the scan command. Set this to 0 (success) to always return a success exit code despite any findings from the scan. (default -1)
       --external-rule-dir strings            Specify directories paths that contain .yaml files with external rules configuration
       --force                                Disable the cache and runs the detections again
+      --hide-progress-bar                    Hide progress bar from output
       --internal-domains strings             Define regular expressions for better classification of private or unreachable domains e.g. --internal-domains=".*.my-company.com,private.sh"
       --parallel int                         Specify the amount of parallelism to use during the scan
       --quiet                                Suppress non-essential messages

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-report-flag
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-report-flag
@@ -29,6 +29,7 @@ Scan Flags
       --exit-code int                        Force a given exit code for the scan command. Set this to 0 (success) to always return a success exit code despite any findings from the scan. (default -1)
       --external-rule-dir strings            Specify directories paths that contain .yaml files with external rules configuration
       --force                                Disable the cache and runs the detections again
+      --hide-progress-bar                    Hide progress bar from output
       --internal-domains strings             Define regular expressions for better classification of private or unreachable domains e.g. --internal-domains=".*.my-company.com,private.sh"
       --parallel int                         Specify the amount of parallelism to use during the scan
       --quiet                                Suppress non-essential messages

--- a/e2e/flags/metadata_flags_test.go
+++ b/e2e/flags/metadata_flags_test.go
@@ -7,7 +7,15 @@ import (
 )
 
 func newMetadataTest(name string, arguments []string) testhelper.TestCase {
-	return testhelper.NewTestCase(name, arguments, testhelper.TestCaseOptions{DisplayStdErr: true, IgnoreForce: true})
+	return testhelper.NewTestCase(
+		name,
+		arguments,
+		testhelper.TestCaseOptions{
+			DisplayStdErr:      true,
+			IgnoreForce:        true,
+			DisplayProgressBar: true,
+		},
+	)
 }
 
 func TestMetadataFlags(t *testing.T) {

--- a/e2e/internal/testhelper/testhelper.go
+++ b/e2e/internal/testhelper/testhelper.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"os"
 	"os/exec"
-	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -16,12 +15,13 @@ import (
 var TestTimeout = 1 * time.Minute
 
 type TestCase struct {
-	name          string
-	arguments     []string
-	ShouldSucceed bool
-	options       TestCaseOptions
-	displayStdErr bool
-	ignoreForce   bool
+	name               string
+	arguments          []string
+	ShouldSucceed      bool
+	options            TestCaseOptions
+	displayStdErr      bool
+	displayProgressBar bool
+	ignoreForce        bool
 }
 
 type TestCaseOptions struct {
@@ -54,9 +54,6 @@ func executeApp(t *testing.T, arguments []string) (string, error) {
 	commandFinished := make(chan struct{}, 1)
 	combinedOutput := func() string {
 		errStr := buffErr.String()
-		// trim any progrss bars as the output isnt consistant
-		re := regexp.MustCompile(`\s└.*`)
-		errStr = re.ReplaceAllString(errStr, "")
 		// trim exit status
 		errStr = strings.TrimSuffix(errStr, "exit status 1\n")
 		return buffOut.String() + "\n--\n" + errStr
@@ -153,6 +150,10 @@ func RunTests(t *testing.T, tests []TestCase) {
 
 func executeTest(test TestCase, t *testing.T) (string, error) {
 	arguments := test.arguments
+
+	if !test.displayProgressBar {
+		arguments = append(arguments, "--hide-progress-bar")
+	}
 
 	if !test.displayStdErr {
 		arguments = append(arguments, "--quiet")

--- a/e2e/internal/testhelper/testhelper.go
+++ b/e2e/internal/testhelper/testhelper.go
@@ -25,18 +25,20 @@ type TestCase struct {
 }
 
 type TestCaseOptions struct {
-	DisplayStdErr bool
-	IgnoreForce   bool
+	DisplayStdErr      bool
+	DisplayProgressBar bool
+	IgnoreForce        bool
 }
 
 func NewTestCase(name string, arguments []string, options TestCaseOptions) TestCase {
 	return TestCase{
-		name:          name,
-		arguments:     arguments,
-		ShouldSucceed: true,
-		options:       options,
-		displayStdErr: options.DisplayStdErr,
-		ignoreForce:   options.IgnoreForce,
+		name:               name,
+		arguments:          arguments,
+		ShouldSucceed:      true,
+		options:            options,
+		displayStdErr:      options.DisplayStdErr,
+		displayProgressBar: options.DisplayProgressBar,
+		ignoreForce:        options.IgnoreForce,
 	}
 }
 

--- a/internal/flag/scan_flags.go
+++ b/internal/flag/scan_flags.go
@@ -67,6 +67,12 @@ var (
 		Value:      false,
 		Usage:      "Suppress non-essential messages",
 	}
+	HideProgressBarFlag = Flag{
+		Name:       "hide-progress-bar",
+		ConfigName: "scan.hide_progress_bar",
+		Value:      false,
+		Usage:      "Hide progress bar from output",
+	}
 	ForceFlag = Flag{
 		Name:       "force",
 		ConfigName: "scan.force",
@@ -108,6 +114,7 @@ type ScanFlagGroup struct {
 	ContextFlag                 *Flag
 	DataSubjectMappingFlag      *Flag
 	QuietFlag                   *Flag
+	HideProgressBarFlag         *Flag
 	ForceFlag                   *Flag
 	ExternalRuleDirFlag         *Flag
 	ParallelFlag                *Flag
@@ -123,6 +130,7 @@ type ScanOptions struct {
 	Context                 Context       `mapstructure:"context" json:"context" yaml:"context"`
 	DataSubjectMapping      string        `mapstructure:"data_subject_mapping" json:"data_subject_mapping" yaml:"data_subject_mapping"`
 	Quiet                   bool          `mapstructure:"quiet" json:"quiet" yaml:"quiet"`
+	HideProgressBar         bool          `mapstructure:"hide_progress_bar" json:"hide_progress_bar" yaml:"hide_progress_bar"`
 	Force                   bool          `mapstructure:"force" json:"force" yaml:"force"`
 	ExternalRuleDir         []string      `mapstructure:"external-rule-dir" json:"external-rule-dir" yaml:"external-rule-dir"`
 	Scanner                 []string      `mapstructure:"scanner" json:"scanner" yaml:"scanner"`
@@ -141,6 +149,7 @@ func NewScanFlagGroup() *ScanFlagGroup {
 		ContextFlag:                 &ContextFlag,
 		DataSubjectMappingFlag:      &DataSubjectMappingFlag,
 		QuietFlag:                   &QuietFlag,
+		HideProgressBarFlag:         &HideProgressBarFlag,
 		ForceFlag:                   &ForceFlag,
 		ExternalRuleDirFlag:         &ExternalRuleDirFlag,
 		ScannerFlag:                 &ScannerFlag,
@@ -162,6 +171,7 @@ func (f *ScanFlagGroup) Flags() []*Flag {
 		f.ContextFlag,
 		f.DataSubjectMappingFlag,
 		f.QuietFlag,
+		f.HideProgressBarFlag,
 		f.ForceFlag,
 		f.ExternalRuleDirFlag,
 		f.ScannerFlag,
@@ -201,6 +211,7 @@ func (f *ScanFlagGroup) ToOptions(args []string) (ScanOptions, error) {
 		Context:                 context,
 		DataSubjectMapping:      getString(f.DataSubjectMappingFlag),
 		Quiet:                   getBool(f.QuietFlag),
+		HideProgressBar:         getBool(f.HideProgressBarFlag),
 		Force:                   getBool(f.ForceFlag),
 		Target:                  target,
 		ExternalRuleDir:         getStringSlice(f.ExternalRuleDirFlag),

--- a/internal/util/progressbar/progressbar.go
+++ b/internal/util/progressbar/progressbar.go
@@ -7,7 +7,7 @@ import (
 )
 
 func GetProgressBar(filesLength int, config settings.Config, display_type string) *progressbar.ProgressBar {
-	hideProgress := config.Scan.Quiet || config.Debug
+	hideProgress := config.Scan.HideProgressBar || config.Scan.Quiet || config.Debug
 	return progressbar.NewOptions(filesLength,
 		progressbar.OptionSetVisibility(!hideProgress),
 		progressbar.OptionSetWriter(output.ErrorWriter()),


### PR DESCRIPTION
## Description

Add new scan flag to hide progress bar: `--hide-progress-bar`

Note, this affects Security and Privacy reports (default format) since these are the report types that currently show a progress bar. 

Closes #1288

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
