### PR TITLE
fix: exit cleanly when meta is not available

### DIFF
--- a/internal/report/output/saas/saas.go
+++ b/internal/report/output/saas/saas.go
@@ -75,6 +75,7 @@ func SendReport(config settings.Config, reportData *types.ReportData) {
 			errorMessage := fmt.Sprintf("Unable to calculate Metadata. %s", err)
 			log.Debug().Msgf(errorMessage)
 			config.Client.Error = &errorMessage
+			return
 		}
 	}
 


### PR DESCRIPTION
## Description
When metadata cannot be calculated and the report is invalid do not try and then upload it.

## Related
- Close #1307


## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
