### PR TITLE
chore(release): migrate to our own gon version

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -77,7 +77,7 @@ jobs:
         with:
           go-version: 1.21
       - name: Setup Gon
-        run: brew install mitchellh/gon/gon
+        run: brew install Bearer/tap/gon
       - name: Import Code-Signing Certificates
         uses: Apple-Actions/import-codesign-certs@v2
         with:
@@ -105,6 +105,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AC_USERNAME: ${{ secrets.AC_USERNAME }}
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
+          AC_PROVIDER: ${{ secrets.AC_PROVIDER }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
 
   publish:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
         with:
           go-version: 1.21
       - name: Setup Gon
-        run: brew install mitchellh/gon/gon
+        run: brew install Bearer/tap/gon
       - name: Import Code-Signing Certificates
         uses: Apple-Actions/import-codesign-certs@v2
         with:
@@ -105,6 +105,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AC_USERNAME: ${{ secrets.AC_USERNAME }}
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
+          AC_PROVIDER: ${{ secrets.AC_PROVIDER }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
 
   publish:

--- a/.goreleaser/common.yaml
+++ b/.goreleaser/common.yaml
@@ -30,10 +30,6 @@ builds:
 
           bundle_id = "com.bearer.bearer"
 
-          apple_id {
-            password = "@env:AC_PASSWORD"
-          }
-
           sign {
             application_identity = "Developer ID Application: Bearer Inc (5T2VP4YAG8)"
           }
@@ -73,8 +69,7 @@ changelog:
       - "^ci:"
 
 nfpms:
-  -
-    formats:
+  - formats:
       - deb
       - rpm
       - archlinux


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Closes #1301

Switch to our own Gon which uses Notarytool instead of the soon to be removed altool.

I tried to contact Mitchell but the clock is ticking so here is the process I've followed:
- Fork [Gon](https://github.com/bearer/gon)
- Merge [LuisUrr's PR](https://github.com/mitchellh/gon/pull/72)
- Resolve deprecation warnings
  - [tap](https://goreleaser.com/deprecations/?h=dep#brewstap)
  - [replacements](https://goreleaser.com/deprecations/?h=dep#archivesreplacements)
- Move build / release process to a GH Actions
- Build our own version of Gon using [mitchellh](https://github.com/mitchellh/gon)'s version (which will work until the end of the month) and release in our [Homebrew tap](https://github.com/bearer/homebrew-tap)
  - https://github.com/Bearer/gon/releases/tag/v0.0.26
- Switch GH Action to using our own https://github.com/Bearer/gon/blob/2f659a8c6d6546356c5d52ce83b09db8ec57943f/.github/workflows/release.yml#L45
- Release again
  - https://github.com/Bearer/gon/releases/tag/v0.0.27

As part of this work, I realized that the previously `@env:AC_PASSWORD` wasn't working anymore. I've updated the documentation and the code accordingly.

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
