### PR TITLE
fix(php): try catch anchoring

### DIFF
--- a/internal/languages/golang/pattern/pattern.go
+++ b/internal/languages/golang/pattern/pattern.go
@@ -131,8 +131,8 @@ func (*Pattern) IsAnchored(node *tree.Node) (bool, bool) {
 		"var_declaration",
 	}
 
-	isUnanchored := !slices.Contains(unAnchored, parent.Type())
-	return isUnanchored, isUnanchored
+	isAnchored := !slices.Contains(unAnchored, parent.Type())
+	return isAnchored, isAnchored
 }
 
 func (*Pattern) IsRoot(node *tree.Node) bool {

--- a/internal/languages/java/pattern/pattern.go
+++ b/internal/languages/java/pattern/pattern.go
@@ -103,8 +103,8 @@ func (*Pattern) IsAnchored(node *tree.Node) (bool, bool) {
 	// try {} catch () {}
 	unAnchored := []string{"class_body", "block", "try_statement", "catch_type", "resource_specification"}
 
-	isUnanchored := !slices.Contains(unAnchored, parent.Type())
-	return isUnanchored, isUnanchored
+	isAnchored := !slices.Contains(unAnchored, parent.Type())
+	return isAnchored, isAnchored
 }
 
 func (*Pattern) IsRoot(node *tree.Node) bool {

--- a/internal/languages/javascript/pattern/pattern.go
+++ b/internal/languages/javascript/pattern/pattern.go
@@ -106,8 +106,8 @@ func (*Pattern) IsAnchored(node *tree.Node) (bool, bool) {
 	// method statement_block
 	unAnchored := []string{"statement_block", "class_body", "object_pattern", "named_imports"}
 
-	isUnanchored := !slices.Contains(unAnchored, parent.Type())
-	return isUnanchored, isUnanchored
+	isAnchored := !slices.Contains(unAnchored, parent.Type())
+	return isAnchored, isAnchored
 }
 
 func (*Pattern) IsRoot(node *tree.Node) bool {

--- a/internal/languages/php/.snapshots/TestPattern-catch_clauses_and_types_are_unanchored
+++ b/internal/languages/php/.snapshots/TestPattern-catch_clauses_and_types_are_unanchored
@@ -1,5 +1,5 @@
 (*builder.Result)({
-  Query: (string) (len=224) "([(class_declaration  . (_) . [(declaration_list  [(method_declaration [ (visibility_modifier )]  (_) . [(formal_parameters  . [(simple_parameter . [(type_list (_))] (_) @match)] . )] [ (compound_statement )])] )] .)] @root)",
+  Query: (string) (len=158) "([(try_statement  . [ (compound_statement )] [(catch_clause   . [(type_list (_))] . [(variable_name  . (_) .)] @match  . [ (compound_statement )] .)])] @root)",
   VariableNames: ([]string) (len=1) {
     (string) (len=1) "_"
   },

--- a/internal/languages/php/analyzer/analyzer.go
+++ b/internal/languages/php/analyzer/analyzer.go
@@ -49,6 +49,8 @@ func (analyzer *analyzer) Analyze(node *sitter.Node, visitChildren func() error)
 		return analyzer.analyzeDynamicVariableName(node, visitChildren)
 	case "subscript_expression":
 		return analyzer.analyzeSubscript(node, visitChildren)
+	case "catch_clause":
+		return analyzer.analyzeCatchClause(node, visitChildren)
 	case "binary_expression",
 		"unary_op_expression",
 		"argument",
@@ -191,6 +193,16 @@ func (analyzer *analyzer) analyzeSubscript(node *sitter.Node, visitChildren func
 	analyzer.lookupVariable(node.NamedChild(1))
 
 	return visitChildren()
+}
+
+// catch(FooException | BarException $e) {}
+func (analyzer *analyzer) analyzeCatchClause(node *sitter.Node, visitChildren func() error) error {
+	return analyzer.withScope(language.NewScope(analyzer.scope), func() error {
+		name := node.ChildByFieldName("name")
+		analyzer.scope.Declare(analyzer.builder.ContentFor(name), name)
+
+		return visitChildren()
+	})
 }
 
 // default analysis, where the children are assumed to be aliases

--- a/internal/languages/php/pattern/pattern.go
+++ b/internal/languages/php/pattern/pattern.go
@@ -208,8 +208,8 @@ func (*Pattern) IsAnchored(node *tree.Node) (bool, bool) {
 		"compound_statement",
 	}
 
-	isUnanchored := !slices.Contains(unAnchored, parent.Type())
-	return isUnanchored, isUnanchored
+	isAnchored := !slices.Contains(unAnchored, parent.Type())
+	return isAnchored, isAnchored
 }
 
 func (*Pattern) IsRoot(node *tree.Node) bool {

--- a/internal/languages/php/pattern/pattern.go
+++ b/internal/languages/php/pattern/pattern.go
@@ -16,8 +16,8 @@ var (
 	patternQueryVariableRegex      = regexp.MustCompile(`\$<(?P<name>[^>:!\.]+)(?::(?P<types>[^>]+))?>`)
 	matchNodeRegex                 = regexp.MustCompile(`\$<!>`)
 	ellipsisRegex                  = regexp.MustCompile(`\$<\.\.\.>`)
-	unanchoredPatternNodeTypes     = []string{}
-	patternMatchNodeContainerTypes = []string{"formal_parameters", "simple_parameter", "argument"}
+	unanchoredPatternNodeTypes     = []string{"catch_clause"}
+	patternMatchNodeContainerTypes = []string{"formal_parameters", "simple_parameter", "argument", "type_list"}
 
 	allowedPatternQueryTypes = []string{"_"}
 
@@ -203,9 +203,11 @@ func (*Pattern) IsAnchored(node *tree.Node) (bool, bool) {
 
 	// Class body declaration_list
 	// function/block compound_statement
+	// Type1 | Type2
 	unAnchored := []string{
 		"declaration_list",
 		"compound_statement",
+		"type_list",
 	}
 
 	isAnchored := !slices.Contains(unAnchored, parent.Type())

--- a/internal/languages/php/php_test.go
+++ b/internal/languages/php/php_test.go
@@ -43,6 +43,9 @@ func TestPattern(t *testing.T) {
 					public function $<_>($<_> $<!>$<_>) {}
 				}
 		`},
+		{"catch clauses and types are unanchored", `
+				try {} catch ($<_> $<!>$$<_>) {}
+		`},
 	} {
 		t.Run(test.name, func(tt *testing.T) {
 			result, err := patternquerybuilder.Build(php.Get(), test.pattern, "")

--- a/internal/languages/python/pattern/pattern.go
+++ b/internal/languages/python/pattern/pattern.go
@@ -133,8 +133,8 @@ func (*Pattern) IsAnchored(node *tree.Node) (bool, bool) {
 	// function/block compound_statement
 	unAnchored := []string{}
 
-	isUnanchored := !slices.Contains(unAnchored, parent.Type())
-	return isUnanchored, isUnanchored
+	isAnchored := !slices.Contains(unAnchored, parent.Type())
+	return isAnchored, isAnchored
 }
 
 func (*Pattern) IsRoot(node *tree.Node) bool {


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Makes PHP catch clauses and associated exception type lists unanchored. This allows a pattern like:

```php
try {} catch (Foo $e) {}
```

to match code:

```php
try {
 ...
} catch (Foo | Bar $e) {
} catch (Other $f) {
}
```

Also fixes the naming of a variable in the anchoring logic of all languages (the meaning was the inverse of the name).

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
