### PR TITLE
fix: replace use of bufio.Scanner

### DIFF
--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -1,12 +1,13 @@
 package git
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"io"
 	"strconv"
 	"strings"
+
+	"github.com/bearer/bearer/internal/util/linescanner"
 )
 
 type ChunkRange struct {
@@ -46,7 +47,7 @@ func Diff(rootDir, baseRef string) ([]FilePatch, error) {
 		},
 		func(stdout io.Reader) error {
 			var err error
-			result, err = parseDiff(bufio.NewScanner(stdout))
+			result, err = parseDiff(linescanner.New(stdout))
 			if err != nil {
 				return err
 			}
@@ -58,7 +59,7 @@ func Diff(rootDir, baseRef string) ([]FilePatch, error) {
 	return result, err
 }
 
-func parseDiff(scanner *bufio.Scanner) ([]FilePatch, error) {
+func parseDiff(scanner *linescanner.Scanner) ([]FilePatch, error) {
 	var result []FilePatch
 	var fromPath, toPath string
 	var chunks []Chunk
@@ -108,7 +109,7 @@ func parseDiff(scanner *bufio.Scanner) ([]FilePatch, error) {
 
 	flush()
 
-	return result, nil
+	return result, scanner.Err()
 }
 
 func parseDiffHeader(value string) (string, string, error) {

--- a/internal/util/file/file.go
+++ b/internal/util/file/file.go
@@ -1,7 +1,6 @@
 package file
 
 import (
-	"bufio"
 	"fmt"
 	"io"
 	"os"
@@ -14,6 +13,7 @@ import (
 	"github.com/go-enry/go-enry/v2"
 	"github.com/rs/zerolog/log"
 
+	"github.com/bearer/bearer/internal/util/linescanner"
 	"github.com/bearer/bearer/internal/util/regex"
 
 	ignore "github.com/sabhiram/go-gitignore"
@@ -326,7 +326,7 @@ func ReadFileSinkLines(
 
 	defer file.Close()
 
-	scanner := bufio.NewScanner(file)
+	scanner := linescanner.New(file)
 	lineCounter := 1
 	var extract []Line
 
@@ -370,7 +370,7 @@ func ReadFileSingleLine(filePath string, lineNumber int) (string, error) {
 	}
 	defer file.Close()
 
-	scanner := bufio.NewScanner(file)
+	scanner := linescanner.New(file)
 	lineCounter := 1
 	for scanner.Scan() {
 		if lineCounter == lineNumber {


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Replaces all usage of `bufio.Scanner` with `linescanner.Scanner`. The `bufio` scanner has a limited buffer size and shouldn't be used.

Also returns the scanner error when parsing diffs.

## Related
- Close #1509 
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
