### PR TITLE
fix(php): make named arguments unanchored in patterns

### DIFF
--- a/internal/languages/php/.snapshots/TestPattern-named_arguments_are_unanchored
+++ b/internal/languages/php/.snapshots/TestPattern-named_arguments_are_unanchored
@@ -1,0 +1,18 @@
+(*builder.Result)({
+  Query: (string) (len=127) "([(function_call_expression . [ (name )] @param1 . [(arguments  [(argument . [ (name )] @param2  . (_) @match .)] )] .)] @root)",
+  VariableNames: ([]string) (len=1) {
+    (string) (len=1) "_"
+  },
+  ParamToVariable: (map[string]string) {
+  },
+  EqualParams: ([][]string) <nil>,
+  ParamToContent: (map[string]map[string]string) (len=2) {
+    (string) (len=6) "param1": (map[string]string) (len=1) {
+      (string) (len=4) "name": (string) (len=3) "foo"
+    },
+    (string) (len=6) "param2": (map[string]string) (len=1) {
+      (string) (len=4) "name": (string) (len=1) "x"
+    }
+  },
+  RootVariable: (*language.PatternVariable)(<nil>)
+})

--- a/internal/languages/php/pattern/pattern.go
+++ b/internal/languages/php/pattern/pattern.go
@@ -125,6 +125,12 @@ func (*Pattern) IsAnchored(node *tree.Node) (bool, bool) {
 		return false, false
 	}
 
+	// Named arguments are unanchored
+	// eg. f(x: 42)
+	if node.Type() == "argument" && node.ChildByFieldName("name") != nil {
+		return false, false
+	}
+
 	parent := node.Parent()
 	if parent == nil {
 		return true, true

--- a/internal/languages/php/php_test.go
+++ b/internal/languages/php/php_test.go
@@ -30,6 +30,9 @@ func TestPattern(t *testing.T) {
 		{"class name in object creation is unanchored", `
 				new $<!>Foo;
 		`},
+		{"named arguments are unanchored", `
+				foo(x: $<!>$<_>)
+		`},
 	} {
 		t.Run(test.name, func(tt *testing.T) {
 			result, err := patternquerybuilder.Build(php.Get(), test.pattern, "")


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Makes named arguments unanchored in PHP patterns. eg. allowing `f(x: 42)` to match `f(1, x: 42, y: 2)`, etc.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
