### PR TITLE
fix(python): add 'split' to reflexive methods

### DIFF
--- a/pkg/languages/python/analyzer/analyzer.go
+++ b/pkg/languages/python/analyzer/analyzer.go
@@ -14,6 +14,7 @@ var reflexiveMethods = []string{
 	"encode",
 	"format",
 	"replace",
+	"split",
 }
 
 type analyzer struct {


### PR DESCRIPTION
## Description

Add `split` to Python's reflexive methods so that, for example, we still consider the following as user input 

```python
url = sys.argv[2]
filename = url.split('/')[-1] # still user input
```

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.

