### PR TITLE
fix: don't use asterisk for non-literal strings

### DIFF
--- a/internal/languages/java/detectors/.snapshots/TestJavaString-string
+++ b/internal/languages/java/detectors/.snapshots/TestJavaString-string
@@ -371,12 +371,12 @@ children:
 - node: 57
   content: s2 += args[0]
   data:
-    value: hey *
+    value: hey �
     isliteral: false
 - node: 67
   content: s2 += " there"
   data:
-    value: hey * there
+    value: hey � there
     isliteral: false
 - node: 38
   content: Greeting + "!"

--- a/internal/languages/javascript/detectors/.snapshots/TestJavascriptStringDetector-string_assign_eq
+++ b/internal/languages/javascript/detectors/.snapshots/TestJavascriptStringDetector-string_assign_eq
@@ -189,12 +189,12 @@ children:
 - node: 19
   content: x += name
   data:
-    value: ab*
+    value: ab�
     isliteral: false
 - node: 30
   content: y += "c"
   data:
-    value: '*c'
+    value: �c
     isliteral: false
 - node: 6
   content: '"a"'

--- a/internal/languages/javascript/detectors/.snapshots/TestJavascriptStringDetector-string_non_literal
+++ b/internal/languages/javascript/detectors/.snapshots/TestJavascriptStringDetector-string_non_literal
@@ -82,12 +82,12 @@ children:
 - node: 2
   content: '"a" + x'
   data:
-    value: a*
+    value: a�
     isliteral: false
 - node: 10
   content: '`${x} b`'
   data:
-    value: '* b'
+    value: � b
     isliteral: false
 - node: 3
   content: '"a"'

--- a/internal/languages/javascript/detectors/string/string.go
+++ b/internal/languages/javascript/detectors/string/string.go
@@ -85,7 +85,7 @@ func handleTemplateString(node *tree.Node, detectorContext types.Context) ([]int
 		}
 
 		if childValue == "" && !childIsLiteral {
-			childValue = "*"
+			childValue = common.NonLiteralValue
 		}
 
 		text += childValue

--- a/internal/languages/php/detectors/.snapshots/TestPHPString-string
+++ b/internal/languages/php/detectors/.snapshots/TestPHPString-string
@@ -533,22 +533,22 @@ children:
 - node: 52
   content: $s .= "!!"
   data:
-    value: '*!!!'
+    value: �!!!
     isliteral: false
 - node: 74
   content: $s2 .= $args[0]
   data:
-    value: hey *
+    value: hey �
     isliteral: false
 - node: 88
   content: $s2 .= " there"
   data:
-    value: hey * there
+    value: hey � there
     isliteral: false
 - node: 39
   content: self::Greeting . "!"
   data:
-    value: '*!'
+    value: �!
     isliteral: false
 - node: 57
   content: '"!!"'
@@ -568,7 +568,7 @@ children:
 - node: 104
   content: '"foo ''{$s2}'' bar"'
   data:
-    value: foo 'hey * there' bar
+    value: foo 'hey � there' bar
     isliteral: false
 - node: 46
   content: '"!"'

--- a/internal/languages/ruby/detectors/.snapshots/TestRubyStringDetector-string_assign_eq
+++ b/internal/languages/ruby/detectors/.snapshots/TestRubyStringDetector-string_assign_eq
@@ -157,12 +157,12 @@ children:
 - node: 15
   content: x += name
   data:
-    value: ab*
+    value: ab�
     isliteral: false
 - node: 23
   content: y += "c"
   data:
-    value: '*c'
+    value: �c
     isliteral: false
 - node: 4
   content: '"a"'

--- a/internal/languages/ruby/detectors/.snapshots/TestRubyStringDetector-string_non_literal
+++ b/internal/languages/ruby/detectors/.snapshots/TestRubyStringDetector-string_non_literal
@@ -79,12 +79,12 @@ children:
 - node: 1
   content: '"a" + x'
   data:
-    value: a*
+    value: a�
     isliteral: false
 - node: 8
   content: '"#{x} b"'
   data:
-    value: '* b'
+    value: � b
     isliteral: false
 - node: 2
   content: '"a"'
@@ -94,7 +94,7 @@ children:
 - node: 10
   content: '#{x}'
   data:
-    value: '*'
+    value: �
     isliteral: false
 - node: 14
   content: ' b'

--- a/internal/scanner/detectors/common/string.go
+++ b/internal/scanner/detectors/common/string.go
@@ -8,6 +8,8 @@ import (
 	"github.com/bearer/bearer/internal/scanner/detectors/types"
 )
 
+const NonLiteralValue = "\uFFFD" // unicode Replacement character
+
 type String struct {
 	Value     string
 	IsLiteral bool
@@ -58,7 +60,7 @@ func ConcatenateChildStrings(node *tree.Node, detectorContext types.Context) ([]
 		}
 
 		if childValue == "" && !childIsLiteral {
-			childValue = "*"
+			childValue = NonLiteralValue
 		}
 
 		value += childValue
@@ -86,7 +88,7 @@ func ConcatenateAssignEquals(node *tree.Node, detectorContext types.Context) ([]
 	}
 
 	if left == "" && !leftIsLiteral {
-		left = "*"
+		left = NonLiteralValue
 
 		// No detection when neither parts are a string
 		if right == "" && !rightIsLiteral {
@@ -95,7 +97,7 @@ func ConcatenateAssignEquals(node *tree.Node, detectorContext types.Context) ([]
 	}
 
 	if right == "" && !rightIsLiteral {
-		right = "*"
+		right = NonLiteralValue
 	}
 
 	return []interface{}{String{


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Use the Unicode Replacement character instead of using an asterisk `*` for non-literal portions of strings. This allows rules to match any string value (eg. including asterisks) without false positives.

The Object Replacement character (`U+FFFC`) is more suited to this application but many fonts will render the character as whitespace, which would make it harder to understand when debugging. Therefore we use the Replacement character (`U+FFFD`) instead (intended for a single unknown character).

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
