### PR TITLE
feat: reduced output in reports

### DIFF
--- a/docs/_data/bearer_scan.yaml
+++ b/docs/_data/bearer_scan.yaml
@@ -113,6 +113,16 @@ options:
     usage: Disable color in output
     environment_variables:
       - BEARER_NO_COLOR
+  - name: no-extract
+    default_value: "false"
+    usage: Do not include code extract in report.
+    environment_variables:
+      - BEARER_NO_EXTRACT
+  - name: no-rule-meta
+    default_value: "false"
+    usage: Do not include rule description content.
+    environment_variables:
+      - BEARER_NO_RULE_META
   - name: only-rule
     default_value: "[]"
     usage: |

--- a/e2e/flags/.snapshots/TestInitCommand
+++ b/e2e/flags/.snapshots/TestInitCommand
@@ -4,6 +4,8 @@ report:
     fail-on-severity: critical,high,medium,low
     format: ""
     no-color: false
+    no-extract: false
+    no-rule-meta: false
     output: ""
     report: security
     severity: critical,high,medium,low,warning

--- a/e2e/flags/.snapshots/TestMetadataFlags-help-scan
+++ b/e2e/flags/.snapshots/TestMetadataFlags-help-scan
@@ -12,6 +12,8 @@ Examples:
 Report Flags
       --fail-on-severity string   Specify which severities cause the report to fail. Works in conjunction with --exit-code. (default "critical,high,medium,low")
   -f, --format string             Specify report format (json, yaml, sarif, gitlab-sast, rdjson, html)
+      --no-extract                Do not include code extract in report.
+      --no-rule-meta              Do not include rule description content.
       --output string             Specify the output path for the report.
       --report string             Specify the type of report (security, privacy, dataflow). (default "security")
       --severity string           Specify which severities are included in the report. (default "critical,high,medium,low,warning")

--- a/e2e/flags/.snapshots/TestMetadataFlags-scan-help
+++ b/e2e/flags/.snapshots/TestMetadataFlags-scan-help
@@ -12,6 +12,8 @@ Examples:
 Report Flags
       --fail-on-severity string   Specify which severities cause the report to fail. Works in conjunction with --exit-code. (default "critical,high,medium,low")
   -f, --format string             Specify report format (json, yaml, sarif, gitlab-sast, rdjson, html)
+      --no-extract                Do not include code extract in report.
+      --no-rule-meta              Do not include rule description content.
       --output string             Specify the output path for the report.
       --report string             Specify the type of report (security, privacy, dataflow). (default "security")
       --severity string           Specify which severities are included in the report. (default "critical,high,medium,low,warning")

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-context-flag
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-context-flag
@@ -13,6 +13,8 @@ Examples:
 Report Flags
       --fail-on-severity string   Specify which severities cause the report to fail. Works in conjunction with --exit-code. (default "critical,high,medium,low")
   -f, --format string             Specify report format (json, yaml, sarif, gitlab-sast, rdjson, html)
+      --no-extract                Do not include code extract in report.
+      --no-rule-meta              Do not include rule description content.
       --output string             Specify the output path for the report.
       --report string             Specify the type of report (security, privacy, dataflow). (default "security")
       --severity string           Specify which severities are included in the report. (default "critical,high,medium,low,warning")

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag-privacy
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag-privacy
@@ -13,6 +13,8 @@ Examples:
 Report Flags
       --fail-on-severity string   Specify which severities cause the report to fail. Works in conjunction with --exit-code. (default "critical,high,medium,low")
   -f, --format string             Specify report format (json, yaml, sarif, gitlab-sast, rdjson, html)
+      --no-extract                Do not include code extract in report.
+      --no-rule-meta              Do not include rule description content.
       --output string             Specify the output path for the report.
       --report string             Specify the type of report (security, privacy, dataflow). (default "security")
       --severity string           Specify which severities are included in the report. (default "critical,high,medium,low,warning")

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag-security
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag-security
@@ -13,6 +13,8 @@ Examples:
 Report Flags
       --fail-on-severity string   Specify which severities cause the report to fail. Works in conjunction with --exit-code. (default "critical,high,medium,low")
   -f, --format string             Specify report format (json, yaml, sarif, gitlab-sast, rdjson, html)
+      --no-extract                Do not include code extract in report.
+      --no-rule-meta              Do not include rule description content.
       --output string             Specify the output path for the report.
       --report string             Specify the type of report (security, privacy, dataflow). (default "security")
       --severity string           Specify which severities are included in the report. (default "critical,high,medium,low,warning")

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-report-flag
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-report-flag
@@ -13,6 +13,8 @@ Examples:
 Report Flags
       --fail-on-severity string   Specify which severities cause the report to fail. Works in conjunction with --exit-code. (default "critical,high,medium,low")
   -f, --format string             Specify report format (json, yaml, sarif, gitlab-sast, rdjson, html)
+      --no-extract                Do not include code extract in report.
+      --no-rule-meta              Do not include rule description content.
       --output string             Specify the output path for the report.
       --report string             Specify the type of report (security, privacy, dataflow). (default "security")
       --severity string           Specify which severities are included in the report. (default "critical,high,medium,low,warning")

--- a/pkg/flag/report_flags.go
+++ b/pkg/flag/report_flags.go
@@ -83,6 +83,18 @@ var (
 		Hide:            true,
 		Deprecated:      true,
 	})
+	NoExtractFlag = ReportFlagGroup.add(flagtypes.Flag{
+		Name:       "no-extract",
+		ConfigName: "report.no-extract",
+		Value:      false,
+		Usage:      "Do not include code extract in report.",
+	})
+	NoRuleMetaFlag = ReportFlagGroup.add(flagtypes.Flag{
+		Name:       "no-rule-meta",
+		ConfigName: "report.no-rule-meta",
+		Value:      false,
+		Usage:      "Do not include rule description content.",
+	})
 )
 
 type ReportOptions struct {
@@ -155,6 +167,8 @@ func (reportFlagGroup) SetOptions(options *flagtypes.Options, args []string) err
 		Severity:           severity,
 		FailOnSeverity:     failOnSeverity,
 		ExcludeFingerprint: excludeFingerprintsMapping,
+		NoExtract:          getBool(NoExtractFlag),
+		NoRuleMeta:         getBool(NoRuleMetaFlag),
 	}
 
 	return nil

--- a/pkg/flag/types/types.go
+++ b/pkg/flag/types/types.go
@@ -90,6 +90,8 @@ type ReportOptions struct {
 	Severity           set.Set[string] `mapstructure:"severity" json:"severity" yaml:"severity"`
 	FailOnSeverity     set.Set[string] `mapstructure:"fail-on-severity" json:"fail-on-severity" yaml:"fail-on-severity"`
 	ExcludeFingerprint map[string]bool `mapstructure:"exclude_fingerprints" json:"exclude_fingerprints" yaml:"exclude_fingerprints"`
+	NoExtract          bool            `mapstructure:"no-extract" json:"no-extract" yaml:"no-extract"`
+	NoRuleMeta         bool            `mapstructure:"no-rule-meta" json:"no-rule-meta" yaml:"no-rule-meta"`
 }
 
 type RepositoryOptions struct {


### PR DESCRIPTION
## Description
Give the option to reduce the overall output when code extract or rule description are not required.

Added the following commands:
```
      --no-extract                Do not include code extract in report.
      --no-rule-meta              Do not include rule description content.
```

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.

