### PR TITLE
docs: add links to discord and quickstart from issue menu

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Not sure where to start?
+    url: https://docs.bearer.com/quickstart/
+    about: Try our quickstart guides.
+  - name: Want to discuss your findings?
+    url: https://discord.gg/eaHZBJUXRF
+    about: Join our Discord community!


### PR DESCRIPTION
## Description
Take advantage of external link on issue creation see: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
