### PR TITLE
fix(golang): improve engine following rules

### DIFF
--- a/internal/languages/golang/analyzer/analyzer.go
+++ b/internal/languages/golang/analyzer/analyzer.go
@@ -47,7 +47,7 @@ func (analyzer *analyzer) Analyze(node *sitter.Node, visitChildren func() error)
 		return analyzer.analyzeGenericConstruct(node, visitChildren)
 	case "qualified_type":
 		return analyzer.analyzeQualifiedType(node, visitChildren)
-	case "argument_list", "binary_expression", "expression_list", "unary_expression":
+	case "argument_list", "binary_expression", "expression_list", "unary_expression", "literal_element":
 		return analyzer.analyzeGenericOperation(node, visitChildren)
 	case "return_statement", "go_statement", "defer_statement", "if_statement": // statements don't have results
 		return visitChildren()

--- a/internal/languages/golang/pattern/pattern.go
+++ b/internal/languages/golang/pattern/pattern.go
@@ -25,6 +25,7 @@ var (
 		"parameter_list",
 		"var_spec",
 		"import_spec",
+		"literal_element", // Can be removed once the tree-sitter-go is updated
 	}
 
 	allowedPatternQueryTypes = []string{"_"}
@@ -150,6 +151,7 @@ func (*Pattern) IsAnchored(node *tree.Node) (bool, bool) {
 	unAnchored := []string{
 		"function_declaration",
 		"var_declaration",
+		"literal_value",
 	}
 
 	isAnchored := !slices.Contains(unAnchored, parent.Type())


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Handle `literal_element` and `literal_value`.

Worth noting that the tree-sitter playground for go is using the updated version but our version of tree-sitter-go is still a bit behind.

<img width="726" alt="image" src="https://github.com/Bearer/bearer/assets/110196/502eb505-e5d8-48b3-afe0-964cf775460b">

**64457ea6b73ef5422ed1687178d4545c3e91334a**
<img width="371" alt="image" src="https://github.com/Bearer/bearer/assets/110196/32ff528d-2930-4bf6-afbe-9917d26bf20a">


<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
