### PR TITLE
perf: avoid allocations with `(*regexp.Regexp).MatchString`

### DIFF
--- a/internal/detectors/custom/custom.go
+++ b/internal/detectors/custom/custom.go
@@ -387,7 +387,7 @@ func filterCaptures(params []config.Param, captures []parser.Captures) (filtered
 
 				paramContent := capture[param.BuildFullName()].Content()
 
-				if !regex.Match([]byte(paramContent)) {
+				if !regex.MatchString(paramContent) {
 					shouldIgnore = true
 					break
 				}

--- a/internal/detectors/sql/util/util.go
+++ b/internal/detectors/sql/util/util.go
@@ -18,7 +18,7 @@ func ConvertToSimpleType(value string) string {
 	numberMap := []string{"bit", `tinyint(\(\d?\))?`, "smallint", "mediumint", "int", "integer", "bigint", `float(\(\d?,\d?\))`, `double(\(\d?,\d?\))?`, `decimal(\(\d?,\d?\))`, `dec`}
 	for _, typeValue := range numberMap {
 		reg := regexp.MustCompile(typeValue)
-		if reg.Match([]byte(simplified)) {
+		if reg.MatchString(simplified) {
 			return schema.SimpleTypeNumber
 		}
 	}
@@ -33,7 +33,7 @@ func ConvertToSimpleType(value string) string {
 	stringMap := []string{`char(\(\d?\))?`, `varchar(\(\d?\))?`, `character(\(\d?\))?`, "tinytext", "mediumtext", "longtext"}
 	for _, typeValue := range stringMap {
 		reg := regexp.MustCompile(typeValue)
-		if reg.Match([]byte(simplified)) {
+		if reg.MatchString(simplified) {
 			return schema.SimpleTypeString
 		}
 	}

--- a/internal/git/defunct_cleanup.go
+++ b/internal/git/defunct_cleanup.go
@@ -36,7 +36,7 @@ func cleanupDefunct() {
 	lines := strings.Split(string(stdout), "\n")
 
 	for _, line := range lines {
-		if !regexpDefunctProcess.Match([]byte(line)) {
+		if !regexpDefunctProcess.MatchString(line) {
 			continue
 		}
 

--- a/internal/parser/interfaces/paths/paths.go
+++ b/internal/parser/interfaces/paths/paths.go
@@ -41,11 +41,11 @@ func ValueIsRelevant(value *values.Value) bool {
 		return false
 	}
 
-	if looksLikeUrl.Match([]byte(text)) {
+	if looksLikeUrl.MatchString(text) {
 		return false
 	}
 
-	if !hasNormalChars.Match([]byte(text)) {
+	if !hasNormalChars.MatchString(text) {
 		return false
 	}
 

--- a/internal/parser/interfaces/urls/urls.go
+++ b/internal/parser/interfaces/urls/urls.go
@@ -60,7 +60,7 @@ func textIsRelevant(value *values.Value) bool {
 		return false
 	}
 
-	if !hasUsefulInformation.Match([]byte(text)) {
+	if !hasUsefulInformation.MatchString(text) {
 		return false
 	}
 


### PR DESCRIPTION
## Description

We should use `(*regexp.Regexp).MatchString` instead of `(*regexp.Regexp).Match([]byte(...))` when matching string to avoid unnecessary `[]byte` conversions and reduce allocations.

Example benchmark:

```go
func BenchmarkMatch(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if match := looksLikeUrl.Match([]byte("https://www.example.com")); !match {
			b.Fail()
		}
	}
}

func BenchmarkMatchString(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if match := looksLikeUrl.MatchString("https://www.example.com"); !match {
			b.Fail()
		}
	}
}
```

Result:

```
goos: linux
goarch: amd64
pkg: github.com/bearer/bearer/internal/parser/interfaces/paths cpu: AMD Ryzen 7 PRO 4750U with Radeon Graphics
BenchmarkMatch-16          	 1788562	       812.1 ns/op	      24 B/op	       1 allocs/op
BenchmarkMatchString-16    	 2106370	       517.8 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/bearer/bearer/internal/parser/interfaces/paths	3.628s
```

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
