### PR TITLE
fix: ensure parent folder symlinks are resolved

### DIFF
--- a/internal/util/file/file.go
+++ b/internal/util/file/file.go
@@ -426,7 +426,12 @@ func IsDir(path string) bool {
 }
 
 func CanonicalPath(path string) (string, error) {
-	resolvedPath, err := filepath.EvalSymlinks(path)
+	absolutePath, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+
+	resolvedPath, err := filepath.EvalSymlinks(absolutePath)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Handle parent folder symlinks in `CanonicalPath`. 

We resolve symlinks but if the links are in an unspecified part of the path, then they aren't resolved currently. This is causing a mismatch with the target path and the paths returned from git.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.

