### PR TITLE
fix: account for severity flag in fail-on-severity logic

### DIFF
--- a/internal/report/output/security/security.go
+++ b/internal/report/output/security/security.go
@@ -228,11 +228,11 @@ func evaluateRules(
 						ignoredOutputFindings[severity] = append(ignoredOutputFindings[severity], types.IgnoredFinding{Finding: finding, IgnoreMeta: ignoredFingerprint})
 					} else {
 						outputFindings[severity] = append(outputFindings[severity], finding)
-					}
-				}
 
-				if config.Report.FailOnSeverity.Has(severity) && !ignored {
-					failed = true
+						if config.Report.FailOnSeverity.Has(severity) {
+							failed = true
+						}
+					}
 				}
 			}
 		}

--- a/internal/report/output/security/security_test.go
+++ b/internal/report/output/security/security_test.go
@@ -133,21 +133,30 @@ func TestAddReportDataWithSeverity(t *testing.T) {
 
 func TestAddReportDataWithFailOnSeverity(t *testing.T) {
 	for _, test := range []struct {
+		FailOnSeverity,
 		Severity string
 		Expected bool
 	}{
-		{Severity: globaltypes.LevelCritical, Expected: true},
-		{Severity: globaltypes.LevelHigh, Expected: true},
-		{Severity: globaltypes.LevelMedium, Expected: false},
-		{Severity: globaltypes.LevelLow, Expected: false},
-		{Severity: globaltypes.LevelWarning, Expected: false},
+		{FailOnSeverity: globaltypes.LevelCritical, Expected: true},
+		{FailOnSeverity: globaltypes.LevelHigh, Expected: true},
+		{FailOnSeverity: globaltypes.LevelHigh, Severity: globaltypes.LevelCritical, Expected: false},
+		{FailOnSeverity: globaltypes.LevelMedium, Expected: false},
+		{FailOnSeverity: globaltypes.LevelLow, Expected: false},
+		{FailOnSeverity: globaltypes.LevelWarning, Expected: false},
 	} {
-		t.Run(test.Severity, func(tt *testing.T) {
+		t.Run(test.FailOnSeverity, func(tt *testing.T) {
 			failOnSeverity := set.New[string]()
-			failOnSeverity.Add(test.Severity)
+			failOnSeverity.Add(test.FailOnSeverity)
+
+			var severity set.Set[string]
+			if test.Severity != "" {
+				severity = set.New[string]()
+				severity.Add(test.Severity)
+			}
 
 			config, err := generateConfig(flag.ReportOptions{
 				Report:         "security",
+				Severity:       severity,
 				FailOnSeverity: failOnSeverity,
 			})
 


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Only treat findings as a failure if their severity is enabled (eg. with `--severity`). Currently, `--fail-on-severity` and `--severity` are separate, so you can skip a level with `--severity` but still have a failure if there is a finding with that level.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
