### PR TITLE
fix: remove use of rego keyword

### DIFF
--- a/pkg/commands/process/settings/policies/privacy_report.rego
+++ b/pkg/commands/process/settings/policies/privacy_report.rego
@@ -4,7 +4,7 @@ import rego.v1
 
 import data.bearer.common
 
-contains(arr, elem) if {
+array_contains(arr, elem) if {
 	arr[_] = elem
 }
 
@@ -38,7 +38,7 @@ items contains item if {
 	some location in detector.locations
 
 	not location.subject_name
-	not contains(data_types_with_subject, data_type.name)
+	not array_contains(data_types_with_subject, data_type.name)
 
 	item := {
 		"name": data_type.name,

--- a/pkg/commands/process/settings/policies/risk_policy.rego
+++ b/pkg/commands/process/settings/policies/risk_policy.rego
@@ -4,7 +4,7 @@ import rego.v1
 
 import data.bearer.common
 
-contains(arr, elem) if {
+array_contains(arr, elem) if {
 	arr[_] = elem
 }
 
@@ -108,7 +108,7 @@ policy_failure contains item if {
 	some detector in presence_failures
 	some data_type_location in detector.locations
 	some data_type in data_type_location.data_types
-	contains(input.rule.only_data_types, data_type.name)
+	array_contains(input.rule.only_data_types, data_type.name)
 
 	item := data.bearer.common.build_local_item(data_type_location, data_type)
 }
@@ -119,7 +119,7 @@ policy_failure contains item if {
 	some detector in presence_failures
 	some data_type_location in detector.locations
 	some data_type in data_type_location.data_types
-	not contains(input.rule.skip_data_types, data_type.name)
+	not array_contains(input.rule.skip_data_types, data_type.name)
 
 	item := data.bearer.common.build_local_item(data_type_location, data_type)
 }
@@ -146,13 +146,13 @@ policy_failure contains item if {
 policy_failure contains item if {
 	input.rule.trigger.match_on == "stored_data_types"
 
-	contains(input.rule.languages, input.dataflow.data_types[_].detectors[_].name)
+	array_contains(input.rule.languages, input.dataflow.data_types[_].detectors[_].name)
 	data_type = input.dataflow.data_types[_]
-	not contains(input.rule.skip_data_types, data_type.name)
+	not array_contains(input.rule.skip_data_types, data_type.name)
 
 	some detector in data_type.detectors
 
-	contains(input.rule.detectors, detector.name)
+	array_contains(input.rule.detectors, detector.name)
 
 	location = detector.locations[_]
 	count(input.rule.auto_encrypt_prefix) != 0

--- a/pkg/commands/process/settings/policies/verifier_policy.rego
+++ b/pkg/commands/process/settings/policies/verifier_policy.rego
@@ -4,7 +4,7 @@ import rego.v1
 
 import data.bearer.common
 
-contains(arr, elem) if {
+array_contains(arr, elem) if {
 	# arr # ensure array is defined
 	arr[_] = elem
 }
@@ -13,11 +13,11 @@ policy_failure contains item if {
 	input.rule.trigger == "stored_data_types"
 
 	data_type = input.dataflow.data_types[_]
-	not contains(input.rule.skip_data_types, data_type.name)
+	not array_contains(input.rule.skip_data_types, data_type.name)
 
 	some detector in data_type.detectors
 
-	contains(input.rule.detectors, detector.name)
+	array_contains(input.rule.detectors, detector.name)
 
 	location = detector.locations[_]
 	count(input.rule.auto_encrypt_prefix) != 0
@@ -55,10 +55,10 @@ policy_failure contains item if {
 
 	data_type = input.dataflow.data_types[_]
 
-	not contains(input.rule.skip_data_types, data_type.name)
+	not array_contains(input.rule.skip_data_types, data_type.name)
 	some detector in data_type.detectors
 
-	contains(input.rule.detectors, detector.name)
+	array_contains(input.rule.detectors, detector.name)
 
 	location = detector.locations[_]
 


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Renames `contains` to `array_contains` in rego code. 

`contains` is a Rego keyword and this causes an error in later versions. See https://github.com/Bearer/bearer/pull/1656

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.

