### PR TITLE
docs: duplicate bearer display in command docs

### DIFF
--- a/docs/reference/commands.njk
+++ b/docs/reference/commands.njk
@@ -21,11 +21,11 @@ Bearer CLI offers a number of commands to use and customize the CLI to your need
 </ul>
 
 {% for item in items %}
-  <h2 class="inline-block text-neutral-100 bg-code p-1 rounded-md leading-none font-mono" id="{{ item.name | trim | e | replace(" ", "_")}}">bearer {{ item.name | trim | escape }}</h2>
+  <h2 class="inline-block text-neutral-100 bg-code p-1 rounded-md leading-none font-mono" id="{{ item.name | trim | e | replace(" ", "_")}}">{{ item.name | trim | escape }}</h2>
 
   <p>{{item.synopsis}}</p>
 
-  <pre class="language-bash"><code class="language-bash">bearer {{item.usage | trim}}</code></pre>
+  <pre class="language-bash"><code class="language-bash">{{item.usage | trim}}</code></pre>
 
   <h3 id="{{item.name | trim}}-flags">Flags</h3>
   <table class="table-auto">


### PR DESCRIPTION
## Description

Since the changes to support console code completion, we must update the docs so that "bearer" is not duplicated

## Before

<img width="799" alt="Screenshot 2023-11-08 at 14 47 48" src="https://github.com/Bearer/bearer/assets/4560746/469af0cf-7ec9-4fc8-ae94-d90392c62b35">

## After

<img width="807" alt="Screenshot 2023-11-08 at 14 48 21" src="https://github.com/Bearer/bearer/assets/4560746/a8eb9845-0876-4125-8fff-6bab6256c549">

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
