### PR TITLE
fix(python): update analyzer

### DIFF
--- a/internal/languages/python/analyzer/analyzer.go
+++ b/internal/languages/python/analyzer/analyzer.go
@@ -150,7 +150,7 @@ func (analyzer *analyzer) analyzeBoolean(node *sitter.Node, visitChildren func()
 	return visitChildren()
 }
 
-func (analyzer *analyzer) analyzeKeywordArgumentOperation(node *sitter.Node, visitChildren func() error) error {
+func (analyzer *analyzer) analyzeKeywordArgument(node *sitter.Node, visitChildren func() error) error {
 	value := node.ChildByFieldName("value")
 
 	analyzer.builder.Alias(node, value)

--- a/internal/languages/python/analyzer/analyzer.go
+++ b/internal/languages/python/analyzer/analyzer.go
@@ -35,10 +35,12 @@ func (analyzer *analyzer) Analyze(node *sitter.Node, visitChildren func() error)
 		return analyzer.analyzeSubscript(node, visitChildren)
 	case "call":
 		return analyzer.analyzeCall(node, visitChildren)
-	case "argument_list":
+	case "argument_list", "expression_statement", "list", "tuple":
 		return analyzer.analyzeGenericOperation(node, visitChildren)
-	case "expression_statement":
-		return analyzer.analyzeGenericOperation(node, visitChildren)
+	case "parenthesized_expression":
+		return analyzer.analyzeGenericConstruct(node, visitChildren)
+	case "keyword_argument":
+		return analyzer.analyzeKeywordArgumentOperation(node, visitChildren)
 	case "while_statement", "try_statement", "if_statement": // statements don't have results
 		return visitChildren()
 	case "conditional_expression":
@@ -144,6 +146,27 @@ func (analyzer *analyzer) analyzeBoolean(node *sitter.Node, visitChildren func()
 	analyzer.lookupVariable(right)
 
 	analyzer.builder.Alias(node, left, right)
+
+	return visitChildren()
+}
+
+func (analyzer *analyzer) analyzeKeywordArgumentOperation(node *sitter.Node, visitChildren func() error) error {
+	value := node.ChildByFieldName("value")
+
+	analyzer.builder.Alias(node, value)
+	analyzer.lookupVariable(value)
+
+	return visitChildren()
+}
+
+// default analysis, where the children are assumed to be aliases
+func (analyzer *analyzer) analyzeGenericConstruct(node *sitter.Node, visitChildren func() error) error {
+	children := analyzer.builder.ChildrenFor(node)
+	analyzer.builder.Alias(node, children...)
+
+	for _, child := range children {
+		analyzer.lookupVariable(child)
+	}
 
 	return visitChildren()
 }

--- a/internal/languages/python/analyzer/analyzer.go
+++ b/internal/languages/python/analyzer/analyzer.go
@@ -40,7 +40,7 @@ func (analyzer *analyzer) Analyze(node *sitter.Node, visitChildren func() error)
 	case "parenthesized_expression":
 		return analyzer.analyzeGenericConstruct(node, visitChildren)
 	case "keyword_argument":
-		return analyzer.analyzeKeywordArgumentOperation(node, visitChildren)
+		return analyzer.analyzeKeywordArgument(node, visitChildren)
 	case "while_statement", "try_statement", "if_statement": // statements don't have results
 		return visitChildren()
 	case "conditional_expression":


### PR DESCRIPTION
## Description

Add `parenthesized_expression` and a few more cases to the analyzer

We now catch the following sorts of things: 

```python

# args list with parenthesized expression
with fileinput.input(files=(filepath), encoding="utf-8") as f:

# args as arrays
subprocess.run([unsafe, "exit 0"], shell=True, capture_output=True)
```

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.

