### PR TITLE
feat(java): define imported classes

### DIFF
--- a/pkg/languages/java/.snapshots/TestImport-import.yml
+++ b/pkg/languages/java/.snapshots/TestImport-import.yml
@@ -1,0 +1,30 @@
+high:
+    - rule:
+        cwe_ids:
+            - "42"
+        id: import_test
+        title: Test import handling
+        description: Test import handling
+        documentation_url: ""
+      line_number: 7
+      full_filename: import.java
+      filename: import.java
+      source:
+        location:
+            start: 7
+            end: 7
+            column:
+                start: 9
+                end: 21
+      sink:
+        location:
+            start: 7
+            end: 7
+            column:
+                start: 9
+                end: 21
+        content: ""
+      parent_line_number: 7
+      fingerprint: fd41a77f77dc09c75355f0d8bf69d976_0
+      old_fingerprint: fd41a77f77dc09c75355f0d8bf69d976_0
+

--- a/pkg/languages/java/java_test.go
+++ b/pkg/languages/java/java_test.go
@@ -11,11 +11,18 @@ import (
 	patternquerybuilder "github.com/bearer/bearer/pkg/scanner/detectors/customrule/patternquery/builder"
 )
 
+//go:embed testdata/import.yml
+var importRule []byte
+
 //go:embed testdata/logger.yml
 var loggerRule []byte
 
 //go:embed testdata/scope_rule.yml
 var scopeRule []byte
+
+func TestImport(t *testing.T) {
+	testhelper.GetRunner(t, importRule, java.Get()).RunTest(t, "./testdata/import", ".snapshots/")
+}
 
 func TestFlow(t *testing.T) {
 	testhelper.GetRunner(t, loggerRule, java.Get()).RunTest(t, "./testdata/testcases/flow", ".snapshots/flow/")

--- a/pkg/languages/java/testdata/import.yml
+++ b/pkg/languages/java/testdata/import.yml
@@ -1,0 +1,21 @@
+languages:
+  - java
+patterns:
+  - pattern: sink($<IMPORT>)
+    filters:
+      - variable: IMPORT
+        detection: flow_test_source
+        scope: cursor
+auxiliary:
+  - id: flow_test_source
+    patterns:
+      - import $<!>foo.Import
+      - import $<!>foo.Import2
+      - import $<!>foo.Import3
+severity: high
+metadata:
+  description: Test import handling
+  remediation_message: Test import handling
+  cwe_id:
+    - 42
+  id: import_test

--- a/pkg/languages/java/testdata/import/import.java
+++ b/pkg/languages/java/testdata/import/import.java
@@ -1,0 +1,11 @@
+import foo.Import;
+import foo.Import2.*;
+import static foo.Import3;
+
+class A {
+    public void exec() {
+        sink(Import);
+        sink(Import2); // no match
+        sink(Import3); // no match
+    }
+}


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Define variables for imported Java classes. This allows full class name matching in rules (for non-wildcard imports)

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.

