### PR TITLE
fix: include discarded rules in rule check

### DIFF
--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -432,7 +432,7 @@ func (r *runner) Report(
 		}
 	}
 
-	if len(r.scanSettings.Rules) == 0 && slices.Contains(r.scanSettings.Scan.Scanner, flag.ScannerSAST) && r.scanSettings.Report.Report == flag.ReportSecurity {
+	if r.scanSettings.LoadedRuleCount == 0 && slices.Contains(r.scanSettings.Scan.Scanner, flag.ScannerSAST) && r.scanSettings.Report.Report == flag.ReportSecurity {
 		return false, fmt.Errorf("%d rules found for supported language, default rules could not be downloaded or possibly disabled without using --external-rule-dir", len(r.scanSettings.Rules))
 	}
 

--- a/pkg/commands/process/settings/loader/loader.go
+++ b/pkg/commands/process/settings/loader/loader.go
@@ -65,6 +65,7 @@ func FromOptions(
 		IgnoreGit:           opts.GeneralOptions.IgnoreGit,
 		Policies:            policies,
 		Rules:               result.Rules,
+		LoadedRuleCount:     result.LoadedRuleCount,
 		BuiltInRules:        result.BuiltInRules,
 		CacheUsed:           result.CacheUsed,
 		BearerRulesVersion:  result.BearerRulesVersion,

--- a/pkg/commands/process/settings/settings.go
+++ b/pkg/commands/process/settings/settings.go
@@ -50,14 +50,15 @@ type Config struct {
 	Target                     string                                    `mapstructure:"target" json:"target" yaml:"target"`
 	IgnoreFile                 string                                    `mapstructure:"ignore_file" json:"ignore_file" yaml:"ignore_file"`
 	Rules                      map[string]*Rule                          `mapstructure:"rules" json:"rules" yaml:"rules"`
-	BuiltInRules               map[string]*Rule                          `mapstructure:"built_in_rules" json:"built_in_rules" yaml:"built_in_rules"`
-	CacheUsed                  bool                                      `mapstructure:"cache_used" json:"cache_used" yaml:"cache_used"`
-	BearerRulesVersion         string                                    `mapstructure:"bearer_rules_version" json:"bearer_rules_version" yaml:"bearer_rules_version"`
-	NoColor                    bool                                      `mapstructure:"no_color" json:"no_color" yaml:"no_color"`
-	Debug                      bool                                      `mapstructure:"debug" json:"debug" yaml:"debug"`
-	LogLevel                   string                                    `mapstructure:"log_level" json:"log_level" yaml:"log_level"`
-	DebugProfile               bool                                      `mapstructure:"debug_profile" json:"debug_profile" yaml:"debug_profile"`
-	IgnoreGit                  bool                                      `mapstructure:"ignore_git" json:"ignore_git" yaml:"ignore_git"`
+	LoadedRuleCount            int
+	BuiltInRules               map[string]*Rule `mapstructure:"built_in_rules" json:"built_in_rules" yaml:"built_in_rules"`
+	CacheUsed                  bool             `mapstructure:"cache_used" json:"cache_used" yaml:"cache_used"`
+	BearerRulesVersion         string           `mapstructure:"bearer_rules_version" json:"bearer_rules_version" yaml:"bearer_rules_version"`
+	NoColor                    bool             `mapstructure:"no_color" json:"no_color" yaml:"no_color"`
+	Debug                      bool             `mapstructure:"debug" json:"debug" yaml:"debug"`
+	LogLevel                   string           `mapstructure:"log_level" json:"log_level" yaml:"log_level"`
+	DebugProfile               bool             `mapstructure:"debug_profile" json:"debug_profile" yaml:"debug_profile"`
+	IgnoreGit                  bool             `mapstructure:"ignore_git" json:"ignore_git" yaml:"ignore_git"`
 }
 
 type Processor struct {


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Don't return the error `default rules could not be downloaded or possibly disabled...` when rules were loaded but discarded due to no target files to scan.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.

