### PR TITLE
docs(rules): show documentation for built in gitleaks rule

### DIFF
--- a/docs/.eleventy.js
+++ b/docs/.eleventy.js
@@ -116,6 +116,11 @@ module.exports = function (eleventyConfig) {
     arr.sort((a, b) => (a.metadata.id > b.metadata.id ? 1 : -1))
     return arr
   })
+  eleventyConfig.addFilter("removeGitleaks", (arr) => {
+    return arr.filter((value) => {
+      value.metadata.id == "gitleaks"
+    })
+  })
   eleventyConfig.addFilter("setAttribute", (obj, key, value) => {
     obj[key] = value
     return obj

--- a/docs/_data/rules.js
+++ b/docs/_data/rules.js
@@ -8,6 +8,8 @@ const gitly = require("gitly")
 const source = "bearer/bearer-rules"
 const rulesPath = "_tmp/rules-data"
 const excludeDirectories = [".github", "scripts"]
+const gitleaksInternalRule =
+  "../internal/commands/process/settings/built_in_rules/third_party/gitleaks/secret_detection.yml"
 
 const counts = {
   languages: {},
@@ -77,6 +79,8 @@ async function fetchRelease() {
 async function fetchData(location) {
   const rules = []
   const dirs = await readdir(location)
+  const gitleaks = await fetchFile(gitleaksInternalRule, "/")
+  rules.push(gitleaks)
   // ex: looping through rules [ruby, gitleaks, sql]
   dirs.forEach(async (dir) => {
     const dirPath = path.join(location, dir)
@@ -147,7 +151,10 @@ async function fetchFile(location, breadcrumb) {
       lang = subdir[subdir.length - 3]
     }
 
-    updateCounts(lang, framework, out.metadata.id)
+    if (subdir && lang) {
+      updateCounts(lang, framework, out.metadata.id)
+    }
+
     if (out.metadata.cwe_id) {
       out.metadata.cwe_id.forEach((i) => {
         if (cweList[i] && cweList[i].owasp) {

--- a/docs/reference/rule-pages.njk
+++ b/docs/reference/rule-pages.njk
@@ -26,7 +26,11 @@ eleventyComputed:
   {% endif %}
   <li>
     <strong>Source:</strong>
+    {% if rule.metadata.id == "gitleaks" %}
+    N/A
+    {% else %}
     <a class="text-main dark:text-main-300 hover:underline" href="https://github.com/bearer/bearer-rules/blob/main/rules/{{rule.location}}.yml">{{rule.name}}.yml</a>
+    {% endif %}
   </li>
 </ul>
 {% renderTemplate 'liquid,md',
@@ -60,7 +64,7 @@ rule.metadata %}
       </ul>
     {% endif %}
   {% endif %}
-
+  {% if rule.metadata.id != "gitleaks" %}
   {% renderTemplate "liquid,md",
   rule.metadata %}
   ## Configuration
@@ -75,3 +79,16 @@ rule.metadata %}
   bearer scan /path/to/your-project/ --only-rule={{id}}
   ```
 {% endrenderTemplate %}
+{% else %}
+  {% renderTemplate "liquid,md",
+  rule.metadata %}
+  ## Configuration
+
+  This is a built in rule that represents findings from the secrets scanner.
+
+  To enable this during a scan, use the following flag
+  ```shell
+  bearer scan /path/to/your-project/ --scanner=secrets,sast
+  ```
+{% endrenderTemplate %}
+{% endif %}

--- a/docs/rules.csv.njk
+++ b/docs/rules.csv.njk
@@ -5,5 +5,5 @@ layout: false
 ---
 
 Language; Rule Title; Rule ID; Framework; CWE; Doc
-{% for rule in rules.rules | sortById %}{{ rule.languages | join(", ")}}; {{ rule.metadata.description | safe }}; {{ rule.metadata.id }} ;{{ rule.framework }}; {{ rule.metadata.cwe_id | join(", ")}}; {{ rule.metadata.documentation_url }}
+{% for rule in rules.rules | sortById | removeGitleaks %}{{ rule.languages | join(", ")}}; {{ rule.metadata.description | safe }}; {{ rule.metadata.id }} ;{{ rule.framework }}; {{ rule.metadata.cwe_id | join(", ")}}; {{ rule.metadata.documentation_url }}
 {% endfor %}

--- a/e2e/rules/.snapshots/TestSecrets-secrets
+++ b/e2e/rules/.snapshots/TestSecrets-secrets
@@ -7,7 +7,7 @@ high:
         description: |
             ## Description
 
-            Hard-coding secrets in a project opens them up to leakage. This rule checks for common secret types such as keys, tokens, and passwords using the popular Gitleaks library and ensures they aren't hard-coded.
+            Hard-coding secrets in a project opens them up to leakage. This rule checks for common secret types such as keys, tokens, and passwords using the popular Gitleaks library and ensures they aren't hard-coded. This rule is part of the secrets scanner and language agnostic.
 
             ## Remediations
 
@@ -15,7 +15,7 @@ high:
 
             ## Resources
             - [Gitleaks](https://gitleaks.io/)
-        documentation_url: ""
+        documentation_url: https://docs.bearer.com/reference/rules/gitleaks
       line_number: 3
       full_filename: e2e/rules/testdata/data/secrets/leaked.rb
       filename: leaked.rb

--- a/internal/commands/process/settings/built_in_rules/third_party/gitleaks/secret_detection.yml
+++ b/internal/commands/process/settings/built_in_rules/third_party/gitleaks/secret_detection.yml
@@ -6,7 +6,7 @@ metadata:
   remediation_message: |
     ## Description
 
-    Hard-coding secrets in a project opens them up to leakage. This rule checks for common secret types such as keys, tokens, and passwords using the popular Gitleaks library and ensures they aren't hard-coded.
+    Hard-coding secrets in a project opens them up to leakage. This rule checks for common secret types such as keys, tokens, and passwords using the popular Gitleaks library and ensures they aren't hard-coded. This rule is part of the secrets scanner and language agnostic.
 
     ## Remediations
 
@@ -17,3 +17,4 @@ metadata:
   cwe_id:
     - 798
   id: gitleaks
+  documentation_url: https://docs.bearer.com/reference/rules/gitleaks


### PR DESCRIPTION
## Description
Add gitleaks to doc pages 

## Related
- #1520

## Checklist

- [x] I've added test coverage that shows my fix or feature works as expected.
- [x] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
