### PR TITLE
fix(php): lookup variables in subscript indices

### DIFF
--- a/internal/languages/php/analyzer/analyzer.go
+++ b/internal/languages/php/analyzer/analyzer.go
@@ -47,6 +47,8 @@ func (analyzer *analyzer) Analyze(node *sitter.Node, visitChildren func() error)
 		return visitChildren()
 	case "dynamic_variable_name":
 		return analyzer.analyzeDynamicVariableName(node, visitChildren)
+	case "subscript_expression":
+		return analyzer.analyzeSubscript(node, visitChildren)
 	case "binary_expression",
 		"unary_op_expression",
 		"argument",
@@ -174,6 +176,17 @@ func (analyzer *analyzer) analyzeSwitch(node *sitter.Node, visitChildren func() 
 
 func (analyzer *analyzer) analyzeDynamicVariableName(node *sitter.Node, visitChildren func() error) error {
 	analyzer.lookupVariable(node.NamedChild(0))
+
+	return visitChildren()
+}
+
+// foo["bar"]
+func (analyzer *analyzer) analyzeSubscript(node *sitter.Node, visitChildren func() error) error {
+	object := node.NamedChild(0)
+	analyzer.builder.Dataflow(node, object)
+	analyzer.lookupVariable(object)
+
+	analyzer.lookupVariable(node.NamedChild(1))
 
 	return visitChildren()
 }

--- a/internal/languages/php/detectors/.snapshots/TestPHPString-string
+++ b/internal/languages/php/detectors/.snapshots/TestPHPString-string
@@ -353,15 +353,14 @@ children:
                               range: 11:16 - 11:24
                               dataflow_sources:
                                 - 80
-                                - 83
-                                - 84
-                                - 85
                               queries:
                                 - 4
                               children:
                                 - type: variable_name
                                   id: 80
                                   range: 11:16 - 11:21
+                                  alias_of:
+                                    - 27
                                   children:
                                     - type: '"$"'
                                       id: 81


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Lookup variables in PHP subscript indices. eg. `$a[$here]`

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
