### PR TITLE
fix(python): lookup variables in string interpolations

### DIFF
--- a/internal/languages/python/analyzer/analyzer.go
+++ b/internal/languages/python/analyzer/analyzer.go
@@ -39,7 +39,7 @@ func (analyzer *analyzer) Analyze(node *sitter.Node, visitChildren func() error)
 		return analyzer.analyzeCall(node, visitChildren)
 	case "argument_list", "expression_statement", "list", "tuple":
 		return analyzer.analyzeGenericOperation(node, visitChildren)
-	case "parenthesized_expression":
+	case "parenthesized_expression", "interpolation":
 		return analyzer.analyzeGenericConstruct(node, visitChildren)
 	case "parameters":
 		return analyzer.analyzeParameters(node, visitChildren)

--- a/internal/languages/python/detectors/.snapshots/TestPythonString-string
+++ b/internal/languages/python/detectors/.snapshots/TestPythonString-string
@@ -339,7 +339,7 @@ children:
                                 - type: interpolation
                                   id: 71
                                   range: 12:21 - 12:25
-                                  dataflow_sources:
+                                  alias_of:
                                     - 72
                                     - 73
                                     - 74
@@ -351,6 +351,8 @@ children:
                                       id: 73
                                       range: 12:22 - 12:24
                                       content: s2
+                                      alias_of:
+                                        - 59
                                     - type: '"}"'
                                       id: 74
                                       range: 12:24 - 12:25
@@ -401,7 +403,7 @@ children:
 - node: 69
   content: f"foo '{s2}' bar"
   data:
-    value: foo '�' bar
+    value: foo 'hey � there' bar
     isliteral: false
 - node: 32
   content: '"!"'

--- a/internal/languages/python/detectors/.snapshots/TestPythonString-string_literal
+++ b/internal/languages/python/detectors/.snapshots/TestPythonString-string_literal
@@ -148,7 +148,7 @@ children:
             - type: interpolation
               id: 28
               range: 6:3 - 6:8
-              dataflow_sources:
+              alias_of:
                 - 29
                 - 30
                 - 31


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Lookup variables in Python string interpolations. eg. `f"hello{x}"`

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.

