### PR TITLE
fix: use of fatal, double error output and vague errors

### DIFF
--- a/cmd/bearer/main.go
+++ b/cmd/bearer/main.go
@@ -1,22 +1,16 @@
 package main
 
 import (
-	"github.com/bearer/bearer/cmd/bearer/build"
+	"os"
 
+	"github.com/bearer/bearer/cmd/bearer/build"
 	"github.com/bearer/bearer/internal/commands"
-	"github.com/bearer/bearer/internal/util/output"
 )
 
 func main() {
-	if err := run(); err != nil {
-		output.Fatal(err.Error())
-	}
-}
-
-func run() error {
 	app := commands.NewApp(build.Version, build.CommitSHA)
 	if err := app.Execute(); err != nil {
-		return err
+		// error messages are printed by the framework
+		os.Exit(1)
 	}
-	return nil
 }

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-context-flag
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-context-flag
@@ -48,5 +48,4 @@ General Flags
       --no-color                Disable color in output
 
 
-flag error: Scan flags error: invalid context argument; supported values: health
 

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag-privacy
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag-privacy
@@ -48,5 +48,4 @@ General Flags
       --no-color                Disable color in output
 
 
-flag error: Report flags error: invalid format argument for privacy report; supported values: csv, json, yaml, html
 

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag-security
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag-security
@@ -48,5 +48,4 @@ General Flags
       --no-color                Disable color in output
 
 
-flag error: Report flags error: invalid format argument for security report; supported values: json, yaml, sarif, gitlab-sast, rdjson, html, jsonv2
 

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-report-flag
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-report-flag
@@ -48,5 +48,4 @@ General Flags
       --no-color                Disable color in output
 
 
-flag error: Report flags error: invalid report argument; supported values: security, privacy
 

--- a/internal/commands/process/settings/rules.go
+++ b/internal/commands/process/settings/rules.go
@@ -95,7 +95,7 @@ func loadRuleDefinitionsFromRemote(
 	definitions map[string]RuleDefinition,
 	options flagtypes.RuleOptions,
 	versionMeta *version_check.VersionMeta,
-) {
+) (err error) {
 	if options.DisableDefaultRules {
 		return
 	}
@@ -111,11 +111,12 @@ func loadRuleDefinitionsFromRemote(
 		urls = append(urls, value)
 	}
 
-	err := LoadRuleDefinitionsFromUrls(definitions, urls)
+	err = LoadRuleDefinitionsFromUrls(definitions, urls)
 	if err != nil {
-		output.Fatal(fmt.Sprintf("Error loading rules: %s", err))
-		// sysexit
+		err = fmt.Errorf("loading rules failed: %s", err)
 	}
+
+	return
 }
 
 func loadRuleDefinitionsFromDir(definitions map[string]RuleDefinition, dir fs.FS) error {

--- a/internal/util/ignore/ignore.go
+++ b/internal/util/ignore/ignore.go
@@ -43,6 +43,9 @@ func GetIgnoredFingerprints(filePath string, target *string) (ignoredFingerprint
 	}
 
 	err = json.Unmarshal(content, &ignoredFingerprints)
+	if err != nil {
+		err = fmt.Errorf("ignore file '%s' is invalid - %s", ignoreFilePath, err)
+	}
 	return ignoredFingerprints, ignoreFilePath, true, err
 }
 


### PR DESCRIPTION
## Description

When `bearer.ignore`  is invalid you would receive an error like.

```
Error: unexpected end of JSON input
unexpected end of JSON input
exit status 1
```
This PR:

- Improves error handling for invalid `bearer.ignore` files to give more context
- Fixes issue where the error was printed twice
- Fixes some cases where errors resulted in a immediate call to fatal that did not flow though the normal framework error handling

New output 
```
Error: ignore file '/My/Path/bearer.ignore' is invalid - unexpected end of JSON input
exit status 1
```


<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [x] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
