### PR TITLE
fix: incorrect framework component type

### DIFF
--- a/internal/report/output/dataflow/components/components.go
+++ b/internal/report/output/dataflow/components/components.go
@@ -143,7 +143,7 @@ func (holder *Holder) AddFramework(classifiedDetection frameworkclassification.C
 		return nil
 	}
 
-	componentType := getComponentType(classifiedDetection.Classification.Decision.Reason, classifiedDetection.Classification.Decision.Reason)
+	componentType := getComponentType(classifiedDetection.Classification.RecipeType, classifiedDetection.Classification.Decision.Reason)
 	componentSubType := classifiedDetection.Classification.RecipeSubType
 
 	if classifiedDetection.Classification.Decision.State == classify.Valid {

--- a/internal/report/output/dataflow/components/components_test.go
+++ b/internal/report/output/dataflow/components/components_test.go
@@ -64,6 +64,26 @@ func TestDataflowComponents(t *testing.T) {
 			},
 		},
 		{
+			Name:        "single detection - framework",
+			FileContent: `{  "detector_type": "rails", "type": "framework_classified", "source": {"filename": "config/storage.yml", "line_number": 5, "start_line_number": 5}, "classification": { "Decision": { "state": "valid" }, "recipe_name": "Disk", "recipe_match": true, "recipe_type": "data_type", "recipe_sub_type": "flat_file"}}`,
+			Want: []types.Component{
+				{
+					Name:    "Disk",
+					Type:    "data_type",
+					SubType: "flat_file",
+					UUID:    "",
+					Locations: []types.ComponentLocation{
+						{
+							Detector:     "rails",
+							FullFilename: "config/storage.yml",
+							Filename:     "config/storage.yml",
+							LineNumber:   5,
+						},
+					},
+				},
+			},
+		},
+		{
 			Name:        "single detection - interface - no classification",
 			FileContent: `{	"detector_type": "ruby", "type": "interface_classified", "source": {"filename": "billing.rb", "line_number": 2, "start_line_number": 2}}`,
 			Want:        []types.Component{},


### PR DESCRIPTION
## Description

By mistake we were sending the classification reason as the recipe type for framework detections.

Note: clean up work is required on the Cloud for existing data that has "recipe match" set as its component type, but this Bearer fix can be released independently

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [x] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
