### PR TITLE
fix(reports): ordinal in html report

### DIFF
--- a/internal/report/output/html/html.go
+++ b/internal/report/output/html/html.go
@@ -32,7 +32,7 @@ func ReportHTMLWrapper(title string, body *string) (string, error) {
 	htmlContent := &strings.Builder{}
 
 	t := time.Now()
-	timeLayout := "January 2nd 2006, 15:04:05 pm (MST-0700)"
+	timeLayout := "January 2 2006, 15:04:05 pm (MST-0700)"
 
 	wrapperContent := html.WrapperHTMLPage{
 		Body:      *body,


### PR DESCRIPTION
## Description
Go does not support ordinal in time format

## New output
![Screenshot 2024-05-17 at 14 18 06](https://github.com/Bearer/bearer/assets/699436/682d7726-1f10-4660-9e94-f31f19cf4511)


## Related
- Close #1602


## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.

