### PR TITLE
fix: php fixes from writing rules

### DIFF
--- a/internal/languages/java/detectors/.snapshots/TestJavaString-string
+++ b/internal/languages/java/detectors/.snapshots/TestJavaString-string
@@ -363,6 +363,21 @@ children:
   data:
     value: Hello World
     isliteral: true
+- node: 44
+  content: s += "!!"
+  data:
+    value: Hello World!!!
+    isliteral: true
+- node: 57
+  content: s2 += args[0]
+  data:
+    value: hey *
+    isliteral: false
+- node: 67
+  content: s2 += " there"
+  data:
+    value: hey * there
+    isliteral: false
 - node: 38
   content: Greeting + "!"
   data:

--- a/internal/languages/javascript/detectors/.snapshots/TestJavascriptStringDetector-string_assign_eq
+++ b/internal/languages/javascript/detectors/.snapshots/TestJavascriptStringDetector-string_assign_eq
@@ -181,6 +181,21 @@ children:
                   id: 36
                   range: 6:8 - 6:9
 
+- node: 11
+  content: x += "b"
+  data:
+    value: ab
+    isliteral: true
+- node: 19
+  content: x += name
+  data:
+    value: ab*
+    isliteral: false
+- node: 30
+  content: y += "c"
+  data:
+    value: '*c'
+    isliteral: false
 - node: 6
   content: '"a"'
   data:

--- a/internal/languages/php/analyzer/analyzer.go
+++ b/internal/languages/php/analyzer/analyzer.go
@@ -45,6 +45,8 @@ func (analyzer *analyzer) Analyze(node *sitter.Node, visitChildren func() error)
 		return analyzer.analyzeGenericConstruct(node, visitChildren)
 	case "switch_label":
 		return visitChildren()
+	case "dynamic_variable_name":
+		return analyzer.analyzeDynamicVariableName(node, visitChildren)
 	case "binary_expression",
 		"unary_op_expression",
 		"argument",
@@ -164,6 +166,12 @@ func (analyzer *analyzer) analyzeParameter(node *sitter.Node, visitChildren func
 
 func (analyzer *analyzer) analyzeSwitch(node *sitter.Node, visitChildren func() error) error {
 	analyzer.builder.Alias(node, node.ChildByFieldName("body"))
+
+	return visitChildren()
+}
+
+func (analyzer *analyzer) analyzeDynamicVariableName(node *sitter.Node, visitChildren func() error) error {
+	analyzer.lookupVariable(node.NamedChild(0))
 
 	return visitChildren()
 }

--- a/internal/languages/php/analyzer/analyzer.go
+++ b/internal/languages/php/analyzer/analyzer.go
@@ -50,7 +50,12 @@ func (analyzer *analyzer) Analyze(node *sitter.Node, visitChildren func() error)
 		return analyzer.analyzeGenericConstruct(node, visitChildren)
 	case "switch_label":
 		return visitChildren()
-	case "binary_expression", "unary_op_expression", "argument", "encapsed_string", "sequence_expression":
+	case "binary_expression",
+		"unary_op_expression",
+		"argument",
+		"encapsed_string",
+		"sequence_expression",
+		"array_element_initializer":
 		return analyzer.analyzeGenericOperation(node, visitChildren)
 	case "while_statement", "do_statement", "if_statement", "expression_statement", "compound_statement": // statements don't have results
 		return visitChildren()

--- a/internal/languages/php/analyzer/analyzer.go
+++ b/internal/languages/php/analyzer/analyzer.go
@@ -133,9 +133,11 @@ func (analyzer *analyzer) analyzeConditional(node *sitter.Node, visitChildren fu
 	return visitChildren()
 }
 
+// foo(1, 2);
 // foo->bar(1, 2);
 func (analyzer *analyzer) analyzeMethodInvocation(node *sitter.Node, visitChildren func() error) error {
-	analyzer.lookupVariable(node.ChildByFieldName("object"))
+	analyzer.lookupVariable(node.ChildByFieldName("object"))   // method
+	analyzer.lookupVariable(node.ChildByFieldName("function")) // function
 
 	if arguments := node.ChildByFieldName("arguments"); arguments != nil {
 		analyzer.builder.Dataflow(node, arguments)

--- a/internal/languages/php/analyzer/analyzer.go
+++ b/internal/languages/php/analyzer/analyzer.go
@@ -45,7 +45,17 @@ func (analyzer *analyzer) Analyze(node *sitter.Node, visitChildren func() error)
 		return analyzer.analyzeGenericConstruct(node, visitChildren)
 	case "switch_label":
 		return visitChildren()
-	case "binary_expression", "unary_op_expression", "argument", "encapsed_string", "sequence_expression", "array_element_initializer", "formal_parameters":
+	case "binary_expression",
+		"unary_op_expression",
+		"argument",
+		"encapsed_string",
+		"sequence_expression",
+		"array_element_initializer",
+		"formal_parameters",
+		"include_expression",
+		"include_once_expression",
+		"require_expression",
+		"require_once_expression":
 		return analyzer.analyzeGenericOperation(node, visitChildren)
 	case "while_statement", "do_statement", "if_statement", "expression_statement", "compound_statement": // statements don't have results
 		return visitChildren()

--- a/internal/languages/php/analyzer/analyzer.go
+++ b/internal/languages/php/analyzer/analyzer.go
@@ -1,7 +1,6 @@
 package analyzer
 
 import (
-	"github.com/rs/zerolog/log"
 	sitter "github.com/smacker/go-tree-sitter"
 
 	"github.com/bearer/bearer/internal/scanner/ast/tree"
@@ -26,8 +25,6 @@ func (analyzer *analyzer) Analyze(node *sitter.Node, visitChildren func() error)
 		return analyzer.withScope(language.NewScope(analyzer.scope), func() error {
 			return visitChildren()
 		})
-	// case "formal_parameters":
-	// return analyzer.analyzeParameterList(node, visitChildren)
 	case "augmented_assignment_expression":
 		return analyzer.analyzeAugmentedAssignment(node, visitChildren)
 	case "assignment_expression":
@@ -96,26 +93,6 @@ func (analyzer *analyzer) analyzeAugmentedAssignment(node *sitter.Node, visitChi
 	return err
 }
 
-// // I think there is still an issue with the linking between the parameter for functions???
-// // all parameter definitions for a method
-// // function m($a, int $b)
-// func (analyzer *analyzer) analyzeParameterList(node *sitter.Node, visitChildren func() error) error {
-// 	children := analyzer.builder.ChildrenFor(node)
-// 	analyzer.builder.Dataflow(node, children...)
-
-// 	for _, child := range children {
-// 		log.Error().Msgf("analyzerParameterList[%s]", child.Type())
-// 		if child.Type() == "simple_parameter" {
-// 			name := child.ChildByFieldName("name")
-// 			log.Error().Msgf("analyzerParameterList -> %s", analyzer.builder.ContentFor(name))
-// 			analyzer.builder.Alias(node, name)
-// 			analyzer.scope.Declare(analyzer.builder.ContentFor(name), name)
-// 		}
-// 	}
-
-// 	return visitChildren()
-// }
-
 func (analyzer *analyzer) analyzeParentheses(node *sitter.Node, visitChildren func() error) error {
 	analyzer.builder.Alias(node, node.NamedChild(0))
 	analyzer.lookupVariable(node.NamedChild(0))
@@ -168,7 +145,6 @@ func (analyzer *analyzer) analyzeFieldAccess(node *sitter.Node, visitChildren fu
 // fn($x = 42) => $x;
 // fn($x, ...$rest) => $rest;
 func (analyzer *analyzer) analyzeParameter(node *sitter.Node, visitChildren func() error) error {
-	log.Error().Msgf("analyzeParameter[%s] %s", node.Type(), analyzer.builder.ContentFor(node))
 	name := node.ChildByFieldName("name")
 	analyzer.builder.Alias(node, name)
 	analyzer.scope.Declare(analyzer.builder.ContentFor(name), name)
@@ -217,7 +193,6 @@ func (analyzer *analyzer) lookupVariable(node *sitter.Node) {
 	}
 
 	if pointsToNode := analyzer.scope.Lookup(analyzer.builder.ContentFor(node)); pointsToNode != nil {
-		log.Error().Msgf("lookupVariable[%s] %s", node.Type(), analyzer.builder.ContentFor(node))
 		analyzer.builder.Alias(node, pointsToNode)
 	}
 }

--- a/internal/languages/php/detectors/.snapshots/TestPHPString-string
+++ b/internal/languages/php/detectors/.snapshots/TestPHPString-string
@@ -1,10 +1,10 @@
 type: program
 id: 0
-range: 1:1 - 15:3
+range: 1:1 - 18:1
 dataflow_sources:
     - 1
     - 2
-    - 100
+    - 117
 children:
     - type: php_tag
       id: 1
@@ -12,7 +12,7 @@ children:
       content: <?php
     - type: class_declaration
       id: 2
-      range: 2:1 - 14:2
+      range: 2:1 - 16:2
       queries:
         - 1
       children:
@@ -25,7 +25,7 @@ children:
           content: Greet
         - type: declaration_list
           id: 5
-          range: 2:13 - 14:2
+          range: 2:13 - 16:2
           children:
             - type: '"{"'
               id: 6
@@ -79,7 +79,7 @@ children:
                   range: 3:35 - 3:36
             - type: method_declaration
               id: 17
-              range: 5:5 - 13:6
+              range: 5:5 - 15:6
               children:
                 - type: visibility_modifier
                   id: 18
@@ -139,7 +139,7 @@ children:
                       range: 5:38 - 5:39
                 - type: compound_statement
                   id: 31
-                  range: 6:5 - 13:6
+                  range: 6:5 - 15:6
                   children:
                     - type: '"{"'
                       id: 32
@@ -431,32 +431,151 @@ children:
                         - type: '";"'
                           id: 97
                           range: 12:24 - 12:25
-                    - type: '"}"'
+                    - type: expression_statement
                       id: 98
-                      range: 13:5 - 13:6
+                      range: 14:9 - 14:33
+                      children:
+                        - type: assignment_expression
+                          id: 99
+                          range: 14:9 - 14:32
+                          alias_of:
+                            - 104
+                          queries:
+                            - 0
+                          children:
+                            - type: variable_name
+                              id: 100
+                              range: 14:9 - 14:12
+                              children:
+                                - type: '"$"'
+                                  id: 101
+                                  range: 14:9 - 14:10
+                                - type: name
+                                  id: 102
+                                  range: 14:10 - 14:12
+                                  content: s3
+                            - type: '"="'
+                              id: 103
+                              range: 14:13 - 14:14
+                            - type: encapsed_string
+                              id: 104
+                              range: 14:15 - 14:32
+                              dataflow_sources:
+                                - 105
+                                - 106
+                                - 107
+                                - 108
+                                - 111
+                                - 112
+                                - 113
+                              children:
+                                - type: '"""'
+                                  id: 105
+                                  range: 14:15 - 14:16
+                                - type: string
+                                  id: 106
+                                  range: 14:16 - 14:21
+                                  content: foo '
+                                - type: '"{"'
+                                  id: 107
+                                  range: 14:21 - 14:22
+                                - type: variable_name
+                                  id: 108
+                                  range: 14:22 - 14:25
+                                  alias_of:
+                                    - 88
+                                  children:
+                                    - type: '"$"'
+                                      id: 109
+                                      range: 14:22 - 14:23
+                                    - type: name
+                                      id: 110
+                                      range: 14:23 - 14:25
+                                      content: s2
+                                - type: '"}"'
+                                  id: 111
+                                  range: 14:25 - 14:26
+                                - type: string
+                                  id: 112
+                                  range: 14:26 - 14:31
+                                  content: ''' bar'
+                                - type: '"""'
+                                  id: 113
+                                  range: 14:31 - 14:32
+                        - type: '";"'
+                          id: 114
+                          range: 14:32 - 14:33
+                    - type: '"}"'
+                      id: 115
+                      range: 15:5 - 15:6
             - type: '"}"'
-              id: 99
-              range: 14:1 - 14:2
+              id: 116
+              range: 16:1 - 16:2
     - type: text_interpolation
-      id: 100
-      range: 15:1 - 15:3
+      id: 117
+      range: 17:1 - 17:3
       dataflow_sources:
-        - 101
+        - 118
       children:
         - type: '"?>"'
-          id: 101
-          range: 15:1 - 15:3
+          id: 118
+          range: 17:1 - 17:3
 
+- node: 12
+  content: '"Hello World"'
+  data:
+    value: Hello World
+    isliteral: true
 - node: 14
   content: Hello World
   data:
     value: Hello World
     isliteral: true
+- node: 52
+  content: $s .= "!!"
+  data:
+    value: '*!!!'
+    isliteral: false
+- node: 74
+  content: $s2 .= $args[0]
+  data:
+    value: hey *
+    isliteral: false
+- node: 88
+  content: $s2 .= " there"
+  data:
+    value: hey * there
+    isliteral: false
 - node: 39
   content: self::Greeting . "!"
   data:
-    value: '**'
+    value: '*!'
     isliteral: false
+- node: 57
+  content: '"!!"'
+  data:
+    value: '!!'
+    isliteral: true
+- node: 68
+  content: '"hey "'
+  data:
+    value: 'hey '
+    isliteral: true
+- node: 93
+  content: '" there"'
+  data:
+    value: ' there'
+    isliteral: true
+- node: 104
+  content: '"foo ''{$s2}'' bar"'
+  data:
+    value: foo 'hey * there' bar
+    isliteral: false
+- node: 46
+  content: '"!"'
+  data:
+    value: '!'
+    isliteral: true
 - node: 59
   content: '!!'
   data:
@@ -471,6 +590,16 @@ children:
   content: ' there'
   data:
     value: ' there'
+    isliteral: true
+- node: 106
+  content: foo '
+  data:
+    value: foo '
+    isliteral: true
+- node: 112
+  content: ''' bar'
+  data:
+    value: ''' bar'
     isliteral: true
 - node: 48
   content: '!'

--- a/internal/languages/php/detectors/string/string.go
+++ b/internal/languages/php/detectors/string/string.go
@@ -28,10 +28,17 @@ func (detector *stringDetector) DetectAt(
 ) ([]interface{}, error) {
 	switch node.Type() {
 	case "string":
+		value := node.Content()
+		if node.Parent() != nil && node.Parent().Type() != "encapsed_string" {
+			value = stringutil.StripQuotes(value)
+		}
+
 		return []interface{}{common.String{
-			Value:     stringutil.StripQuotes(node.Content()),
+			Value:     value,
 			IsLiteral: true,
 		}}, nil
+	case "encapsed_string":
+		return common.ConcatenateChildStrings(node, detectorContext)
 	case "binary_expression":
 		if node.Children()[1].Content() == "." {
 			return common.ConcatenateChildStrings(node, detectorContext)

--- a/internal/languages/php/detectors/testdata/string.php
+++ b/internal/languages/php/detectors/testdata/string.php
@@ -10,6 +10,8 @@ class Greet {
         $s2 = "hey ";
         $s2 .= $args[0];
         $s2 .= " there";
+
+        $s3 = "foo '{$s2}' bar";
     }
 }
 ?>

--- a/internal/languages/php/pattern/pattern.go
+++ b/internal/languages/php/pattern/pattern.go
@@ -104,12 +104,17 @@ func (*Pattern) IsAnchored(node *tree.Node) (bool, bool) {
 		return true, true
 	}
 
-	// Class body class_body
-	// function block
-	// lambda () -> {} block
-	// try {} catch () {}
-	// unAnchored := []string{"class_body", "block", "try_statement", "catch_type", "resource_specification"}
-	unAnchored := []string{""}
+	// Associative array elements are unanchored
+	// eg. array("foo" => 42)
+	if parent.Type() == "array_creation_expression" &&
+		node.Type() == "array_element_initializer" &&
+		len(node.NamedChildren()) == 2 {
+		return false, false
+	}
+
+	// Class body declaration_list
+	// function/block compound_statement
+	unAnchored := []string{"declaration_list", "compound_statement"}
 
 	isUnanchored := !slices.Contains(unAnchored, parent.Type())
 	return isUnanchored, isUnanchored

--- a/internal/languages/php/pattern/pattern.go
+++ b/internal/languages/php/pattern/pattern.go
@@ -17,7 +17,7 @@ var (
 	matchNodeRegex                 = regexp.MustCompile(`\$<!>`)
 	ellipsisRegex                  = regexp.MustCompile(`\$<\.\.\.>`)
 	unanchoredPatternNodeTypes     = []string{}
-	patternMatchNodeContainerTypes = []string{"formal_parameters", "simple_parameter"}
+	patternMatchNodeContainerTypes = []string{"formal_parameters", "simple_parameter", "argument"}
 
 	allowedPatternQueryTypes = []string{"_"}
 )

--- a/internal/languages/php/pattern/pattern.go
+++ b/internal/languages/php/pattern/pattern.go
@@ -17,8 +17,7 @@ var (
 	matchNodeRegex                 = regexp.MustCompile(`\$<!>`)
 	ellipsisRegex                  = regexp.MustCompile(`\$<\.\.\.>`)
 	unanchoredPatternNodeTypes     = []string{}
-	patternMatchNodeContainerTypes = []string{"formal_parameters"}
-	// unanchoredPatternNodeTypes = []string{"simple_parameter"}
+	patternMatchNodeContainerTypes = []string{"formal_parameters", "simple_parameter"}
 
 	allowedPatternQueryTypes = []string{"_"}
 )

--- a/internal/languages/ruby/detectors/.snapshots/TestRubyStringDetector-string_assign_eq
+++ b/internal/languages/ruby/detectors/.snapshots/TestRubyStringDetector-string_assign_eq
@@ -149,6 +149,21 @@ children:
               id: 29
               range: 6:8 - 6:9
 
+- node: 8
+  content: x += "b"
+  data:
+    value: ab
+    isliteral: true
+- node: 15
+  content: x += name
+  data:
+    value: ab*
+    isliteral: false
+- node: 23
+  content: y += "c"
+  data:
+    value: '*c'
+    isliteral: false
 - node: 4
   content: '"a"'
   data:

--- a/internal/scanner/detectors/common/string.go
+++ b/internal/scanner/detectors/common/string.go
@@ -1,8 +1,6 @@
 package common
 
 import (
-	"fmt"
-
 	"github.com/bearer/bearer/internal/scanner/ast/traversalstrategy"
 	"github.com/bearer/bearer/internal/scanner/ast/tree"
 	"github.com/bearer/bearer/internal/scanner/ruleset"
@@ -77,15 +75,7 @@ func ConcatenateChildStrings(node *tree.Node, detectorContext types.Context) ([]
 }
 
 func ConcatenateAssignEquals(node *tree.Node, detectorContext types.Context) ([]interface{}, error) {
-	dataflowSources := node.ChildByFieldName("left").DataflowSources()
-	if len(dataflowSources) == 0 {
-		return nil, nil
-	}
-	if len(dataflowSources) != 1 {
-		return nil, fmt.Errorf("expected exactly one data source for `+=` node but got %d", len(dataflowSources))
-	}
-
-	left, leftIsLiteral, err := GetStringValue(dataflowSources[0], detectorContext)
+	left, leftIsLiteral, err := GetStringValue(node.ChildByFieldName("left"), detectorContext)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/scanner/detectors/customrule/patternquery/builder/builder.go
+++ b/internal/scanner/detectors/customrule/patternquery/builder/builder.go
@@ -201,9 +201,6 @@ func (builder *builder) build(rootNode *asttree.Node) (*Result, error) {
 
 	builder.write(" @root")
 	builder.write(")")
-	log.Error().Msgf("build %s", rootNode.SitterNode().String())
-	log.Error().Msgf("string builder %s", builder.stringBuilder.String())
-	log.Error().Msgf("input params builder %s", builder.stringBuilder.String())
 
 	paramToVariable, equalParams := builder.processVariableToParams()
 
@@ -382,8 +379,12 @@ func getVariableFor(
 	patternLanguage language.Pattern,
 	variables []language.PatternVariable,
 ) *language.PatternVariable {
+	if slices.Contains(patternLanguage.ContainerTypes(), node.Type()) {
+		return nil
+	}
+
 	for i, variable := range variables {
-		if (len(node.NamedChildren()) == 0 || patternLanguage.IsLeaf(node)) && node.Content() == variable.DummyValue {
+		if node.Content() == variable.DummyValue {
 			return &variables[i]
 		}
 	}

--- a/internal/scanner/detectors/customrule/patternquery/builder/builder.go
+++ b/internal/scanner/detectors/customrule/patternquery/builder/builder.go
@@ -257,7 +257,7 @@ func (builder *builder) compileNode(node *asttree.Node, isRoot bool, isLastChild
 		builder.compileVariableNode(variable)
 	} else if !node.IsNamed() {
 		builder.compileAnonymousNode(node)
-	} else if len(node.NamedChildren()) == 0 {
+	} else if len(node.NamedChildren()) == 0 || builder.patternLanguage.IsLeaf(node) {
 		builder.compileLeafNode(node)
 	} else if err := builder.compileNodeWithChildren(node); err != nil {
 		return err

--- a/internal/scanner/detectors/customrule/patternquery/builder/builder.go
+++ b/internal/scanner/detectors/customrule/patternquery/builder/builder.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bearer/bearer/internal/parser/nodeid"
 	"github.com/bearer/bearer/internal/scanner/ast"
 	asttree "github.com/bearer/bearer/internal/scanner/ast/tree"
+	"github.com/bearer/bearer/internal/scanner/detectors/customrule/patternquery/builder/bytereplacer"
 	"github.com/bearer/bearer/internal/scanner/language"
 )
 
@@ -57,15 +58,29 @@ func Build(
 		return nil, err
 	}
 
-	if fixedInput, fixed := fixupInput(
+	fixupResult, err := fixupInput(
 		patternLanguage,
 		processedInput,
 		inputParams.Variables,
 		tree.RootNode(),
-	); fixed {
-		tree, err = ast.Parse(context.TODO(), language, fixedInput)
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if fixupResult.Changed() {
+		if log.Trace().Enabled() {
+			log.Trace().Msgf("fixedInput -> %s", fixupResult.Value())
+		}
+
+		tree, err = ast.Parse(context.TODO(), language, fixupResult.Value())
 		if err != nil {
 			return nil, err
+		}
+
+		inputParams.MatchNodeOffset = fixupResult.Translate(inputParams.MatchNodeOffset)
+		for i := range inputParams.UnanchoredOffsets {
+			inputParams.UnanchoredOffsets[i] = fixupResult.Translate(inputParams.UnanchoredOffsets[i])
 		}
 	}
 
@@ -118,13 +133,9 @@ func fixupInput(
 	byteInput []byte,
 	variables []language.PatternVariable,
 	rootNode *asttree.Node,
-) ([]byte, bool) {
+) (*bytereplacer.Result, error) {
+	replacer := bytereplacer.New(byteInput)
 	insideError := false
-	inputOffset := 0
-
-	newInput := make([]byte, len(byteInput))
-	copy(newInput, byteInput)
-	fixed := false
 
 	err := rootNode.Walk(func(node *asttree.Node, visitChildren func() error) error {
 		oldInsideError := insideError
@@ -141,7 +152,6 @@ func fixupInput(
 		}
 
 		var newValue string
-		var originalValue string
 
 		if insideError {
 			variable := getVariableFor(node, patternLanguage, variables)
@@ -158,7 +168,6 @@ func fixupInput(
 				return nil
 			}
 			variable.DummyValue = newValue
-			originalValue = variable.DummyValue
 		} else {
 			if log.Trace().Enabled() {
 				log.Trace().Msgf("attempting pattern fixup (missing node). node: %s", node.Debug())
@@ -170,42 +179,10 @@ func fixupInput(
 			}
 		}
 
-		fixed = true
-		valueOffset := len(newValue) - len(originalValue)
-
-		prefix := newInput[:node.ContentStart.Byte+inputOffset]
-		suffix := newInput[node.ContentEnd.Byte+inputOffset:]
-		// FIXME: We need to append suffix before
-		// newInput seems to be sharing memory in some circumstances
-		// suffix before and after the first append are not equal
-		appendedInput := appendByte([]byte(newValue), suffix...)
-		newInput = appendByte(prefix, appendedInput...)
-
-		inputOffset += valueOffset
-
-		return nil
+		return replacer.Replace(node.ContentStart.Byte, node.ContentEnd.Byte, []byte(newValue))
 	})
 
-	// walk errors are only ones we produce, and we don't make any
-	if err != nil {
-		panic(err)
-	}
-
-	return newInput, fixed
-}
-
-func appendByte(slice []byte, data ...byte) []byte {
-	m := len(slice)
-	n := m + len(data)
-	if n > cap(slice) { // if necessary, reallocate
-		// allocate double what's needed, for future growth.
-		newSlice := make([]byte, (n+1)*2)
-		copy(newSlice, slice)
-		slice = newSlice
-	}
-	slice = slice[0:n]
-	copy(slice[m:n], data)
-	return slice
+	return replacer.Done(), err
 }
 
 func (builder *builder) build(rootNode *asttree.Node) (*Result, error) {
@@ -224,6 +201,9 @@ func (builder *builder) build(rootNode *asttree.Node) (*Result, error) {
 
 	builder.write(" @root")
 	builder.write(")")
+	log.Error().Msgf("build %s", rootNode.SitterNode().String())
+	log.Error().Msgf("string builder %s", builder.stringBuilder.String())
+	log.Error().Msgf("input params builder %s", builder.stringBuilder.String())
 
 	paramToVariable, equalParams := builder.processVariableToParams()
 
@@ -270,6 +250,8 @@ func (builder *builder) compileNode(node *asttree.Node, isRoot bool, isLastChild
 	if anchored && isLastChild && nodeAnchoredAfter && !slices.Contains(builder.inputParams.UnanchoredOffsets, node.ContentEnd.Byte) {
 		builder.write(" .")
 	}
+
+	log.Error().Msgf("stringBuilder %s", builder.stringBuilder.String())
 
 	return nil
 }

--- a/internal/scanner/detectors/customrule/patternquery/builder/builder.go
+++ b/internal/scanner/detectors/customrule/patternquery/builder/builder.go
@@ -248,8 +248,6 @@ func (builder *builder) compileNode(node *asttree.Node, isRoot bool, isLastChild
 		builder.write(" .")
 	}
 
-	log.Error().Msgf("stringBuilder %s", builder.stringBuilder.String())
-
 	return nil
 }
 

--- a/internal/scanner/detectors/customrule/patternquery/builder/bytereplacer/bytereplacer.go
+++ b/internal/scanner/detectors/customrule/patternquery/builder/bytereplacer/bytereplacer.go
@@ -1,0 +1,91 @@
+package bytereplacer
+
+import (
+	"bytes"
+	"fmt"
+)
+
+type Replacer struct {
+	offsetDelta
+	result *Result
+}
+
+type offsetDelta struct {
+	originalOffset,
+	delta int
+}
+
+type Result struct {
+	value        []byte
+	offsetDeltas []offsetDelta
+	changed      bool
+}
+
+func New(original []byte) *Replacer {
+	value := make([]byte, len(original))
+	copy(value, original)
+
+	return &Replacer{result: &Result{value: value}}
+}
+
+func (replacer *Replacer) Replace(originalStart, originalEnd int, newValue []byte) error {
+	if originalStart < replacer.originalOffset {
+		return fmt.Errorf(
+			"replacements must be made in sequential order. last offset %d, replacement start %d",
+			replacer.originalOffset,
+			originalStart,
+		)
+	}
+
+	if bytes.Equal(replacer.result.value[originalStart:originalEnd], newValue) {
+		return nil
+	}
+
+	replacer.result.changed = true
+
+	currentLength := len(replacer.result.value)
+	suffix := replacer.result.value[replacer.delta+originalEnd : currentLength : currentLength]
+
+	replacer.result.value = append(
+		replacer.result.value[:replacer.delta+originalStart],
+		append(newValue, suffix...)...,
+	)
+
+	delta := len(newValue) - originalEnd + originalStart
+
+	replacer.originalOffset = originalEnd
+	replacer.delta += delta
+
+	replacer.result.offsetDeltas = append(replacer.result.offsetDeltas, offsetDelta{
+		originalOffset: originalEnd,
+		delta:          delta,
+	})
+
+	return nil
+}
+
+func (replacer *Replacer) Done() *Result {
+	return replacer.result
+}
+
+func (result *Result) Changed() bool {
+	return result.changed
+}
+
+func (result *Result) Value() []byte {
+	return result.value
+}
+
+func (result *Result) Translate(originalOffset int) int {
+	delta := 0
+
+	for _, offsetDelta := range result.offsetDeltas {
+		if offsetDelta.originalOffset > originalOffset {
+			break
+		}
+
+		delta += offsetDelta.delta
+	}
+
+	return delta + originalOffset
+}

--- a/internal/scanner/detectors/customrule/patternquery/builder/bytereplacer/bytereplacer_suite_test.go
+++ b/internal/scanner/detectors/customrule/patternquery/builder/bytereplacer/bytereplacer_suite_test.go
@@ -1,0 +1,13 @@
+package bytereplacer_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestFilters(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ByteReplacer Suite")
+}

--- a/internal/scanner/detectors/customrule/patternquery/builder/bytereplacer/bytereplacer_test.go
+++ b/internal/scanner/detectors/customrule/patternquery/builder/bytereplacer/bytereplacer_test.go
@@ -1,0 +1,138 @@
+package bytereplacer_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/bearer/bearer/internal/scanner/detectors/customrule/patternquery/builder/bytereplacer"
+)
+
+var _ = Describe("Replacer", func() {
+	var replacer *bytereplacer.Replacer
+
+	BeforeEach(func(ctx SpecContext) {
+		replacer = bytereplacer.New([]byte("hello world"))
+	})
+
+	Describe("Replace", func() {
+		When("replacements are made in sequential order", func() {
+			BeforeEach(func(ctx SpecContext) {
+				Expect(replacer.Replace(0, 1, nil)).To(Succeed())
+			})
+
+			It("does not fail", func(ctx SpecContext) {
+				Expect(replacer.Replace(1, 2, []byte("foo"))).To(Succeed())
+			})
+		})
+
+		When("replacements are made out of order", func() {
+			BeforeEach(func(ctx SpecContext) {
+				Expect(replacer.Replace(0, 2, nil)).To(Succeed())
+			})
+
+			It("returns an error", func(ctx SpecContext) {
+				Expect(replacer.Replace(1, 2, []byte("foo"))).To(
+					MatchError(ContainSubstring("replacements must be made in sequential order")),
+				)
+			})
+		})
+	})
+})
+
+var _ = Describe("Result", func() {
+	var replacer *bytereplacer.Replacer
+	original := []byte("hello world")
+
+	BeforeEach(func(ctx SpecContext) {
+		replacer = bytereplacer.New(original)
+	})
+
+	When("no replacements are made", func() {
+		var result *bytereplacer.Result
+
+		BeforeEach(func(ctx SpecContext) {
+			result = replacer.Done()
+		})
+
+		Describe("Changed", func() {
+			It("returns false", func(ctx SpecContext) {
+				Expect(result.Changed()).To(BeFalse())
+			})
+		})
+
+		Describe("Value", func() {
+			It("returns the original value", func(ctx SpecContext) {
+				Expect(result.Value()).To(Equal(original))
+			})
+		})
+
+		Describe("Translate", func() {
+			It("returns the original offset", func(ctx SpecContext) {
+				Expect(result.Translate(0)).To(Equal(0))
+				Expect(result.Translate(5)).To(Equal(5))
+				Expect(result.Translate(10)).To(Equal(10))
+			})
+		})
+	})
+
+	When("noop replacements are made", func() {
+		var result *bytereplacer.Result
+
+		BeforeEach(func(ctx SpecContext) {
+			replacer.Replace(0, 5, []byte("hello"))
+			replacer.Replace(6, 6, nil)
+			result = replacer.Done()
+		})
+
+		Describe("Changed", func() {
+			It("returns false", func(ctx SpecContext) {
+				Expect(result.Changed()).To(BeFalse())
+			})
+		})
+
+		Describe("Value", func() {
+			It("returns the original value", func(ctx SpecContext) {
+				Expect(result.Value()).To(Equal(original))
+			})
+		})
+
+		Describe("Translate", func() {
+			It("returns the original offset", func(ctx SpecContext) {
+				Expect(result.Translate(0)).To(Equal(0))
+				Expect(result.Translate(5)).To(Equal(5))
+				Expect(result.Translate(10)).To(Equal(10))
+			})
+		})
+	})
+
+	When("replacements are made", func() {
+		var result *bytereplacer.Result
+
+		BeforeEach(func(ctx SpecContext) {
+			replacer.Replace(0, 5, []byte("hi"))
+			replacer.Replace(5, 5, []byte("!"))
+			replacer.Replace(6, 11, []byte("testing123"))
+			result = replacer.Done()
+		})
+
+		Describe("Changed", func() {
+			It("returns true", func(ctx SpecContext) {
+				Expect(result.Changed()).To(BeTrue())
+			})
+		})
+
+		Describe("Value", func() {
+			It("returns the updated value", func(ctx SpecContext) {
+				Expect(result.Value()).To(Equal([]byte("hi! testing123")))
+			})
+		})
+
+		Describe("Translate", func() {
+			It("returns the new offset", func(ctx SpecContext) {
+				Expect(result.Translate(0)).To(Equal(0))
+				Expect(result.Translate(5)).To(Equal(3))
+				Expect(result.Translate(11)).To(Equal(14))
+			})
+		})
+	})
+})

--- a/internal/scanner/detectors/customrule/patternquery/builder/bytereplacer/bytereplacer_test.go
+++ b/internal/scanner/detectors/customrule/patternquery/builder/bytereplacer/bytereplacer_test.go
@@ -79,8 +79,8 @@ var _ = Describe("Result", func() {
 		var result *bytereplacer.Result
 
 		BeforeEach(func(ctx SpecContext) {
-			replacer.Replace(0, 5, []byte("hello"))
-			replacer.Replace(6, 6, nil)
+			replacer.Replace(0, 5, []byte("hello")) // nolint:errcheck
+			replacer.Replace(6, 6, nil)             // nolint:errcheck
 			result = replacer.Done()
 		})
 
@@ -109,9 +109,9 @@ var _ = Describe("Result", func() {
 		var result *bytereplacer.Result
 
 		BeforeEach(func(ctx SpecContext) {
-			replacer.Replace(0, 5, []byte("hi"))
-			replacer.Replace(5, 5, []byte("!"))
-			replacer.Replace(6, 11, []byte("testing123"))
+			replacer.Replace(0, 5, []byte("hi"))          // nolint:errcheck
+			replacer.Replace(5, 5, []byte("!"))           // nolint:errcheck
+			replacer.Replace(6, 11, []byte("testing123")) // nolint:errcheck
 			result = replacer.Done()
 		})
 

--- a/internal/scanner/languagescanner/languagescanner.go
+++ b/internal/scanner/languagescanner/languagescanner.go
@@ -93,7 +93,7 @@ func (scanner *Scanner) Scan(
 	}
 
 	if log.Trace().Enabled() {
-		log.Trace().Msgf("tree (%d nodes):\n%s", tree.NodeCount(), tree.RootNode().SitterNode().String())
+		log.Trace().Msgf("tree (%d nodes):\n%s", tree.NodeCount(), tree.RootNode().Dump())
 	}
 
 	sharedCache := cache.NewShared(scanner.ruleSet.Rules())

--- a/internal/scanner/variableshape/variableshape.go
+++ b/internal/scanner/variableshape/variableshape.go
@@ -143,7 +143,7 @@ func NewSet(language language.Language, ruleSet *ruleset.Set) (*Set, error) {
 
 	for _, rule := range ruleSet.Rules() {
 		if err := set.add(language, rule); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error adding %s: %w", rule.ID(), err)
 		}
 	}
 


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Fixes for PHP:

- Make elements in associative array initializers unanchored
- Improve usefulness of variable shape error message - this is encountered sometimes when a rule is invalid
- Handle both single and double quoted strings in patterns - these now match both kinds of strings in the code (for literals)
- Lookup variables in more places
- Update pattern match node and unanchored offsets to account for fixups
- Add more container types
- Fix string handling (applies to other languages also)

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
