### PR TITLE
fix(php): make property names unanchored

### DIFF
--- a/internal/languages/php/.snapshots/TestPattern-property_names_are_unanchored
+++ b/internal/languages/php/.snapshots/TestPattern-property_names_are_unanchored
@@ -1,0 +1,12 @@
+(*builder.Result)({
+  Query: (string) (len=128) "([(class_declaration  . (_) . [(declaration_list  [(property_declaration . [ (visibility_modifier )] (_) @match )] )] .)] @root)",
+  VariableNames: ([]string) (len=1) {
+    (string) (len=1) "_"
+  },
+  ParamToVariable: (map[string]string) {
+  },
+  EqualParams: ([][]string) <nil>,
+  ParamToContent: (map[string]map[string]string) {
+  },
+  RootVariable: (*language.PatternVariable)(<nil>)
+})

--- a/internal/languages/php/pattern/pattern.go
+++ b/internal/languages/php/pattern/pattern.go
@@ -39,8 +39,11 @@ func (*Pattern) FixupMissing(node *tree.Node) string {
 }
 
 func (*Pattern) FixupVariableDummyValue(input []byte, node *tree.Node, dummyValue string) string {
-	if slices.Contains([]string{"named_type"}, node.Parent().Type()) {
-		return "$" + dummyValue
+	if parent := node.Parent(); parent != nil {
+		if parent.Type() == "named_type" ||
+			(parent.Type() == "ERROR" && parent.Parent() != nil && parent.Parent().Type() == "declaration_list") {
+			return "$" + dummyValue
+		}
 	}
 
 	return dummyValue
@@ -129,6 +132,10 @@ func (*Pattern) IsAnchored(node *tree.Node) (bool, bool) {
 	// eg. f(x: 42)
 	if node.Type() == "argument" && node.ChildByFieldName("name") != nil {
 		return false, false
+	}
+
+	if node.Type() == "property_element" {
+		return false, true
 	}
 
 	parent := node.Parent()

--- a/internal/languages/php/php_test.go
+++ b/internal/languages/php/php_test.go
@@ -33,6 +33,11 @@ func TestPattern(t *testing.T) {
 		{"named arguments are unanchored", `
 				foo(x: $<!>$<_>)
 		`},
+		{"property names are unanchored", `
+				class $<_> {
+					public $<!>$<_>;
+				}
+		`},
 	} {
 		t.Run(test.name, func(tt *testing.T) {
 			result, err := patternquerybuilder.Build(php.Get(), test.pattern, "")


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Makes PHP property names unanchored, allowing patterns to match when there is an optional type.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
