### PR TITLE
feat: add string entropy greater than filter

### DIFF
--- a/internal/commands/process/settings/settings.go
+++ b/internal/commands/process/settings/settings.go
@@ -236,6 +236,7 @@ type PatternFilter struct {
 	GreaterThan        *int     `mapstructure:"greater_than" json:"greater_than" yaml:"greater_than"`
 	GreaterThanOrEqual *int     `mapstructure:"greater_than_or_equal" json:"greater_than_or_equal" yaml:"greater_than_or_equal"`
 	StringRegex        *Regexp  `mapstructure:"string_regex" json:"string_regex" yaml:"string_regex"`
+	EntropyGreaterThan *float64 `mapstructure:"entropy_greater_than" json:"entropy_greater_than" yaml:"entropy_greater_than"`
 	FilenameRegex      *Regexp  `mapstructure:"filename_regex" json:"filename_regex" yaml:"filename_regex"`
 }
 

--- a/internal/scanner/detectors/customrule/filter.go
+++ b/internal/scanner/detectors/customrule/filter.go
@@ -160,6 +160,13 @@ func translateFilter(
 		}, nil
 	}
 
+	if sourceFilter.EntropyGreaterThan != nil {
+		return &filters.EntropyGreaterThan{
+			Variable: variable,
+			Value:    *sourceFilter.EntropyGreaterThan,
+		}, nil
+	}
+
 	if sourceFilter.LessThan != nil {
 		return &filters.IntegerLessThan{
 			Variable: variable,
@@ -228,6 +235,7 @@ func scoreFilter(filter settings.PatternFilter) int {
 	}
 
 	if filter.StringRegex != nil ||
+		filter.EntropyGreaterThan != nil ||
 		filter.Detection != "" && filter.Scope == settings.CURSOR_STRICT_SCOPE {
 		return 2
 	}

--- a/internal/scanner/detectors/customrule/filters/filters_test.go
+++ b/internal/scanner/detectors/customrule/filters/filters_test.go
@@ -479,6 +479,52 @@ var _ = Describe("StringRegex", func() {
 	})
 })
 
+var _ = Describe("EntropyGreaterThan", func() {
+	var filter *filters.EntropyGreaterThan
+	var variable *variableshape.Variable
+	var detectorContext detectortypes.Context
+	var patternVariables variableshape.Values
+
+	BeforeEach(func(ctx SpecContext) {
+		variable, patternVariables = setupContentTest(ctx, "hello", "other")
+		// entropy("Au+u1hvsvJeEXxky") == 3.75
+		detectorContext = setupStringTest(patternVariables.Node(variable), pointers.String("Au+u1hvsvJeEXxky"))
+	})
+
+	When("the variable node's content is a string with entropy greater than the filter value", func() {
+		BeforeEach(func(ctx SpecContext) {
+			filter = &filters.EntropyGreaterThan{Variable: variable, Value: 3.7}
+		})
+
+		It("returns a result with a match using the pattern variables", func(ctx SpecContext) {
+			Expect(filter.Evaluate(detectorContext, patternVariables)).To(Equal(
+				filters.NewResult(filters.NewMatch(patternVariables, nil)),
+			))
+		})
+	})
+
+	When("the variable node's content is a string with entropy less than or equal to the filter value", func() {
+		BeforeEach(func(ctx SpecContext) {
+			filter = &filters.EntropyGreaterThan{Variable: variable, Value: 3.8}
+		})
+
+		It("returns a result with NO matches", func(ctx SpecContext) {
+			Expect(filter.Evaluate(detectorContext, patternVariables)).To(Equal(filters.NewResult()))
+		})
+	})
+
+	When("the variable node is not a string value", func() {
+		BeforeEach(func(ctx SpecContext) {
+			filter = &filters.EntropyGreaterThan{Variable: variable, Value: 3.7}
+			detectorContext = setupStringTest(patternVariables.Node(variable), nil)
+		})
+
+		It("returns an unknown result", func(ctx SpecContext) {
+			Expect(filter.Evaluate(detectorContext, patternVariables)).To(BeNil())
+		})
+	})
+})
+
 var _ = Describe("IntegerLessThan", func() {
 	var filter *filters.IntegerLessThan
 	var variable *variableshape.Variable

--- a/internal/util/entropy/.snapshots/TestShannon
+++ b/internal/util/entropy/.snapshots/TestShannon
@@ -1,0 +1,6 @@
+([]string) (len=4) {
+  (string) (len=4) "1.58",
+  (string) (len=4) "2.75",
+  (string) (len=4) "2.85",
+  (string) (len=4) "3.75"
+}

--- a/internal/util/entropy/entropy.go
+++ b/internal/util/entropy/entropy.go
@@ -1,0 +1,24 @@
+package entropy
+
+import "math"
+
+func Shannon(value string) float64 {
+	if value == "" {
+		return 0
+	}
+
+	counts := make(map[rune]int)
+	for _, character := range value {
+		counts[character]++
+	}
+
+	length := float64(len(value))
+	var negativeEntropy float64
+
+	for _, count := range counts {
+		characterProbability := float64(count) / length
+		negativeEntropy += characterProbability * math.Log2(characterProbability)
+	}
+
+	return -negativeEntropy
+}

--- a/internal/util/entropy/entropy_test.go
+++ b/internal/util/entropy/entropy_test.go
@@ -1,0 +1,26 @@
+package entropy_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/bradleyjkemp/cupaloy"
+
+	"github.com/bearer/bearer/internal/util/entropy"
+)
+
+func TestShannon(t *testing.T) {
+	examples := []string{
+		"one",
+		"password",
+		"secret_key",
+		"Au+u1hvsvJeEXxky",
+	}
+
+	results := make([]string, len(examples))
+	for i, example := range examples {
+		results[i] = fmt.Sprintf("%.2f", entropy.Shannon(example))
+	}
+
+	cupaloy.SnapshotT(t, results)
+}


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Adds a new filter type `entropy_greater_than` which takes a decimal number and compares it to the [Shannon Entropy](https://en.wikipedia.org/wiki/Entropy_(information_theory)) of the string.

This will be used to improve the PHP hardcoded secret rule which currently triggers many false positives.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
