### PR TITLE
fix(php): unanchor class name in new object expressions

### DIFF
--- a/internal/languages/java/java_test.go
+++ b/internal/languages/java/java_test.go
@@ -4,10 +4,11 @@ import (
 	_ "embed"
 	"testing"
 
+	"github.com/bradleyjkemp/cupaloy"
+
 	"github.com/bearer/bearer/internal/languages/java"
 	"github.com/bearer/bearer/internal/languages/testhelper"
 	patternquerybuilder "github.com/bearer/bearer/internal/scanner/detectors/customrule/patternquery/builder"
-	"github.com/bradleyjkemp/cupaloy"
 )
 
 //go:embed testdata/logger.yml

--- a/internal/languages/php/.snapshots/TestPattern-class_name_in_object_creation_is_unanchored
+++ b/internal/languages/php/.snapshots/TestPattern-class_name_in_object_creation_is_unanchored
@@ -1,0 +1,14 @@
+(*builder.Result)({
+  Query: (string) (len=67) "([(object_creation_expression  . [ (name )] @param1 @match)] @root)",
+  VariableNames: ([]string) {
+  },
+  ParamToVariable: (map[string]string) {
+  },
+  EqualParams: ([][]string) <nil>,
+  ParamToContent: (map[string]map[string]string) (len=1) {
+    (string) (len=6) "param1": (map[string]string) (len=1) {
+      (string) (len=4) "name": (string) (len=3) "Foo"
+    }
+  },
+  RootVariable: (*language.PatternVariable)(<nil>)
+})

--- a/internal/languages/php/pattern/pattern.go
+++ b/internal/languages/php/pattern/pattern.go
@@ -152,6 +152,13 @@ func (*Pattern) IsAnchored(node *tree.Node) (bool, bool) {
 		return false, false
 	}
 
+	// `new Foo` should match `new Foo()`
+	if parent.Type() == "object_creation_expression" {
+		if node == parent.NamedChildren()[0] {
+			return true, false
+		}
+	}
+
 	// Class body declaration_list
 	// function/block compound_statement
 	unAnchored := []string{

--- a/internal/languages/php/php_test.go
+++ b/internal/languages/php/php_test.go
@@ -4,7 +4,11 @@ import (
 	_ "embed"
 	"testing"
 
+	"github.com/bradleyjkemp/cupaloy"
+
+	"github.com/bearer/bearer/internal/languages/php"
 	"github.com/bearer/bearer/internal/languages/testhelper"
+	patternquerybuilder "github.com/bearer/bearer/internal/scanner/detectors/customrule/patternquery/builder"
 )
 
 //go:embed testdata/logger.yml
@@ -19,4 +23,21 @@ func TestFlow(t *testing.T) {
 
 func TestScope(t *testing.T) {
 	testhelper.GetRunner(t, scopeRule, "PHP").RunTest(t, "./testdata/scope", ".snapshots/")
+}
+
+func TestPattern(t *testing.T) {
+	for _, test := range []struct{ name, pattern string }{
+		{"class name in object creation is unanchored", `
+				new $<!>Foo;
+		`},
+	} {
+		t.Run(test.name, func(tt *testing.T) {
+			result, err := patternquerybuilder.Build(php.Get(), test.pattern, "")
+			if err != nil {
+				tt.Fatalf("failed to build pattern: %s", err)
+			}
+
+			cupaloy.SnapshotT(tt, result)
+		})
+	}
 }


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Allow `new Foo` to match `new Foo()` by not anchoring the `Foo` node within the object creation expression.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
