### PR TITLE
fix: fixes for go ga

### DIFF
--- a/internal/languages/golang/.snapshots/TestImport--main.yml
+++ b/internal/languages/golang/.snapshots/TestImport--main.yml
@@ -6,62 +6,6 @@ high:
         title: Test imports
         description: Test imports
         documentation_url: ""
-      line_number: 11
-      full_filename: main.go
-      filename: main.go
-      source:
-        location:
-            start: 11
-            end: 11
-            column:
-                start: 2
-                end: 12
-      sink:
-        location:
-            start: 11
-            end: 11
-            column:
-                start: 2
-                end: 12
-        content: ""
-      parent_line_number: 11
-      fingerprint: 7cec89718a2276537c30e7b656c0ecb2_0
-      old_fingerprint: 7cec89718a2276537c30e7b656c0ecb2_0
-    - rule:
-        cwe_ids:
-            - "42"
-        id: import_test
-        title: Test imports
-        description: Test imports
-        documentation_url: ""
-      line_number: 12
-      full_filename: main.go
-      filename: main.go
-      source:
-        location:
-            start: 12
-            end: 12
-            column:
-                start: 2
-                end: 12
-      sink:
-        location:
-            start: 12
-            end: 12
-            column:
-                start: 2
-                end: 12
-        content: ""
-      parent_line_number: 12
-      fingerprint: 7cec89718a2276537c30e7b656c0ecb2_1
-      old_fingerprint: 7cec89718a2276537c30e7b656c0ecb2_1
-    - rule:
-        cwe_ids:
-            - "42"
-        id: import_test
-        title: Test imports
-        description: Test imports
-        documentation_url: ""
       line_number: 13
       full_filename: main.go
       filename: main.go
@@ -71,16 +15,128 @@ high:
             end: 13
             column:
                 start: 2
-                end: 12
+                end: 10
       sink:
         location:
             start: 13
             end: 13
             column:
                 start: 2
-                end: 12
+                end: 10
         content: ""
       parent_line_number: 13
+      fingerprint: 7cec89718a2276537c30e7b656c0ecb2_0
+      old_fingerprint: 7cec89718a2276537c30e7b656c0ecb2_0
+    - rule:
+        cwe_ids:
+            - "42"
+        id: import_test
+        title: Test imports
+        description: Test imports
+        documentation_url: ""
+      line_number: 14
+      full_filename: main.go
+      filename: main.go
+      source:
+        location:
+            start: 14
+            end: 14
+            column:
+                start: 2
+                end: 10
+      sink:
+        location:
+            start: 14
+            end: 14
+            column:
+                start: 2
+                end: 10
+        content: ""
+      parent_line_number: 14
+      fingerprint: 7cec89718a2276537c30e7b656c0ecb2_1
+      old_fingerprint: 7cec89718a2276537c30e7b656c0ecb2_1
+    - rule:
+        cwe_ids:
+            - "42"
+        id: import_test
+        title: Test imports
+        description: Test imports
+        documentation_url: ""
+      line_number: 15
+      full_filename: main.go
+      filename: main.go
+      source:
+        location:
+            start: 15
+            end: 15
+            column:
+                start: 2
+                end: 10
+      sink:
+        location:
+            start: 15
+            end: 15
+            column:
+                start: 2
+                end: 10
+        content: ""
+      parent_line_number: 15
       fingerprint: 7cec89718a2276537c30e7b656c0ecb2_2
       old_fingerprint: 7cec89718a2276537c30e7b656c0ecb2_2
+    - rule:
+        cwe_ids:
+            - "42"
+        id: import_test
+        title: Test imports
+        description: Test imports
+        documentation_url: ""
+      line_number: 16
+      full_filename: main.go
+      filename: main.go
+      source:
+        location:
+            start: 16
+            end: 16
+            column:
+                start: 2
+                end: 10
+      sink:
+        location:
+            start: 16
+            end: 16
+            column:
+                start: 2
+                end: 10
+        content: ""
+      parent_line_number: 16
+      fingerprint: 7cec89718a2276537c30e7b656c0ecb2_3
+      old_fingerprint: 7cec89718a2276537c30e7b656c0ecb2_3
+    - rule:
+        cwe_ids:
+            - "42"
+        id: import_test
+        title: Test imports
+        description: Test imports
+        documentation_url: ""
+      line_number: 17
+      full_filename: main.go
+      filename: main.go
+      source:
+        location:
+            start: 17
+            end: 17
+            column:
+                start: 2
+                end: 10
+      sink:
+        location:
+            start: 17
+            end: 17
+            column:
+                start: 2
+                end: 10
+        content: ""
+      parent_line_number: 17
+      fingerprint: 7cec89718a2276537c30e7b656c0ecb2_4
+      old_fingerprint: 7cec89718a2276537c30e7b656c0ecb2_4
 

--- a/internal/languages/golang/.snapshots/TestImport--main.yml
+++ b/internal/languages/golang/.snapshots/TestImport--main.yml
@@ -1,0 +1,86 @@
+high:
+    - rule:
+        cwe_ids:
+            - "42"
+        id: import_test
+        title: Test imports
+        description: Test imports
+        documentation_url: ""
+      line_number: 11
+      full_filename: main.go
+      filename: main.go
+      source:
+        location:
+            start: 11
+            end: 11
+            column:
+                start: 2
+                end: 12
+      sink:
+        location:
+            start: 11
+            end: 11
+            column:
+                start: 2
+                end: 12
+        content: ""
+      parent_line_number: 11
+      fingerprint: 7cec89718a2276537c30e7b656c0ecb2_0
+      old_fingerprint: 7cec89718a2276537c30e7b656c0ecb2_0
+    - rule:
+        cwe_ids:
+            - "42"
+        id: import_test
+        title: Test imports
+        description: Test imports
+        documentation_url: ""
+      line_number: 12
+      full_filename: main.go
+      filename: main.go
+      source:
+        location:
+            start: 12
+            end: 12
+            column:
+                start: 2
+                end: 12
+      sink:
+        location:
+            start: 12
+            end: 12
+            column:
+                start: 2
+                end: 12
+        content: ""
+      parent_line_number: 12
+      fingerprint: 7cec89718a2276537c30e7b656c0ecb2_1
+      old_fingerprint: 7cec89718a2276537c30e7b656c0ecb2_1
+    - rule:
+        cwe_ids:
+            - "42"
+        id: import_test
+        title: Test imports
+        description: Test imports
+        documentation_url: ""
+      line_number: 13
+      full_filename: main.go
+      filename: main.go
+      source:
+        location:
+            start: 13
+            end: 13
+            column:
+                start: 2
+                end: 12
+      sink:
+        location:
+            start: 13
+            end: 13
+            column:
+                start: 2
+                end: 12
+        content: ""
+      parent_line_number: 13
+      fingerprint: 7cec89718a2276537c30e7b656c0ecb2_2
+      old_fingerprint: 7cec89718a2276537c30e7b656c0ecb2_2
+

--- a/internal/languages/golang/analyzer/analyzer.go
+++ b/internal/languages/golang/analyzer/analyzer.go
@@ -111,7 +111,9 @@ func (analyzer *analyzer) analyzeImportSpec(node *sitter.Node, visitChildren fun
 		}
 	}
 
-	analyzer.scope.Declare(strings.TrimSuffix(guessedName, "-go"), path)
+	guessedName = strings.TrimSuffix(guessedName, "-go")
+	guessedName = strings.TrimPrefix(guessedName, "go-")
+	analyzer.scope.Declare(guessedName, path)
 
 	return visitChildren()
 }

--- a/internal/languages/golang/analyzer/analyzer.go
+++ b/internal/languages/golang/analyzer/analyzer.go
@@ -98,19 +98,20 @@ func (analyzer *analyzer) analyzeImportSpec(node *sitter.Node, visitChildren fun
 	name := node.ChildByFieldName("name")
 	path := node.ChildByFieldName("path")
 
+	var guessedName string
 	if name != nil {
-		analyzer.scope.Declare(analyzer.builder.ContentFor(name), path)
+		guessedName = analyzer.builder.ContentFor(name)
 	} else {
 		packageName := strings.Split(analyzer.builder.ContentFor(path), "/")
-		guessedName := stringutil.StripQuotes((packageName[len(packageName)-1]))
+		guessedName = stringutil.StripQuotes((packageName[len(packageName)-1]))
 
 		// account for imports like `github.com/airbrake/gobrake/v5`
 		if versionRegex.MatchString(guessedName) && len(packageName) > 1 {
 			guessedName = stringutil.StripQuotes((packageName[len(packageName)-2]))
 		}
-
-		analyzer.scope.Declare(guessedName, path)
 	}
+
+	analyzer.scope.Declare(strings.TrimSuffix(guessedName, "-go"), path)
 
 	return visitChildren()
 }

--- a/internal/languages/golang/analyzer/analyzer.go
+++ b/internal/languages/golang/analyzer/analyzer.go
@@ -13,6 +13,7 @@ import (
 )
 
 var versionRegex = regexp.MustCompile(`\Av\d+\z`)
+var versionSuffixRegex = regexp.MustCompile(`\.v\d+\z`)
 
 type analyzer struct {
 	builder *tree.Builder
@@ -109,6 +110,9 @@ func (analyzer *analyzer) analyzeImportSpec(node *sitter.Node, visitChildren fun
 		if versionRegex.MatchString(guessedName) && len(packageName) > 1 {
 			guessedName = stringutil.StripQuotes((packageName[len(packageName)-2]))
 		}
+
+		// account for imports like `github.com/foo/bar.v3`
+		guessedName = versionSuffixRegex.ReplaceAllString(guessedName, "")
 	}
 
 	guessedName = strings.TrimSuffix(guessedName, "-go")

--- a/internal/languages/golang/analyzer/analyzer.go
+++ b/internal/languages/golang/analyzer/analyzer.go
@@ -61,7 +61,7 @@ func (analyzer *analyzer) Analyze(node *sitter.Node, visitChildren func() error)
 	case "identifier":
 		return visitChildren()
 	case "index_expression":
-		return visitChildren()
+		return analyzer.analyzeIndexExpression(node, visitChildren)
 	default:
 		analyzer.builder.Dataflow(node, analyzer.builder.ChildrenFor(node)...)
 		return visitChildren()
@@ -191,6 +191,13 @@ func (analyzer *analyzer) analyzeSelectorExpression(node *sitter.Node, visitChil
 	return visitChildren()
 }
 
+// foo[bar]
+func (analyzer *analyzer) analyzeIndexExpression(node *sitter.Node, visitChildren func() error) error {
+	analyzer.lookupVariable(node.ChildByFieldName("operand"))
+
+	return visitChildren()
+}
+
 // method parameter declaration
 //
 // fn(a string)
@@ -244,6 +251,5 @@ func (analyzer *analyzer) lookupVariable(node *sitter.Node) {
 
 	if pointsToNode := analyzer.scope.Lookup(analyzer.builder.ContentFor(node)); pointsToNode != nil {
 		analyzer.builder.Alias(node, pointsToNode)
-	} else {
 	}
 }

--- a/internal/languages/golang/golang_test.go
+++ b/internal/languages/golang/golang_test.go
@@ -13,10 +13,17 @@ var loggerRule []byte
 //go:embed testdata/scope_rule.yml
 var scopeRule []byte
 
+//go:embed testdata/import_rule.yml
+var importRule []byte
+
 func TestFlow(t *testing.T) {
 	testhelper.GetRunner(t, loggerRule, "Go").RunTest(t, "./testdata/testcases/flow", ".snapshots/flow/")
 }
 
 func TestScope(t *testing.T) {
 	testhelper.GetRunner(t, scopeRule, "Go").RunTest(t, "./testdata/scope", ".snapshots/")
+}
+
+func TestImport(t *testing.T) {
+	testhelper.GetRunner(t, importRule, "Go").RunTest(t, "./testdata/import", ".snapshots/")
 }

--- a/internal/languages/golang/pattern/pattern.go
+++ b/internal/languages/golang/pattern/pattern.go
@@ -164,6 +164,10 @@ func (*Pattern) IsRoot(node *tree.Node) bool {
 }
 
 func (patternLanguage *Pattern) NodeTypes(node *tree.Node) []string {
+	if node.Type() == "identifier" && node.Parent().Type() == "source_file" {
+		return []string{"identifier", "package_identifier"}
+	}
+
 	return []string{node.Type()}
 }
 

--- a/internal/languages/golang/testdata/import/main.go
+++ b/internal/languages/golang/testdata/import/main.go
@@ -1,0 +1,15 @@
+package main
+
+import "example.com/bar/v5"
+import "example.com/foo"
+
+import (
+	baz "example.com/foo"
+)
+
+func m() {
+	foo.Test()
+	bar.Test()
+	baz.Test()
+	other.Test()
+}

--- a/internal/languages/golang/testdata/import/main.go
+++ b/internal/languages/golang/testdata/import/main.go
@@ -1,15 +1,19 @@
 package main
 
-import "example.com/bar/v5"
-import "example.com/foo"
-
 import (
-	baz "example.com/foo"
+	"example.com/a/v5"
+	"example.com/b"
+	"example.com/c-go.v5"
+	"example.com/go-d"
+
+	e "example.com/foo"
 )
 
 func m() {
-	foo.Test()
-	bar.Test()
-	baz.Test()
+	a.Test()
+	b.Test()
+	c.Test()
+	d.Test()
+	e.Test()
 	other.Test()
 }

--- a/internal/languages/golang/testdata/import_rule.yml
+++ b/internal/languages/golang/testdata/import_rule.yml
@@ -9,8 +9,10 @@ patterns:
 auxiliary:
   - id: import_test_package
     patterns:
-      - import $<!>"example.com/bar/v5"
-      - import $<!>"example.com/foo"
+      - import ($<!>"example.com/a/v5")
+      - import ($<!>"example.com/b")
+      - import ($<!>"example.com/c-go.v5")
+      - import ($<!>"example.com/go-d")
       - import ($<!>"example.com/foo")
 severity: high
 metadata:

--- a/internal/languages/golang/testdata/import_rule.yml
+++ b/internal/languages/golang/testdata/import_rule.yml
@@ -1,0 +1,21 @@
+languages:
+  - go
+patterns:
+  - pattern: $<PACKAGE>.Test()
+    filters:
+      - variable: PACKAGE
+        detection: import_test_package
+        scope: cursor
+auxiliary:
+  - id: import_test_package
+    patterns:
+      - import $<!>"example.com/bar/v5"
+      - import $<!>"example.com/foo"
+      - import ($<!>"example.com/foo")
+severity: high
+metadata:
+  description: Test imports
+  remediation_message: Test imports
+  cwe_id:
+    - 42
+  id: import_test


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Makes the following fixes/improvements for Go GA:
- Guess package names for versioned imports. eg. `github.com/bearer/foo/v2` guesses `foo` as the package name
- Strip `go-` prefix and `-go` suffix from package names
- Allow rule patterns consisting of a single identifier to match package identifiers
- Lookup operand for index operations

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
