### PR TITLE
fix: add git untracked files to the list of files to scan

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -11,4 +11,4 @@ export BEARER_DISABLE_VERSION_CHECK=true
 export BEARER_DISABLE_DEFAULT_RULES=true
 export BEARER_EXTERNAL_RULE_DIR=$PWD/../bearer-rules/rules
 export BEARER_FORCE=true
-export BEARER_IGNORE_GIT=true
+# export BEARER_IGNORE_GIT=true

--- a/internal/commands/process/gitrepository/gitrepository.go
+++ b/internal/commands/process/gitrepository/gitrepository.go
@@ -226,7 +226,6 @@ func (repository *Repository) fileFor(
 	}
 
 	fullPath := filepath.Join(repository.targetPath, relativePath)
-
 	fileInfo, err := os.Stat(fullPath)
 	if err != nil {
 		log.Debug().Msgf("error getting file stat: %s, %s", fullPath, err)


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Fixes #1424 

Incidentally removes the `BEARER_IGNORE_GIT` from the `envrc.example` which was mainly a workaround for this.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
