### PR TITLE
fix: avoid compiling privacy report twice

### DIFF
--- a/internal/report/output/privacy/privacy.go
+++ b/internal/report/output/privacy/privacy.go
@@ -68,12 +68,6 @@ const PLACEHOLDER_VALUE = "Unknown"
 func BuildCsvString(reportData *outputtypes.ReportData, config settings.Config) (*strings.Builder, error) {
 	csvStr := &strings.Builder{}
 	csvStr.WriteString("\nSubject,Data Types,Detection Count,Critical Risk Finding,High Risk Finding,Medium Risk Finding,Low Risk Finding,Rules Passed\n")
-	if reportData.PrivacyReport == nil {
-		err := AddReportData(reportData, config)
-		if err != nil {
-			return csvStr, err
-		}
-	}
 
 	for _, subject := range reportData.PrivacyReport.Subjects {
 		subjectArr := []string{

--- a/internal/report/output/privacy/privacy.go
+++ b/internal/report/output/privacy/privacy.go
@@ -68,9 +68,11 @@ const PLACEHOLDER_VALUE = "Unknown"
 func BuildCsvString(reportData *outputtypes.ReportData, config settings.Config) (*strings.Builder, error) {
 	csvStr := &strings.Builder{}
 	csvStr.WriteString("\nSubject,Data Types,Detection Count,Critical Risk Finding,High Risk Finding,Medium Risk Finding,Low Risk Finding,Rules Passed\n")
-	err := AddReportData(reportData, config)
-	if err != nil {
-		return csvStr, err
+	if reportData.PrivacyReport == nil {
+		err := AddReportData(reportData, config)
+		if err != nil {
+			return csvStr, err
+		}
 	}
 
 	for _, subject := range reportData.PrivacyReport.Subjects {

--- a/internal/report/output/privacy/privacy_test.go
+++ b/internal/report/output/privacy/privacy_test.go
@@ -28,6 +28,10 @@ func TestBuildCsvString(t *testing.T) {
 	output := &outputtypes.ReportData{
 		Dataflow: dummyDataflow(),
 	}
+	err = privacy.AddReportData(output, config)
+	if err != nil {
+		t.Fatalf("failed to add privacy report:%s", err)
+	}
 	stringBuilder, _ := privacy.BuildCsvString(output, config)
 	cupaloy.SnapshotT(t, stringBuilder.String())
 }


### PR DESCRIPTION
## Description

We were compiling the privacy report again, when building the CSV string. We should check to see if it's already present in the report data before we do this

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
