### PR TITLE
docs(gitlab): add missing env vars to examples

### DIFF
--- a/docs/guides/bearer-cloud.md
+++ b/docs/guides/bearer-cloud.md
@@ -82,6 +82,11 @@ bearer:
   image:
     name: bearer/bearer
     entrypoint: [ "" ]
+  variables:
+    SHA: $CI_COMMIT_SHA
+    CURRENT_BRANCH: $CI_COMMIT_REF_NAME
+    DEFAULT_BRANCH: $CI_DEFAULT_BRANCH
+    ORIGIN_URL: $CI_REPOSITORY_URL
   script: bearer scan . --api-key=$BEARER_TOKEN
 ```
 

--- a/docs/guides/ci-setup.md
+++ b/docs/guides/ci-setup.md
@@ -27,7 +27,11 @@ bearer:
   image:
     name: bearer/bearer
     entrypoint: [ "" ]
-
+  variables:
+    SHA: $CI_COMMIT_SHA
+    CURRENT_BRANCH: $CI_COMMIT_REF_NAME
+    DEFAULT_BRANCH: $CI_DEFAULT_BRANCH
+    ORIGIN_URL: $CI_REPOSITORY_URL
   script: bearer scan .
 ```
 

--- a/docs/guides/gitlab.md
+++ b/docs/guides/gitlab.md
@@ -17,7 +17,11 @@ bearer:
   image:
     name: bearer/bearer
     entrypoint: [ "" ]
-
+  variables:
+    SHA: $CI_COMMIT_SHA
+    CURRENT_BRANCH: $CI_COMMIT_REF_NAME
+    DEFAULT_BRANCH: $CI_DEFAULT_BRANCH
+    ORIGIN_URL: $CI_REPOSITORY_URL
   script: bearer scan .
 ```
 
@@ -38,6 +42,11 @@ bearer:
   image:
     name: bearer/bearer
     entrypoint: [ "" ]
+  variables:
+    SHA: $CI_COMMIT_SHA
+    CURRENT_BRANCH: $CI_COMMIT_REF_NAME
+    DEFAULT_BRANCH: $CI_DEFAULT_BRANCH
+    ORIGIN_URL: $CI_REPOSITORY_URL
   script:
     - bearer scan . --format gitlab-sast --output gl-sast-report.json
 
@@ -60,6 +69,10 @@ bearer:
     name: bearer/bearer
     entrypoint: [ "" ]
   variables:
+    SHA: $CI_COMMIT_SHA
+    CURRENT_BRANCH: $CI_COMMIT_REF_NAME
+    DEFAULT_BRANCH: $CI_DEFAULT_BRANCH
+    ORIGIN_URL: $CI_REPOSITORY_URL
     DIFF_BASE_BRANCH: $CI_MERGE_REQUEST_TARGET_BRANCH_NAME
     DIFF_BASE_COMMIT: $CI_MERGE_REQUEST_DIFF_BASE_SHA
   script: bearer scan .
@@ -82,6 +95,7 @@ pr_check:
     SHA: $CI_COMMIT_SHA
     CURRENT_BRANCH: $CI_COMMIT_REF_NAME
     DEFAULT_BRANCH: $CI_DEFAULT_BRANCH
+    ORIGIN_URL: $CI_REPOSITORY_URL
     DIFF_BASE_BRANCH: $CI_MERGE_REQUEST_TARGET_BRANCH_NAME
     DIFF_BASE_COMMIT: $CI_MERGE_REQUEST_DIFF_BASE_SHA
   script:


### PR DESCRIPTION
## Description
While not strictly needed these env vars are required when using cloud if there are issues with resolving them internally in the binary with the use of the git cli command. As such its probably best to add them to all examples to increase the chances that things will work as expected.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
