### PR TITLE
ci: make sure canary does not get promoted to latest release

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -23,7 +23,9 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tag_prefix: v
           default_bump: patch
-          append_to_pre_release_tag: "canary"
+          release_branches: ""
+          pre_release_branches: ".*"
+          append_to_pre_release_tag: "rc"
     outputs:
       ref: refs/tags/${{ steps.tag_version.outputs.new_tag || github.ref_name }}
 

--- a/.goreleaser/canary.yaml
+++ b/.goreleaser/canary.yaml
@@ -7,6 +7,8 @@ snapshot:
 
 release:
   draft: true
+  make_latest: false
+  prerelease: auto
   header: |
     ## Canary ({{ .Date }})
   mode: append


### PR DESCRIPTION
## Description
Seems like canary was set to latest when it should have been draft - try adding some options to ensure its not set to latest even if its built not as a draft.

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.

