### PR TITLE
feat: allow diffscans to be sent to bearer cloud

### DIFF
--- a/internal/commands/artifact/run.go
+++ b/internal/commands/artifact/run.go
@@ -38,7 +38,7 @@ import (
 	"github.com/bearer/bearer/internal/types"
 )
 
-var ErrFileListEmpty = errors.New("couldn't find any files to scan in the specified directory")
+var ErrFileListEmpty = errors.New("couldn't find any files to scan in the specified directory, for diff scans this can mean the compared branches were identical")
 
 // TargetKind represents what kind of artifact bearer scans
 type TargetKind string

--- a/internal/commands/process/settings/settings.go
+++ b/internal/commands/process/settings/settings.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v3"
 
 	"github.com/bearer/bearer/api"
@@ -364,7 +365,7 @@ func FromOptions(opts flag.Options, versionMeta *version_check.VersionMeta) (Con
 	}
 
 	if config.Scan.DiffBaseBranch != "" {
-		if config.Report.Report != flag.ReportSecurity && config.Report.Report != flag.ReportSaaS {
+		if !slices.Contains([]string{flag.ReportSecurity, flag.ReportSaaS}, config.Report.Report) {
 			return Config{}, errors.New("diff base branch is only supported for the security report")
 		}
 	}

--- a/internal/commands/process/settings/settings.go
+++ b/internal/commands/process/settings/settings.go
@@ -364,12 +364,8 @@ func FromOptions(opts flag.Options, versionMeta *version_check.VersionMeta) (Con
 	}
 
 	if config.Scan.DiffBaseBranch != "" {
-		if config.Report.Report != flag.ReportSecurity {
+		if config.Report.Report != flag.ReportSecurity && config.Report.Report != flag.ReportSaaS {
 			return Config{}, errors.New("diff base branch is only supported for the security report")
-		}
-
-		if config.Client != nil {
-			return Config{}, errors.New("diff base branch is not supported when using an api key")
 		}
 	}
 


### PR DESCRIPTION
## Description
- We want to start processing the output of diffscans in cloud so allow them to be sent
- Impoved error messaging a bit

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
