### PR TITLE
chore(cli): set version for root

### DIFF
--- a/e2e/flags/.snapshots/TestMetadataFlags-version
+++ b/e2e/flags/.snapshots/TestMetadataFlags-version
@@ -1,5 +1,4 @@
 
 --
-bearer version: dev
-sha: devSHA
+bearer version dev, build devSHA
 

--- a/internal/commands/app.go
+++ b/internal/commands/app.go
@@ -66,7 +66,7 @@ Learn More:
 	For more examples, tutorials, and to learn more about the project
 	visit https://docs.bearer.com
 `
-	version := fmt.Sprintf("%s@%s", build.Version, build.CommitSHA)
+	version := fmt.Sprintf("%s, build %s", build.Version, build.CommitSHA)
 	cmd := &cobra.Command{
 		Use:     "bearer",
 		Args:    cobra.NoArgs,

--- a/internal/commands/app.go
+++ b/internal/commands/app.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 
+	"github.com/bearer/bearer/cmd/bearer/build"
 	"github.com/bearer/bearer/internal/commands/artifact"
 	"github.com/bearer/bearer/internal/flag"
 	"github.com/spf13/cobra"
@@ -65,12 +66,14 @@ Learn More:
 	For more examples, tutorials, and to learn more about the project
 	visit https://docs.bearer.com
 `
-
+	version := fmt.Sprintf("%s@%s", build.Version, build.CommitSHA)
 	cmd := &cobra.Command{
-		Use:  "bearer",
-		Args: cobra.NoArgs,
+		Use:     "bearer",
+		Args:    cobra.NoArgs,
+		Version: version,
 	}
 	cmd.SetUsageTemplate(usageTemplate)
+
 	return cmd
 }
 

--- a/internal/commands/version.go
+++ b/internal/commands/version.go
@@ -42,7 +42,7 @@ func NewVersionCommand(version string, commitSHA string) *cobra.Command {
 			} else {
 				version_check.DisplayBinaryVersionWarning(meta, false)
 			}
-			cmd.Printf("bearer version: %s\nsha: %s\n", version, commitSHA)
+			cmd.Printf("bearer version %s, build %s\n", version, commitSHA)
 			return nil
 		},
 	}


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Setting the version will automatically enable `bearer --version`.
I found it particularly annoying/confusing in some occasions to not have it available.

<img width="342" alt="image" src="https://github.com/Bearer/bearer/assets/110196/866685ee-7ec6-478d-b7a2-cafb585deb16">

---

https://github.com/spf13/cobra/blob/main/site/content/user_guide.md#version-flag

> Cobra adds a top-level '--version' flag if the Version field is set on the root command. Running an application with the '--version' flag will print the version to stdout using the version template. The template can be customized using the cmd.SetVersionTemplate(s string) function.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
