### PR TITLE
fix: fix mapping of gocloc language to bearer

### DIFF
--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -240,10 +240,10 @@ func getIgnoredFingerprints(settings settings.Config) (
 	return false, localIgnoredFingerprints, []string{}, nil
 }
 
-
 type ReportFailedError int
+
 func (exitcode ReportFailedError) Error() string {
-  return "Report failed with exitcode"
+	return "Report failed with exitcode"
 }
 
 // Run performs artifact scanning
@@ -349,7 +349,7 @@ func Run(ctx context.Context, opts flagtypes.Options, engine engine.Engine) (err
 		if scanSettings.Scan.ExitCode == -1 {
 			return ReportFailedError(1)
 		} else {
-		  return ReportFailedError(scanSettings.Scan.ExitCode)
+			return ReportFailedError(scanSettings.Scan.ExitCode)
 		}
 	}
 
@@ -456,14 +456,11 @@ func anySupportedLanguagesPresent(engine engine.Engine, inputgocloc *gocloc.Resu
 		}
 	}
 
-	foundLanguages := make(map[string]bool)
-	for _, language := range inputgocloc.Languages {
-		foundLanguages[strings.ToLower(language.Name)] = true
-	}
-
-	for _, supportedLanguage := range engine.GetLanguages() {
-		if _, supportedLangPresent := foundLanguages[supportedLanguage.ID()]; supportedLangPresent {
-			return true
+	for _, goclocLanguage := range inputgocloc.Languages {
+		for _, language := range engine.GetLanguages() {
+			if slices.Contains(language.GoclocLanguages(), goclocLanguage.Name) {
+				return true
+			}
 		}
 	}
 

--- a/pkg/commands/process/settings/settings.go
+++ b/pkg/commands/process/settings/settings.go
@@ -305,3 +305,7 @@ func (rule *Rule) GetSeverity() string {
 
 	return rule.Severity
 }
+
+func (rule *Rule) IsSecrets() bool {
+	return rule.Languages == nil
+}

--- a/pkg/detectors/dependencies/buildgradle/.snapshots/TestDependenciesReport
+++ b/pkg/detectors/dependencies/buildgradle/.snapshots/TestDependenciesReport
@@ -2,7 +2,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gradleparser",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "build.gradle",
@@ -25,7 +25,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gradleparser",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "build.gradle",

--- a/pkg/detectors/dependencies/buildgradle/parser/parser.go
+++ b/pkg/detectors/dependencies/buildgradle/parser/parser.go
@@ -31,7 +31,7 @@ func init() {
 func Discover(file *file.FileInfo) (report *depsbase.DiscoveredDependency) {
 	report = &depsbase.DiscoveredDependency{}
 	report.Provider = "gradleparser"
-	report.Language = "Java"
+	report.Language = "java"
 	report.PackageManager = "maven"
 
 	fileBytes, err := os.ReadFile(file.AbsolutePath)

--- a/pkg/detectors/dependencies/composerjson/.snapshots/TestDependenciesReport
+++ b/pkg/detectors/dependencies/composerjson/.snapshots/TestDependenciesReport
@@ -2,7 +2,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "composerjson",
-    DetectorLanguage: (detectors.Language) (len=3) "PHP",
+    DetectorLanguage: (detectors.Language) (len=3) "php",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=13) "composer.json",
@@ -25,7 +25,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "composerjson",
-    DetectorLanguage: (detectors.Language) (len=3) "PHP",
+    DetectorLanguage: (detectors.Language) (len=3) "php",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=13) "composer.json",

--- a/pkg/detectors/dependencies/composerjson/composerjson.go
+++ b/pkg/detectors/dependencies/composerjson/composerjson.go
@@ -22,7 +22,7 @@ var queryDependencies = parser.QueryMustCompile(language, `
 func Discover(f *file.FileInfo) (report *depsbase.DiscoveredDependency) {
 	report = &depsbase.DiscoveredDependency{}
 	report.Provider = "composerjson"
-	report.Language = "PHP"
+	report.Language = "php"
 	report.PackageManager = "packagist"
 	tree, err := parser.ParseFile(f, f.Path, javascript.GetLanguage())
 	if err != nil {

--- a/pkg/detectors/dependencies/composerlock/.snapshots/TestDependenciesReport
+++ b/pkg/detectors/dependencies/composerlock/.snapshots/TestDependenciesReport
@@ -2,7 +2,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "composerlock",
-    DetectorLanguage: (detectors.Language) (len=3) "PHP",
+    DetectorLanguage: (detectors.Language) (len=3) "php",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=13) "composer.lock",
@@ -25,7 +25,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "composerlock",
-    DetectorLanguage: (detectors.Language) (len=3) "PHP",
+    DetectorLanguage: (detectors.Language) (len=3) "php",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=13) "composer.lock",
@@ -48,7 +48,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "composerlock",
-    DetectorLanguage: (detectors.Language) (len=3) "PHP",
+    DetectorLanguage: (detectors.Language) (len=3) "php",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=13) "composer.lock",
@@ -71,7 +71,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "composerlock",
-    DetectorLanguage: (detectors.Language) (len=3) "PHP",
+    DetectorLanguage: (detectors.Language) (len=3) "php",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=13) "composer.lock",
@@ -94,7 +94,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "composerlock",
-    DetectorLanguage: (detectors.Language) (len=3) "PHP",
+    DetectorLanguage: (detectors.Language) (len=3) "php",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=13) "composer.lock",
@@ -117,7 +117,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "composerlock",
-    DetectorLanguage: (detectors.Language) (len=3) "PHP",
+    DetectorLanguage: (detectors.Language) (len=3) "php",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=13) "composer.lock",
@@ -140,7 +140,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "composerlock",
-    DetectorLanguage: (detectors.Language) (len=3) "PHP",
+    DetectorLanguage: (detectors.Language) (len=3) "php",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=13) "composer.lock",

--- a/pkg/detectors/dependencies/composerlock/composerlock.go
+++ b/pkg/detectors/dependencies/composerlock/composerlock.go
@@ -34,7 +34,7 @@ var queryDependencies = parser.QueryMustCompile(language, `
 func Discover(f *file.FileInfo) (report *depsbase.DiscoveredDependency) {
 	report = &depsbase.DiscoveredDependency{}
 	report.Provider = "composerlock"
-	report.Language = "PHP"
+	report.Language = "php"
 	report.PackageManager = "packagist"
 	tree, err := parser.ParseFile(f, f.Path, javascript.GetLanguage())
 	if err != nil {

--- a/pkg/detectors/dependencies/gemfile/.snapshots/TestDependenciesReport
+++ b/pkg/detectors/dependencies/gemfile/.snapshots/TestDependenciesReport
@@ -2,7 +2,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -25,7 +25,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -48,7 +48,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -71,7 +71,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -94,7 +94,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -117,7 +117,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -140,7 +140,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -163,7 +163,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -186,7 +186,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -209,7 +209,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -232,7 +232,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -255,7 +255,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -278,7 +278,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -301,7 +301,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -324,7 +324,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -347,7 +347,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -370,7 +370,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -393,7 +393,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -416,7 +416,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -439,7 +439,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -462,7 +462,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -485,7 +485,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -508,7 +508,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -531,7 +531,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -554,7 +554,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -577,7 +577,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -600,7 +600,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -623,7 +623,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -646,7 +646,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -669,7 +669,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -692,7 +692,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -715,7 +715,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -738,7 +738,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -761,7 +761,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -784,7 +784,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -807,7 +807,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -830,7 +830,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -853,7 +853,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -876,7 +876,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -899,7 +899,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -922,7 +922,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -945,7 +945,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -968,7 +968,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -991,7 +991,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -1014,7 +1014,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -1037,7 +1037,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -1060,7 +1060,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -1083,7 +1083,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -1106,7 +1106,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -1129,7 +1129,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -1152,7 +1152,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -1175,7 +1175,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -1198,7 +1198,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -1221,7 +1221,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -1244,7 +1244,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -1267,7 +1267,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -1290,7 +1290,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -1313,7 +1313,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -1336,7 +1336,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -1359,7 +1359,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -1382,7 +1382,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -1405,7 +1405,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -1428,7 +1428,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -1451,7 +1451,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -1474,7 +1474,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -1497,7 +1497,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -1520,7 +1520,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -1543,7 +1543,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -1566,7 +1566,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -1589,7 +1589,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -1612,7 +1612,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -1635,7 +1635,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -1658,7 +1658,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -1681,7 +1681,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -1704,7 +1704,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -1727,7 +1727,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -1750,7 +1750,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -1773,7 +1773,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -1796,7 +1796,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -1819,7 +1819,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -1842,7 +1842,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -1865,7 +1865,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -1888,7 +1888,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -1911,7 +1911,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -1934,7 +1934,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -1957,7 +1957,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -1980,7 +1980,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -2003,7 +2003,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -2026,7 +2026,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -2049,7 +2049,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -2072,7 +2072,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -2095,7 +2095,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",
@@ -2118,7 +2118,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "gemfile-lock",
-    DetectorLanguage: (detectors.Language) (len=4) "Ruby",
+    DetectorLanguage: (detectors.Language) (len=4) "ruby",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Gemfile.lock",

--- a/pkg/detectors/dependencies/gemfile/gemfile-lock.go
+++ b/pkg/detectors/dependencies/gemfile/gemfile-lock.go
@@ -43,7 +43,7 @@ type SourceType struct {
 func Discover(file *file.FileInfo) (report *depsbase.DiscoveredDependency) {
 	report = &depsbase.DiscoveredDependency{}
 	report.Provider = "gemfile-lock"
-	report.Language = "Ruby"
+	report.Language = "ruby"
 	report.PackageManager = "rubygems"
 
 	fileBytes, err := os.ReadFile(file.AbsolutePath)

--- a/pkg/detectors/dependencies/gosum/.snapshots/TestDependenciesReport
+++ b/pkg/detectors/dependencies/gosum/.snapshots/TestDependenciesReport
@@ -2,7 +2,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -25,7 +25,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -48,7 +48,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -71,7 +71,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -94,7 +94,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -117,7 +117,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -140,7 +140,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -163,7 +163,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -186,7 +186,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -209,7 +209,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -232,7 +232,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -255,7 +255,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -278,7 +278,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -301,7 +301,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -324,7 +324,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -347,7 +347,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -370,7 +370,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -393,7 +393,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -416,7 +416,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -439,7 +439,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -462,7 +462,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -485,7 +485,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -508,7 +508,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -531,7 +531,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -554,7 +554,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -577,7 +577,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -600,7 +600,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -623,7 +623,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -646,7 +646,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -669,7 +669,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -692,7 +692,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -715,7 +715,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -738,7 +738,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -761,7 +761,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -784,7 +784,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -807,7 +807,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -830,7 +830,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -853,7 +853,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -876,7 +876,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -899,7 +899,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -922,7 +922,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -945,7 +945,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -968,7 +968,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -991,7 +991,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -1014,7 +1014,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -1037,7 +1037,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -1060,7 +1060,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -1083,7 +1083,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -1106,7 +1106,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -1129,7 +1129,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -1152,7 +1152,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -1175,7 +1175,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -1198,7 +1198,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -1221,7 +1221,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -1244,7 +1244,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -1267,7 +1267,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -1290,7 +1290,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -1313,7 +1313,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -1336,7 +1336,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -1359,7 +1359,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -1382,7 +1382,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -1405,7 +1405,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -1428,7 +1428,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -1451,7 +1451,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -1474,7 +1474,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -1497,7 +1497,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -1520,7 +1520,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",
@@ -1543,7 +1543,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "gosum",
-    DetectorLanguage: (detectors.Language) (len=2) "Go",
+    DetectorLanguage: (detectors.Language) (len=2) "go",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=6) "go.sum",

--- a/pkg/detectors/dependencies/gosum/go.go
+++ b/pkg/detectors/dependencies/gosum/go.go
@@ -15,7 +15,7 @@ import (
 func Discover(file *file.FileInfo) (report *depsbase.DiscoveredDependency) {
 	report = &depsbase.DiscoveredDependency{}
 	report.Provider = "gosum"
-	report.Language = "Go"
+	report.Language = "go"
 	report.PackageManager = "go"
 
 	fileBytes, err := os.ReadFile(file.AbsolutePath)

--- a/pkg/detectors/dependencies/ivy/.snapshots/TestDependenciesReport
+++ b/pkg/detectors/dependencies/ivy/.snapshots/TestDependenciesReport
@@ -2,7 +2,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "ivy",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=14) "ivy-report.xml",
@@ -25,7 +25,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "ivy",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=14) "ivy-report.xml",
@@ -48,7 +48,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "ivy",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=14) "ivy-report.xml",
@@ -71,7 +71,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "ivy",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=14) "ivy-report.xml",
@@ -94,7 +94,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "ivy",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=14) "ivy-report.xml",
@@ -117,7 +117,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "ivy",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=14) "ivy-report.xml",
@@ -140,7 +140,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "ivy",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=14) "ivy-report.xml",
@@ -163,7 +163,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "ivy",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=14) "ivy-report.xml",
@@ -186,7 +186,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "ivy",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=14) "ivy-report.xml",
@@ -209,7 +209,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "ivy",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=14) "ivy-report.xml",
@@ -232,7 +232,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "ivy",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=14) "ivy-report.xml",
@@ -255,7 +255,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "ivy",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=14) "ivy-report.xml",
@@ -278,7 +278,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "ivy",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=14) "ivy-report.xml",
@@ -301,7 +301,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "ivy",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=14) "ivy-report.xml",
@@ -324,7 +324,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "ivy",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=14) "ivy-report.xml",
@@ -347,7 +347,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "ivy",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=14) "ivy-report.xml",

--- a/pkg/detectors/dependencies/ivy/ivy.go
+++ b/pkg/detectors/dependencies/ivy/ivy.go
@@ -81,7 +81,7 @@ func formattedName(inputname string) string {
 func Discover(f *file.FileInfo) (report *depsbase.DiscoveredDependency) {
 	report = &depsbase.DiscoveredDependency{}
 	report.Provider = "ivy"
-	report.Language = "Java"
+	report.Language = "java"
 	report.PackageManager = "maven"
 
 	bytes, err := os.ReadFile(f.AbsolutePath)

--- a/pkg/detectors/dependencies/mvnplugin/.snapshots/TestDependenciesReport
+++ b/pkg/detectors/dependencies/mvnplugin/.snapshots/TestDependenciesReport
@@ -2,7 +2,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "mvnplugin",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=23) "maven-dependencies.json",
@@ -25,7 +25,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "mvnplugin",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=23) "maven-dependencies.json",

--- a/pkg/detectors/dependencies/mvnplugin/mvnplugin.go
+++ b/pkg/detectors/dependencies/mvnplugin/mvnplugin.go
@@ -34,7 +34,7 @@ var queryDependencies = parser.QueryMustCompile(language, `
 func Discover(f *file.FileInfo) (report *depsbase.DiscoveredDependency) {
 	report = &depsbase.DiscoveredDependency{}
 	report.Provider = "mvnplugin"
-	report.Language = "Java"
+	report.Language = "java"
 	report.PackageManager = "maven"
 	tree, err := parser.ParseFile(f, f.Path, language)
 	if err != nil {

--- a/pkg/detectors/dependencies/npm/.snapshots/TestDependenciesReport
+++ b/pkg/detectors/dependencies/npm/.snapshots/TestDependenciesReport
@@ -2,7 +2,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -25,7 +25,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -48,7 +48,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -71,7 +71,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -94,7 +94,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -117,7 +117,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -140,7 +140,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -163,7 +163,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -186,7 +186,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -209,7 +209,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -232,7 +232,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -255,7 +255,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -278,7 +278,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -301,7 +301,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -324,7 +324,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -347,7 +347,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -370,7 +370,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -393,7 +393,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -416,7 +416,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -439,7 +439,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -462,7 +462,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -485,7 +485,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -508,7 +508,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -531,7 +531,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -554,7 +554,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -577,7 +577,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -600,7 +600,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -623,7 +623,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -646,7 +646,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -669,7 +669,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -692,7 +692,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -715,7 +715,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -738,7 +738,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -761,7 +761,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -784,7 +784,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -807,7 +807,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -830,7 +830,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -853,7 +853,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -876,7 +876,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -899,7 +899,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -922,7 +922,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -945,7 +945,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -968,7 +968,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -991,7 +991,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -1014,7 +1014,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -1037,7 +1037,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -1060,7 +1060,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -1083,7 +1083,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -1106,7 +1106,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -1129,7 +1129,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -1152,7 +1152,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -1175,7 +1175,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -1198,7 +1198,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -1221,7 +1221,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -1244,7 +1244,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -1267,7 +1267,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -1290,7 +1290,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -1313,7 +1313,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -1336,7 +1336,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -1359,7 +1359,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -1382,7 +1382,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -1405,7 +1405,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -1428,7 +1428,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -1451,7 +1451,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -1474,7 +1474,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -1497,7 +1497,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -1520,7 +1520,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -1543,7 +1543,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -1566,7 +1566,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -1589,7 +1589,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -1612,7 +1612,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -1635,7 +1635,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -1658,7 +1658,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -1681,7 +1681,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -1704,7 +1704,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -1727,7 +1727,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -1750,7 +1750,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -1773,7 +1773,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -1796,7 +1796,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -1819,7 +1819,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -1842,7 +1842,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -1865,7 +1865,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -1888,7 +1888,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -1911,7 +1911,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -1934,7 +1934,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -1957,7 +1957,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -1980,7 +1980,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -2003,7 +2003,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -2026,7 +2026,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -2049,7 +2049,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -2072,7 +2072,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -2095,7 +2095,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -2118,7 +2118,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -2141,7 +2141,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -2164,7 +2164,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -2187,7 +2187,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -2210,7 +2210,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -2233,7 +2233,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -2256,7 +2256,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -2279,7 +2279,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -2302,7 +2302,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -2325,7 +2325,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -2348,7 +2348,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -2371,7 +2371,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -2394,7 +2394,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -2417,7 +2417,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -2440,7 +2440,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -2463,7 +2463,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -2486,7 +2486,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -2509,7 +2509,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -2532,7 +2532,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -2555,7 +2555,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -2578,7 +2578,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -2601,7 +2601,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -2624,7 +2624,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -2647,7 +2647,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -2670,7 +2670,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -2693,7 +2693,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -2716,7 +2716,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -2739,7 +2739,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -2762,7 +2762,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -2785,7 +2785,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -2808,7 +2808,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -2831,7 +2831,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -2854,7 +2854,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -2877,7 +2877,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -2900,7 +2900,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -2923,7 +2923,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -2946,7 +2946,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -2969,7 +2969,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -2992,7 +2992,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -3015,7 +3015,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -3038,7 +3038,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -3061,7 +3061,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -3084,7 +3084,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -3107,7 +3107,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -3130,7 +3130,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -3153,7 +3153,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -3176,7 +3176,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -3199,7 +3199,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -3222,7 +3222,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -3245,7 +3245,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -3268,7 +3268,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -3291,7 +3291,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -3314,7 +3314,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -3337,7 +3337,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -3360,7 +3360,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -3383,7 +3383,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -3406,7 +3406,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -3429,7 +3429,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -3452,7 +3452,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -3475,7 +3475,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -3498,7 +3498,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -3521,7 +3521,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -3544,7 +3544,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -3567,7 +3567,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -3590,7 +3590,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -3613,7 +3613,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -3636,7 +3636,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -3659,7 +3659,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -3682,7 +3682,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -3705,7 +3705,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -3728,7 +3728,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -3751,7 +3751,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -3774,7 +3774,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -3797,7 +3797,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -3820,7 +3820,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -3843,7 +3843,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -3866,7 +3866,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -3889,7 +3889,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -3912,7 +3912,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -3935,7 +3935,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -3958,7 +3958,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -3981,7 +3981,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -4004,7 +4004,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -4027,7 +4027,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -4050,7 +4050,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -4073,7 +4073,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -4096,7 +4096,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -4119,7 +4119,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -4142,7 +4142,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -4165,7 +4165,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -4188,7 +4188,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -4211,7 +4211,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -4234,7 +4234,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -4257,7 +4257,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -4280,7 +4280,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -4303,7 +4303,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -4326,7 +4326,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -4349,7 +4349,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -4372,7 +4372,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -4395,7 +4395,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -4418,7 +4418,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -4441,7 +4441,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -4464,7 +4464,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -4487,7 +4487,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -4510,7 +4510,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -4533,7 +4533,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -4556,7 +4556,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -4579,7 +4579,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -4602,7 +4602,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -4625,7 +4625,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -4648,7 +4648,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -4671,7 +4671,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -4694,7 +4694,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -4717,7 +4717,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -4740,7 +4740,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -4763,7 +4763,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -4786,7 +4786,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -4809,7 +4809,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -4832,7 +4832,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -4855,7 +4855,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -4878,7 +4878,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -4901,7 +4901,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -4924,7 +4924,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -4947,7 +4947,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -4970,7 +4970,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -4993,7 +4993,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -5016,7 +5016,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -5039,7 +5039,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -5062,7 +5062,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -5085,7 +5085,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -5108,7 +5108,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -5131,7 +5131,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -5154,7 +5154,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -5177,7 +5177,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -5200,7 +5200,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -5223,7 +5223,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -5246,7 +5246,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -5269,7 +5269,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -5292,7 +5292,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -5315,7 +5315,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -5338,7 +5338,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -5361,7 +5361,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -5384,7 +5384,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -5407,7 +5407,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -5430,7 +5430,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -5453,7 +5453,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -5476,7 +5476,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -5499,7 +5499,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -5522,7 +5522,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -5545,7 +5545,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -5568,7 +5568,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -5591,7 +5591,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -5614,7 +5614,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -5637,7 +5637,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -5660,7 +5660,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -5683,7 +5683,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -5706,7 +5706,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -5729,7 +5729,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -5752,7 +5752,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -5775,7 +5775,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -5798,7 +5798,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -5821,7 +5821,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -5844,7 +5844,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -5867,7 +5867,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -5890,7 +5890,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -5913,7 +5913,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -5936,7 +5936,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -5959,7 +5959,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -5982,7 +5982,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -6005,7 +6005,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -6028,7 +6028,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -6051,7 +6051,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -6074,7 +6074,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -6097,7 +6097,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -6120,7 +6120,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -6143,7 +6143,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -6166,7 +6166,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -6189,7 +6189,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -6212,7 +6212,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -6235,7 +6235,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -6258,7 +6258,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -6281,7 +6281,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -6304,7 +6304,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -6327,7 +6327,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -6350,7 +6350,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -6373,7 +6373,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -6396,7 +6396,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -6419,7 +6419,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -6442,7 +6442,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -6465,7 +6465,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -6488,7 +6488,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -6511,7 +6511,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -6534,7 +6534,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -6557,7 +6557,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -6580,7 +6580,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -6603,7 +6603,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -6626,7 +6626,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -6649,7 +6649,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -6672,7 +6672,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -6695,7 +6695,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -6718,7 +6718,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -6741,7 +6741,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -6764,7 +6764,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -6787,7 +6787,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -6810,7 +6810,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -6833,7 +6833,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -6856,7 +6856,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -6879,7 +6879,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -6902,7 +6902,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -6925,7 +6925,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -6948,7 +6948,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -6971,7 +6971,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -6994,7 +6994,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -7017,7 +7017,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -7040,7 +7040,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -7063,7 +7063,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -7086,7 +7086,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -7109,7 +7109,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -7132,7 +7132,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -7155,7 +7155,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -7178,7 +7178,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -7201,7 +7201,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -7224,7 +7224,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -7247,7 +7247,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -7270,7 +7270,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -7293,7 +7293,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -7316,7 +7316,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -7339,7 +7339,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -7362,7 +7362,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -7385,7 +7385,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -7408,7 +7408,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -7431,7 +7431,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -7454,7 +7454,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -7477,7 +7477,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -7500,7 +7500,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -7523,7 +7523,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -7546,7 +7546,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -7569,7 +7569,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -7592,7 +7592,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -7615,7 +7615,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -7638,7 +7638,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -7661,7 +7661,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -7684,7 +7684,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -7707,7 +7707,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -7730,7 +7730,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -7753,7 +7753,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -7776,7 +7776,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -7799,7 +7799,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -7822,7 +7822,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -7845,7 +7845,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -7868,7 +7868,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -7891,7 +7891,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -7914,7 +7914,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -7937,7 +7937,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -7960,7 +7960,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -7983,7 +7983,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -8006,7 +8006,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -8029,7 +8029,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -8052,7 +8052,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -8075,7 +8075,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -8098,7 +8098,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -8121,7 +8121,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -8144,7 +8144,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -8167,7 +8167,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -8190,7 +8190,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -8213,7 +8213,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -8236,7 +8236,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -8259,7 +8259,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -8282,7 +8282,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -8305,7 +8305,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -8328,7 +8328,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -8351,7 +8351,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -8374,7 +8374,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -8397,7 +8397,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -8420,7 +8420,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -8443,7 +8443,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -8466,7 +8466,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -8489,7 +8489,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -8512,7 +8512,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -8535,7 +8535,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -8558,7 +8558,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -8581,7 +8581,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -8604,7 +8604,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -8627,7 +8627,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -8650,7 +8650,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -8673,7 +8673,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -8696,7 +8696,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -8719,7 +8719,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -8742,7 +8742,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -8765,7 +8765,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -8788,7 +8788,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -8811,7 +8811,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -8834,7 +8834,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -8857,7 +8857,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -8880,7 +8880,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -8903,7 +8903,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -8926,7 +8926,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -8949,7 +8949,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -8972,7 +8972,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -8995,7 +8995,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -9018,7 +9018,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -9041,7 +9041,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -9064,7 +9064,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -9087,7 +9087,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -9110,7 +9110,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -9133,7 +9133,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -9156,7 +9156,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -9179,7 +9179,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -9202,7 +9202,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -9225,7 +9225,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -9248,7 +9248,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -9271,7 +9271,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -9294,7 +9294,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -9317,7 +9317,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -9340,7 +9340,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -9363,7 +9363,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -9386,7 +9386,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -9409,7 +9409,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -9432,7 +9432,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -9455,7 +9455,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -9478,7 +9478,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -9501,7 +9501,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -9524,7 +9524,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -9547,7 +9547,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -9570,7 +9570,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -9593,7 +9593,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -9616,7 +9616,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -9639,7 +9639,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -9662,7 +9662,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -9685,7 +9685,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -9708,7 +9708,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -9731,7 +9731,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -9754,7 +9754,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -9777,7 +9777,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -9800,7 +9800,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -9823,7 +9823,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -9846,7 +9846,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -9869,7 +9869,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -9892,7 +9892,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -9915,7 +9915,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -9938,7 +9938,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -9961,7 +9961,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -9984,7 +9984,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -10007,7 +10007,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -10030,7 +10030,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -10053,7 +10053,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -10076,7 +10076,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -10099,7 +10099,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -10122,7 +10122,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -10145,7 +10145,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -10168,7 +10168,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -10191,7 +10191,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -10214,7 +10214,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -10237,7 +10237,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -10260,7 +10260,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -10283,7 +10283,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -10306,7 +10306,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -10329,7 +10329,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -10352,7 +10352,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -10375,7 +10375,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -10398,7 +10398,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -10421,7 +10421,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -10444,7 +10444,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -10467,7 +10467,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -10490,7 +10490,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -10513,7 +10513,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -10536,7 +10536,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -10559,7 +10559,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -10582,7 +10582,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -10605,7 +10605,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -10628,7 +10628,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -10651,7 +10651,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -10674,7 +10674,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -10697,7 +10697,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -10720,7 +10720,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -10743,7 +10743,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -10766,7 +10766,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -10789,7 +10789,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -10812,7 +10812,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -10835,7 +10835,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -10858,7 +10858,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -10881,7 +10881,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -10904,7 +10904,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -10927,7 +10927,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -10950,7 +10950,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -10973,7 +10973,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -10996,7 +10996,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -11019,7 +11019,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -11042,7 +11042,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -11065,7 +11065,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -11088,7 +11088,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -11111,7 +11111,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -11134,7 +11134,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -11157,7 +11157,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -11180,7 +11180,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -11203,7 +11203,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -11226,7 +11226,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -11249,7 +11249,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -11272,7 +11272,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -11295,7 +11295,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -11318,7 +11318,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -11341,7 +11341,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -11364,7 +11364,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -11387,7 +11387,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -11410,7 +11410,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -11433,7 +11433,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -11456,7 +11456,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -11479,7 +11479,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -11502,7 +11502,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -11525,7 +11525,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -11548,7 +11548,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -11571,7 +11571,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -11594,7 +11594,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -11617,7 +11617,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -11640,7 +11640,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -11663,7 +11663,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -11686,7 +11686,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -11709,7 +11709,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -11732,7 +11732,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -11755,7 +11755,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -11778,7 +11778,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -11801,7 +11801,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -11824,7 +11824,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -11847,7 +11847,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -11870,7 +11870,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -11893,7 +11893,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -11916,7 +11916,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -11939,7 +11939,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -11962,7 +11962,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -11985,7 +11985,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -12008,7 +12008,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -12031,7 +12031,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -12054,7 +12054,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -12077,7 +12077,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -12100,7 +12100,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -12123,7 +12123,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -12146,7 +12146,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -12169,7 +12169,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -12192,7 +12192,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -12215,7 +12215,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -12238,7 +12238,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -12261,7 +12261,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -12284,7 +12284,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -12307,7 +12307,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -12330,7 +12330,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -12353,7 +12353,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -12376,7 +12376,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -12399,7 +12399,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -12422,7 +12422,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -12445,7 +12445,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -12468,7 +12468,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -12491,7 +12491,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -12514,7 +12514,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -12537,7 +12537,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -12560,7 +12560,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -12583,7 +12583,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -12606,7 +12606,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -12629,7 +12629,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -12652,7 +12652,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -12675,7 +12675,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -12698,7 +12698,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -12721,7 +12721,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -12744,7 +12744,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -12767,7 +12767,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -12790,7 +12790,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -12813,7 +12813,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -12836,7 +12836,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -12859,7 +12859,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -12882,7 +12882,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -12905,7 +12905,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -12928,7 +12928,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -12951,7 +12951,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -12974,7 +12974,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -12997,7 +12997,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -13020,7 +13020,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -13043,7 +13043,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -13066,7 +13066,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -13089,7 +13089,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -13112,7 +13112,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -13135,7 +13135,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -13158,7 +13158,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -13181,7 +13181,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -13204,7 +13204,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -13227,7 +13227,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -13250,7 +13250,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -13273,7 +13273,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -13296,7 +13296,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -13319,7 +13319,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -13342,7 +13342,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -13365,7 +13365,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -13388,7 +13388,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -13411,7 +13411,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -13434,7 +13434,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -13457,7 +13457,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -13480,7 +13480,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -13503,7 +13503,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -13526,7 +13526,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -13549,7 +13549,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -13572,7 +13572,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -13595,7 +13595,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -13618,7 +13618,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -13641,7 +13641,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -13664,7 +13664,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -13687,7 +13687,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -13710,7 +13710,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -13733,7 +13733,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -13756,7 +13756,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -13779,7 +13779,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -13802,7 +13802,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -13825,7 +13825,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -13848,7 +13848,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -13871,7 +13871,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -13894,7 +13894,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -13917,7 +13917,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -13940,7 +13940,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -13963,7 +13963,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -13986,7 +13986,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -14009,7 +14009,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -14032,7 +14032,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -14055,7 +14055,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -14078,7 +14078,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -14101,7 +14101,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -14124,7 +14124,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -14147,7 +14147,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -14170,7 +14170,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -14193,7 +14193,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -14216,7 +14216,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -14239,7 +14239,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -14262,7 +14262,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -14285,7 +14285,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -14308,7 +14308,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -14331,7 +14331,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -14354,7 +14354,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -14377,7 +14377,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -14400,7 +14400,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -14423,7 +14423,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -14446,7 +14446,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -14469,7 +14469,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -14492,7 +14492,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -14515,7 +14515,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -14538,7 +14538,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -14561,7 +14561,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -14584,7 +14584,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -14607,7 +14607,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -14630,7 +14630,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -14653,7 +14653,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -14676,7 +14676,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -14699,7 +14699,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -14722,7 +14722,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -14745,7 +14745,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -14768,7 +14768,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -14791,7 +14791,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -14814,7 +14814,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -14837,7 +14837,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -14860,7 +14860,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -14883,7 +14883,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -14906,7 +14906,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -14929,7 +14929,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -14952,7 +14952,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -14975,7 +14975,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -14998,7 +14998,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -15021,7 +15021,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -15044,7 +15044,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -15067,7 +15067,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -15090,7 +15090,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -15113,7 +15113,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -15136,7 +15136,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -15159,7 +15159,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -15182,7 +15182,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -15205,7 +15205,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -15228,7 +15228,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -15251,7 +15251,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -15274,7 +15274,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -15297,7 +15297,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -15320,7 +15320,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -15343,7 +15343,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -15366,7 +15366,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -15389,7 +15389,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -15412,7 +15412,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -15435,7 +15435,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -15458,7 +15458,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -15481,7 +15481,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -15504,7 +15504,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -15527,7 +15527,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -15550,7 +15550,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -15573,7 +15573,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -15596,7 +15596,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -15619,7 +15619,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -15642,7 +15642,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -15665,7 +15665,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -15688,7 +15688,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -15711,7 +15711,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -15734,7 +15734,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -15757,7 +15757,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -15780,7 +15780,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -15803,7 +15803,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -15826,7 +15826,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -15849,7 +15849,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -15872,7 +15872,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -15895,7 +15895,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -15918,7 +15918,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -15941,7 +15941,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -15964,7 +15964,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -15987,7 +15987,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -16010,7 +16010,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -16033,7 +16033,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -16056,7 +16056,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -16079,7 +16079,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -16102,7 +16102,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -16125,7 +16125,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -16148,7 +16148,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -16171,7 +16171,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -16194,7 +16194,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -16217,7 +16217,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -16240,7 +16240,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -16263,7 +16263,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -16286,7 +16286,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -16309,7 +16309,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -16332,7 +16332,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -16355,7 +16355,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -16378,7 +16378,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -16401,7 +16401,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -16424,7 +16424,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -16447,7 +16447,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -16470,7 +16470,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -16493,7 +16493,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -16516,7 +16516,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -16539,7 +16539,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -16562,7 +16562,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -16585,7 +16585,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -16608,7 +16608,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -16631,7 +16631,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -16654,7 +16654,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -16677,7 +16677,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -16700,7 +16700,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -16723,7 +16723,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -16746,7 +16746,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -16769,7 +16769,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -16792,7 +16792,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -16815,7 +16815,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -16838,7 +16838,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -16861,7 +16861,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -16884,7 +16884,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -16907,7 +16907,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -16930,7 +16930,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -16953,7 +16953,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -16976,7 +16976,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -16999,7 +16999,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -17022,7 +17022,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -17045,7 +17045,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -17068,7 +17068,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -17091,7 +17091,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -17114,7 +17114,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -17137,7 +17137,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -17160,7 +17160,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -17183,7 +17183,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -17206,7 +17206,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -17229,7 +17229,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -17252,7 +17252,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -17275,7 +17275,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -17298,7 +17298,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -17321,7 +17321,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -17344,7 +17344,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -17367,7 +17367,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -17390,7 +17390,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -17413,7 +17413,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -17436,7 +17436,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -17459,7 +17459,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -17482,7 +17482,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -17505,7 +17505,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -17528,7 +17528,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -17551,7 +17551,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -17574,7 +17574,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -17597,7 +17597,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -17620,7 +17620,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -17643,7 +17643,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -17666,7 +17666,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -17689,7 +17689,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -17712,7 +17712,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -17735,7 +17735,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -17758,7 +17758,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -17781,7 +17781,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -17804,7 +17804,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -17827,7 +17827,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -17850,7 +17850,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -17873,7 +17873,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -17896,7 +17896,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -17919,7 +17919,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -17942,7 +17942,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -17965,7 +17965,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -17988,7 +17988,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -18011,7 +18011,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -18034,7 +18034,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -18057,7 +18057,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -18080,7 +18080,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -18103,7 +18103,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -18126,7 +18126,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -18149,7 +18149,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -18172,7 +18172,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -18195,7 +18195,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -18218,7 +18218,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -18241,7 +18241,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -18264,7 +18264,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -18287,7 +18287,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -18310,7 +18310,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -18333,7 +18333,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -18356,7 +18356,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -18379,7 +18379,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -18402,7 +18402,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -18425,7 +18425,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -18448,7 +18448,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -18471,7 +18471,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -18494,7 +18494,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -18517,7 +18517,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -18540,7 +18540,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -18563,7 +18563,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -18586,7 +18586,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -18609,7 +18609,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -18632,7 +18632,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -18655,7 +18655,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -18678,7 +18678,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -18701,7 +18701,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -18724,7 +18724,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -18747,7 +18747,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -18770,7 +18770,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -18793,7 +18793,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -18816,7 +18816,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -18839,7 +18839,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -18862,7 +18862,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -18885,7 +18885,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -18908,7 +18908,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -18931,7 +18931,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -18954,7 +18954,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -18977,7 +18977,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -19000,7 +19000,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -19023,7 +19023,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -19046,7 +19046,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -19069,7 +19069,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -19092,7 +19092,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -19115,7 +19115,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -19138,7 +19138,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -19161,7 +19161,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -19184,7 +19184,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -19207,7 +19207,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -19230,7 +19230,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -19253,7 +19253,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -19276,7 +19276,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -19299,7 +19299,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -19322,7 +19322,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -19345,7 +19345,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -19368,7 +19368,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -19391,7 +19391,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -19414,7 +19414,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -19437,7 +19437,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -19460,7 +19460,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -19483,7 +19483,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -19506,7 +19506,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -19529,7 +19529,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -19552,7 +19552,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -19575,7 +19575,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -19598,7 +19598,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -19621,7 +19621,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -19644,7 +19644,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -19667,7 +19667,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -19690,7 +19690,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -19713,7 +19713,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -19736,7 +19736,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -19759,7 +19759,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -19782,7 +19782,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -19805,7 +19805,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -19828,7 +19828,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -19851,7 +19851,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -19874,7 +19874,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -19897,7 +19897,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -19920,7 +19920,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -19943,7 +19943,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -19966,7 +19966,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -19989,7 +19989,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -20012,7 +20012,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -20035,7 +20035,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -20058,7 +20058,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -20081,7 +20081,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -20104,7 +20104,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -20127,7 +20127,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -20150,7 +20150,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -20173,7 +20173,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -20196,7 +20196,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -20219,7 +20219,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -20242,7 +20242,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -20265,7 +20265,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -20288,7 +20288,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -20311,7 +20311,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -20334,7 +20334,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -20357,7 +20357,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -20380,7 +20380,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -20403,7 +20403,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -20426,7 +20426,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -20449,7 +20449,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -20472,7 +20472,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -20495,7 +20495,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -20518,7 +20518,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -20541,7 +20541,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -20564,7 +20564,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -20587,7 +20587,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -20610,7 +20610,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -20633,7 +20633,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -20656,7 +20656,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -20679,7 +20679,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -20702,7 +20702,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -20725,7 +20725,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -20748,7 +20748,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -20771,7 +20771,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -20794,7 +20794,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -20817,7 +20817,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -20840,7 +20840,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -20863,7 +20863,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -20886,7 +20886,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -20909,7 +20909,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -20932,7 +20932,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -20955,7 +20955,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -20978,7 +20978,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -21001,7 +21001,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -21024,7 +21024,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -21047,7 +21047,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -21070,7 +21070,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -21093,7 +21093,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -21116,7 +21116,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -21139,7 +21139,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -21162,7 +21162,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -21185,7 +21185,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -21208,7 +21208,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -21231,7 +21231,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -21254,7 +21254,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -21277,7 +21277,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -21300,7 +21300,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -21323,7 +21323,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -21346,7 +21346,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -21369,7 +21369,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -21392,7 +21392,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -21415,7 +21415,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -21438,7 +21438,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -21461,7 +21461,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -21484,7 +21484,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -21507,7 +21507,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -21530,7 +21530,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -21553,7 +21553,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -21576,7 +21576,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -21599,7 +21599,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -21622,7 +21622,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -21645,7 +21645,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -21668,7 +21668,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -21691,7 +21691,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -21714,7 +21714,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -21737,7 +21737,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -21760,7 +21760,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -21783,7 +21783,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -21806,7 +21806,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -21829,7 +21829,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -21852,7 +21852,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -21875,7 +21875,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -21898,7 +21898,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -21921,7 +21921,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -21944,7 +21944,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -21967,7 +21967,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -21990,7 +21990,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -22013,7 +22013,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -22036,7 +22036,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -22059,7 +22059,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -22082,7 +22082,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -22105,7 +22105,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -22128,7 +22128,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -22151,7 +22151,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -22174,7 +22174,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -22197,7 +22197,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -22220,7 +22220,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -22243,7 +22243,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -22266,7 +22266,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -22289,7 +22289,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -22312,7 +22312,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -22335,7 +22335,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -22358,7 +22358,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -22381,7 +22381,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -22404,7 +22404,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -22427,7 +22427,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -22450,7 +22450,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -22473,7 +22473,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -22496,7 +22496,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -22519,7 +22519,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -22542,7 +22542,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -22565,7 +22565,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -22588,7 +22588,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -22611,7 +22611,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -22634,7 +22634,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -22657,7 +22657,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -22680,7 +22680,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -22703,7 +22703,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -22726,7 +22726,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -22749,7 +22749,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -22772,7 +22772,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -22795,7 +22795,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -22818,7 +22818,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -22841,7 +22841,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -22864,7 +22864,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -22887,7 +22887,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -22910,7 +22910,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -22933,7 +22933,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -22956,7 +22956,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -22979,7 +22979,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -23002,7 +23002,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -23025,7 +23025,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -23048,7 +23048,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -23071,7 +23071,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -23094,7 +23094,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -23117,7 +23117,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -23140,7 +23140,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -23163,7 +23163,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -23186,7 +23186,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -23209,7 +23209,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -23232,7 +23232,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -23255,7 +23255,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -23278,7 +23278,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -23301,7 +23301,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -23324,7 +23324,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -23347,7 +23347,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -23370,7 +23370,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -23393,7 +23393,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -23416,7 +23416,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -23439,7 +23439,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -23462,7 +23462,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -23485,7 +23485,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -23508,7 +23508,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -23531,7 +23531,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -23554,7 +23554,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -23577,7 +23577,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -23600,7 +23600,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -23623,7 +23623,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -23646,7 +23646,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -23669,7 +23669,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -23692,7 +23692,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -23715,7 +23715,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -23738,7 +23738,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -23761,7 +23761,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -23784,7 +23784,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -23807,7 +23807,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -23830,7 +23830,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -23853,7 +23853,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -23876,7 +23876,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -23899,7 +23899,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -23922,7 +23922,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -23945,7 +23945,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -23968,7 +23968,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -23991,7 +23991,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -24014,7 +24014,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -24037,7 +24037,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -24060,7 +24060,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -24083,7 +24083,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -24106,7 +24106,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -24129,7 +24129,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -24152,7 +24152,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -24175,7 +24175,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -24198,7 +24198,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -24221,7 +24221,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -24244,7 +24244,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -24267,7 +24267,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -24290,7 +24290,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -24313,7 +24313,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -24336,7 +24336,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -24359,7 +24359,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -24382,7 +24382,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -24405,7 +24405,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -24428,7 +24428,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -24451,7 +24451,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -24474,7 +24474,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -24497,7 +24497,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -24520,7 +24520,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -24543,7 +24543,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -24566,7 +24566,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -24589,7 +24589,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=19) "npm-shrinkwrap.json",
@@ -24612,7 +24612,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -24635,7 +24635,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -24658,7 +24658,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -24681,7 +24681,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -24704,7 +24704,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -24727,7 +24727,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -24750,7 +24750,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -24773,7 +24773,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -24796,7 +24796,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -24819,7 +24819,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -24842,7 +24842,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -24865,7 +24865,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -24888,7 +24888,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -24911,7 +24911,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -24934,7 +24934,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -24957,7 +24957,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -24980,7 +24980,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -25003,7 +25003,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -25026,7 +25026,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -25049,7 +25049,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -25072,7 +25072,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -25095,7 +25095,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -25118,7 +25118,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -25141,7 +25141,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -25164,7 +25164,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -25187,7 +25187,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -25210,7 +25210,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -25233,7 +25233,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -25256,7 +25256,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -25279,7 +25279,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -25302,7 +25302,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -25325,7 +25325,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -25348,7 +25348,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -25371,7 +25371,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -25394,7 +25394,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -25417,7 +25417,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -25440,7 +25440,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -25463,7 +25463,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -25486,7 +25486,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -25509,7 +25509,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -25532,7 +25532,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -25555,7 +25555,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -25578,7 +25578,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -25601,7 +25601,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -25624,7 +25624,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -25647,7 +25647,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -25670,7 +25670,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -25693,7 +25693,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -25716,7 +25716,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -25739,7 +25739,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -25762,7 +25762,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -25785,7 +25785,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -25808,7 +25808,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -25831,7 +25831,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -25854,7 +25854,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -25877,7 +25877,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -25900,7 +25900,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -25923,7 +25923,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -25946,7 +25946,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -25969,7 +25969,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -25992,7 +25992,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -26015,7 +26015,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -26038,7 +26038,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -26061,7 +26061,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -26084,7 +26084,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -26107,7 +26107,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -26130,7 +26130,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -26153,7 +26153,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -26176,7 +26176,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -26199,7 +26199,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -26222,7 +26222,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -26245,7 +26245,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -26268,7 +26268,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -26291,7 +26291,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -26314,7 +26314,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -26337,7 +26337,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -26360,7 +26360,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -26383,7 +26383,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -26406,7 +26406,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -26429,7 +26429,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -26452,7 +26452,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -26475,7 +26475,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -26498,7 +26498,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -26521,7 +26521,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -26544,7 +26544,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -26567,7 +26567,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -26590,7 +26590,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -26613,7 +26613,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -26636,7 +26636,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -26659,7 +26659,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -26682,7 +26682,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -26705,7 +26705,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -26728,7 +26728,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -26751,7 +26751,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -26774,7 +26774,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -26797,7 +26797,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -26820,7 +26820,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -26843,7 +26843,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -26866,7 +26866,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -26889,7 +26889,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -26912,7 +26912,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -26935,7 +26935,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -26958,7 +26958,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -26981,7 +26981,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -27004,7 +27004,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -27027,7 +27027,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -27050,7 +27050,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -27073,7 +27073,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -27096,7 +27096,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -27119,7 +27119,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -27142,7 +27142,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -27165,7 +27165,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -27188,7 +27188,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -27211,7 +27211,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -27234,7 +27234,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -27257,7 +27257,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -27280,7 +27280,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -27303,7 +27303,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -27326,7 +27326,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -27349,7 +27349,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -27372,7 +27372,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -27395,7 +27395,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -27418,7 +27418,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -27441,7 +27441,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -27464,7 +27464,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -27487,7 +27487,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -27510,7 +27510,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -27533,7 +27533,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -27556,7 +27556,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -27579,7 +27579,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -27602,7 +27602,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -27625,7 +27625,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -27648,7 +27648,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -27671,7 +27671,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -27694,7 +27694,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -27717,7 +27717,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -27740,7 +27740,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -27763,7 +27763,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -27786,7 +27786,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -27809,7 +27809,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -27832,7 +27832,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -27855,7 +27855,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -27878,7 +27878,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -27901,7 +27901,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -27924,7 +27924,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -27947,7 +27947,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -27970,7 +27970,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -27993,7 +27993,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -28016,7 +28016,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -28039,7 +28039,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -28062,7 +28062,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -28085,7 +28085,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -28108,7 +28108,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -28131,7 +28131,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -28154,7 +28154,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -28177,7 +28177,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -28200,7 +28200,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -28223,7 +28223,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -28246,7 +28246,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -28269,7 +28269,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -28292,7 +28292,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -28315,7 +28315,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -28338,7 +28338,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -28361,7 +28361,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -28384,7 +28384,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -28407,7 +28407,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -28430,7 +28430,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -28453,7 +28453,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -28476,7 +28476,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -28499,7 +28499,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -28522,7 +28522,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -28545,7 +28545,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -28568,7 +28568,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -28591,7 +28591,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -28614,7 +28614,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -28637,7 +28637,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -28660,7 +28660,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -28683,7 +28683,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -28706,7 +28706,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -28729,7 +28729,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -28752,7 +28752,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -28775,7 +28775,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -28798,7 +28798,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -28821,7 +28821,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -28844,7 +28844,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -28867,7 +28867,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -28890,7 +28890,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -28913,7 +28913,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -28936,7 +28936,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -28959,7 +28959,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -28982,7 +28982,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -29005,7 +29005,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -29028,7 +29028,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -29051,7 +29051,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -29074,7 +29074,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -29097,7 +29097,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -29120,7 +29120,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -29143,7 +29143,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -29166,7 +29166,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -29189,7 +29189,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -29212,7 +29212,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -29235,7 +29235,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -29258,7 +29258,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -29281,7 +29281,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -29304,7 +29304,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -29327,7 +29327,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -29350,7 +29350,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -29373,7 +29373,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -29396,7 +29396,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -29419,7 +29419,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -29442,7 +29442,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -29465,7 +29465,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -29488,7 +29488,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -29511,7 +29511,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -29534,7 +29534,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -29557,7 +29557,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -29580,7 +29580,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -29603,7 +29603,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -29626,7 +29626,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -29649,7 +29649,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -29672,7 +29672,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -29695,7 +29695,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -29718,7 +29718,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -29741,7 +29741,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -29764,7 +29764,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -29787,7 +29787,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -29810,7 +29810,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -29833,7 +29833,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -29856,7 +29856,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -29879,7 +29879,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -29902,7 +29902,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -29925,7 +29925,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -29948,7 +29948,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -29971,7 +29971,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -29994,7 +29994,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -30017,7 +30017,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -30040,7 +30040,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -30063,7 +30063,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -30086,7 +30086,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -30109,7 +30109,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -30132,7 +30132,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -30155,7 +30155,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -30178,7 +30178,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -30201,7 +30201,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -30224,7 +30224,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -30247,7 +30247,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -30270,7 +30270,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -30293,7 +30293,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -30316,7 +30316,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -30339,7 +30339,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -30362,7 +30362,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -30385,7 +30385,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -30408,7 +30408,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -30431,7 +30431,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -30454,7 +30454,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -30477,7 +30477,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -30500,7 +30500,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -30523,7 +30523,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -30546,7 +30546,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -30569,7 +30569,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -30592,7 +30592,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -30615,7 +30615,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -30638,7 +30638,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -30661,7 +30661,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -30684,7 +30684,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -30707,7 +30707,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -30730,7 +30730,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -30753,7 +30753,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -30776,7 +30776,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -30799,7 +30799,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -30822,7 +30822,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -30845,7 +30845,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -30868,7 +30868,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -30891,7 +30891,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -30914,7 +30914,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -30937,7 +30937,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -30960,7 +30960,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -30983,7 +30983,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -31006,7 +31006,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -31029,7 +31029,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -31052,7 +31052,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -31075,7 +31075,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -31098,7 +31098,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -31121,7 +31121,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -31144,7 +31144,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -31167,7 +31167,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -31190,7 +31190,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -31213,7 +31213,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -31236,7 +31236,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -31259,7 +31259,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -31282,7 +31282,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -31305,7 +31305,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -31328,7 +31328,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -31351,7 +31351,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -31374,7 +31374,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -31397,7 +31397,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -31420,7 +31420,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -31443,7 +31443,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -31466,7 +31466,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -31489,7 +31489,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -31512,7 +31512,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -31535,7 +31535,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -31558,7 +31558,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -31581,7 +31581,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -31604,7 +31604,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -31627,7 +31627,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -31650,7 +31650,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -31673,7 +31673,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -31696,7 +31696,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -31719,7 +31719,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -31742,7 +31742,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -31765,7 +31765,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -31788,7 +31788,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -31811,7 +31811,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -31834,7 +31834,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -31857,7 +31857,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -31880,7 +31880,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -31903,7 +31903,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -31926,7 +31926,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -31949,7 +31949,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -31972,7 +31972,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -31995,7 +31995,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -32018,7 +32018,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -32041,7 +32041,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -32064,7 +32064,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -32087,7 +32087,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -32110,7 +32110,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -32133,7 +32133,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -32156,7 +32156,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -32179,7 +32179,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -32202,7 +32202,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -32225,7 +32225,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -32248,7 +32248,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -32271,7 +32271,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -32294,7 +32294,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -32317,7 +32317,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -32340,7 +32340,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -32363,7 +32363,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -32386,7 +32386,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -32409,7 +32409,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -32432,7 +32432,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -32455,7 +32455,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -32478,7 +32478,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -32501,7 +32501,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -32524,7 +32524,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -32547,7 +32547,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -32570,7 +32570,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -32593,7 +32593,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -32616,7 +32616,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -32639,7 +32639,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -32662,7 +32662,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -32685,7 +32685,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -32708,7 +32708,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -32731,7 +32731,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -32754,7 +32754,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -32777,7 +32777,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -32800,7 +32800,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -32823,7 +32823,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -32846,7 +32846,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -32869,7 +32869,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -32892,7 +32892,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -32915,7 +32915,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -32938,7 +32938,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -32961,7 +32961,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -32984,7 +32984,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -33007,7 +33007,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -33030,7 +33030,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -33053,7 +33053,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -33076,7 +33076,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -33099,7 +33099,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -33122,7 +33122,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -33145,7 +33145,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -33168,7 +33168,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -33191,7 +33191,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -33214,7 +33214,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -33237,7 +33237,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -33260,7 +33260,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -33283,7 +33283,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -33306,7 +33306,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -33329,7 +33329,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -33352,7 +33352,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -33375,7 +33375,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -33398,7 +33398,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -33421,7 +33421,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -33444,7 +33444,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -33467,7 +33467,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -33490,7 +33490,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -33513,7 +33513,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -33536,7 +33536,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -33559,7 +33559,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -33582,7 +33582,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -33605,7 +33605,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -33628,7 +33628,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -33651,7 +33651,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -33674,7 +33674,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -33697,7 +33697,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -33720,7 +33720,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -33743,7 +33743,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -33766,7 +33766,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -33789,7 +33789,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -33812,7 +33812,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -33835,7 +33835,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -33858,7 +33858,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -33881,7 +33881,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -33904,7 +33904,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -33927,7 +33927,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -33950,7 +33950,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -33973,7 +33973,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -33996,7 +33996,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -34019,7 +34019,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -34042,7 +34042,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -34065,7 +34065,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -34088,7 +34088,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -34111,7 +34111,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -34134,7 +34134,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -34157,7 +34157,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -34180,7 +34180,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -34203,7 +34203,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -34226,7 +34226,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -34249,7 +34249,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -34272,7 +34272,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -34295,7 +34295,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -34318,7 +34318,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -34341,7 +34341,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -34364,7 +34364,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -34387,7 +34387,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -34410,7 +34410,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -34433,7 +34433,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -34456,7 +34456,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -34479,7 +34479,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -34502,7 +34502,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -34525,7 +34525,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -34548,7 +34548,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -34571,7 +34571,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -34594,7 +34594,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -34617,7 +34617,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -34640,7 +34640,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -34663,7 +34663,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -34686,7 +34686,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -34709,7 +34709,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -34732,7 +34732,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -34755,7 +34755,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -34778,7 +34778,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -34801,7 +34801,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -34824,7 +34824,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -34847,7 +34847,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -34870,7 +34870,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -34893,7 +34893,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -34916,7 +34916,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -34939,7 +34939,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -34962,7 +34962,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -34985,7 +34985,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -35008,7 +35008,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -35031,7 +35031,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -35054,7 +35054,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -35077,7 +35077,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -35100,7 +35100,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -35123,7 +35123,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -35146,7 +35146,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -35169,7 +35169,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -35192,7 +35192,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -35215,7 +35215,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -35238,7 +35238,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -35261,7 +35261,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -35284,7 +35284,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -35307,7 +35307,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -35330,7 +35330,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -35353,7 +35353,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -35376,7 +35376,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -35399,7 +35399,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -35422,7 +35422,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -35445,7 +35445,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -35468,7 +35468,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -35491,7 +35491,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -35514,7 +35514,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -35537,7 +35537,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -35560,7 +35560,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -35583,7 +35583,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -35606,7 +35606,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -35629,7 +35629,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -35652,7 +35652,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -35675,7 +35675,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -35698,7 +35698,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -35721,7 +35721,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -35744,7 +35744,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -35767,7 +35767,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -35790,7 +35790,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -35813,7 +35813,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -35836,7 +35836,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -35859,7 +35859,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -35882,7 +35882,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -35905,7 +35905,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -35928,7 +35928,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -35951,7 +35951,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -35974,7 +35974,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -35997,7 +35997,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -36020,7 +36020,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -36043,7 +36043,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -36066,7 +36066,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -36089,7 +36089,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -36112,7 +36112,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -36135,7 +36135,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -36158,7 +36158,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -36181,7 +36181,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -36204,7 +36204,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -36227,7 +36227,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -36250,7 +36250,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -36273,7 +36273,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -36296,7 +36296,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -36319,7 +36319,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -36342,7 +36342,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -36365,7 +36365,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -36388,7 +36388,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -36411,7 +36411,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -36434,7 +36434,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -36457,7 +36457,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -36480,7 +36480,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -36503,7 +36503,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -36526,7 +36526,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -36549,7 +36549,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -36572,7 +36572,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -36595,7 +36595,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -36618,7 +36618,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -36641,7 +36641,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -36664,7 +36664,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -36687,7 +36687,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -36710,7 +36710,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -36733,7 +36733,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -36756,7 +36756,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -36779,7 +36779,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -36802,7 +36802,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -36825,7 +36825,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -36848,7 +36848,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -36871,7 +36871,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -36894,7 +36894,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -36917,7 +36917,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -36940,7 +36940,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -36963,7 +36963,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -36986,7 +36986,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -37009,7 +37009,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -37032,7 +37032,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -37055,7 +37055,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -37078,7 +37078,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -37101,7 +37101,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -37124,7 +37124,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -37147,7 +37147,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -37170,7 +37170,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -37193,7 +37193,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -37216,7 +37216,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -37239,7 +37239,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -37262,7 +37262,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -37285,7 +37285,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -37308,7 +37308,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -37331,7 +37331,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -37354,7 +37354,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -37377,7 +37377,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -37400,7 +37400,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -37423,7 +37423,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -37446,7 +37446,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -37469,7 +37469,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -37492,7 +37492,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -37515,7 +37515,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -37538,7 +37538,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -37561,7 +37561,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -37584,7 +37584,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -37607,7 +37607,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -37630,7 +37630,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -37653,7 +37653,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -37676,7 +37676,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -37699,7 +37699,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -37722,7 +37722,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -37745,7 +37745,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -37768,7 +37768,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -37791,7 +37791,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -37814,7 +37814,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -37837,7 +37837,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -37860,7 +37860,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -37883,7 +37883,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -37906,7 +37906,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -37929,7 +37929,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -37952,7 +37952,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -37975,7 +37975,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -37998,7 +37998,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -38021,7 +38021,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -38044,7 +38044,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -38067,7 +38067,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -38090,7 +38090,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -38113,7 +38113,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -38136,7 +38136,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -38159,7 +38159,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -38182,7 +38182,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -38205,7 +38205,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -38228,7 +38228,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -38251,7 +38251,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -38274,7 +38274,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -38297,7 +38297,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -38320,7 +38320,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -38343,7 +38343,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -38366,7 +38366,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -38389,7 +38389,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -38412,7 +38412,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -38435,7 +38435,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -38458,7 +38458,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -38481,7 +38481,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -38504,7 +38504,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -38527,7 +38527,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -38550,7 +38550,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -38573,7 +38573,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -38596,7 +38596,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -38619,7 +38619,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -38642,7 +38642,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -38665,7 +38665,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -38688,7 +38688,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -38711,7 +38711,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -38734,7 +38734,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -38757,7 +38757,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -38780,7 +38780,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -38803,7 +38803,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -38826,7 +38826,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -38849,7 +38849,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -38872,7 +38872,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -38895,7 +38895,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -38918,7 +38918,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -38941,7 +38941,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -38964,7 +38964,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -38987,7 +38987,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -39010,7 +39010,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -39033,7 +39033,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -39056,7 +39056,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -39079,7 +39079,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -39102,7 +39102,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -39125,7 +39125,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -39148,7 +39148,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -39171,7 +39171,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -39194,7 +39194,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -39217,7 +39217,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -39240,7 +39240,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -39263,7 +39263,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -39286,7 +39286,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -39309,7 +39309,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -39332,7 +39332,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -39355,7 +39355,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -39378,7 +39378,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -39401,7 +39401,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -39424,7 +39424,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -39447,7 +39447,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -39470,7 +39470,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -39493,7 +39493,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -39516,7 +39516,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -39539,7 +39539,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -39562,7 +39562,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -39585,7 +39585,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -39608,7 +39608,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -39631,7 +39631,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -39654,7 +39654,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -39677,7 +39677,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -39700,7 +39700,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -39723,7 +39723,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -39746,7 +39746,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -39769,7 +39769,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -39792,7 +39792,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -39815,7 +39815,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -39838,7 +39838,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -39861,7 +39861,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -39884,7 +39884,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -39907,7 +39907,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -39930,7 +39930,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -39953,7 +39953,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -39976,7 +39976,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -39999,7 +39999,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -40022,7 +40022,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -40045,7 +40045,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -40068,7 +40068,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -40091,7 +40091,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -40114,7 +40114,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -40137,7 +40137,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -40160,7 +40160,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -40183,7 +40183,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -40206,7 +40206,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -40229,7 +40229,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -40252,7 +40252,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -40275,7 +40275,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -40298,7 +40298,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -40321,7 +40321,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -40344,7 +40344,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -40367,7 +40367,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -40390,7 +40390,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -40413,7 +40413,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -40436,7 +40436,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -40459,7 +40459,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -40482,7 +40482,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -40505,7 +40505,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -40528,7 +40528,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -40551,7 +40551,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -40574,7 +40574,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -40597,7 +40597,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -40620,7 +40620,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -40643,7 +40643,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -40666,7 +40666,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -40689,7 +40689,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -40712,7 +40712,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -40735,7 +40735,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -40758,7 +40758,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -40781,7 +40781,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -40804,7 +40804,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -40827,7 +40827,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -40850,7 +40850,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -40873,7 +40873,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -40896,7 +40896,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -40919,7 +40919,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -40942,7 +40942,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -40965,7 +40965,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -40988,7 +40988,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -41011,7 +41011,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -41034,7 +41034,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -41057,7 +41057,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -41080,7 +41080,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -41103,7 +41103,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -41126,7 +41126,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -41149,7 +41149,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -41172,7 +41172,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -41195,7 +41195,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -41218,7 +41218,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -41241,7 +41241,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -41264,7 +41264,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -41287,7 +41287,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -41310,7 +41310,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -41333,7 +41333,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -41356,7 +41356,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -41379,7 +41379,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -41402,7 +41402,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -41425,7 +41425,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -41448,7 +41448,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -41471,7 +41471,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -41494,7 +41494,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -41517,7 +41517,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -41540,7 +41540,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -41563,7 +41563,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -41586,7 +41586,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -41609,7 +41609,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -41632,7 +41632,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -41655,7 +41655,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -41678,7 +41678,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -41701,7 +41701,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -41724,7 +41724,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -41747,7 +41747,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -41770,7 +41770,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -41793,7 +41793,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -41816,7 +41816,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -41839,7 +41839,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -41862,7 +41862,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -41885,7 +41885,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -41908,7 +41908,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -41931,7 +41931,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -41954,7 +41954,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -41977,7 +41977,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -42000,7 +42000,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -42023,7 +42023,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -42046,7 +42046,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -42069,7 +42069,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -42092,7 +42092,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -42115,7 +42115,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -42138,7 +42138,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -42161,7 +42161,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -42184,7 +42184,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -42207,7 +42207,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -42230,7 +42230,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -42253,7 +42253,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -42276,7 +42276,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -42299,7 +42299,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -42322,7 +42322,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -42345,7 +42345,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -42368,7 +42368,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -42391,7 +42391,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -42414,7 +42414,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -42437,7 +42437,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -42460,7 +42460,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -42483,7 +42483,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -42506,7 +42506,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -42529,7 +42529,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -42552,7 +42552,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -42575,7 +42575,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -42598,7 +42598,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -42621,7 +42621,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -42644,7 +42644,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -42667,7 +42667,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -42690,7 +42690,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -42713,7 +42713,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -42736,7 +42736,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -42759,7 +42759,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -42782,7 +42782,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -42805,7 +42805,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -42828,7 +42828,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -42851,7 +42851,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -42874,7 +42874,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -42897,7 +42897,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -42920,7 +42920,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -42943,7 +42943,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -42966,7 +42966,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -42989,7 +42989,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -43012,7 +43012,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -43035,7 +43035,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -43058,7 +43058,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -43081,7 +43081,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -43104,7 +43104,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -43127,7 +43127,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -43150,7 +43150,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -43173,7 +43173,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -43196,7 +43196,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -43219,7 +43219,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -43242,7 +43242,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -43265,7 +43265,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -43288,7 +43288,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -43311,7 +43311,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -43334,7 +43334,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -43357,7 +43357,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -43380,7 +43380,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -43403,7 +43403,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -43426,7 +43426,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -43449,7 +43449,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -43472,7 +43472,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -43495,7 +43495,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -43518,7 +43518,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -43541,7 +43541,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -43564,7 +43564,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -43587,7 +43587,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -43610,7 +43610,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -43633,7 +43633,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -43656,7 +43656,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -43679,7 +43679,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -43702,7 +43702,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -43725,7 +43725,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -43748,7 +43748,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -43771,7 +43771,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -43794,7 +43794,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -43817,7 +43817,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -43840,7 +43840,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -43863,7 +43863,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -43886,7 +43886,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -43909,7 +43909,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -43932,7 +43932,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -43955,7 +43955,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -43978,7 +43978,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -44001,7 +44001,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -44024,7 +44024,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -44047,7 +44047,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -44070,7 +44070,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -44093,7 +44093,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -44116,7 +44116,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -44139,7 +44139,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -44162,7 +44162,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -44185,7 +44185,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -44208,7 +44208,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -44231,7 +44231,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -44254,7 +44254,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -44277,7 +44277,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -44300,7 +44300,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -44323,7 +44323,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -44346,7 +44346,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -44369,7 +44369,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -44392,7 +44392,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -44415,7 +44415,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -44438,7 +44438,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -44461,7 +44461,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -44484,7 +44484,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -44507,7 +44507,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -44530,7 +44530,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -44553,7 +44553,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -44576,7 +44576,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -44599,7 +44599,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -44622,7 +44622,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -44645,7 +44645,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -44668,7 +44668,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -44691,7 +44691,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -44714,7 +44714,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -44737,7 +44737,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -44760,7 +44760,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -44783,7 +44783,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -44806,7 +44806,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -44829,7 +44829,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -44852,7 +44852,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -44875,7 +44875,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -44898,7 +44898,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -44921,7 +44921,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -44944,7 +44944,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -44967,7 +44967,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -44990,7 +44990,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -45013,7 +45013,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -45036,7 +45036,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -45059,7 +45059,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -45082,7 +45082,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -45105,7 +45105,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -45128,7 +45128,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -45151,7 +45151,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -45174,7 +45174,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -45197,7 +45197,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -45220,7 +45220,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -45243,7 +45243,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -45266,7 +45266,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -45289,7 +45289,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -45312,7 +45312,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -45335,7 +45335,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -45358,7 +45358,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -45381,7 +45381,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -45404,7 +45404,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -45427,7 +45427,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -45450,7 +45450,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -45473,7 +45473,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -45496,7 +45496,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -45519,7 +45519,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -45542,7 +45542,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -45565,7 +45565,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -45588,7 +45588,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -45611,7 +45611,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -45634,7 +45634,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -45657,7 +45657,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -45680,7 +45680,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -45703,7 +45703,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -45726,7 +45726,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -45749,7 +45749,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -45772,7 +45772,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -45795,7 +45795,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -45818,7 +45818,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -45841,7 +45841,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -45864,7 +45864,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -45887,7 +45887,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -45910,7 +45910,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -45933,7 +45933,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -45956,7 +45956,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -45979,7 +45979,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -46002,7 +46002,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -46025,7 +46025,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -46048,7 +46048,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -46071,7 +46071,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -46094,7 +46094,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -46117,7 +46117,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -46140,7 +46140,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -46163,7 +46163,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -46186,7 +46186,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -46209,7 +46209,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -46232,7 +46232,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -46255,7 +46255,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -46278,7 +46278,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -46301,7 +46301,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -46324,7 +46324,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -46347,7 +46347,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -46370,7 +46370,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -46393,7 +46393,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -46416,7 +46416,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -46439,7 +46439,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -46462,7 +46462,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -46485,7 +46485,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -46508,7 +46508,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -46531,7 +46531,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -46554,7 +46554,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -46577,7 +46577,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -46600,7 +46600,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -46623,7 +46623,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -46646,7 +46646,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -46669,7 +46669,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -46692,7 +46692,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -46715,7 +46715,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -46738,7 +46738,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -46761,7 +46761,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -46784,7 +46784,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -46807,7 +46807,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -46830,7 +46830,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -46853,7 +46853,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -46876,7 +46876,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -46899,7 +46899,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -46922,7 +46922,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -46945,7 +46945,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -46968,7 +46968,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -46991,7 +46991,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -47014,7 +47014,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -47037,7 +47037,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -47060,7 +47060,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -47083,7 +47083,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -47106,7 +47106,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -47129,7 +47129,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -47152,7 +47152,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -47175,7 +47175,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -47198,7 +47198,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -47221,7 +47221,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -47244,7 +47244,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -47267,7 +47267,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -47290,7 +47290,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -47313,7 +47313,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -47336,7 +47336,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -47359,7 +47359,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -47382,7 +47382,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -47405,7 +47405,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -47428,7 +47428,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -47451,7 +47451,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -47474,7 +47474,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -47497,7 +47497,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -47520,7 +47520,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -47543,7 +47543,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -47566,7 +47566,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -47589,7 +47589,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -47612,7 +47612,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -47635,7 +47635,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -47658,7 +47658,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -47681,7 +47681,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -47704,7 +47704,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -47727,7 +47727,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -47750,7 +47750,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -47773,7 +47773,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -47796,7 +47796,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -47819,7 +47819,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -47842,7 +47842,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -47865,7 +47865,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -47888,7 +47888,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -47911,7 +47911,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -47934,7 +47934,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -47957,7 +47957,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -47980,7 +47980,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -48003,7 +48003,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -48026,7 +48026,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -48049,7 +48049,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -48072,7 +48072,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -48095,7 +48095,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -48118,7 +48118,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -48141,7 +48141,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -48164,7 +48164,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -48187,7 +48187,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -48210,7 +48210,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -48233,7 +48233,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -48256,7 +48256,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -48279,7 +48279,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -48302,7 +48302,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -48325,7 +48325,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -48348,7 +48348,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -48371,7 +48371,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -48394,7 +48394,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -48417,7 +48417,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -48440,7 +48440,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -48463,7 +48463,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -48486,7 +48486,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -48509,7 +48509,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -48532,7 +48532,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -48555,7 +48555,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -48578,7 +48578,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -48601,7 +48601,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -48624,7 +48624,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -48647,7 +48647,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -48670,7 +48670,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -48693,7 +48693,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -48716,7 +48716,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -48739,7 +48739,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -48762,7 +48762,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -48785,7 +48785,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -48808,7 +48808,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -48831,7 +48831,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -48854,7 +48854,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -48877,7 +48877,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -48900,7 +48900,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -48923,7 +48923,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -48946,7 +48946,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -48969,7 +48969,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -48992,7 +48992,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -49015,7 +49015,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -49038,7 +49038,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -49061,7 +49061,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -49084,7 +49084,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -49107,7 +49107,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -49130,7 +49130,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -49153,7 +49153,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -49176,7 +49176,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -49199,7 +49199,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -49222,7 +49222,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -49245,7 +49245,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -49268,7 +49268,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -49291,7 +49291,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -49314,7 +49314,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -49337,7 +49337,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -49360,7 +49360,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -49383,7 +49383,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -49406,7 +49406,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -49429,7 +49429,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -49452,7 +49452,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -49475,7 +49475,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -49498,7 +49498,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -49521,7 +49521,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -49544,7 +49544,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -49567,7 +49567,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -49590,7 +49590,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -49613,7 +49613,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -49636,7 +49636,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -49659,7 +49659,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -49682,7 +49682,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -49705,7 +49705,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -49728,7 +49728,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -49751,7 +49751,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -49774,7 +49774,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -49797,7 +49797,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -49820,7 +49820,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",
@@ -49843,7 +49843,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=3) "npm",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=17) "package-lock.json",

--- a/pkg/detectors/dependencies/npm/npm.go
+++ b/pkg/detectors/dependencies/npm/npm.go
@@ -54,7 +54,7 @@ var queryRequires = parser.QueryMustCompile(language, `
 func Discover(f *file.FileInfo) (report *depsbase.DiscoveredDependency) {
 	report = &depsbase.DiscoveredDependency{}
 	report.Provider = "npm"
-	report.Language = "JavaScript"
+	report.Language = "javascript"
 	report.PackageManager = "npm"
 	tree, err := parser.ParseFile(f, f.Path, language)
 	if err != nil {

--- a/pkg/detectors/dependencies/nuget/.snapshots/TestDependenciesReport
+++ b/pkg/detectors/dependencies/nuget/.snapshots/TestDependenciesReport
@@ -2,7 +2,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -25,7 +25,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -48,7 +48,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -71,7 +71,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -94,7 +94,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -117,7 +117,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -140,7 +140,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -163,7 +163,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -186,7 +186,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -209,7 +209,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -232,7 +232,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -255,7 +255,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -278,7 +278,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -301,7 +301,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -324,7 +324,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -347,7 +347,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -370,7 +370,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -393,7 +393,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -416,7 +416,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -439,7 +439,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -462,7 +462,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -485,7 +485,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -508,7 +508,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -531,7 +531,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -554,7 +554,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -577,7 +577,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -600,7 +600,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -623,7 +623,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -646,7 +646,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -669,7 +669,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -692,7 +692,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -715,7 +715,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -738,7 +738,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -761,7 +761,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -784,7 +784,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -807,7 +807,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -830,7 +830,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -853,7 +853,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -876,7 +876,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -899,7 +899,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -922,7 +922,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -945,7 +945,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -968,7 +968,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -991,7 +991,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -1014,7 +1014,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -1037,7 +1037,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -1060,7 +1060,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -1083,7 +1083,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -1106,7 +1106,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -1129,7 +1129,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -1152,7 +1152,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -1175,7 +1175,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -1198,7 +1198,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -1221,7 +1221,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -1244,7 +1244,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -1267,7 +1267,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -1290,7 +1290,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -1313,7 +1313,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -1336,7 +1336,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -1359,7 +1359,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -1382,7 +1382,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -1405,7 +1405,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -1428,7 +1428,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -1451,7 +1451,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -1474,7 +1474,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -1497,7 +1497,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -1520,7 +1520,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -1543,7 +1543,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -1566,7 +1566,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -1589,7 +1589,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -1612,7 +1612,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -1635,7 +1635,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -1658,7 +1658,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -1681,7 +1681,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -1704,7 +1704,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -1727,7 +1727,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -1750,7 +1750,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -1773,7 +1773,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -1796,7 +1796,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -1819,7 +1819,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -1842,7 +1842,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -1865,7 +1865,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -1888,7 +1888,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -1911,7 +1911,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -1934,7 +1934,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -1957,7 +1957,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -1980,7 +1980,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -2003,7 +2003,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -2026,7 +2026,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -2049,7 +2049,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -2072,7 +2072,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -2095,7 +2095,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -2118,7 +2118,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -2141,7 +2141,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -2164,7 +2164,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -2187,7 +2187,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -2210,7 +2210,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -2233,7 +2233,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -2256,7 +2256,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -2279,7 +2279,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -2302,7 +2302,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -2325,7 +2325,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -2348,7 +2348,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -2371,7 +2371,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -2394,7 +2394,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -2417,7 +2417,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",
@@ -2440,7 +2440,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=5) "nuget",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "packages.lock.json",

--- a/pkg/detectors/dependencies/nuget/nuget.go
+++ b/pkg/detectors/dependencies/nuget/nuget.go
@@ -55,7 +55,7 @@ var queryNestedDependencies = parser.QueryMustCompile(language, `
 func Discover(f *file.FileInfo) (report *depsbase.DiscoveredDependency) {
 	report = &depsbase.DiscoveredDependency{}
 	report.Provider = "nuget"
-	report.Language = "C#"
+	report.Language = "csharp"
 	report.PackageManager = "nuget"
 	tree, err := parser.ParseFile(f, f.Path, language)
 	if err != nil {

--- a/pkg/detectors/dependencies/package-config/.snapshots/TestDependenciesReport
+++ b/pkg/detectors/dependencies/package-config/.snapshots/TestDependenciesReport
@@ -2,7 +2,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=14) "package-config",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=15) "packages.config",
@@ -25,7 +25,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=14) "package-config",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=15) "packages.config",

--- a/pkg/detectors/dependencies/package-config/package-config.go
+++ b/pkg/detectors/dependencies/package-config/package-config.go
@@ -34,7 +34,7 @@ var queryDependencies = parser.QueryMustCompile(language, `
 func Discover(f *file.FileInfo) (report *depsbase.DiscoveredDependency) {
 	report = &depsbase.DiscoveredDependency{}
 	report.Provider = "package-config"
-	report.Language = "C#"
+	report.Language = "csharp"
 	report.PackageManager = "nuget"
 	tree, err := parser.ParseFile(f, f.Path, language)
 	if err != nil {

--- a/pkg/detectors/dependencies/package-json/.snapshots/TestDependenciesReport
+++ b/pkg/detectors/dependencies/package-json/.snapshots/TestDependenciesReport
@@ -2,7 +2,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "package-json",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "package.json",
@@ -25,7 +25,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "package-json",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "package.json",
@@ -48,7 +48,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "package-json",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "package.json",
@@ -71,7 +71,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "package-json",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "package.json",
@@ -94,7 +94,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "package-json",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "package.json",
@@ -117,7 +117,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "package-json",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "package.json",
@@ -140,7 +140,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "package-json",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "package.json",
@@ -163,7 +163,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "package-json",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "package.json",
@@ -186,7 +186,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "package-json",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "package.json",
@@ -209,7 +209,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "package-json",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "package.json",
@@ -232,7 +232,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "package-json",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "package.json",
@@ -255,7 +255,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "package-json",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "package.json",
@@ -278,7 +278,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "package-json",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "package.json",
@@ -301,7 +301,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "package-json",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "package.json",
@@ -324,7 +324,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "package-json",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "package.json",
@@ -347,7 +347,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "package-json",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "package.json",
@@ -370,7 +370,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "package-json",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "package.json",
@@ -393,7 +393,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "package-json",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "package.json",
@@ -416,7 +416,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "package-json",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "package.json",
@@ -439,7 +439,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "package-json",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "package.json",
@@ -462,7 +462,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "package-json",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "package.json",
@@ -485,7 +485,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "package-json",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "package.json",
@@ -508,7 +508,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "package-json",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "package.json",
@@ -531,7 +531,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "package-json",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "package.json",
@@ -554,7 +554,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "package-json",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "package.json",
@@ -577,7 +577,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "package-json",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "package.json",
@@ -600,7 +600,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "package-json",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "package.json",
@@ -623,7 +623,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "package-json",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "package.json",
@@ -646,7 +646,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "package-json",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "package.json",
@@ -669,7 +669,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "package-json",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "package.json",
@@ -692,7 +692,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "package-json",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "package.json",
@@ -715,7 +715,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "package-json",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "package.json",
@@ -738,7 +738,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "package-json",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "package.json",
@@ -761,7 +761,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "package-json",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "package.json",
@@ -784,7 +784,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "package-json",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "package.json",
@@ -807,7 +807,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "package-json",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "package.json",
@@ -830,7 +830,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "package-json",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "package.json",
@@ -853,7 +853,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "package-json",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "package.json",

--- a/pkg/detectors/dependencies/package-json/package-json.go
+++ b/pkg/detectors/dependencies/package-json/package-json.go
@@ -30,7 +30,7 @@ var queryDependencies = parser.QueryMustCompile(language, `
 func Discover(f *file.FileInfo) (report *depsbase.DiscoveredDependency) {
 	report = &depsbase.DiscoveredDependency{}
 	report.Provider = "package-json"
-	report.Language = "JavaScript"
+	report.Language = "javascript"
 	report.PackageManager = "npm"
 	tree, err := parser.ParseFile(f, f.Path, language)
 	if err != nil {

--- a/pkg/detectors/dependencies/paket-dependencies/.snapshots/TestDependenciesReport
+++ b/pkg/detectors/dependencies/paket-dependencies/.snapshots/TestDependenciesReport
@@ -2,7 +2,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=18) "paket-dependencies",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "paket.dependencies",
@@ -25,7 +25,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=18) "paket-dependencies",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "paket.dependencies",
@@ -48,7 +48,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=18) "paket-dependencies",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "paket.dependencies",
@@ -71,7 +71,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=18) "paket-dependencies",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "paket.dependencies",
@@ -94,7 +94,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=18) "paket-dependencies",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "paket.dependencies",
@@ -117,7 +117,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=18) "paket-dependencies",
-    DetectorLanguage: (detectors.Language) (len=2) "C#",
+    DetectorLanguage: (detectors.Language) (len=6) "csharp",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "paket.dependencies",

--- a/pkg/detectors/dependencies/paket-dependencies/paket-dependencies.go
+++ b/pkg/detectors/dependencies/paket-dependencies/paket-dependencies.go
@@ -80,7 +80,7 @@ func githubDependency(lineNumber int64, fields []string) depsbase.Dependency {
 func Discover(file *file.FileInfo) (report *depsbase.DiscoveredDependency) {
 	report = &depsbase.DiscoveredDependency{}
 	report.Provider = "paket-dependencies"
-	report.Language = "C#"
+	report.Language = "csharp"
 	report.PackageManager = "nuget"
 
 	result := document{}

--- a/pkg/detectors/dependencies/pipdeptree/.snapshots/TestDependenciesReport
+++ b/pkg/detectors/dependencies/pipdeptree/.snapshots/TestDependenciesReport
@@ -2,7 +2,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=10) "pipdeptree",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=15) "pipdeptree.json",
@@ -25,7 +25,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=10) "pipdeptree",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=15) "pipdeptree.json",
@@ -48,7 +48,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=10) "pipdeptree",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=15) "pipdeptree.json",
@@ -71,7 +71,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=10) "pipdeptree",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=15) "pipdeptree.json",
@@ -94,7 +94,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=10) "pipdeptree",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=15) "pipdeptree.json",
@@ -117,7 +117,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=10) "pipdeptree",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=15) "pipdeptree.json",
@@ -140,7 +140,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=10) "pipdeptree",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=15) "pipdeptree.json",
@@ -163,7 +163,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=10) "pipdeptree",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=15) "pipdeptree.json",
@@ -186,7 +186,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=10) "pipdeptree",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=15) "pipdeptree.json",
@@ -209,7 +209,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=10) "pipdeptree",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=15) "pipdeptree.json",
@@ -232,7 +232,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=10) "pipdeptree",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=15) "pipdeptree.json",
@@ -255,7 +255,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=10) "pipdeptree",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=15) "pipdeptree.json",
@@ -278,7 +278,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=10) "pipdeptree",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=15) "pipdeptree.json",
@@ -301,7 +301,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=10) "pipdeptree",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=15) "pipdeptree.json",
@@ -324,7 +324,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=10) "pipdeptree",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=15) "pipdeptree.json",
@@ -347,7 +347,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=10) "pipdeptree",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=15) "pipdeptree.json",
@@ -370,7 +370,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=10) "pipdeptree",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=15) "pipdeptree.json",
@@ -393,7 +393,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=10) "pipdeptree",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=15) "pipdeptree.json",
@@ -416,7 +416,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=10) "pipdeptree",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=15) "pipdeptree.json",
@@ -439,7 +439,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=10) "pipdeptree",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=15) "pipdeptree.json",
@@ -462,7 +462,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=10) "pipdeptree",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=15) "pipdeptree.json",
@@ -485,7 +485,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=10) "pipdeptree",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=15) "pipdeptree.json",
@@ -508,7 +508,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=10) "pipdeptree",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=15) "pipdeptree.json",
@@ -531,7 +531,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=10) "pipdeptree",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=15) "pipdeptree.json",
@@ -554,7 +554,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=10) "pipdeptree",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=15) "pipdeptree.json",
@@ -577,7 +577,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=10) "pipdeptree",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=15) "pipdeptree.json",
@@ -600,7 +600,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=10) "pipdeptree",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=15) "pipdeptree.json",
@@ -623,7 +623,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=10) "pipdeptree",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=15) "pipdeptree.json",
@@ -646,7 +646,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=10) "pipdeptree",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=15) "pipdeptree.json",
@@ -669,7 +669,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=10) "pipdeptree",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=15) "pipdeptree.json",
@@ -692,7 +692,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=10) "pipdeptree",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=15) "pipdeptree.json",
@@ -715,7 +715,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=10) "pipdeptree",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=15) "pipdeptree.json",

--- a/pkg/detectors/dependencies/pipdeptree/pipdeptree.go
+++ b/pkg/detectors/dependencies/pipdeptree/pipdeptree.go
@@ -29,7 +29,7 @@ var queryDependencies = parser.QueryMustCompile(language, `
 func Discover(f *file.FileInfo) (report *depsbase.DiscoveredDependency) {
 	report = &depsbase.DiscoveredDependency{}
 	report.Provider = "pipdeptree"
-	report.Language = "Python"
+	report.Language = "python"
 	report.PackageManager = "pypi"
 	tree, err := parser.ParseFile(f, f.Path, language)
 	if err != nil {

--- a/pkg/detectors/dependencies/piplock/.snapshots/TestDependenciesReport
+++ b/pkg/detectors/dependencies/piplock/.snapshots/TestDependenciesReport
@@ -2,7 +2,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "piplock",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Pipfile.lock",
@@ -25,7 +25,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "piplock",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Pipfile.lock",
@@ -48,7 +48,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "piplock",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Pipfile.lock",
@@ -71,7 +71,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "piplock",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "Pipfile.lock",

--- a/pkg/detectors/dependencies/piplock/piplock.go
+++ b/pkg/detectors/dependencies/piplock/piplock.go
@@ -27,7 +27,7 @@ var queryDependencies = parser.QueryMustCompile(language, `
 func Discover(f *file.FileInfo) (report *depsbase.DiscoveredDependency) {
 	report = &depsbase.DiscoveredDependency{}
 	report.Provider = "piplock"
-	report.Language = "Python"
+	report.Language = "python"
 	report.PackageManager = "pypi"
 	tree, err := parser.ParseFile(f, f.Path, language)
 	if err != nil {

--- a/pkg/detectors/dependencies/poetry/.snapshots/TestDependenciesReport
+++ b/pkg/detectors/dependencies/poetry/.snapshots/TestDependenciesReport
@@ -2,7 +2,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=6) "poetry",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=11) "poetry.lock",
@@ -25,7 +25,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=6) "poetry",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=11) "poetry.lock",
@@ -48,7 +48,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=6) "poetry",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=11) "poetry.lock",
@@ -71,7 +71,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=6) "poetry",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=11) "poetry.lock",
@@ -94,7 +94,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=6) "poetry",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=11) "poetry.lock",
@@ -117,7 +117,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=6) "poetry",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=11) "poetry.lock",
@@ -140,7 +140,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=6) "poetry",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=11) "poetry.lock",
@@ -163,7 +163,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=6) "poetry",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=11) "poetry.lock",
@@ -186,7 +186,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=6) "poetry",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=11) "poetry.lock",
@@ -209,7 +209,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=6) "poetry",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=11) "poetry.lock",
@@ -232,7 +232,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=6) "poetry",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=11) "poetry.lock",
@@ -255,7 +255,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=6) "poetry",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=11) "poetry.lock",
@@ -278,7 +278,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=6) "poetry",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=11) "poetry.lock",
@@ -301,7 +301,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=6) "poetry",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=11) "poetry.lock",
@@ -324,7 +324,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=6) "poetry",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=11) "poetry.lock",
@@ -347,7 +347,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=6) "poetry",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=11) "poetry.lock",
@@ -370,7 +370,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=6) "poetry",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=11) "poetry.lock",
@@ -393,7 +393,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=6) "poetry",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=11) "poetry.lock",
@@ -416,7 +416,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=6) "poetry",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=11) "poetry.lock",

--- a/pkg/detectors/dependencies/poetry/poetry.go
+++ b/pkg/detectors/dependencies/poetry/poetry.go
@@ -30,7 +30,7 @@ var queryDependencies = parser.QueryMustCompile(language, `
 func Discover(f *file.FileInfo) (report *depsbase.DiscoveredDependency) {
 	report = &depsbase.DiscoveredDependency{}
 	report.Provider = "poetry"
-	report.Language = "Python"
+	report.Language = "python"
 	report.PackageManager = "pypi"
 	tree, err := parser.ParseFile(f, f.Path, language)
 	if err != nil {

--- a/pkg/detectors/dependencies/pom-xml/.snapshots/TestDependenciesReport
+++ b/pkg/detectors/dependencies/pom-xml/.snapshots/TestDependenciesReport
@@ -2,7 +2,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -25,7 +25,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -48,7 +48,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -71,7 +71,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -94,7 +94,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -117,7 +117,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -140,7 +140,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -163,7 +163,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -186,7 +186,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -209,7 +209,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -232,7 +232,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -255,7 +255,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -278,7 +278,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -301,7 +301,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -324,7 +324,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -347,7 +347,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -370,7 +370,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -393,7 +393,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -416,7 +416,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -439,7 +439,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -462,7 +462,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -485,7 +485,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -508,7 +508,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -531,7 +531,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -554,7 +554,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -577,7 +577,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -600,7 +600,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -623,7 +623,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -646,7 +646,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -669,7 +669,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -692,7 +692,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -715,7 +715,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -738,7 +738,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -761,7 +761,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -784,7 +784,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -807,7 +807,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -830,7 +830,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -853,7 +853,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -876,7 +876,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -899,7 +899,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -922,7 +922,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -945,7 +945,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -968,7 +968,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -991,7 +991,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -1014,7 +1014,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -1037,7 +1037,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -1060,7 +1060,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -1083,7 +1083,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -1106,7 +1106,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -1129,7 +1129,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -1152,7 +1152,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -1175,7 +1175,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -1198,7 +1198,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -1221,7 +1221,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -1244,7 +1244,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -1267,7 +1267,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -1290,7 +1290,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -1313,7 +1313,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -1336,7 +1336,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -1359,7 +1359,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -1382,7 +1382,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -1405,7 +1405,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -1428,7 +1428,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -1451,7 +1451,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -1474,7 +1474,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -1497,7 +1497,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -1520,7 +1520,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -1543,7 +1543,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -1566,7 +1566,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -1589,7 +1589,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -1612,7 +1612,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -1635,7 +1635,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -1658,7 +1658,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -1681,7 +1681,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -1704,7 +1704,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -1727,7 +1727,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -1750,7 +1750,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -1773,7 +1773,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -1796,7 +1796,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -1819,7 +1819,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -1842,7 +1842,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -1865,7 +1865,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -1888,7 +1888,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -1911,7 +1911,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -1934,7 +1934,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -1957,7 +1957,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -1980,7 +1980,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -2003,7 +2003,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -2026,7 +2026,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -2049,7 +2049,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -2072,7 +2072,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -2095,7 +2095,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -2118,7 +2118,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -2141,7 +2141,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -2164,7 +2164,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -2187,7 +2187,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -2210,7 +2210,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -2233,7 +2233,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -2256,7 +2256,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -2279,7 +2279,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -2302,7 +2302,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -2325,7 +2325,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -2348,7 +2348,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -2371,7 +2371,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -2394,7 +2394,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -2417,7 +2417,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -2440,7 +2440,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -2463,7 +2463,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -2486,7 +2486,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -2509,7 +2509,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -2532,7 +2532,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -2555,7 +2555,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -2578,7 +2578,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -2601,7 +2601,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -2624,7 +2624,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -2647,7 +2647,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -2670,7 +2670,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -2693,7 +2693,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -2716,7 +2716,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -2739,7 +2739,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -2762,7 +2762,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -2785,7 +2785,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -2808,7 +2808,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -2831,7 +2831,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -2854,7 +2854,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -2877,7 +2877,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -2900,7 +2900,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -2923,7 +2923,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -2946,7 +2946,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -2969,7 +2969,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -2992,7 +2992,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -3015,7 +3015,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -3038,7 +3038,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -3061,7 +3061,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -3084,7 +3084,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -3107,7 +3107,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -3130,7 +3130,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -3153,7 +3153,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -3176,7 +3176,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -3199,7 +3199,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -3222,7 +3222,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -3245,7 +3245,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -3268,7 +3268,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -3291,7 +3291,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -3314,7 +3314,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -3337,7 +3337,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -3360,7 +3360,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -3383,7 +3383,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -3406,7 +3406,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -3429,7 +3429,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -3452,7 +3452,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -3475,7 +3475,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -3498,7 +3498,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -3521,7 +3521,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -3544,7 +3544,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -3567,7 +3567,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -3590,7 +3590,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -3613,7 +3613,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -3636,7 +3636,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -3659,7 +3659,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -3682,7 +3682,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -3705,7 +3705,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -3728,7 +3728,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -3751,7 +3751,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -3774,7 +3774,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -3797,7 +3797,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -3820,7 +3820,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -3843,7 +3843,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -3866,7 +3866,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -3889,7 +3889,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -3912,7 +3912,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -3935,7 +3935,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -3958,7 +3958,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -3981,7 +3981,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -4004,7 +4004,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -4027,7 +4027,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -4050,7 +4050,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -4073,7 +4073,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -4096,7 +4096,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -4119,7 +4119,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -4142,7 +4142,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -4165,7 +4165,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -4188,7 +4188,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -4211,7 +4211,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -4234,7 +4234,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -4257,7 +4257,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -4280,7 +4280,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -4303,7 +4303,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -4326,7 +4326,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -4349,7 +4349,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -4372,7 +4372,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -4395,7 +4395,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -4418,7 +4418,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -4441,7 +4441,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -4464,7 +4464,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -4487,7 +4487,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -4510,7 +4510,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -4533,7 +4533,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -4556,7 +4556,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -4579,7 +4579,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -4602,7 +4602,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -4625,7 +4625,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -4648,7 +4648,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -4671,7 +4671,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -4694,7 +4694,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -4717,7 +4717,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -4740,7 +4740,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -4763,7 +4763,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -4786,7 +4786,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -4809,7 +4809,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -4832,7 +4832,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -4855,7 +4855,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -4878,7 +4878,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -4901,7 +4901,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -4924,7 +4924,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -4947,7 +4947,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -4970,7 +4970,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -4993,7 +4993,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -5016,7 +5016,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -5039,7 +5039,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -5062,7 +5062,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -5085,7 +5085,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -5108,7 +5108,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -5131,7 +5131,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -5154,7 +5154,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -5177,7 +5177,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -5200,7 +5200,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -5223,7 +5223,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -5246,7 +5246,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -5269,7 +5269,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -5292,7 +5292,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -5315,7 +5315,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -5338,7 +5338,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -5361,7 +5361,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -5384,7 +5384,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -5407,7 +5407,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -5430,7 +5430,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -5453,7 +5453,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -5476,7 +5476,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -5499,7 +5499,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -5522,7 +5522,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -5545,7 +5545,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -5568,7 +5568,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -5591,7 +5591,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -5614,7 +5614,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -5637,7 +5637,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -5660,7 +5660,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -5683,7 +5683,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -5706,7 +5706,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -5729,7 +5729,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -5752,7 +5752,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -5775,7 +5775,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -5798,7 +5798,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -5821,7 +5821,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -5844,7 +5844,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -5867,7 +5867,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -5890,7 +5890,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -5913,7 +5913,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -5936,7 +5936,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -5959,7 +5959,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -5982,7 +5982,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -6005,7 +6005,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -6028,7 +6028,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -6051,7 +6051,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -6074,7 +6074,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -6097,7 +6097,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -6120,7 +6120,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -6143,7 +6143,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -6166,7 +6166,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -6189,7 +6189,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -6212,7 +6212,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -6235,7 +6235,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -6258,7 +6258,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -6281,7 +6281,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -6304,7 +6304,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -6327,7 +6327,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -6350,7 +6350,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -6373,7 +6373,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -6396,7 +6396,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -6419,7 +6419,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -6442,7 +6442,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -6465,7 +6465,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -6488,7 +6488,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -6511,7 +6511,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -6534,7 +6534,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -6557,7 +6557,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -6580,7 +6580,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -6603,7 +6603,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -6626,7 +6626,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -6649,7 +6649,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -6672,7 +6672,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -6695,7 +6695,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -6718,7 +6718,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -6741,7 +6741,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -6764,7 +6764,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -6787,7 +6787,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -6810,7 +6810,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=18) "large-file/pom.xml",
@@ -6833,7 +6833,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=10) "v1/pom.xml",
@@ -6856,7 +6856,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=10) "v1/pom.xml",
@@ -6879,7 +6879,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=10) "v1/pom.xml",
@@ -6902,7 +6902,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=10) "v1/pom.xml",
@@ -6925,7 +6925,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=10) "v1/pom.xml",
@@ -6948,7 +6948,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=10) "v1/pom.xml",
@@ -6971,7 +6971,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=10) "v1/pom.xml",
@@ -6994,7 +6994,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=10) "v1/pom.xml",
@@ -7017,7 +7017,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=10) "v1/pom.xml",
@@ -7040,7 +7040,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=10) "v1/pom.xml",
@@ -7063,7 +7063,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=10) "v1/pom.xml",
@@ -7086,7 +7086,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=10) "v2/pom.xml",
@@ -7109,7 +7109,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=10) "v2/pom.xml",
@@ -7132,7 +7132,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=10) "v2/pom.xml",
@@ -7155,7 +7155,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=10) "v2/pom.xml",
@@ -7178,7 +7178,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=10) "v2/pom.xml",
@@ -7201,7 +7201,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=10) "v2/pom.xml",
@@ -7224,7 +7224,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=10) "v2/pom.xml",
@@ -7247,7 +7247,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=10) "v2/pom.xml",
@@ -7270,7 +7270,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=10) "v2/pom.xml",
@@ -7293,7 +7293,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=10) "v2/pom.xml",
@@ -7316,7 +7316,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=10) "v2/pom.xml",
@@ -7339,7 +7339,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=10) "v2/pom.xml",
@@ -7362,7 +7362,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=14) "v2-iso/pom.xml",
@@ -7385,7 +7385,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=14) "v2-iso/pom.xml",
@@ -7408,7 +7408,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=14) "v2-iso/pom.xml",
@@ -7431,7 +7431,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=14) "v2-iso/pom.xml",
@@ -7454,7 +7454,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=14) "v2-iso/pom.xml",
@@ -7477,7 +7477,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=14) "v2-iso/pom.xml",
@@ -7500,7 +7500,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=14) "v2-iso/pom.xml",
@@ -7523,7 +7523,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=14) "v2-iso/pom.xml",
@@ -7546,7 +7546,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=14) "v2-iso/pom.xml",
@@ -7569,7 +7569,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=14) "v2-iso/pom.xml",
@@ -7592,7 +7592,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=14) "v2-iso/pom.xml",
@@ -7615,7 +7615,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=7) "pom-xml",
-    DetectorLanguage: (detectors.Language) (len=4) "Java",
+    DetectorLanguage: (detectors.Language) (len=4) "java",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=14) "v2-iso/pom.xml",

--- a/pkg/detectors/dependencies/pom-xml/pom-xml.go
+++ b/pkg/detectors/dependencies/pom-xml/pom-xml.go
@@ -24,7 +24,7 @@ var queryDependencies = parser.QueryMustCompile(language, `
 func Discover(f *file.FileInfo) (report *depsbase.DiscoveredDependency) {
 	report = &depsbase.DiscoveredDependency{}
 	report.Provider = "pom-xml"
-	report.Language = "Java"
+	report.Language = "java"
 	report.PackageManager = "maven"
 	tree, err := parser.ParseFile(f, f.Path, language)
 	if err != nil {

--- a/pkg/detectors/dependencies/project-json/.snapshots/TestDependenciesReport
+++ b/pkg/detectors/dependencies/project-json/.snapshots/TestDependenciesReport
@@ -2,7 +2,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "package-json",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "project.json",
@@ -25,7 +25,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "package-json",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "project.json",
@@ -48,7 +48,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=12) "package-json",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=12) "project.json",

--- a/pkg/detectors/dependencies/project-json/project-json.go
+++ b/pkg/detectors/dependencies/project-json/project-json.go
@@ -30,7 +30,7 @@ var queryDependencies = parser.QueryMustCompile(language, `
 func Discover(f *file.FileInfo) (report *depsbase.DiscoveredDependency) {
 	report = &depsbase.DiscoveredDependency{}
 	report.Provider = "package-json"
-	report.Language = "JavaScript"
+	report.Language = "javascript"
 	report.PackageManager = "nuget"
 	tree, err := parser.ParseFile(f, f.Path, language)
 	if err != nil {

--- a/pkg/detectors/dependencies/pyproject/.snapshots/TestDependenciesReport
+++ b/pkg/detectors/dependencies/pyproject/.snapshots/TestDependenciesReport
@@ -2,7 +2,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "pyproject",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=14) "pyproject.toml",
@@ -25,7 +25,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "pyproject",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=14) "pyproject.toml",
@@ -48,7 +48,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "pyproject",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=14) "pyproject.toml",

--- a/pkg/detectors/dependencies/pyproject/pyproject.go
+++ b/pkg/detectors/dependencies/pyproject/pyproject.go
@@ -26,7 +26,7 @@ var queryDependencies = parser.QueryMustCompile(language, `
 func Discover(f *file.FileInfo) (report *depsbase.DiscoveredDependency) {
 	report = &depsbase.DiscoveredDependency{}
 	report.Provider = "pyproject"
-	report.Language = "Python"
+	report.Language = "python"
 	report.PackageManager = "pypi"
 	tree, err := parser.ParseFile(f, f.Path, language)
 	if err != nil {

--- a/pkg/detectors/dependencies/requirements/.snapshots/TestDependenciesReport
+++ b/pkg/detectors/dependencies/requirements/.snapshots/TestDependenciesReport
@@ -2,7 +2,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=16) "requirements.txt",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=16) "requirements.txt",
@@ -25,7 +25,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=16) "requirements.txt",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=16) "requirements.txt",
@@ -48,7 +48,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=16) "requirements.txt",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=16) "requirements.txt",
@@ -71,7 +71,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=16) "requirements.txt",
-    DetectorLanguage: (detectors.Language) (len=6) "Python",
+    DetectorLanguage: (detectors.Language) (len=6) "python",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=16) "requirements.txt",

--- a/pkg/detectors/dependencies/requirements/requirements.go
+++ b/pkg/detectors/dependencies/requirements/requirements.go
@@ -16,7 +16,7 @@ var lineRegexp = regexp.MustCompile(`^\s*([^#\s~=<>]+)\s*(?:[~=<>]=?([^#,\s]+))?
 func Discover(f *file.FileInfo) (report *depsbase.DiscoveredDependency) {
 	report = &depsbase.DiscoveredDependency{}
 	report.Provider = "requirements.txt"
-	report.Language = "Python"
+	report.Language = "python"
 	report.PackageManager = "pypi"
 
 	fileBytes, err := os.ReadFile(f.AbsolutePath)

--- a/pkg/detectors/dependencies/yarnlock/.snapshots/TestDependenciesReport
+++ b/pkg/detectors/dependencies/yarnlock/.snapshots/TestDependenciesReport
@@ -2,7 +2,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -25,7 +25,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -48,7 +48,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -71,7 +71,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -94,7 +94,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -117,7 +117,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -140,7 +140,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -163,7 +163,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -186,7 +186,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -209,7 +209,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -232,7 +232,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -255,7 +255,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -278,7 +278,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -301,7 +301,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -324,7 +324,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -347,7 +347,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -370,7 +370,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -393,7 +393,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -416,7 +416,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -439,7 +439,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -462,7 +462,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -485,7 +485,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -508,7 +508,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -531,7 +531,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -554,7 +554,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -577,7 +577,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -600,7 +600,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -623,7 +623,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -646,7 +646,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -669,7 +669,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -692,7 +692,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -715,7 +715,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -738,7 +738,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -761,7 +761,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -784,7 +784,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -807,7 +807,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -830,7 +830,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -853,7 +853,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -876,7 +876,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -899,7 +899,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -922,7 +922,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -945,7 +945,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -968,7 +968,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -991,7 +991,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -1014,7 +1014,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -1037,7 +1037,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -1060,7 +1060,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -1083,7 +1083,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -1106,7 +1106,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -1129,7 +1129,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -1152,7 +1152,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -1175,7 +1175,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -1198,7 +1198,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -1221,7 +1221,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -1244,7 +1244,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -1267,7 +1267,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -1290,7 +1290,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -1313,7 +1313,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -1336,7 +1336,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -1359,7 +1359,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -1382,7 +1382,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -1405,7 +1405,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -1428,7 +1428,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -1451,7 +1451,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -1474,7 +1474,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -1497,7 +1497,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -1520,7 +1520,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -1543,7 +1543,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -1566,7 +1566,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -1589,7 +1589,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -1612,7 +1612,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -1635,7 +1635,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -1658,7 +1658,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -1681,7 +1681,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -1704,7 +1704,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -1727,7 +1727,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -1750,7 +1750,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -1773,7 +1773,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -1796,7 +1796,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -1819,7 +1819,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -1842,7 +1842,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -1865,7 +1865,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -1888,7 +1888,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -1911,7 +1911,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -1934,7 +1934,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -1957,7 +1957,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -1980,7 +1980,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -2003,7 +2003,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -2026,7 +2026,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -2049,7 +2049,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -2072,7 +2072,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -2095,7 +2095,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -2118,7 +2118,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -2141,7 +2141,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -2164,7 +2164,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -2187,7 +2187,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -2210,7 +2210,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -2233,7 +2233,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -2256,7 +2256,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -2279,7 +2279,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -2302,7 +2302,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -2325,7 +2325,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -2348,7 +2348,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -2371,7 +2371,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -2394,7 +2394,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -2417,7 +2417,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -2440,7 +2440,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -2463,7 +2463,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -2486,7 +2486,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -2509,7 +2509,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -2532,7 +2532,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -2555,7 +2555,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -2578,7 +2578,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -2601,7 +2601,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -2624,7 +2624,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -2647,7 +2647,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -2670,7 +2670,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -2693,7 +2693,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -2716,7 +2716,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -2739,7 +2739,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -2762,7 +2762,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -2785,7 +2785,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -2808,7 +2808,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -2831,7 +2831,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -2854,7 +2854,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -2877,7 +2877,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -2900,7 +2900,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -2923,7 +2923,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -2946,7 +2946,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -2969,7 +2969,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -2992,7 +2992,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -3015,7 +3015,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -3038,7 +3038,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -3061,7 +3061,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -3084,7 +3084,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -3107,7 +3107,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -3130,7 +3130,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -3153,7 +3153,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -3176,7 +3176,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -3199,7 +3199,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -3222,7 +3222,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -3245,7 +3245,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -3268,7 +3268,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -3291,7 +3291,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -3314,7 +3314,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -3337,7 +3337,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -3360,7 +3360,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -3383,7 +3383,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -3406,7 +3406,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -3429,7 +3429,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -3452,7 +3452,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -3475,7 +3475,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -3498,7 +3498,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -3521,7 +3521,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -3544,7 +3544,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -3567,7 +3567,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -3590,7 +3590,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -3613,7 +3613,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -3636,7 +3636,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -3659,7 +3659,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -3682,7 +3682,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -3705,7 +3705,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -3728,7 +3728,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -3751,7 +3751,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -3774,7 +3774,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -3797,7 +3797,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -3820,7 +3820,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -3843,7 +3843,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -3866,7 +3866,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -3889,7 +3889,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -3912,7 +3912,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -3935,7 +3935,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -3958,7 +3958,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -3981,7 +3981,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -4004,7 +4004,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -4027,7 +4027,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -4050,7 +4050,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -4073,7 +4073,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -4096,7 +4096,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -4119,7 +4119,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -4142,7 +4142,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -4165,7 +4165,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -4188,7 +4188,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -4211,7 +4211,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -4234,7 +4234,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -4257,7 +4257,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -4280,7 +4280,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -4303,7 +4303,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -4326,7 +4326,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -4349,7 +4349,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -4372,7 +4372,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -4395,7 +4395,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -4418,7 +4418,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -4441,7 +4441,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -4464,7 +4464,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -4487,7 +4487,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -4510,7 +4510,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -4533,7 +4533,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -4556,7 +4556,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -4579,7 +4579,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -4602,7 +4602,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -4625,7 +4625,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -4648,7 +4648,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -4671,7 +4671,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -4694,7 +4694,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -4717,7 +4717,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -4740,7 +4740,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -4763,7 +4763,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -4786,7 +4786,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -4809,7 +4809,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -4832,7 +4832,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -4855,7 +4855,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -4878,7 +4878,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -4901,7 +4901,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -4924,7 +4924,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -4947,7 +4947,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -4970,7 +4970,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -4993,7 +4993,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -5016,7 +5016,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -5039,7 +5039,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -5062,7 +5062,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -5085,7 +5085,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -5108,7 +5108,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -5131,7 +5131,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -5154,7 +5154,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -5177,7 +5177,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -5200,7 +5200,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -5223,7 +5223,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -5246,7 +5246,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -5269,7 +5269,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -5292,7 +5292,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -5315,7 +5315,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -5338,7 +5338,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -5361,7 +5361,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -5384,7 +5384,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -5407,7 +5407,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -5430,7 +5430,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -5453,7 +5453,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -5476,7 +5476,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -5499,7 +5499,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -5522,7 +5522,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -5545,7 +5545,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -5568,7 +5568,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -5591,7 +5591,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -5614,7 +5614,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -5637,7 +5637,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -5660,7 +5660,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -5683,7 +5683,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -5706,7 +5706,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -5729,7 +5729,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -5752,7 +5752,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -5775,7 +5775,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -5798,7 +5798,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -5821,7 +5821,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -5844,7 +5844,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -5867,7 +5867,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -5890,7 +5890,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -5913,7 +5913,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -5936,7 +5936,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -5959,7 +5959,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -5982,7 +5982,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -6005,7 +6005,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -6028,7 +6028,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -6051,7 +6051,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -6074,7 +6074,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -6097,7 +6097,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -6120,7 +6120,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -6143,7 +6143,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -6166,7 +6166,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -6189,7 +6189,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -6212,7 +6212,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -6235,7 +6235,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -6258,7 +6258,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -6281,7 +6281,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -6304,7 +6304,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -6327,7 +6327,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -6350,7 +6350,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -6373,7 +6373,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -6396,7 +6396,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -6419,7 +6419,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -6442,7 +6442,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -6465,7 +6465,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -6488,7 +6488,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -6511,7 +6511,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -6534,7 +6534,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -6557,7 +6557,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -6580,7 +6580,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -6603,7 +6603,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -6626,7 +6626,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -6649,7 +6649,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -6672,7 +6672,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -6695,7 +6695,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -6718,7 +6718,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -6741,7 +6741,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -6764,7 +6764,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -6787,7 +6787,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -6810,7 +6810,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -6833,7 +6833,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -6856,7 +6856,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -6879,7 +6879,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -6902,7 +6902,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -6925,7 +6925,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -6948,7 +6948,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -6971,7 +6971,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -6994,7 +6994,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -7017,7 +7017,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -7040,7 +7040,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -7063,7 +7063,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -7086,7 +7086,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -7109,7 +7109,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -7132,7 +7132,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -7155,7 +7155,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -7178,7 +7178,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -7201,7 +7201,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -7224,7 +7224,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -7247,7 +7247,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -7270,7 +7270,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -7293,7 +7293,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -7316,7 +7316,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -7339,7 +7339,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -7362,7 +7362,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -7385,7 +7385,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -7408,7 +7408,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -7431,7 +7431,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -7454,7 +7454,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -7477,7 +7477,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -7500,7 +7500,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -7523,7 +7523,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -7546,7 +7546,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -7569,7 +7569,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -7592,7 +7592,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -7615,7 +7615,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -7638,7 +7638,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -7661,7 +7661,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -7684,7 +7684,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -7707,7 +7707,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -7730,7 +7730,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -7753,7 +7753,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -7776,7 +7776,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -7799,7 +7799,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -7822,7 +7822,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -7845,7 +7845,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -7868,7 +7868,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -7891,7 +7891,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -7914,7 +7914,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -7937,7 +7937,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -7960,7 +7960,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -7983,7 +7983,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -8006,7 +8006,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -8029,7 +8029,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -8052,7 +8052,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -8075,7 +8075,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -8098,7 +8098,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -8121,7 +8121,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -8144,7 +8144,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -8167,7 +8167,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -8190,7 +8190,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -8213,7 +8213,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -8236,7 +8236,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -8259,7 +8259,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -8282,7 +8282,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -8305,7 +8305,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -8328,7 +8328,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -8351,7 +8351,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -8374,7 +8374,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -8397,7 +8397,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -8420,7 +8420,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -8443,7 +8443,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -8466,7 +8466,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -8489,7 +8489,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -8512,7 +8512,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -8535,7 +8535,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -8558,7 +8558,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -8581,7 +8581,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -8604,7 +8604,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -8627,7 +8627,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -8650,7 +8650,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -8673,7 +8673,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -8696,7 +8696,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -8719,7 +8719,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -8742,7 +8742,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -8765,7 +8765,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -8788,7 +8788,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -8811,7 +8811,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -8834,7 +8834,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -8857,7 +8857,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -8880,7 +8880,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -8903,7 +8903,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -8926,7 +8926,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -8949,7 +8949,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -8972,7 +8972,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -8995,7 +8995,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -9018,7 +9018,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -9041,7 +9041,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -9064,7 +9064,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -9087,7 +9087,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -9110,7 +9110,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -9133,7 +9133,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -9156,7 +9156,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -9179,7 +9179,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -9202,7 +9202,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -9225,7 +9225,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -9248,7 +9248,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -9271,7 +9271,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -9294,7 +9294,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -9317,7 +9317,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -9340,7 +9340,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -9363,7 +9363,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -9386,7 +9386,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -9409,7 +9409,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -9432,7 +9432,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -9455,7 +9455,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -9478,7 +9478,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -9501,7 +9501,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -9524,7 +9524,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -9547,7 +9547,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -9570,7 +9570,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -9593,7 +9593,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -9616,7 +9616,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -9639,7 +9639,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -9662,7 +9662,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -9685,7 +9685,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -9708,7 +9708,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -9731,7 +9731,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -9754,7 +9754,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -9777,7 +9777,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -9800,7 +9800,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -9823,7 +9823,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -9846,7 +9846,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -9869,7 +9869,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -9892,7 +9892,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -9915,7 +9915,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -9938,7 +9938,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -9961,7 +9961,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -9984,7 +9984,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -10007,7 +10007,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -10030,7 +10030,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -10053,7 +10053,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -10076,7 +10076,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -10099,7 +10099,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -10122,7 +10122,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -10145,7 +10145,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -10168,7 +10168,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -10191,7 +10191,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -10214,7 +10214,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -10237,7 +10237,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -10260,7 +10260,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -10283,7 +10283,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -10306,7 +10306,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -10329,7 +10329,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -10352,7 +10352,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -10375,7 +10375,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -10398,7 +10398,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -10421,7 +10421,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -10444,7 +10444,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -10467,7 +10467,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -10490,7 +10490,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -10513,7 +10513,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -10536,7 +10536,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -10559,7 +10559,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -10582,7 +10582,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -10605,7 +10605,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -10628,7 +10628,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -10651,7 +10651,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -10674,7 +10674,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -10697,7 +10697,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -10720,7 +10720,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -10743,7 +10743,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -10766,7 +10766,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -10789,7 +10789,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -10812,7 +10812,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -10835,7 +10835,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -10858,7 +10858,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -10881,7 +10881,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -10904,7 +10904,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -10927,7 +10927,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -10950,7 +10950,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -10973,7 +10973,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -10996,7 +10996,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -11019,7 +11019,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -11042,7 +11042,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -11065,7 +11065,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -11088,7 +11088,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -11111,7 +11111,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -11134,7 +11134,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -11157,7 +11157,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -11180,7 +11180,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -11203,7 +11203,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -11226,7 +11226,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -11249,7 +11249,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -11272,7 +11272,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -11295,7 +11295,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -11318,7 +11318,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -11341,7 +11341,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -11364,7 +11364,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -11387,7 +11387,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -11410,7 +11410,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -11433,7 +11433,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -11456,7 +11456,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -11479,7 +11479,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -11502,7 +11502,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -11525,7 +11525,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -11548,7 +11548,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -11571,7 +11571,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -11594,7 +11594,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -11617,7 +11617,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -11640,7 +11640,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -11663,7 +11663,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -11686,7 +11686,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -11709,7 +11709,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -11732,7 +11732,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -11755,7 +11755,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -11778,7 +11778,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -11801,7 +11801,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -11824,7 +11824,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -11847,7 +11847,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -11870,7 +11870,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -11893,7 +11893,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -11916,7 +11916,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -11939,7 +11939,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -11962,7 +11962,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -11985,7 +11985,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -12008,7 +12008,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -12031,7 +12031,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -12054,7 +12054,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -12077,7 +12077,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -12100,7 +12100,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -12123,7 +12123,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -12146,7 +12146,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -12169,7 +12169,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -12192,7 +12192,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -12215,7 +12215,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -12238,7 +12238,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -12261,7 +12261,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -12284,7 +12284,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -12307,7 +12307,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -12330,7 +12330,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -12353,7 +12353,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -12376,7 +12376,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -12399,7 +12399,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -12422,7 +12422,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -12445,7 +12445,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -12468,7 +12468,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -12491,7 +12491,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -12514,7 +12514,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -12537,7 +12537,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -12560,7 +12560,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -12583,7 +12583,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -12606,7 +12606,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -12629,7 +12629,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -12652,7 +12652,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -12675,7 +12675,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -12698,7 +12698,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -12721,7 +12721,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -12744,7 +12744,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -12767,7 +12767,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -12790,7 +12790,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -12813,7 +12813,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -12836,7 +12836,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -12859,7 +12859,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -12882,7 +12882,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -12905,7 +12905,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -12928,7 +12928,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -12951,7 +12951,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -12974,7 +12974,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -12997,7 +12997,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -13020,7 +13020,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -13043,7 +13043,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -13066,7 +13066,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -13089,7 +13089,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -13112,7 +13112,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -13135,7 +13135,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -13158,7 +13158,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -13181,7 +13181,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -13204,7 +13204,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -13227,7 +13227,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -13250,7 +13250,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -13273,7 +13273,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -13296,7 +13296,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -13319,7 +13319,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -13342,7 +13342,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -13365,7 +13365,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -13388,7 +13388,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -13411,7 +13411,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -13434,7 +13434,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -13457,7 +13457,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -13480,7 +13480,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -13503,7 +13503,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -13526,7 +13526,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -13549,7 +13549,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -13572,7 +13572,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -13595,7 +13595,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -13618,7 +13618,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -13641,7 +13641,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -13664,7 +13664,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -13687,7 +13687,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -13710,7 +13710,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -13733,7 +13733,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -13756,7 +13756,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -13779,7 +13779,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -13802,7 +13802,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -13825,7 +13825,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -13848,7 +13848,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -13871,7 +13871,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -13894,7 +13894,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -13917,7 +13917,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -13940,7 +13940,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -13963,7 +13963,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -13986,7 +13986,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -14009,7 +14009,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -14032,7 +14032,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -14055,7 +14055,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -14078,7 +14078,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -14101,7 +14101,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -14124,7 +14124,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -14147,7 +14147,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -14170,7 +14170,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -14193,7 +14193,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -14216,7 +14216,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -14239,7 +14239,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -14262,7 +14262,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -14285,7 +14285,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -14308,7 +14308,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -14331,7 +14331,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -14354,7 +14354,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -14377,7 +14377,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -14400,7 +14400,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -14423,7 +14423,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -14446,7 +14446,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -14469,7 +14469,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -14492,7 +14492,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -14515,7 +14515,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -14538,7 +14538,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -14561,7 +14561,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -14584,7 +14584,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -14607,7 +14607,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -14630,7 +14630,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -14653,7 +14653,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -14676,7 +14676,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -14699,7 +14699,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -14722,7 +14722,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -14745,7 +14745,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -14768,7 +14768,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -14791,7 +14791,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -14814,7 +14814,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -14837,7 +14837,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -14860,7 +14860,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -14883,7 +14883,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -14906,7 +14906,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -14929,7 +14929,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -14952,7 +14952,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -14975,7 +14975,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -14998,7 +14998,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -15021,7 +15021,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -15044,7 +15044,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -15067,7 +15067,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -15090,7 +15090,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -15113,7 +15113,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -15136,7 +15136,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -15159,7 +15159,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -15182,7 +15182,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -15205,7 +15205,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -15228,7 +15228,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -15251,7 +15251,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -15274,7 +15274,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -15297,7 +15297,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -15320,7 +15320,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -15343,7 +15343,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -15366,7 +15366,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -15389,7 +15389,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -15412,7 +15412,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -15435,7 +15435,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -15458,7 +15458,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -15481,7 +15481,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -15504,7 +15504,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -15527,7 +15527,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -15550,7 +15550,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -15573,7 +15573,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -15596,7 +15596,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -15619,7 +15619,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -15642,7 +15642,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -15665,7 +15665,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -15688,7 +15688,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -15711,7 +15711,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -15734,7 +15734,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -15757,7 +15757,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -15780,7 +15780,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -15803,7 +15803,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -15826,7 +15826,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -15849,7 +15849,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -15872,7 +15872,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -15895,7 +15895,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -15918,7 +15918,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -15941,7 +15941,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -15964,7 +15964,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -15987,7 +15987,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -16010,7 +16010,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -16033,7 +16033,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -16056,7 +16056,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -16079,7 +16079,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -16102,7 +16102,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -16125,7 +16125,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -16148,7 +16148,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -16171,7 +16171,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -16194,7 +16194,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -16217,7 +16217,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -16240,7 +16240,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -16263,7 +16263,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -16286,7 +16286,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -16309,7 +16309,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -16332,7 +16332,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -16355,7 +16355,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -16378,7 +16378,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -16401,7 +16401,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -16424,7 +16424,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -16447,7 +16447,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -16470,7 +16470,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -16493,7 +16493,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -16516,7 +16516,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -16539,7 +16539,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -16562,7 +16562,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -16585,7 +16585,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -16608,7 +16608,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -16631,7 +16631,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -16654,7 +16654,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -16677,7 +16677,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -16700,7 +16700,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -16723,7 +16723,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -16746,7 +16746,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -16769,7 +16769,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -16792,7 +16792,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -16815,7 +16815,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -16838,7 +16838,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -16861,7 +16861,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -16884,7 +16884,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -16907,7 +16907,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -16930,7 +16930,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -16953,7 +16953,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -16976,7 +16976,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -16999,7 +16999,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -17022,7 +17022,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -17045,7 +17045,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -17068,7 +17068,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -17091,7 +17091,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -17114,7 +17114,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -17137,7 +17137,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -17160,7 +17160,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -17183,7 +17183,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -17206,7 +17206,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -17229,7 +17229,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -17252,7 +17252,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -17275,7 +17275,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -17298,7 +17298,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -17321,7 +17321,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -17344,7 +17344,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -17367,7 +17367,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -17390,7 +17390,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -17413,7 +17413,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -17436,7 +17436,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -17459,7 +17459,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -17482,7 +17482,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -17505,7 +17505,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -17528,7 +17528,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -17551,7 +17551,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -17574,7 +17574,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -17597,7 +17597,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -17620,7 +17620,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -17643,7 +17643,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -17666,7 +17666,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -17689,7 +17689,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -17712,7 +17712,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -17735,7 +17735,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -17758,7 +17758,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -17781,7 +17781,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -17804,7 +17804,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -17827,7 +17827,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -17850,7 +17850,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -17873,7 +17873,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -17896,7 +17896,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -17919,7 +17919,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -17942,7 +17942,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -17965,7 +17965,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -17988,7 +17988,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -18011,7 +18011,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -18034,7 +18034,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -18057,7 +18057,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -18080,7 +18080,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -18103,7 +18103,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -18126,7 +18126,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -18149,7 +18149,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -18172,7 +18172,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -18195,7 +18195,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -18218,7 +18218,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -18241,7 +18241,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -18264,7 +18264,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -18287,7 +18287,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -18310,7 +18310,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -18333,7 +18333,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -18356,7 +18356,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -18379,7 +18379,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -18402,7 +18402,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -18425,7 +18425,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -18448,7 +18448,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -18471,7 +18471,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -18494,7 +18494,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -18517,7 +18517,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -18540,7 +18540,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -18563,7 +18563,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -18586,7 +18586,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -18609,7 +18609,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -18632,7 +18632,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -18655,7 +18655,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -18678,7 +18678,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -18701,7 +18701,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -18724,7 +18724,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -18747,7 +18747,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -18770,7 +18770,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -18793,7 +18793,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -18816,7 +18816,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -18839,7 +18839,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -18862,7 +18862,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -18885,7 +18885,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -18908,7 +18908,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -18931,7 +18931,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -18954,7 +18954,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -18977,7 +18977,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -19000,7 +19000,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -19023,7 +19023,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -19046,7 +19046,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -19069,7 +19069,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -19092,7 +19092,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -19115,7 +19115,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -19138,7 +19138,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -19161,7 +19161,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -19184,7 +19184,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -19207,7 +19207,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -19230,7 +19230,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -19253,7 +19253,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -19276,7 +19276,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -19299,7 +19299,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -19322,7 +19322,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -19345,7 +19345,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -19368,7 +19368,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -19391,7 +19391,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -19414,7 +19414,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -19437,7 +19437,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -19460,7 +19460,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -19483,7 +19483,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -19506,7 +19506,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -19529,7 +19529,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -19552,7 +19552,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -19575,7 +19575,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -19598,7 +19598,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -19621,7 +19621,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -19644,7 +19644,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -19667,7 +19667,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -19690,7 +19690,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -19713,7 +19713,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -19736,7 +19736,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -19759,7 +19759,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -19782,7 +19782,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -19805,7 +19805,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -19828,7 +19828,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -19851,7 +19851,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -19874,7 +19874,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -19897,7 +19897,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -19920,7 +19920,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -19943,7 +19943,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -19966,7 +19966,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -19989,7 +19989,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -20012,7 +20012,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -20035,7 +20035,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -20058,7 +20058,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -20081,7 +20081,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -20104,7 +20104,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -20127,7 +20127,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -20150,7 +20150,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -20173,7 +20173,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -20196,7 +20196,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -20219,7 +20219,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -20242,7 +20242,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -20265,7 +20265,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -20288,7 +20288,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -20311,7 +20311,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -20334,7 +20334,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -20357,7 +20357,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -20380,7 +20380,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -20403,7 +20403,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -20426,7 +20426,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -20449,7 +20449,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -20472,7 +20472,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -20495,7 +20495,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -20518,7 +20518,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -20541,7 +20541,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -20564,7 +20564,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -20587,7 +20587,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -20610,7 +20610,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -20633,7 +20633,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -20656,7 +20656,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -20679,7 +20679,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -20702,7 +20702,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -20725,7 +20725,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -20748,7 +20748,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -20771,7 +20771,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -20794,7 +20794,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -20817,7 +20817,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -20840,7 +20840,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",
@@ -20863,7 +20863,7 @@
   (*detections.Detection)({
     Type: (detections.DetectionType) (len=10) "dependency",
     DetectorType: (detectors.Type) (len=9) "yarn.lock",
-    DetectorLanguage: (detectors.Language) (len=10) "JavaScript",
+    DetectorLanguage: (detectors.Language) (len=10) "javascript",
     CommitSHA: (string) "",
     Source: (source.Source) {
       Filename: (string) (len=9) "yarn.lock",

--- a/pkg/detectors/dependencies/yarnlock/yarnlock.go
+++ b/pkg/detectors/dependencies/yarnlock/yarnlock.go
@@ -22,7 +22,7 @@ var dependencyLockedVersionRegexp *regexp.Regexp
 func Discover(f *file.FileInfo) (report *depsbase.DiscoveredDependency) {
 	report = &depsbase.DiscoveredDependency{}
 	report.Provider = "yarn.lock"
-	report.Language = "JavaScript"
+	report.Language = "javascript"
 	report.PackageManager = "npm"
 
 	fileBytes, err := os.ReadFile(f.AbsolutePath)

--- a/pkg/languages/golang/golang.go
+++ b/pkg/languages/golang/golang.go
@@ -42,6 +42,10 @@ func (*implementation) EnryLanguages() []string {
 	return []string{"Go"}
 }
 
+func (*implementation) GoclocLanguages() []string {
+	return []string{"Go"}
+}
+
 func (*implementation) NewBuiltInDetectors(schemaClassifier *schema.Classifier, querySet *query.Set) []detectortypes.Detector {
 	return []detectortypes.Detector{
 		object.New(querySet),

--- a/pkg/languages/java/java.go
+++ b/pkg/languages/java/java.go
@@ -40,6 +40,10 @@ func (*implementation) EnryLanguages() []string {
 	return []string{"Java"}
 }
 
+func (*implementation) GoclocLanguages() []string {
+	return []string{"Java"}
+}
+
 func (*implementation) NewBuiltInDetectors(schemaClassifier *schema.Classifier, querySet *query.Set) []detectortypes.Detector {
 	return []detectortypes.Detector{
 		object.New(querySet),

--- a/pkg/languages/javascript/javascript.go
+++ b/pkg/languages/javascript/javascript.go
@@ -40,6 +40,10 @@ func (*implementation) EnryLanguages() []string {
 	return []string{"JavaScript", "TypeScript", "TSX"}
 }
 
+func (*implementation) GoclocLanguages() []string {
+	return []string{"JavaScript", "TypeScript", "JSX"}
+}
+
 func (*implementation) NewBuiltInDetectors(schemaClassifier *schema.Classifier, querySet *query.Set) []detectortypes.Detector {
 	return []detectortypes.Detector{
 		object.New(querySet),

--- a/pkg/languages/php/php.go
+++ b/pkg/languages/php/php.go
@@ -40,6 +40,10 @@ func (*implementation) EnryLanguages() []string {
 	return []string{"PHP"}
 }
 
+func (*implementation) GoclocLanguages() []string {
+	return []string{"PHP"}
+}
+
 func (*implementation) NewBuiltInDetectors(schemaClassifier *schema.Classifier, querySet *query.Set) []detectortypes.Detector {
 	return []detectortypes.Detector{
 		object.New(querySet),

--- a/pkg/languages/python/python.go
+++ b/pkg/languages/python/python.go
@@ -40,6 +40,10 @@ func (*implementation) EnryLanguages() []string {
 	return []string{"Python"}
 }
 
+func (*implementation) GoclocLanguages() []string {
+	return []string{"Python"}
+}
+
 func (*implementation) NewBuiltInDetectors(schemaClassifier *schema.Classifier, querySet *query.Set) []detectortypes.Detector {
 	return []detectortypes.Detector{
 		object.New(querySet),

--- a/pkg/languages/ruby/ruby.go
+++ b/pkg/languages/ruby/ruby.go
@@ -40,6 +40,10 @@ func (*implementation) EnryLanguages() []string {
 	return []string{"Ruby"}
 }
 
+func (*implementation) GoclocLanguages() []string {
+	return []string{"Ruby"}
+}
+
 func (*implementation) NewBuiltInDetectors(schemaClassifier *schema.Classifier, querySet *query.Set) []detectortypes.Detector {
 	return []detectortypes.Detector{
 		object.New(querySet),

--- a/pkg/scanner/language/language.go
+++ b/pkg/scanner/language/language.go
@@ -13,6 +13,7 @@ type Language interface {
 	ID() string
 	DisplayName() string
 	EnryLanguages() []string
+	GoclocLanguages() []string
 	NewBuiltInDetectors(schemaClassifier *schema.Classifier, querySet *query.Set) []detectortypes.Detector
 	SitterLanguage() *sitter.Language
 	Pattern() Pattern


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Fixes problems with the mapping of gocloc languages to bearer languages. 

To simplify the code, we also change the dependency detectors to report the bearer language IDs, rather than gocloc language names.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.

