### PR TITLE
fix: always force a diff scan

### DIFF
--- a/internal/commands/artifact/run.go
+++ b/internal/commands/artifact/run.go
@@ -103,7 +103,8 @@ func NewRunner(
 	log.Debug().Msgf("creating report %s", path)
 
 	if _, err := os.Stat(completedPath); err == nil {
-		if !scanSettings.Scan.Force {
+		if !scanSettings.Scan.Force && scanSettings.Scan.DiffBaseBranch == "" {
+			// force is not set, and we are not running a diff scan
 			r.reuseDetection = true
 			log.Debug().Msgf("reuse detection for %s", path)
 			r.reportPath = completedPath


### PR DESCRIPTION
## Description

We were seeing inconsistent results running diff scans locally with and without the `--force` flag set. 
Here we never reuse detections when the diff base branch is set, meaning we will always force diff scans. 

Closes #1328

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
