### PR TITLE
fix(python): lookup variables in operators

### DIFF
--- a/internal/languages/python/analyzer/analyzer.go
+++ b/internal/languages/python/analyzer/analyzer.go
@@ -37,7 +37,7 @@ func (analyzer *analyzer) Analyze(node *sitter.Node, visitChildren func() error)
 		return analyzer.analyzeSubscript(node, visitChildren)
 	case "call":
 		return analyzer.analyzeCall(node, visitChildren)
-	case "argument_list", "expression_statement", "list", "tuple":
+	case "argument_list", "expression_statement", "list", "tuple", "unary_operator", "binary_operator":
 		return analyzer.analyzeGenericOperation(node, visitChildren)
 	case "parenthesized_expression", "interpolation":
 		return analyzer.analyzeGenericConstruct(node, visitChildren)


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

For Python, lookup variables in unary and binary operators.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.

