### PR TITLE
fix: add loc to found languages in saas meta

### DIFF
--- a/internal/report/output/output.go
+++ b/internal/report/output/output.go
@@ -3,12 +3,10 @@ package output
 import (
 	"errors"
 	"fmt"
-	"sort"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/hhatto/gocloc"
-	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 
 	"github.com/bearer/bearer/internal/commands/process/settings"
@@ -34,11 +32,12 @@ func GetData(
 	data := &types.ReportData{}
 
 	// add languages
-	languages := []string{}
-	if report.Inputgocloc != nil && report.Inputgocloc.Languages != nil {
-		languages = maps.Keys(report.Inputgocloc.Languages)
+	languages := make(map[string]int32)
+	if report.Inputgocloc != nil {
+		for _, language := range report.Inputgocloc.Languages {
+			languages[language.Name] = language.Code
+		}
 	}
-	sort.Strings(languages)
 	data.FoundLanguages = languages
 
 	// add detectors

--- a/internal/report/output/saas/types/types.go
+++ b/internal/report/output/saas/types/types.go
@@ -7,21 +7,21 @@ import (
 )
 
 type Meta struct {
-	ID                 string   `json:"id" yaml:"id"`
-	Host               string   `json:"host" yaml:"host"`
-	Username           string   `json:"username" yaml:"username"`
-	Name               string   `json:"name" yaml:"name"`
-	URL                string   `json:"url" yaml:"url"`
-	FullName           string   `json:"full_name" yaml:"full_name"`
-	Target             string   `json:"target" yaml:"target"`
-	SHA                string   `json:"sha" yaml:"sha"`
-	CurrentBranch      string   `json:"current_branch" yaml:"current_branch"`
-	DefaultBranch      string   `json:"default_branch" yaml:"default_branch"`
-	DiffBaseBranch     string   `json:"diff_base_branch,omitempty" yaml:"diff_base_branch,omitempty"`
-	SignedID           string   `json:"signed_id,omitempty" yaml:"signed_id,omitempty"`
-	BearerRulesVersion string   `json:"bearer_rules_version,omitempty" yaml:"bearer_rules_version,omitempty"`
-	BearerVersion      string   `json:"bearer_version,omitempty" yaml:"bearer_version,omitempty"`
-	FoundLanguages     []string `json:"found_languages" yaml:"found_languages"`
+	ID                 string           `json:"id" yaml:"id"`
+	Host               string           `json:"host" yaml:"host"`
+	Username           string           `json:"username" yaml:"username"`
+	Name               string           `json:"name" yaml:"name"`
+	URL                string           `json:"url" yaml:"url"`
+	FullName           string           `json:"full_name" yaml:"full_name"`
+	Target             string           `json:"target" yaml:"target"`
+	SHA                string           `json:"sha" yaml:"sha"`
+	CurrentBranch      string           `json:"current_branch" yaml:"current_branch"`
+	DefaultBranch      string           `json:"default_branch" yaml:"default_branch"`
+	DiffBaseBranch     string           `json:"diff_base_branch,omitempty" yaml:"diff_base_branch,omitempty"`
+	SignedID           string           `json:"signed_id,omitempty" yaml:"signed_id,omitempty"`
+	BearerRulesVersion string           `json:"bearer_rules_version,omitempty" yaml:"bearer_rules_version,omitempty"`
+	BearerVersion      string           `json:"bearer_version,omitempty" yaml:"bearer_version,omitempty"`
+	FoundLanguages     map[string]int32 `json:"found_languages" yaml:"found_languages"`
 }
 
 type BearerReport struct {

--- a/internal/report/output/types/types.go
+++ b/internal/report/output/types/types.go
@@ -11,7 +11,7 @@ import (
 type ReportData struct {
 	ReportFailed              bool
 	Files                     []string
-	FoundLanguages            []string
+	FoundLanguages            map[string]int32 // language => loc e.g. { "Ruby": 6742, "JavaScript": 122 }
 	Detectors                 []any
 	Dataflow                  *DataFlow
 	FindingsBySeverity        map[string][]securitytypes.Finding


### PR DESCRIPTION
## Description

Add lines of code count to found languages in SaaS meta.
This will help on the Cloud side to determine the "main" language of the project. 

Not addressed in this PR, but there is opportunity for refactoring in the scan process - we calculate found and supported languages in a few separate places. We should look into combining these calculations into a single report attribute. This could help us avoid passing the GoCloc object around. 

After: 
```
  "meta": {
    "id": "github.com/juice-shop/juice-shop",
    "host": "github.com",
    "username": "juice-shop",
    "name": "juice-shop",
    "url": "git@github.com:juice-shop/juice-shop.git",
    "full_name": "juice-shop/juice-shop",
    "target": "../juice-shop",
    "sha": "6be94cd16db8a555f88290881daece882a4b677e",
    "current_branch": "master",
    "default_branch": "master",
    "bearer_rules_version": "v0.18.5",
    "bearer_version": "dev",
    "found_languages": {
      "Bourne Shell": 54,
      "CSS": 181,
      "HTML": 3474,
      "Handlebars": 61,
      "JSON": 41377,
      "JavaScript": 21358,
      "Markdown": 2483,
      "Python": 19,
      "Sass": 1853,
      "TypeScript": 35307,
      "XML": 7128,
      "YAML": 4457
    }
  }
```

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
