### PR TITLE
fix(php): anchoring of functions

### DIFF
--- a/internal/languages/php/.snapshots/TestPattern-anonymous_function_names_and_bodies_are_unanchored
+++ b/internal/languages/php/.snapshots/TestPattern-anonymous_function_names_and_bodies_are_unanchored
@@ -1,0 +1,11 @@
+(*builder.Result)({
+  Query: (string) (len=100) "([(anonymous_function_creation_expression  [ (formal_parameters )] [ (compound_statement )])] @root)",
+  VariableNames: ([]string) {
+  },
+  ParamToVariable: (map[string]string) {
+  },
+  EqualParams: ([][]string) <nil>,
+  ParamToContent: (map[string]map[string]string) {
+  },
+  RootVariable: (*language.PatternVariable)(<nil>)
+})

--- a/internal/languages/php/.snapshots/TestPattern-function_names_and_bodies_are_unanchored
+++ b/internal/languages/php/.snapshots/TestPattern-function_names_and_bodies_are_unanchored
@@ -1,5 +1,5 @@
 (*builder.Result)({
-  Query: (string) (len=232) "([(class_declaration  . name: (_) . [(declaration_list  [(method_declaration [ (visibility_modifier )]  name: (_) [(formal_parameters  . [(simple_parameter . type: (_) name: (_) @match)] . )] [ (compound_statement )])] )] .)] @root)",
+  Query: (string) (len=91) "([(function_definition  name: (_) [ (formal_parameters )] [ (compound_statement )])] @root)",
   VariableNames: ([]string) (len=1) {
     (string) (len=1) "_"
   },

--- a/internal/languages/php/pattern/pattern.go
+++ b/internal/languages/php/pattern/pattern.go
@@ -171,15 +171,19 @@ func (*Pattern) IsAnchored(node *tree.Node) (bool, bool) {
 		return false, true
 	}
 
-	if parent.Type() == "method_declaration" {
+	if slices.Contains([]string{
+		"method_declaration",
+		"function_definition",
+		"anonymous_function_creation_expression",
+	}, parent.Type()) {
 		// visibility
 		if node == parent.ChildByFieldName("name") {
 			return false, true
 		}
 
 		// type
-		if node == parent.ChildByFieldName("parameters") {
-			return true, false
+		if node == parent.ChildByFieldName("body") {
+			return false, true
 		}
 
 		return false, false

--- a/internal/languages/php/php_test.go
+++ b/internal/languages/php/php_test.go
@@ -89,6 +89,12 @@ func TestPattern(t *testing.T) {
 		{"catch clauses and types are unanchored", `
 				try {} catch ($<_> $<!>$$<_>) {}
 		`},
+		{"function names and bodies are unanchored", `
+				function $<_>() {}
+		`},
+		{"anonymous function names and bodies are unanchored", `
+				function () {};
+		`},
 	} {
 		t.Run(test.name, func(tt *testing.T) {
 			result, err := patternquerybuilder.Build(php.Get(), test.pattern, "")


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Fixes anchoring of PHP function names and bodies. 

Previously we only applied the logic to methods and not functions or anonymous functions. The logic to account for optional return type also wasn't correct.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
