### PR TITLE
feat(javascript): unanchored method_definition

### DIFF
--- a/internal/languages/javascript/pattern/pattern.go
+++ b/internal/languages/javascript/pattern/pattern.go
@@ -104,7 +104,7 @@ func (*Pattern) IsAnchored(node *tree.Node) (bool, bool) {
 	// arrow functions statement_block
 	// function statement_block
 	// method statement_block
-	unAnchored := []string{"statement_block", "class_body", "object_pattern", "named_imports"}
+	unAnchored := []string{"statement_block", "class_body", "object_pattern", "named_imports", "method_definition"}
 
 	isAnchored := !slices.Contains(unAnchored, parent.Type())
 	return isAnchored, isAnchored


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Makes `method_declaration` unanchored by default to deal with `return_type`

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
