### PR TITLE
fix(python): regard pair children as data sources

### DIFF
--- a/internal/languages/python/.snapshots/TestPair--pair.yml
+++ b/internal/languages/python/.snapshots/TestPair--pair.yml
@@ -1,0 +1,30 @@
+high:
+    - rule:
+        cwe_ids:
+            - "42"
+        id: pair_test
+        title: Test detection filter dictionary pair statements
+        description: Test detection filter dictionary pair statements
+        documentation_url: ""
+      line_number: 4
+      full_filename: pair.py
+      filename: pair.py
+      source:
+        location:
+            start: 4
+            end: 4
+            column:
+                start: 1
+                end: 46
+      sink:
+        location:
+            start: 4
+            end: 4
+            column:
+                start: 1
+                end: 46
+        content: ""
+      parent_line_number: 4
+      fingerprint: ccf6bc0c73d9320075b1353d72b65703_0
+      old_fingerprint: ccf6bc0c73d9320075b1353d72b65703_0
+

--- a/internal/languages/python/analyzer/analyzer.go
+++ b/internal/languages/python/analyzer/analyzer.go
@@ -37,7 +37,7 @@ func (analyzer *analyzer) Analyze(node *sitter.Node, visitChildren func() error)
 		return analyzer.analyzeSubscript(node, visitChildren)
 	case "call":
 		return analyzer.analyzeCall(node, visitChildren)
-	case "argument_list", "expression_statement", "list", "tuple", "unary_operator", "binary_operator":
+	case "pair", "argument_list", "expression_statement", "list", "tuple", "unary_operator", "binary_operator":
 		return analyzer.analyzeGenericOperation(node, visitChildren)
 	case "parenthesized_expression", "interpolation":
 		return analyzer.analyzeGenericConstruct(node, visitChildren)

--- a/internal/languages/python/python_test.go
+++ b/internal/languages/python/python_test.go
@@ -22,6 +22,9 @@ var importRule []byte
 //go:embed testdata/subscript_rule.yml
 var subscriptRule []byte
 
+//go:embed testdata/pair_rule.yml
+var pairRule []byte
+
 func TestDatatypes(t *testing.T) {
 	testhelper.GetRunner(t, datatypesRule, "python").RunTest(t, "./testdata/datatypes", ".snapshots/")
 }
@@ -40,4 +43,8 @@ func TestImport(t *testing.T) {
 
 func TestSubscript(t *testing.T) {
 	testhelper.GetRunner(t, subscriptRule, "python").RunTest(t, "./testdata/subscript", ".snapshots/")
+}
+
+func TestPair(t *testing.T) {
+	testhelper.GetRunner(t, pairRule, "python").RunTest(t, "./testdata/pair", ".snapshots/")
 }

--- a/internal/languages/python/testdata/pair/pair.py
+++ b/internal/languages/python/testdata/pair/pair.py
@@ -1,0 +1,4 @@
+user_input = input("Enter username: ")
+
+# collection is some mongodo collection
+collection.find_one({"username": user_input})

--- a/internal/languages/python/testdata/pair_rule.yml
+++ b/internal/languages/python/testdata/pair_rule.yml
@@ -1,0 +1,19 @@
+languages:
+  - python
+patterns:
+  - pattern: collection.find_one($<...>$<USER_INPUT>$<...>)
+    filters:
+      - variable: USER_INPUT
+        detection: pair_test_user_input
+        scope: result
+auxiliary:
+  - id: pair_test_user_input
+    patterns:
+      - input()
+severity: high
+metadata:
+  description: Test detection filter dictionary pair statements
+  remediation_message: Test detection filter dictionary pair statements
+  cwe_id:
+    - 42
+  id: pair_test


### PR DESCRIPTION
## Description

To handle mongodb cases of NoSQLi such as 

```
collection.find_one({"username": <some user input> })
```

Prior to this suggested fix, pattern is not catching on pair values as data sources
```
(dictionary (pair key: (_) @key value: (_) @value) @pair) @root
```

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.

