### PR TITLE
docs(go): mark Golang as GA

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <br /><br />
   Bearer CLI is a static application security testing (SAST) tool that scans your source code and analyzes your data flows to discover, filter and prioritize security and privacy risks.
   <br /><br />
-  Currently supporting: <strong>JavaScript/TypeScript</strong> (GA), <strong>Ruby</strong> (GA), <strong>PHP</strong> (GA), <strong>Java</strong> (GA), <strong>Go</strong> (Beta), <strong>Python</strong> (Alpha) - <a href="https://docs.bearer.com/reference/supported-languages/">Learn more</a>
+  Currently supporting: <strong>JavaScript/TypeScript</strong> (GA), <strong>Ruby</strong> (GA), <strong>PHP</strong> (GA), <strong>Java</strong> (GA), <strong>Go</strong> (GA), <strong>Python</strong> (Alpha) - <a href="https://docs.bearer.com/reference/supported-languages/">Learn more</a>
 
   <br /><br />
 
@@ -259,11 +259,11 @@ Bearer CLI currently supports:
 <table>
   <tr>
     <td>GA</td>
-    <td>JavaScript/TypeScript, Ruby, PHP, Java</td>
+    <td>JavaScript/TypeScript, Ruby, PHP, Java, Go</td>
   </tr>
   <tr>
     <td>Beta</td>
-    <td>Go</td>
+    <td>-</td>
   </tr>
   <tr>
     <td>Alpha</td>

--- a/docs/reference/supported-languages.njk
+++ b/docs/reference/supported-languages.njk
@@ -42,7 +42,7 @@ supportChart:
     rules: true
     searchName: lang-go
     searchTerm: go_
-    status: Beta
+    status: GA
   python:
     name: Python
     frameworks: []


### PR DESCRIPTION
## Description

Mark Golang as GA language.

Golang was the only Beta language until this change; however, to keep constant representation of the three levels (alpha, beta, GA), we do not remove the "Beta" row in the README table but instead add a placeholder marker

<img width="572" alt="Screenshot 2024-04-09 at 12 53 17" src="https://github.com/Bearer/bearer/assets/4560746/52c361eb-6089-4ec2-b61b-90877e2ac378">

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.
- [ ] I've included usage information in the description if CLI behavior was updated or added.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
