### PR TITLE
fix(python): import statements

### DIFF
--- a/pkg/languages/python/analyzer/analyzer.go
+++ b/pkg/languages/python/analyzer/analyzer.go
@@ -108,6 +108,9 @@ func (analyzer *analyzer) analyzeAssignment(node *sitter.Node, visitChildren fun
 // foo.bar(a, b)
 func (analyzer *analyzer) analyzeCall(node *sitter.Node, visitChildren func() error) error {
 	if function := node.ChildByFieldName("function"); function != nil {
+		analyzer.lookupVariable(function)
+		analyzer.builder.Dataflow(function)
+
 		object := function.ChildByFieldName("object")
 		analyzer.lookupVariable(object)
 

--- a/pkg/languages/python/testdata/import/import.py
+++ b/pkg/languages/python/testdata/import/import.py
@@ -36,3 +36,5 @@ x.qwerty()
 import FooClass as SomethingElse
 y = SomethingElse()
 y.qwerty()
+
+foo()

--- a/pkg/languages/python/testdata/import_rule.yml
+++ b/pkg/languages/python/testdata/import_rule.yml
@@ -1,6 +1,11 @@
 languages:
   - python
 patterns:
+  - pattern: $<IMPORT_FROM>($<...>)
+    filters:
+      - variable: IMPORT_FROM
+        detection: import_test_import_from
+        scope: result
   - pattern: $<IMPORT_FROM>.someMethod($<...>)
     filters:
       - variable: IMPORT_FROM


### PR DESCRIPTION
## Description

Following my changes here https://github.com/Bearer/bearer/pull/1622 we are no longer catching this kind of import: 

```
from hashlib import md5
md5(current_user.password) # not catching
```

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.

