### PR TITLE
fix: handle duplicate var names in assignment

### DIFF
--- a/internal/languages/golang/analyzer/analyzer.go
+++ b/internal/languages/golang/analyzer/analyzer.go
@@ -149,6 +149,11 @@ func (analyzer *analyzer) analyzeShortVarDeclaration(node *sitter.Node, visitChi
 	left := node.ChildByFieldName("left")
 	right := node.ChildByFieldName("right")
 
+	err := visitChildren()
+	if err != nil {
+		return err
+	}
+
 	for _, child := range analyzer.builder.ChildrenFor(left) {
 		if !slices.Contains([]string{"_", ",", "err"}, analyzer.builder.ContentFor(child)) {
 			analyzer.scope.Declare(analyzer.builder.ContentFor(child), child)
@@ -161,22 +166,22 @@ func (analyzer *analyzer) analyzeShortVarDeclaration(node *sitter.Node, visitChi
 		analyzer.lookupVariable(child)
 	}
 
-	err := visitChildren()
-
-	return err
+	return nil
 }
 
 // var a, b string
 func (analyzer *analyzer) analyzeVarSpecDeclaration(node *sitter.Node, visitChildren func() error) error {
+	err := visitChildren()
+	if err != nil {
+		return err
+	}
+
 	for _, child := range analyzer.builder.ChildrenFor(node) {
 		if child.Type() == "identifier" {
 			analyzer.scope.Declare(analyzer.builder.ContentFor(child), child)
 		}
 	}
-
-	err := visitChildren()
-
-	return err
+	return nil
 }
 
 // foo(1, 2)

--- a/internal/languages/golang/detectors/.snapshots/TestGoObjects-object_no_class
+++ b/internal/languages/golang/detectors/.snapshots/TestGoObjects-object_no_class
@@ -109,8 +109,6 @@ children:
                       id: 22
                       range: 6:2 - 6:6
                       content: user
-                      alias_of:
-                        - 20
                 - type: '":="'
                   id: 23
                   range: 6:7 - 6:9

--- a/internal/languages/golang/detectors/.snapshots/TestGoString-string
+++ b/internal/languages/golang/detectors/.snapshots/TestGoString-string
@@ -200,8 +200,6 @@ children:
                       id: 41
                       range: 11:2 - 11:3
                       content: s
-                      alias_of:
-                        - 39
                 - type: '":="'
                   id: 42
                   range: 11:4 - 11:6
@@ -363,8 +361,6 @@ children:
                       id: 72
                       range: 15:2 - 15:4
                       content: s2
-                      alias_of:
-                        - 70
                 - type: '":="'
                   id: 73
                   range: 15:5 - 15:7
@@ -578,8 +574,6 @@ children:
                       id: 114
                       range: 20:2 - 20:4
                       content: s3
-                      alias_of:
-                        - 112
                 - type: '":="'
                   id: 115
                   range: 20:5 - 20:7


### PR DESCRIPTION
## Description

We were hitting issues with overridden var names e.g. 

```
	t := template.New()
	t, err := t.Parse(tmpl)
```

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
