### PR TITLE
fix: filenames with spaces in diff scan

### DIFF
--- a/pkg/git/diff_test.go
+++ b/pkg/git/diff_test.go
@@ -105,6 +105,24 @@ var _ = Describe("Diff", func() {
 				{FromPath: fromPath, ToPath: toPath},
 			}))
 		})
+
+		fromPath = "from bar.txt"
+		toPath = "to foo.txt"
+
+		It("decodes the paths correctly with whitespace in both from and to path", func() {
+			Expect(git.Diff(tempDir, baseSHA)).To(ConsistOf([]git.FilePatch{
+				{FromPath: fromPath, ToPath: toPath},
+			}))
+		})
+
+		fromPath = "from bar.txt"
+		toPath = "to.txt"
+
+		It("decodes the paths correctly with whitespace in from path", func() {
+			Expect(git.Diff(tempDir, baseSHA)).To(ConsistOf([]git.FilePatch{
+				{FromPath: fromPath, ToPath: toPath},
+			}))
+		})
 	})
 
 	When("a file contains changes", func() {

--- a/pkg/git/git_suite_test.go
+++ b/pkg/git/git_suite_test.go
@@ -33,6 +33,7 @@ func addAndCommit(dir string) {
 		dir,
 		"-c", "user.name=Bearer CI",
 		"-c", "user.email=ci@bearer.com",
+		"-c", "commit.gpgSign=false",
 		"commit",
 		"--allow-empty-message",
 		"--message=",


### PR DESCRIPTION
## Description

Add a prefix options to `git diff` command so we can handle filenames with spaces. Note, `git diff` puts quotation marks around some whitespace (e.g. tabs) but not single spaces which is the issue we were seeing. 

Here we use UUID markers for both from and to paths. 


## Related
- Close #1693

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.

