### PR TITLE
ci: update linux builds

### DIFF
--- a/.github/actions/linux-build/Dockerfile
+++ b/.github/actions/linux-build/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && \
     ) && \
     \
     apt-get update && \
-    apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin git gcc-aarch64-linux-gnu g++-aarch64-linux-gnu gcc-i686-linux-gnu g++-i686-linux-gnu && \
+    apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin git gcc-aarch64-linux-gnu g++-aarch64-linux-gnu && \
     \
     wget --output-document=/tmp/go.tar.gz https://go.dev/dl/go1.21.0.linux-amd64.tar.gz && \
     tar --extract --gunzip --file=/tmp/go.tar.gz --directory=/usr/local && \

--- a/.github/actions/linux-build/Dockerfile
+++ b/.github/actions/linux-build/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && \
     ) && \
     \
     apt-get update && \
-    apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin git && \
+    apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin git gcc-aarch64-linux-gnu g++-aarch64-linux-gnu gcc-i686-linux-gnu g++-i686-linux-gnu && \
     \
     wget --output-document=/tmp/go.tar.gz https://go.dev/dl/go1.21.0.linux-amd64.tar.gz && \
     tar --extract --gunzip --file=/tmp/go.tar.gz --directory=/usr/local && \

--- a/.goreleaser/common.yaml
+++ b/.goreleaser/common.yaml
@@ -48,7 +48,6 @@ builds:
     goos:
       - linux
     goarch:
-      - 386
       - amd64
       - arm64
     ldflags:
@@ -56,11 +55,6 @@ builds:
       - -X "github.com/bearer/bearer/cmd/bearer/build.Version={{.Version}}"
       - -X "github.com/bearer/bearer/cmd/bearer/build.CommitSHA={{.Commit}}"
     overrides:
-      - goos: linux
-        goarch: 386
-        env:
-          - CC=i686-linux-gnu-gcc
-          - CXX=i686-linux-gnu-g++
       - goos: linux
         goarch: arm64
         env:

--- a/.goreleaser/common.yaml
+++ b/.goreleaser/common.yaml
@@ -50,10 +50,22 @@ builds:
     goarch:
       - 386
       - amd64
+      - arm64
     ldflags:
       - -w
       - -X "github.com/bearer/bearer/cmd/bearer/build.Version={{.Version}}"
       - -X "github.com/bearer/bearer/cmd/bearer/build.CommitSHA={{.Commit}}"
+    overrides:
+      - goos: linux
+        goarch: 386
+        env:
+          - CC=i686-linux-gnu-gcc
+          - CXX=i686-linux-gnu-g++
+      - goos: linux
+        goarch: arm64
+        env:
+          - CC=aarch64-linux-gnu-gcc
+          - CXX=aarch64-linux-gnu-g++
 
 checksum:
   name_template: "checksums.txt"

--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -57,6 +57,7 @@ get_binaries() {
     darwin/arm64) BINARIES="bearer" ;;
     linux/386) BINARIES="bearer" ;;
     linux/amd64) BINARIES="bearer" ;;
+    linux/arm64) BINARIES="bearer" ;;
     *)
       log_crit "platform $PLATFORM is not supported.  Make sure this script is up-to-date and file request at https://github.com/${PREFIX}/issues/new"
       exit 1

--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -55,7 +55,6 @@ get_binaries() {
   case "$PLATFORM" in
     darwin/amd64) BINARIES="bearer" ;;
     darwin/arm64) BINARIES="bearer" ;;
-    linux/386) BINARIES="bearer" ;;
     linux/amd64) BINARIES="bearer" ;;
     linux/arm64) BINARIES="bearer" ;;
     *)


### PR DESCRIPTION
## Description
- remove linux/i386
- reapply linux/arm64

It would appear i386 has been broken for some time looking at download stats its rarely used so we wont build for now. 

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.

