### PR TITLE
feat: add fail-on-severity flag

### DIFF
--- a/docs/_data/bearer_scan.yaml
+++ b/docs/_data/bearer_scan.yaml
@@ -45,6 +45,10 @@ options:
       default_value: '[]'
       usage: |
         Specify directories paths that contain .yaml files with external rules configuration
+    - name: fail-on-severity
+      default_value: critical,high,medium,low
+      usage: |
+        Specify which severities cause the report to fail. Works in conjunction with --exit-code.
     - name: force
       default_value: "false"
       usage: Disable the cache and runs the detections again

--- a/e2e/flags/.snapshots/TestInitCommand
+++ b/e2e/flags/.snapshots/TestInitCommand
@@ -1,6 +1,7 @@
 disable-version-check: false
 log-level: info
 report:
+    fail-on-severity: critical,high,medium,low
     format: ""
     no-color: false
     output: ""

--- a/e2e/flags/.snapshots/TestMetadataFlags-help-scan
+++ b/e2e/flags/.snapshots/TestMetadataFlags-help-scan
@@ -10,10 +10,11 @@ Examples:
 
 
 Report Flags
-  -f, --format string     Specify report format (json, yaml, sarif, gitlab-sast, rdjson, html)
-      --output string     Specify the output path for the report.
-      --report string     Specify the type of report (security, privacy, dataflow). (default "security")
-      --severity string   Specify which severities are included in the report. (default "critical,high,medium,low,warning")
+      --fail-on-severity string   Specify which severities cause the report to fail. Works in conjunction with --exit-code. (default "critical,high,medium,low")
+  -f, --format string             Specify report format (json, yaml, sarif, gitlab-sast, rdjson, html)
+      --output string             Specify the output path for the report.
+      --report string             Specify the type of report (security, privacy, dataflow). (default "security")
+      --severity string           Specify which severities are included in the report. (default "critical,high,medium,low,warning")
 
 Rule Flags
       --disable-default-rules   Disables all default and built-in rules.

--- a/e2e/flags/.snapshots/TestMetadataFlags-scan-help
+++ b/e2e/flags/.snapshots/TestMetadataFlags-scan-help
@@ -10,10 +10,11 @@ Examples:
 
 
 Report Flags
-  -f, --format string     Specify report format (json, yaml, sarif, gitlab-sast, rdjson, html)
-      --output string     Specify the output path for the report.
-      --report string     Specify the type of report (security, privacy, dataflow). (default "security")
-      --severity string   Specify which severities are included in the report. (default "critical,high,medium,low,warning")
+      --fail-on-severity string   Specify which severities cause the report to fail. Works in conjunction with --exit-code. (default "critical,high,medium,low")
+  -f, --format string             Specify report format (json, yaml, sarif, gitlab-sast, rdjson, html)
+      --output string             Specify the output path for the report.
+      --report string             Specify the type of report (security, privacy, dataflow). (default "security")
+      --severity string           Specify which severities are included in the report. (default "critical,high,medium,low,warning")
 
 Rule Flags
       --disable-default-rules   Disables all default and built-in rules.

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-context-flag
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-context-flag
@@ -11,10 +11,11 @@ Examples:
 
 
 Report Flags
-  -f, --format string     Specify report format (json, yaml, sarif, gitlab-sast, rdjson, html)
-      --output string     Specify the output path for the report.
-      --report string     Specify the type of report (security, privacy, dataflow). (default "security")
-      --severity string   Specify which severities are included in the report. (default "critical,high,medium,low,warning")
+      --fail-on-severity string   Specify which severities cause the report to fail. Works in conjunction with --exit-code. (default "critical,high,medium,low")
+  -f, --format string             Specify report format (json, yaml, sarif, gitlab-sast, rdjson, html)
+      --output string             Specify the output path for the report.
+      --report string             Specify the type of report (security, privacy, dataflow). (default "security")
+      --severity string           Specify which severities are included in the report. (default "critical,high,medium,low,warning")
 
 Rule Flags
       --disable-default-rules   Disables all default and built-in rules.

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag-privacy
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag-privacy
@@ -11,10 +11,11 @@ Examples:
 
 
 Report Flags
-  -f, --format string     Specify report format (json, yaml, sarif, gitlab-sast, rdjson, html)
-      --output string     Specify the output path for the report.
-      --report string     Specify the type of report (security, privacy, dataflow). (default "security")
-      --severity string   Specify which severities are included in the report. (default "critical,high,medium,low,warning")
+      --fail-on-severity string   Specify which severities cause the report to fail. Works in conjunction with --exit-code. (default "critical,high,medium,low")
+  -f, --format string             Specify report format (json, yaml, sarif, gitlab-sast, rdjson, html)
+      --output string             Specify the output path for the report.
+      --report string             Specify the type of report (security, privacy, dataflow). (default "security")
+      --severity string           Specify which severities are included in the report. (default "critical,high,medium,low,warning")
 
 Rule Flags
       --disable-default-rules   Disables all default and built-in rules.

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag-security
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag-security
@@ -11,10 +11,11 @@ Examples:
 
 
 Report Flags
-  -f, --format string     Specify report format (json, yaml, sarif, gitlab-sast, rdjson, html)
-      --output string     Specify the output path for the report.
-      --report string     Specify the type of report (security, privacy, dataflow). (default "security")
-      --severity string   Specify which severities are included in the report. (default "critical,high,medium,low,warning")
+      --fail-on-severity string   Specify which severities cause the report to fail. Works in conjunction with --exit-code. (default "critical,high,medium,low")
+  -f, --format string             Specify report format (json, yaml, sarif, gitlab-sast, rdjson, html)
+      --output string             Specify the output path for the report.
+      --report string             Specify the type of report (security, privacy, dataflow). (default "security")
+      --severity string           Specify which severities are included in the report. (default "critical,high,medium,low,warning")
 
 Rule Flags
       --disable-default-rules   Disables all default and built-in rules.

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-report-flag
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-report-flag
@@ -11,10 +11,11 @@ Examples:
 
 
 Report Flags
-  -f, --format string     Specify report format (json, yaml, sarif, gitlab-sast, rdjson, html)
-      --output string     Specify the output path for the report.
-      --report string     Specify the type of report (security, privacy, dataflow). (default "security")
-      --severity string   Specify which severities are included in the report. (default "critical,high,medium,low,warning")
+      --fail-on-severity string   Specify which severities cause the report to fail. Works in conjunction with --exit-code. (default "critical,high,medium,low")
+  -f, --format string             Specify report format (json, yaml, sarif, gitlab-sast, rdjson, html)
+      --output string             Specify the output path for the report.
+      --report string             Specify the type of report (security, privacy, dataflow). (default "security")
+      --severity string           Specify which severities are included in the report. (default "critical,high,medium,low,warning")
 
 Rule Flags
       --disable-default-rules   Disables all default and built-in rules.

--- a/internal/flag/options.go
+++ b/internal/flag/options.go
@@ -10,6 +10,9 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+
+	"github.com/bearer/bearer/internal/types"
+	"github.com/bearer/bearer/internal/util/set"
 )
 
 var ErrInvalidScannerReportCombination = errors.New("invalid scanner argument; privacy report requires sast scanner")
@@ -175,6 +178,20 @@ func getInteger(flag *Flag) int {
 	}
 
 	return viper.GetInt(flag.ConfigName)
+}
+
+func getSeverities(flag *Flag) set.Set[string] {
+	result := set.New[string]()
+
+	for _, value := range getStringSlice(flag) {
+		if !slices.Contains(types.Severities, value) {
+			return nil
+		}
+
+		result.Add(value)
+	}
+
+	return result
 }
 
 func (f *Flags) groups() []FlagGroup {

--- a/internal/flag/report_flags.go
+++ b/internal/flag/report_flags.go
@@ -2,8 +2,11 @@ package flag
 
 import (
 	"errors"
+	"strings"
 
+	globaltypes "github.com/bearer/bearer/internal/types"
 	"github.com/bearer/bearer/internal/util/set"
+	sliceutil "github.com/bearer/bearer/internal/util/slices"
 )
 
 var (
@@ -22,8 +25,6 @@ var (
 	ReportDetectors = "detectors" // nodoc: internal report type
 	ReportSaaS      = "saas"      // nodoc: internal report type
 	ReportStats     = "stats"     // nodoc: internal report type
-
-	DefaultSeverity = "critical,high,medium,low,warning"
 )
 
 var (
@@ -31,8 +32,8 @@ var (
 	ErrInvalidFormatPrivacy  = errors.New("invalid format argument for privacy report; supported values: csv, json, yaml, html")
 	ErrInvalidFormatDefault  = errors.New("invalid format argument; supported values: json, yaml")
 	ErrInvalidReport         = errors.New("invalid report argument; supported values: security, privacy")
-	ErrInvalidSeverity       = errors.New("invalid severity argument; supported values: critical, high, medium, low, warning")
-	ErrInvalidFailOnSeverity = errors.New("invalid fail-on-severity argument; supported values: critical, high, medium, low, warning")
+	ErrInvalidSeverity       = errors.New("invalid severity argument; supported values: " + strings.Join(globaltypes.Severities, ", "))
+	ErrInvalidFailOnSeverity = errors.New("invalid fail-on-severity argument; supported values: " + strings.Join(globaltypes.Severities, ", "))
 )
 
 var (
@@ -58,13 +59,13 @@ var (
 	SeverityFlag = Flag{
 		Name:       "severity",
 		ConfigName: "report.severity",
-		Value:      DefaultSeverity,
+		Value:      strings.Join(globaltypes.Severities, ","),
 		Usage:      "Specify which severities are included in the report.",
 	}
 	FailOnSeverityFlag = Flag{
 		Name:       "fail-on-severity",
 		ConfigName: "report.fail-on-severity",
-		Value:      "critical,high,medium,low",
+		Value:      strings.Join(sliceutil.Except(globaltypes.Severities, globaltypes.LevelWarning), ","),
 		Usage:      "Specify which severities cause the report to fail. Works in conjunction with --exit-code.",
 	}
 	ExcludeFingerprintFlag = Flag{

--- a/internal/types/severity.go
+++ b/internal/types/severity.go
@@ -5,3 +5,6 @@ var LevelHigh = "high"
 var LevelMedium = "medium"
 var LevelLow = "low"
 var LevelWarning = "warning"
+
+// these must be kept in order
+var Severities = []string{LevelCritical, LevelHigh, LevelMedium, LevelLow, LevelWarning}

--- a/internal/util/slices/slices.go
+++ b/internal/util/slices/slices.go
@@ -1,0 +1,14 @@
+package slices
+
+// Except returns a copy of the slice with the specified value removed
+func Except[T comparable](slice []T, value T) []T {
+	var result []T
+
+	for _, candidate := range slice {
+		if candidate != value {
+			result = append(result, candidate)
+		}
+	}
+
+	return result
+}

--- a/internal/util/slices/slices_suite_test.go
+++ b/internal/util/slices/slices_suite_test.go
@@ -1,0 +1,13 @@
+package slices_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSlices(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Slices Suite")
+}

--- a/internal/util/slices/slices_test.go
+++ b/internal/util/slices/slices_test.go
@@ -1,0 +1,36 @@
+package slices_test
+
+import (
+	"slices"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	sliceutil "github.com/bearer/bearer/internal/util/slices"
+)
+
+var _ = Describe("Except", func() {
+	slice := []string{"a", "b", "b"}
+
+	When("the slice contains the value", func() {
+		It("returns a slice without any occurances of the value", func() {
+			Expect(sliceutil.Except(slice, "b")).To(Equal([]string{"a"}))
+		})
+
+		It("leaves the original slice unchanged", func() {
+			sliceutil.Except(slice, "b")
+
+			Expect(slice).To(Equal([]string{"a", "b", "b"}))
+		})
+	})
+
+	When("the slice does NOT contain the value", func() {
+		It("returns a copy of the original slice", func() {
+			new := sliceutil.Except(slice, "not-there")
+			Expect(new).To(Equal(slice))
+
+			new = slices.Delete(new, 0, 1)
+			Expect(new).NotTo(Equal(slice))
+		})
+	})
+})


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Adds a new `--fail-on-severity` flag which accepts a comma-separated list of severity levels. When there is a finding with one of the specified levels, then the report is deemed to have failed. 

The failure will be reported as before, including exiting with any code specified via `--exit-code`.

## Related
- Close #1200
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
