### PR TITLE
fix: return scan error if exists in parseDiff func

### DIFF
--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -108,6 +108,10 @@ func parseDiff(scanner *bufio.Scanner) ([]FilePatch, error) {
 
 	flush()
 
+	if err := scanner.Err(); err != nil {
+		return result, err
+	}
+
 	return result, nil
 }
 


### PR DESCRIPTION
## Description

When running Bearer with the `--diff` option and the scanner encounters an error it will return a `Error: signal: broken pipe`. This is because the error is not checked before returning from the `parseDiff` function.

Example command: `go run ./cmd/bearer/main.go scan ~/code/repo-with-long-line-diff --diff`

An example error would be a diff that contains a line longer than the [MaxScanTokenSize](https://pkg.go.dev/bufio@go1.21.7#pkg-constants). (64 * 1024 bytes). With this additional code, the returned error will be `Error: bufio.Scanner: token too long`.

I'll create a Github [issue](https://github.com/Bearer/bearer/issues/1509) to accommodate a more thorough fix for handling long lines of diff.

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [x] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
