### PR TITLE
docs: remove removed command from doc generation

### DIFF
--- a/docs/reference/commands.njk
+++ b/docs/reference/commands.njk
@@ -6,7 +6,7 @@ layout: layouts/doc.njk
 They can be found here: https://github.com/Bearer/bearer/tree/main/pkg/commands
  #}
 
-{% set items = [bearer_scan, bearer_init, bearer_ignore_add, bearer_ignore_show, bearer_ignore_remove, bearer_ignore_pull, bearer_ignore_migrate, bearer_version] %}
+{% set items = [bearer_scan, bearer_init, bearer_ignore_add, bearer_ignore_show, bearer_ignore_remove, bearer_ignore_migrate, bearer_version] %}
 {% renderTemplate "md" %}
 # Commands
 


### PR DESCRIPTION
## Description
command was removed in #1616 but we forgot to remove the doc generation for it.


## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.

