### PR TITLE
fix: engine.Close() ordering

### DIFF
--- a/external/run/run.go
+++ b/external/run/run.go
@@ -88,7 +88,6 @@ func DefaultLanguages() []Language {
 
 func Run(version, commitSHA string, engine Engine) {
 	err := commands.NewApp(version, commitSHA, engine).Execute()
-	engine.Close()
 
 	if err != nil {
 		// error messages are printed by the framework

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -240,6 +240,12 @@ func getIgnoredFingerprints(settings settings.Config) (
 	return false, localIgnoredFingerprints, []string{}, nil
 }
 
+
+type ReportFailedError int
+func (exitcode ReportFailedError) Error() string {
+  return "Report failed with exitcode"
+}
+
 // Run performs artifact scanning
 func Run(ctx context.Context, opts flagtypes.Options, engine engine.Engine) (err error) {
 	targetPath, err := file.CanonicalPath(opts.Target)
@@ -341,9 +347,9 @@ func Run(ctx context.Context, opts flagtypes.Options, engine engine.Engine) (err
 
 	if reportFailed {
 		if scanSettings.Scan.ExitCode == -1 {
-			defer os.Exit(1)
+			return ReportFailedError(1)
 		} else {
-			defer os.Exit(scanSettings.Scan.ExitCode)
+		  return ReportFailedError(scanSettings.Scan.ExitCode)
 		}
 	}
 

--- a/pkg/commands/scan.go
+++ b/pkg/commands/scan.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/bearer/bearer/pkg/commands/artifact"
 	"github.com/bearer/bearer/pkg/commands/debugprofile"
@@ -87,6 +88,12 @@ func NewScanCommand(engine engine.Engine) *cobra.Command {
 
 			err = artifact.Run(cmd.Context(), options, engine)
 			debugprofile.Stop()
+			engine.Close()
+			
+			if exitcode, ok := err.(artifact.ReportFailedError); ok {
+        os.Exit(int(exitcode))
+			}
+			
 			return err
 		},
 		SilenceErrors: false,


### PR DESCRIPTION
## Description

* Move `engine.Close()` to inside scan execution
* Move happy path `os.Exit` to inside scan execution (up a level from artifact run)

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.

