### PR TITLE
fix(php): lookup variables in echo/print

### DIFF
--- a/internal/languages/php/analyzer/analyzer.go
+++ b/internal/languages/php/analyzer/analyzer.go
@@ -59,7 +59,9 @@ func (analyzer *analyzer) Analyze(node *sitter.Node, visitChildren func() error)
 		"include_expression",
 		"include_once_expression",
 		"require_expression",
-		"require_once_expression":
+		"require_once_expression",
+		"echo_statement",
+		"print_intrinsic":
 		return analyzer.analyzeGenericOperation(node, visitChildren)
 	case "while_statement", "do_statement", "if_statement", "expression_statement", "compound_statement": // statements don't have results
 		return visitChildren()


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Lookup variables in PHP print and echo statements.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
