### PR TITLE
fix(php): support pattern variables for parameter types

### DIFF
--- a/internal/languages/php/.snapshots/TestPattern-parameter_names_are_unanchored
+++ b/internal/languages/php/.snapshots/TestPattern-parameter_names_are_unanchored
@@ -1,0 +1,12 @@
+(*builder.Result)({
+  Query: (string) (len=210) "([(class_declaration  . (_) . [(declaration_list  [(method_declaration [ (visibility_modifier )]  (_) . [(formal_parameters  . [(simple_parameter . (_) (_) @match)] . )] [ (compound_statement )])] )] .)] @root)",
+  VariableNames: ([]string) (len=1) {
+    (string) (len=1) "_"
+  },
+  ParamToVariable: (map[string]string) {
+  },
+  EqualParams: ([][]string) <nil>,
+  ParamToContent: (map[string]map[string]string) {
+  },
+  RootVariable: (*language.PatternVariable)(<nil>)
+})

--- a/internal/languages/php/analyzer/analyzer.go
+++ b/internal/languages/php/analyzer/analyzer.go
@@ -37,7 +37,7 @@ func (analyzer *analyzer) Analyze(node *sitter.Node, visitChildren func() error)
 		return analyzer.analyzeMethodInvocation(node, visitChildren)
 	case "member_access_expression":
 		return analyzer.analyzeFieldAccess(node, visitChildren)
-	case "simple_parameter", "variadic_parameter":
+	case "simple_parameter", "variadic_parameter", "property_promotion_parameter":
 		return analyzer.analyzeParameter(node, visitChildren)
 	case "switch_statement":
 		return analyzer.analyzeSwitch(node, visitChildren)

--- a/internal/languages/php/php_test.go
+++ b/internal/languages/php/php_test.go
@@ -38,6 +38,11 @@ func TestPattern(t *testing.T) {
 					public $<!>$<_>;
 				}
 		`},
+		{"parameter names are unanchored", `
+				class $<_> {
+					public function $<_>($<_> $<!>$<_>) {}
+				}
+		`},
 	} {
 		t.Run(test.name, func(tt *testing.T) {
 			result, err := patternquerybuilder.Build(php.Get(), test.pattern, "")


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Adds the necessary fixup logic to support pattern variables as function parameter types. 

Also:
- makes parameter names unanchored on the left hand side, to allow for optional types.
- defines a variable for property promotion parameters

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
