### PR TITLE
fix: improve line number reported when datatype detected

### DIFF
--- a/e2e/rules/.snapshots/TestAuxilary-testdata-data-auxilary
+++ b/e2e/rules/.snapshots/TestAuxilary-testdata-data-auxilary
@@ -16,7 +16,7 @@ high:
             - [Datadog docs](https://docs.datadoghq.com)
             - [Scrubbing data](https://docs.datadoghq.com/tracing/configure_data_security/?tab=mongodb#scrub-sensitive-data-from-your-spans)
         documentation_url: ""
-      line_number: 3
+      line_number: 11
       full_filename: e2e/rules/testdata/data/auxilary/unsecure.js
       filename: unsecure.js
       data_type:

--- a/e2e/rules/.snapshots/TestSanitizer-testdata-data-sanitizer
+++ b/e2e/rules/.snapshots/TestSanitizer-testdata-data-sanitizer
@@ -6,42 +6,6 @@ critical:
         title: Test sanitizer
         description: Test sanitizer
         documentation_url: ""
-      line_number: 1
-      full_filename: e2e/rules/testdata/data/sanitizer/sanitizer.rb
-      filename: sanitizer.rb
-      data_type:
-        category_uuid: cef587dd-76db-430b-9e18-7b031e1a193b
-        name: Email Address
-      category_groups:
-        - PII
-        - Personal Data
-      source:
-        location:
-            start: 1
-            end: 1
-            column:
-                start: 5
-                end: 15
-      sink:
-        location:
-            start: 5
-            end: 5
-            column:
-                start: 1
-                end: 15
-        content: log("abc" + x)
-      parent_line_number: 5
-      snippet: log("abc" + x)
-      fingerprint: 6c505050fabde2c4ed17380d19fab254_0
-      old_fingerprint: d2e829ba86a33c5a52844641617ad8a7_0
-      code_extract: log("abc" + x)
-    - rule:
-        cwe_ids:
-            - "42"
-        id: sanitizer_test
-        title: Test sanitizer
-        description: Test sanitizer
-        documentation_url: ""
       line_number: 4
       full_filename: e2e/rules/testdata/data/sanitizer/sanitizer.rb
       filename: sanitizer.rb
@@ -68,9 +32,45 @@ critical:
         content: log("abc" + user.email)
       parent_line_number: 4
       snippet: log("abc" + user.email)
+      fingerprint: 6c505050fabde2c4ed17380d19fab254_0
+      old_fingerprint: d2e829ba86a33c5a52844641617ad8a7_0
+      code_extract: log("abc" + user.email)
+    - rule:
+        cwe_ids:
+            - "42"
+        id: sanitizer_test
+        title: Test sanitizer
+        description: Test sanitizer
+        documentation_url: ""
+      line_number: 5
+      full_filename: e2e/rules/testdata/data/sanitizer/sanitizer.rb
+      filename: sanitizer.rb
+      data_type:
+        category_uuid: cef587dd-76db-430b-9e18-7b031e1a193b
+        name: Email Address
+      category_groups:
+        - PII
+        - Personal Data
+      source:
+        location:
+            start: 1
+            end: 1
+            column:
+                start: 5
+                end: 15
+      sink:
+        location:
+            start: 5
+            end: 5
+            column:
+                start: 1
+                end: 15
+        content: log("abc" + x)
+      parent_line_number: 5
+      snippet: log("abc" + x)
       fingerprint: 6c505050fabde2c4ed17380d19fab254_1
       old_fingerprint: d2e829ba86a33c5a52844641617ad8a7_1
-      code_extract: log("abc" + user.email)
+      code_extract: log("abc" + x)
 
 
 --

--- a/internal/commands/process/settings/policies/common.rego
+++ b/internal/commands/process/settings/policies/common.rego
@@ -63,7 +63,7 @@ build_local_item(location, data_type) := {
 			"end": location.end_column_number,
 		},
 	},
-	"line_number": location.start_line_number,
+	"line_number": location.source.start_line_number,
 } if {
 	not input.rule.has_detailed_context == true
 }

--- a/internal/languages/golang/.snapshots/flow/TestFlow--different-line.yml
+++ b/internal/languages/golang/.snapshots/flow/TestFlow--different-line.yml
@@ -5,75 +5,7 @@ high:
         title: ""
         description: ""
         documentation_url: ""
-      line_number: 20
-      full_filename: different-line.go
-      filename: different-line.go
-      data_type:
-        category_uuid: 14124881-6b92-4fc5-8005-ea7c1c09592e
-        name: Fullname
-      category_groups:
-        - PII
-        - Personal Data
-      source:
-        location:
-            start: 20
-            end: 20
-            column:
-                start: 3
-                end: 7
-      sink:
-        location:
-            start: 31
-            end: 31
-            column:
-                start: 2
-                end: 23
-        content: log.Error().Msg(user)
-      parent_line_number: 31
-      snippet: log.Error().Msg(user)
-      fingerprint: f8cb961f0fc2f87d026bf9f5db408736_0
-      old_fingerprint: f8cb961f0fc2f87d026bf9f5db408736_0
-    - rule:
-        cwe_ids: []
-        id: rule_logger_test
-        title: ""
-        description: ""
-        documentation_url: ""
-      line_number: 21
-      full_filename: different-line.go
-      filename: different-line.go
-      data_type:
-        category_uuid: 94007e1e-57d8-43e8-90f2-246236dc5dde
-        name: Gender
-      category_groups:
-        - PII
-        - Personal Data
-      source:
-        location:
-            start: 21
-            end: 21
-            column:
-                start: 3
-                end: 9
-      sink:
-        location:
-            start: 31
-            end: 31
-            column:
-                start: 2
-                end: 23
-        content: log.Error().Msg(user)
-      parent_line_number: 31
-      snippet: log.Error().Msg(user)
-      fingerprint: f8cb961f0fc2f87d026bf9f5db408736_1
-      old_fingerprint: f8cb961f0fc2f87d026bf9f5db408736_1
-    - rule:
-        cwe_ids: []
-        id: rule_logger_test
-        title: ""
-        description: ""
-        documentation_url: ""
-      line_number: 24
+      line_number: 29
       full_filename: different-line.go
       filename: different-line.go
       data_type:
@@ -99,15 +31,15 @@ high:
         content: log.Error().Msg(name)
       parent_line_number: 29
       snippet: log.Error().Msg(name)
-      fingerprint: f8cb961f0fc2f87d026bf9f5db408736_2
-      old_fingerprint: f8cb961f0fc2f87d026bf9f5db408736_2
+      fingerprint: f8cb961f0fc2f87d026bf9f5db408736_0
+      old_fingerprint: f8cb961f0fc2f87d026bf9f5db408736_0
     - rule:
         cwe_ids: []
         id: rule_logger_test
         title: ""
         description: ""
         documentation_url: ""
-      line_number: 26
+      line_number: 30
       full_filename: different-line.go
       filename: different-line.go
       data_type:
@@ -133,6 +65,40 @@ high:
         content: log.Error().Msg(other)
       parent_line_number: 30
       snippet: log.Error().Msg(other)
-      fingerprint: f8cb961f0fc2f87d026bf9f5db408736_3
-      old_fingerprint: f8cb961f0fc2f87d026bf9f5db408736_3
+      fingerprint: f8cb961f0fc2f87d026bf9f5db408736_1
+      old_fingerprint: f8cb961f0fc2f87d026bf9f5db408736_1
+    - rule:
+        cwe_ids: []
+        id: rule_logger_test
+        title: ""
+        description: ""
+        documentation_url: ""
+      line_number: 31
+      full_filename: different-line.go
+      filename: different-line.go
+      data_type:
+        category_uuid: 14124881-6b92-4fc5-8005-ea7c1c09592e
+        name: Fullname
+      category_groups:
+        - PII
+        - Personal Data
+      source:
+        location:
+            start: 20
+            end: 20
+            column:
+                start: 3
+                end: 7
+      sink:
+        location:
+            start: 31
+            end: 31
+            column:
+                start: 2
+                end: 23
+        content: log.Error().Msg(user)
+      parent_line_number: 31
+      snippet: log.Error().Msg(user)
+      fingerprint: f8cb961f0fc2f87d026bf9f5db408736_2
+      old_fingerprint: f8cb961f0fc2f87d026bf9f5db408736_2
 

--- a/internal/languages/java/.snapshots/flow/TestFlow--different-line.yml
+++ b/internal/languages/java/.snapshots/flow/TestFlow--different-line.yml
@@ -5,7 +5,7 @@ high:
         title: ""
         description: ""
         documentation_url: ""
-      line_number: 2
+      line_number: 3
       full_filename: different-line.java
       filename: different-line.java
       data_type:

--- a/internal/languages/javascript/.snapshots/flow/TestFlow--assigment-expression.yml
+++ b/internal/languages/javascript/.snapshots/flow/TestFlow--assigment-expression.yml
@@ -5,7 +5,7 @@ high:
         title: ""
         description: ""
         documentation_url: ""
-      line_number: 1
+      line_number: 2
       full_filename: assigment-expression.js
       filename: assigment-expression.js
       data_type:

--- a/internal/languages/javascript/.snapshots/flow/TestFlow--variable-declarator.yml
+++ b/internal/languages/javascript/.snapshots/flow/TestFlow--variable-declarator.yml
@@ -5,7 +5,7 @@ high:
         title: ""
         description: ""
         documentation_url: ""
-      line_number: 1
+      line_number: 2
       full_filename: variable-declarator.js
       filename: variable-declarator.js
       data_type:

--- a/internal/languages/php/.snapshots/flow/TestFlow--different-line.yml
+++ b/internal/languages/php/.snapshots/flow/TestFlow--different-line.yml
@@ -5,7 +5,7 @@ high:
         title: ""
         description: ""
         documentation_url: ""
-      line_number: 3
+      line_number: 4
       full_filename: different-line.php
       filename: different-line.php
       data_type:

--- a/internal/languages/python/.snapshots/flow/TestFlow--different-line.yml
+++ b/internal/languages/python/.snapshots/flow/TestFlow--different-line.yml
@@ -5,7 +5,7 @@ high:
         title: ""
         description: ""
         documentation_url: ""
-      line_number: 2
+      line_number: 3
       full_filename: different-line.py
       filename: different-line.py
       data_type:

--- a/internal/languages/ruby/.snapshots/TestRuby--object-variable-reconciliation.yml
+++ b/internal/languages/ruby/.snapshots/TestRuby--object-variable-reconciliation.yml
@@ -5,7 +5,7 @@ high:
         title: ""
         description: ""
         documentation_url: ""
-      line_number: 1
+      line_number: 2
       full_filename: object-variable-reconciliation.rb
       filename: object-variable-reconciliation.rb
       data_type:


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

When `detection: datatype` was used, we were reporting the line number badly. 
This was not helping with the deduplication mechanism in place nor with the linking to the issue. 
We have both the `source` and the `sink` reported but the line number used wasn't correct.

⚠️ I will likely have to update the snapshots on the rules repository but that's ok ⚠️ 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
