### PR TITLE
fix: diff scan fixes

### DIFF
--- a/internal/commands/process/gitrepository/gitrepository.go
+++ b/internal/commands/process/gitrepository/gitrepository.go
@@ -306,6 +306,14 @@ func (repository *Repository) WithBaseBranch(body func() error) error {
 		return fmt.Errorf("error getting git worktree: %w", err)
 	}
 
+	status, err := worktree.Status()
+	if err != nil {
+		return err
+	}
+	if !status.IsClean() {
+		return errors.New("uncommitted changes found in worktree. commit or stash changes your changes and retry")
+	}
+
 	defer repository.restoreHead(worktree)
 
 	if err := worktree.Checkout(&git.CheckoutOptions{

--- a/internal/languages/testhelper/testhelper.go
+++ b/internal/languages/testhelper/testhelper.go
@@ -155,7 +155,8 @@ func (runner *Runner) scanSingleFile(t *testing.T, testDataPath string, fileRela
 	runner.config.Scan.Target = testDataPath
 	reportData, err := output.GetData(
 		types.Report{
-			Path: detectorsReportPath,
+			Path:     detectorsReportPath,
+			HasFiles: true,
 		},
 		runner.config,
 		nil,

--- a/internal/report/output/dataflow/components/components_test.go
+++ b/internal/report/output/dataflow/components/components_test.go
@@ -139,7 +139,7 @@ func TestDataflowComponents(t *testing.T) {
 				return
 			}
 
-			if err = dataflow.AddReportData(output, settings.Config{}, false); err != nil {
+			if err = dataflow.AddReportData(output, settings.Config{}, false, true); err != nil {
 				t.Fatalf("failed to get dataflow output %s", err)
 				return
 			}

--- a/internal/report/output/dataflow/dataflow.go
+++ b/internal/report/output/dataflow/dataflow.go
@@ -42,7 +42,12 @@ func contains(detections []detections.DetectionType, detection detections.Detect
 	return false
 }
 
-func AddReportData(reportData *types.ReportData, config settings.Config, isInternal bool) error {
+func AddReportData(reportData *types.ReportData, config settings.Config, isInternal, hasFiles bool) error {
+	if !hasFiles {
+		reportData.Dataflow = &types.DataFlow{}
+		return nil
+	}
+
 	dataTypesHolder := datatypes.New(config, isInternal)
 	risksHolder := risks.New(config, isInternal)
 	componentsHolder := components.New(isInternal)

--- a/internal/report/output/dataflow/datatypes/datatypes_test.go
+++ b/internal/report/output/dataflow/datatypes/datatypes_test.go
@@ -220,7 +220,7 @@ func TestDataflowDataType(t *testing.T) {
 				return
 			}
 
-			if err = dataflow.AddReportData(output, test.Config, false); err != nil {
+			if err = dataflow.AddReportData(output, test.Config, false, true); err != nil {
 				t.Fatalf("failed to get dataflow output %s", err)
 				return
 			}

--- a/internal/report/output/dataflow/risks/risks_test.go
+++ b/internal/report/output/dataflow/risks/risks_test.go
@@ -233,7 +233,7 @@ func TestDataflowRisks(t *testing.T) {
 				return
 			}
 
-			if err = dataflow.AddReportData(output, test.Config, false); err != nil {
+			if err = dataflow.AddReportData(output, test.Config, false, true); err != nil {
 				t.Fatalf("failed to get dataflow output %s", err)
 				return
 			}

--- a/internal/report/output/detectors/detectors.go
+++ b/internal/report/output/detectors/detectors.go
@@ -13,8 +13,12 @@ import (
 	"github.com/bearer/bearer/internal/util/output"
 )
 
-func AddReportData(reportData *types.ReportData, report globaltypes.Report, config settings.Config) error {
-	if !config.Scan.Quiet {
+func AddReportData(
+	reportData *types.ReportData,
+	report globaltypes.Report,
+	config settings.Config,
+) error {
+	if !config.Scan.Quiet && report.HasFiles {
 		output.StdErrLog("Running Detectors")
 	}
 

--- a/internal/report/output/output.go
+++ b/internal/report/output/output.go
@@ -56,9 +56,9 @@ func GetData(
 	case flag.ReportDataFlow:
 		return data, err
 	case flag.ReportSecurity:
-		err = security.AddReportData(data, config, baseBranchFindings)
+		err = security.AddReportData(data, config, baseBranchFindings, report.HasFiles)
 	case flag.ReportSaaS:
-		if err = security.AddReportData(data, config, baseBranchFindings); err != nil {
+		if err = security.AddReportData(data, config, baseBranchFindings, report.HasFiles); err != nil {
 			return nil, err
 		}
 		err = saas.GetReport(data, config, false)
@@ -81,7 +81,12 @@ func UploadReportToCloud(report *types.ReportData, config settings.Config) {
 	}
 }
 
-func GetDataflow(reportData *types.ReportData, report globaltypes.Report, config settings.Config, isInternal bool) error {
+func GetDataflow(
+	reportData *types.ReportData,
+	report globaltypes.Report,
+	config settings.Config,
+	isInternal bool,
+) error {
 	if reportData.Detectors == nil {
 		if err := detectors.AddReportData(reportData, report, config); err != nil {
 			return err
@@ -90,7 +95,7 @@ func GetDataflow(reportData *types.ReportData, report globaltypes.Report, config
 	for _, detection := range reportData.Detectors {
 		detection.(map[string]interface{})["id"] = uuid.NewString()
 	}
-	return dataflow.AddReportData(reportData, config, isInternal)
+	return dataflow.AddReportData(reportData, config, isInternal, report.HasFiles)
 }
 
 func FormatOutput(

--- a/internal/report/output/security/security.go
+++ b/internal/report/output/security/security.go
@@ -180,6 +180,9 @@ func evaluateRules(
 			sortByLineNumber(policyFailures)
 
 			for i, output := range policyFailures {
+				instanceID := instanceCount[output.Filename]
+				instanceCount[output.Filename]++
+
 				if baseBranchFindings != nil &&
 					baseBranchFindings.Consume(rule.Id, output.Filename, output.Sink.Start, output.Sink.End) {
 					continue
@@ -187,10 +190,9 @@ func evaluateRules(
 
 				fingerprintId := fmt.Sprintf("%s_%s", rule.Id, output.Filename)
 				oldFingerprintId := fmt.Sprintf("%s_%s", rule.Id, output.FullFilename)
-				fingerprint := fmt.Sprintf("%x_%d", md5.Sum([]byte(fingerprintId)), instanceCount[output.Filename])
+				fingerprint := fmt.Sprintf("%x_%d", md5.Sum([]byte(fingerprintId)), instanceID)
 				oldFingerprint := fmt.Sprintf("%x_%d", md5.Sum([]byte(oldFingerprintId)), i)
 
-				instanceCount[output.Filename]++
 				fingerprints = append(fingerprints, fingerprint)
 				rawCodeExtract := codeExtract(output.FullFilename, output.Source, output.Sink)
 				codeExtract := getExtract(rawCodeExtract)

--- a/internal/report/output/security/security_test.go
+++ b/internal/report/output/security/security_test.go
@@ -40,7 +40,7 @@ func TestBuildReportString(t *testing.T) {
 	}
 
 	data := dummyDataflowData()
-	if err := security.AddReportData(data, config, nil); err != nil {
+	if err := security.AddReportData(data, config, nil, true); err != nil {
 		t.Fatalf("failed to generate security output err:%s", err)
 	}
 
@@ -69,7 +69,7 @@ func TestNoRulesBuildReportString(t *testing.T) {
 	}
 
 	output := dummyDataflowData()
-	if err := security.AddReportData(output, config, nil); err != nil {
+	if err := security.AddReportData(output, config, nil, true); err != nil {
 		t.Fatalf("failed to generate security output err:%s", err)
 	}
 
@@ -100,7 +100,7 @@ func TestAddReportData(t *testing.T) {
 	}
 
 	output := dummyDataflowData()
-	if err = security.AddReportData(output, config, nil); err != nil {
+	if err = security.AddReportData(output, config, nil, true); err != nil {
 		t.Fatalf("failed to generate security output err:%s", err)
 	}
 
@@ -127,7 +127,7 @@ func TestAddReportDataWithSeverity(t *testing.T) {
 	}
 
 	data := dummyDataflowData()
-	if err = security.AddReportData(data, config, nil); err != nil {
+	if err = security.AddReportData(data, config, nil, true); err != nil {
 		t.Fatalf("failed to generate security output err:%s", err)
 	}
 
@@ -173,7 +173,7 @@ func TestAddReportDataWithFailOnSeverity(t *testing.T) {
 			}
 
 			data := dummyDataflowData()
-			if err = security.AddReportData(data, config, nil); err != nil {
+			if err = security.AddReportData(data, config, nil, true); err != nil {
 				tt.Fatalf("failed to generate security output err:%s", err)
 			}
 
@@ -256,7 +256,7 @@ func TestFingerprintIsStableWithBaseBranchFindings(t *testing.T) {
 		Files: []string{filename},
 	}
 
-	if err = security.AddReportData(data, config, nil); err != nil {
+	if err = security.AddReportData(data, config, nil, true); err != nil {
 		t.Fatalf("failed to generate security output err:%s", err)
 	}
 
@@ -278,7 +278,7 @@ func TestFingerprintIsStableWithBaseBranchFindings(t *testing.T) {
 	baseBranchFindings := basebranchfindings.New(fileList)
 	baseBranchFindings.Add("ruby_lang_ssl_verification", filename, 1, 1)
 
-	if err = security.AddReportData(data, config, baseBranchFindings); err != nil {
+	if err = security.AddReportData(data, config, baseBranchFindings, true); err != nil {
 		t.Fatalf("failed to generate security output with base branch findings err:%s", err)
 	}
 

--- a/internal/types/report.go
+++ b/internal/types/report.go
@@ -7,4 +7,5 @@ import (
 type Report struct {
 	Path        string
 	Inputgocloc *gocloc.Result
+	HasFiles    bool
 }


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Fixes the following issues with diff scans:
- Support scanning local-only repositories. ie. repositories with no remotes
- Ensure fingerprints are consistent between full scans and diff scans
- Prevent uncommitted changes from being lost when changing branches during a diff scan. For now we raise an error. Ideally, we would scan the files directly from the git data and avoid needing to alter the worktree, but that's a big change.
- Produce output when no files are found to scan. Currently an error is raised which prevents data formats from being generated. Following this change, no error is raised and instead a message is added to the text security report.

## Related
- Close #1368 
- Close #1370 
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
