### PR TITLE
feat: allow test files to be scanned

### DIFF
--- a/docs/_data/bearer_scan.yaml
+++ b/docs/_data/bearer_scan.yaml
@@ -162,6 +162,11 @@ options:
       Specify the comma-separated ids of the rules you would like to skip. Runs all other rules.
     environment_variables:
       - BEARER_SKIP_RULE
+  - name: skip-test
+    default_value: "true"
+    usage: Disable automatic skipping of test files
+    environment_variables:
+      - BEARER_SKIP_TEST
 example: |4-
       # Scan a local project, including language-specific files
       $ bearer scan /path/to/your_project

--- a/e2e/flags/.snapshots/TestInitCommand
+++ b/e2e/flags/.snapshots/TestInitCommand
@@ -26,4 +26,5 @@ scan:
     scanner:
         - sast
     skip-path: []
+    skip-test: true
 

--- a/e2e/flags/.snapshots/TestMetadataFlags-help-scan
+++ b/e2e/flags/.snapshots/TestMetadataFlags-help-scan
@@ -36,6 +36,7 @@ Scan Flags
       --quiet                                Suppress non-essential messages
       --scanner strings                      Specify which scanner to use e.g. --scanner=secrets, --scanner=secrets,sast (default [sast])
       --skip-path strings                    Specify the comma separated files and directories to skip. Supports * syntax, e.g. --skip-path users/*.go,users/admin.sql
+      --skip-test                            Disable automatic skipping of test files (default true)
 
 General Flags
       --api-key string          Use your Bearer API Key to send the report to Bearer.

--- a/e2e/flags/.snapshots/TestMetadataFlags-scan-help
+++ b/e2e/flags/.snapshots/TestMetadataFlags-scan-help
@@ -36,6 +36,7 @@ Scan Flags
       --quiet                                Suppress non-essential messages
       --scanner strings                      Specify which scanner to use e.g. --scanner=secrets, --scanner=secrets,sast (default [sast])
       --skip-path strings                    Specify the comma separated files and directories to skip. Supports * syntax, e.g. --skip-path users/*.go,users/admin.sql
+      --skip-test                            Disable automatic skipping of test files (default true)
 
 General Flags
       --api-key string          Use your Bearer API Key to send the report to Bearer.

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-context-flag
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-context-flag
@@ -37,6 +37,7 @@ Scan Flags
       --quiet                                Suppress non-essential messages
       --scanner strings                      Specify which scanner to use e.g. --scanner=secrets, --scanner=secrets,sast (default [sast])
       --skip-path strings                    Specify the comma separated files and directories to skip. Supports * syntax, e.g. --skip-path users/*.go,users/admin.sql
+      --skip-test                            Disable automatic skipping of test files (default true)
 
 General Flags
       --api-key string          Use your Bearer API Key to send the report to Bearer.

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag-privacy
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag-privacy
@@ -37,6 +37,7 @@ Scan Flags
       --quiet                                Suppress non-essential messages
       --scanner strings                      Specify which scanner to use e.g. --scanner=secrets, --scanner=secrets,sast (default [sast])
       --skip-path strings                    Specify the comma separated files and directories to skip. Supports * syntax, e.g. --skip-path users/*.go,users/admin.sql
+      --skip-test                            Disable automatic skipping of test files (default true)
 
 General Flags
       --api-key string          Use your Bearer API Key to send the report to Bearer.

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag-security
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag-security
@@ -37,6 +37,7 @@ Scan Flags
       --quiet                                Suppress non-essential messages
       --scanner strings                      Specify which scanner to use e.g. --scanner=secrets, --scanner=secrets,sast (default [sast])
       --skip-path strings                    Specify the comma separated files and directories to skip. Supports * syntax, e.g. --skip-path users/*.go,users/admin.sql
+      --skip-test                            Disable automatic skipping of test files (default true)
 
 General Flags
       --api-key string          Use your Bearer API Key to send the report to Bearer.

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-report-flag
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-report-flag
@@ -37,6 +37,7 @@ Scan Flags
       --quiet                                Suppress non-essential messages
       --scanner strings                      Specify which scanner to use e.g. --scanner=secrets, --scanner=secrets,sast (default [sast])
       --skip-path strings                    Specify the comma separated files and directories to skip. Supports * syntax, e.g. --skip-path users/*.go,users/admin.sql
+      --skip-test                            Disable automatic skipping of test files (default true)
 
 General Flags
       --api-key string          Use your Bearer API Key to send the report to Bearer.

--- a/internal/commands/process/orchestrator/worker/worker.go
+++ b/internal/commands/process/orchestrator/worker/worker.go
@@ -34,11 +34,13 @@ type Worker struct {
 	classifer       *classification.Classifier
 	enabledScanners []string
 	sastScanner     *scanner.Scanner
+	skipTest        bool
 }
 
 func (worker *Worker) Setup(config config.Config) error {
 	worker.debug = config.Debug
 	worker.enabledScanners = config.Scan.Scanner
+	worker.skipTest = config.Scan.SkipTest
 
 	if slices.Contains(worker.enabledScanners, "sast") {
 		classifier, err := classification.NewClassifier(&classification.Config{Config: config})
@@ -86,6 +88,7 @@ func (worker *Worker) Scan(ctx context.Context, scanRequest work.ProcessRequest)
 		fileStats,
 		worker.enabledScanners,
 		worker.sastScanner,
+		worker.skipTest,
 	)
 
 	if ctx.Err() != nil {

--- a/internal/detectors/detectors.go
+++ b/internal/detectors/detectors.go
@@ -140,6 +140,7 @@ func Extract(
 	fileStats *stats.FileStats,
 	enabledScanners []string,
 	sastScanner *scanner.Scanner,
+	skipTest bool,
 ) error {
 	return ExtractWithDetectors(
 		ctx,
@@ -149,6 +150,7 @@ func Extract(
 		fileStats,
 		Registrations(enabledScanners),
 		sastScanner,
+		skipTest,
 	)
 }
 
@@ -160,6 +162,7 @@ func ExtractWithDetectors(
 	fileStats *stats.FileStats,
 	allDetectors []InitializedDetector,
 	sastScanner *scanner.Scanner,
+	skipTest bool,
 ) error {
 
 	activeDetectors := make(map[InitializedDetector]activeDetector)
@@ -167,6 +170,7 @@ func ExtractWithDetectors(
 	if err := file.IterateFilesList(
 		rootDir,
 		[]string{filename},
+		skipTest,
 		func(dir *file.Path) (bool, error) {
 			for _, detector := range allDetectors {
 				active, isActive := activeDetectors[detector]

--- a/internal/detectors/internal/testhelper/testhelper.go
+++ b/internal/detectors/internal/testhelper/testhelper.go
@@ -53,7 +53,7 @@ func Extract(
 	}
 
 	for _, filename := range files {
-		err = detectors.ExtractWithDetectors(context.Background(), path, filename, &report, nil, registrations, nil)
+		err = detectors.ExtractWithDetectors(context.Background(), path, filename, &report, nil, registrations, nil, true)
 		if !assert.Nil(t, err) {
 			t.Errorf("report has errored %s", err)
 		}

--- a/internal/flag/scan_flags.go
+++ b/internal/flag/scan_flags.go
@@ -34,6 +34,12 @@ var (
 		Value:      []string{},
 		Usage:      "Specify the comma separated files and directories to skip. Supports * syntax, e.g. --skip-path users/*.go,users/admin.sql",
 	})
+	SkipTestFlag = ScanFlagGroup.add(flagtypes.Flag{
+		Name:       "skip-test",
+		ConfigName: "scan.skip-test",
+		Value:      true,
+		Usage:      "Disable automatic skipping of test files",
+	})
 	DisableDomainResolutionFlag = ScanFlagGroup.add(flagtypes.Flag{
 		Name:       "disable-domain-resolution",
 		ConfigName: "scan.disable-domain-resolution",
@@ -162,6 +168,7 @@ func (scanFlagGroup) SetOptions(options *flagtypes.Options, args []string) error
 
 	options.ScanOptions = flagtypes.ScanOptions{
 		SkipPath:                getStringSlice(SkipPathFlag),
+		SkipTest:                getBool(SkipTestFlag),
 		DisableDomainResolution: getBool(DisableDomainResolutionFlag),
 		DomainResolutionTimeout: getDuration(DomainResolutionTimeoutFlag),
 		InternalDomains:         getStringSlice(InternalDomainsFlag),

--- a/internal/flag/types/types.go
+++ b/internal/flag/types/types.go
@@ -60,6 +60,7 @@ type Options struct {
 
 type ScanOptions struct {
 	Target                  string        `mapstructure:"target" json:"target" yaml:"target"`
+	SkipTest                bool          `mapstructure:"skip-test" json:"skip-test" yaml:"skip-test"`
 	SkipPath                []string      `mapstructure:"skip-path" json:"skip-path" yaml:"skip-path"`
 	DisableDomainResolution bool          `mapstructure:"disable-domain-resolution" json:"disable-domain-resolution" yaml:"disable-domain-resolution"`
 	DomainResolutionTimeout time.Duration `mapstructure:"domain-resolution-timeout" json:"domain-resolution-timeout" yaml:"domain-resolution-timeout"`


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Accept another flag `--skip-test` to skip the test files.
By default, the flag is set to `true`.

Can be set using env variable `BEARER_SKIP_TEST=false` or by using the CLI argument `--skip-test=false`

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
