### PR TITLE
feat: unanchored class declaration

### DIFF
--- a/internal/languages/java/.snapshots/TestPattern-catch_types_is_a_container_type
+++ b/internal/languages/java/.snapshots/TestPattern-catch_types_is_a_container_type
@@ -1,5 +1,5 @@
 (*builder.Result)({
-  Query: (string) (len=334) "([(class_declaration  . name: (_) . [(class_body  [(method_declaration . [ (void_type )] @param1 . [ (identifier )] @param2 . [ (formal_parameters )] . [(block  [(try_statement  [ (block )] [(catch_clause   . [(catch_formal_parameter . [(catch_type (_) @match)] . [ (identifier )] @param3 .)]  . [ (block )] .)])] )] .)] )] .)] @root)",
+  Query: (string) (len=328) "([(class_declaration  name: (_) [(class_body  [(method_declaration . [ (void_type )] @param1 . [ (identifier )] @param2 . [ (formal_parameters )] . [(block  [(try_statement  [ (block )] [(catch_clause   . [(catch_formal_parameter . [(catch_type (_) @match)] . [ (identifier )] @param3 .)]  . [ (block )] .)])] )] .)] )])] @root)",
   VariableNames: ([]string) (len=1) {
     (string) (len=1) "_"
   },

--- a/internal/languages/java/.snapshots/TestPattern-method_params_is_a_container_type
+++ b/internal/languages/java/.snapshots/TestPattern-method_params_is_a_container_type
@@ -1,5 +1,5 @@
 (*builder.Result)({
-  Query: (string) (len=196) "([(class_declaration  . name: (_) . [(class_body  [(method_declaration . [ (void_type )] @param1 . [ (identifier )] @param2 . [(formal_parameters  . (_) @match . )] . [ (block )] .)] )] .)] @root)",
+  Query: (string) (len=190) "([(class_declaration  name: (_) [(class_body  [(method_declaration . [ (void_type )] @param1 . [ (identifier )] @param2 . [(formal_parameters  . (_) @match . )] . [ (block )] .)] )])] @root)",
   VariableNames: ([]string) (len=1) {
     (string) (len=1) "_"
   },

--- a/internal/languages/java/pattern/pattern.go
+++ b/internal/languages/java/pattern/pattern.go
@@ -101,7 +101,7 @@ func (*Pattern) IsAnchored(node *tree.Node) (bool, bool) {
 	// function block
 	// lambda () -> {} block
 	// try {} catch () {}
-	unAnchored := []string{"class_body", "block", "try_statement", "catch_type", "resource_specification"}
+	unAnchored := []string{"class_declaration", "class_body", "block", "try_statement", "catch_type", "resource_specification"}
 
 	isAnchored := !slices.Contains(unAnchored, parent.Type())
 	return isAnchored, isAnchored


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Unanchored `class_declaration` by default in Java to deal with modifier

Ref https://github.com/Bearer/bearer-rules/pull/196#discussion_r1467369775

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
