### PR TITLE
fix: make cache work again after diff fixes

### DIFF
--- a/e2e/.snapshots/TestCache
+++ b/e2e/.snapshots/TestCache
@@ -1,0 +1,39 @@
+critical:
+    - rule:
+        cwe_ids:
+            - "42"
+        id: test_ruby_logger
+        title: Ruby logger
+        description: Ruby logger
+        documentation_url: ""
+      line_number: 1
+      full_filename: e2e/testdata/logger/main.rb
+      filename: main.rb
+      data_type:
+        category_uuid: cef587dd-76db-430b-9e18-7b031e1a193b
+        name: Email Address
+      category_groups:
+        - PII
+        - Personal Data
+      source:
+        location:
+            start: 1
+            end: 1
+            column:
+                start: 26
+                end: 36
+      sink:
+        location:
+            start: 1
+            end: 1
+            column:
+                start: 1
+                end: 37
+        content: logger.info("user info", user.email)
+      parent_line_number: 1
+      snippet: logger.info("user info", user.email)
+      fingerprint: fa5e03644738e4c17cbbd04a580506b1_0
+      old_fingerprint: 16c8aedf4ee6fe1f129aec2a9c14310c_0
+      code_extract: logger.info("user info", user.email)
+
+

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1,0 +1,49 @@
+package e2e_test
+
+import (
+	"testing"
+
+	"github.com/bearer/bearer/e2e/internal/testhelper"
+	"github.com/bradleyjkemp/cupaloy"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCache(t *testing.T) {
+	arguments := []string{
+		"scan",
+		"e2e/testdata/logger",
+		"--format", "yaml",
+		"--disable-version-check",
+		"--disable-default-rules",
+		"--external-rule-dir", "e2e/testdata/rules",
+		"--exit-code=0",
+	}
+
+	noCacheStdOut, noCacheStdErr := testhelper.ExecuteTest(
+		testhelper.NewTestCase(
+			"no_cache",
+			arguments,
+			testhelper.TestCaseOptions{
+				DisplayStdErr: true,
+			},
+		),
+		t,
+	)
+
+	withCacheStdOut, withCacheStdErr := testhelper.ExecuteTest(
+		testhelper.NewTestCase(
+			"with_cache",
+			arguments,
+			testhelper.TestCaseOptions{
+				DisplayStdErr: true,
+				IgnoreForce:   true,
+			},
+		),
+		t,
+	)
+
+	assert.NotContains(t, noCacheStdErr, "Cached data used")
+	assert.Contains(t, withCacheStdErr, "Cached data used")
+	assert.Equal(t, noCacheStdOut, withCacheStdOut)
+	cupaloy.SnapshotT(t, withCacheStdOut)
+}

--- a/e2e/testdata/logger/main.rb
+++ b/e2e/testdata/logger/main.rb
@@ -1,0 +1,1 @@
+logger.info("user info", user.email)

--- a/e2e/testdata/rules/logger.yml
+++ b/e2e/testdata/rules/logger.yml
@@ -1,0 +1,15 @@
+patterns:
+  - pattern: logger.$<_>($<...>$<DATA_TYPE>$<...>)
+    filters:
+      - variable: DATA_TYPE
+        detection: datatype
+        scope: result
+languages:
+  - ruby
+severity: high
+metadata:
+  description: Ruby logger
+  remediation_message: Ruby logger
+  cwe_id:
+    - 42
+  id: test_ruby_logger

--- a/internal/commands/artifact/run.go
+++ b/internal/commands/artifact/run.go
@@ -374,7 +374,11 @@ func (r *runner) Report(
 	startTime := time.Now()
 	cacheUsed := r.CacheUsed()
 
-	report := types.Report{Path: r.reportPath, Inputgocloc: r.goclocResult, HasFiles: len(files) != 0}
+	report := types.Report{
+		Path:        r.reportPath,
+		Inputgocloc: r.goclocResult,
+		HasFiles:    r.CacheUsed() || len(files) != 0,
+	}
 
 	// if output is defined we want to write only to file
 	logger := outputhandler.StdOutLog


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Fixes the cache behaviour and adds a test to check that an uncached and cached scan of the same file match.

Since https://github.com/Bearer/bearer/pull/1381, we were telling the reporting logic that there were no files in the report when using the cache (as we skip getting the file list).

## Related
- Close #1384 
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
