### PR TITLE
fix: cloud uploads on diff scans

### DIFF
--- a/internal/commands/artifact/run.go
+++ b/internal/commands/artifact/run.go
@@ -380,6 +380,7 @@ func (r *runner) Report(
 	if err != nil {
 		return false, err
 	}
+	reportoutput.UploadReportToCloud(reportData, r.scanSettings)
 
 	endTime := time.Now()
 

--- a/internal/report/output/output.go
+++ b/internal/report/output/output.go
@@ -77,8 +77,6 @@ func GetData(
 func UploadReportToCloud(report *types.ReportData, config settings.Config) {
 	if slices.Contains([]string{flag.ReportSecurity, flag.ReportSaaS}, config.Report.Report) {
 		if config.Client != nil && config.Client.Error == nil {
-			// send SaaS report to Cloud
-			report.SendToCloud = true
 			saas.SendReport(config, report)
 		}
 	}

--- a/internal/report/output/types/types.go
+++ b/internal/report/output/types/types.go
@@ -10,7 +10,6 @@ import (
 
 type ReportData struct {
 	ReportFailed              bool
-	SendToCloud               bool
 	Files                     []string
 	FoundLanguages            []string
 	Detectors                 []any


### PR DESCRIPTION
## Description

During a diff scan, we first run a full scan and then the diff scan. We were uploading the first, full, scan to the Cloud which was causing unexpected findings to appear in the PR diff. 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
