### PR TITLE
feat: error early when pattern var is not found

### DIFF
--- a/pkg/scanner/detectors/customrule/filters/filters.go
+++ b/pkg/scanner/detectors/customrule/filters/filters.go
@@ -1,6 +1,7 @@
 package filters
 
 import (
+	"fmt"
 	"regexp"
 	"slices"
 	"strconv"
@@ -203,6 +204,9 @@ func (filter *Rule) Evaluate(
 	patternVariables variableshape.Values,
 ) (*Result, error) {
 	node := patternVariables.Node(filter.Variable)
+	if node == nil {
+		return nil, fmt.Errorf("couldn't find node for var %s", filter.Variable.Name())
+	}
 	detections, err := detectorContext.Scan(node, filter.Rule, filter.TraversalStrategy)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Description

Output helpful error message when scanner cannot find a specified Bearer Var (currently, missing vars blow up)

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.

