### PR TITLE
feat: add option to not process gitignore files

### DIFF
--- a/docs/_data/bearer_ignore_add.yaml
+++ b/docs/_data/bearer_ignore_add.yaml
@@ -3,7 +3,7 @@ synopsis: Add an ignored fingerprint
 usage: bearer ignore add <fingerprint> [flags]
 options:
   - name: api-key
-    usage: Use your Bearer API Key to send the report to Bearer.
+    usage: Legacy.
     environment_variables:
       - BEARER_API_KEY
   - name: author

--- a/docs/_data/bearer_ignore_migrate.yaml
+++ b/docs/_data/bearer_ignore_migrate.yaml
@@ -3,7 +3,7 @@ synopsis: Migrate ignored fingerprints from bearer.yml to ignore file
 usage: bearer ignore migrate [flags]
 options:
   - name: api-key
-    usage: Use your Bearer API Key to send the report to Bearer.
+    usage: Legacy.
     environment_variables:
       - BEARER_API_KEY
   - name: config-file

--- a/docs/_data/bearer_ignore_remove.yaml
+++ b/docs/_data/bearer_ignore_remove.yaml
@@ -3,7 +3,7 @@ synopsis: Remove an ignored fingerprint
 usage: bearer ignore remove <fingerprint> [flags]
 options:
   - name: api-key
-    usage: Use your Bearer API Key to send the report to Bearer.
+    usage: Legacy.
     environment_variables:
       - BEARER_API_KEY
   - name: config-file

--- a/docs/_data/bearer_ignore_show.yaml
+++ b/docs/_data/bearer_ignore_show.yaml
@@ -8,7 +8,7 @@ options:
     environment_variables:
       - BEARER_ALL
   - name: api-key
-    usage: Use your Bearer API Key to send the report to Bearer.
+    usage: Legacy.
     environment_variables:
       - BEARER_API_KEY
   - name: config-file

--- a/docs/_data/bearer_scan.yaml
+++ b/docs/_data/bearer_scan.yaml
@@ -3,7 +3,7 @@ synopsis: Scan a directory or file
 usage: bearer scan [flags] <path>
 options:
   - name: api-key
-    usage: Use your Bearer API Key to send the report to Bearer.
+    usage: Legacy.
     environment_variables:
       - BEARER_API_KEY
   - name: config-file
@@ -160,6 +160,12 @@ options:
     usage: Specify which severities are included in the report.
     environment_variables:
       - BEARER_SEVERITY
+  - name: skip-git-ignore
+    default_value: "false"
+    usage: |
+      Do not automatically skip files that match patterns in .gitignore
+    environment_variables:
+      - BEARER_SKIP_GIT_IGNORE
   - name: skip-path
     default_value: "[]"
     usage: |

--- a/docs/_data/bearer_scan.yaml
+++ b/docs/_data/bearer_scan.yaml
@@ -162,8 +162,7 @@ options:
       - BEARER_SEVERITY
   - name: skip-git-ignore
     default_value: "false"
-    usage: |
-      Do not automatically skip files that match patterns in .gitignore
+    usage: Scan files even if their paths match patterns in .gitignore
     environment_variables:
       - BEARER_SKIP_GIT_IGNORE
   - name: skip-path

--- a/docs/_data/bearer_version.yaml
+++ b/docs/_data/bearer_version.yaml
@@ -3,7 +3,7 @@ synopsis: Print the version
 usage: bearer version [flags]
 options:
   - name: api-key
-    usage: Use your Bearer API Key to send the report to Bearer.
+    usage: Legacy.
     environment_variables:
       - BEARER_API_KEY
   - name: config-file

--- a/e2e/flags/.snapshots/TestInitCommand
+++ b/e2e/flags/.snapshots/TestInitCommand
@@ -27,6 +27,7 @@ scan:
     quiet: false
     scanner:
         - sast
+    skip-git-ignore: false
     skip-path: []
     skip-test: true
 

--- a/e2e/flags/.snapshots/TestMetadataFlags-help-scan
+++ b/e2e/flags/.snapshots/TestMetadataFlags-help-scan
@@ -37,7 +37,7 @@ Scan Flags
       --parallel int                         Specify the amount of parallelism to use during the scan
       --quiet                                Suppress non-essential messages
       --scanner strings                      Specify which scanner to use e.g. --scanner=secrets, --scanner=secrets,sast (default [sast])
-      --skip-git-ignore                      Do not automatically skip files that match patterns in .gitignore
+      --skip-git-ignore                      Scan files even if their paths match patterns in .gitignore
       --skip-path strings                    Specify the comma separated files and directories to skip. Supports * syntax, e.g. --skip-path users/*.go,users/admin.sql
       --skip-test                            Disable automatic skipping of test files (default true)
 

--- a/e2e/flags/.snapshots/TestMetadataFlags-help-scan
+++ b/e2e/flags/.snapshots/TestMetadataFlags-help-scan
@@ -37,6 +37,7 @@ Scan Flags
       --parallel int                         Specify the amount of parallelism to use during the scan
       --quiet                                Suppress non-essential messages
       --scanner strings                      Specify which scanner to use e.g. --scanner=secrets, --scanner=secrets,sast (default [sast])
+      --skip-git-ignore                      Do not automatically skip files that match patterns in .gitignore
       --skip-path strings                    Specify the comma separated files and directories to skip. Supports * syntax, e.g. --skip-path users/*.go,users/admin.sql
       --skip-test                            Disable automatic skipping of test files (default true)
 

--- a/e2e/flags/.snapshots/TestMetadataFlags-scan-help
+++ b/e2e/flags/.snapshots/TestMetadataFlags-scan-help
@@ -37,7 +37,7 @@ Scan Flags
       --parallel int                         Specify the amount of parallelism to use during the scan
       --quiet                                Suppress non-essential messages
       --scanner strings                      Specify which scanner to use e.g. --scanner=secrets, --scanner=secrets,sast (default [sast])
-      --skip-git-ignore                      Do not automatically skip files that match patterns in .gitignore
+      --skip-git-ignore                      Scan files even if their paths match patterns in .gitignore
       --skip-path strings                    Specify the comma separated files and directories to skip. Supports * syntax, e.g. --skip-path users/*.go,users/admin.sql
       --skip-test                            Disable automatic skipping of test files (default true)
 

--- a/e2e/flags/.snapshots/TestMetadataFlags-scan-help
+++ b/e2e/flags/.snapshots/TestMetadataFlags-scan-help
@@ -37,6 +37,7 @@ Scan Flags
       --parallel int                         Specify the amount of parallelism to use during the scan
       --quiet                                Suppress non-essential messages
       --scanner strings                      Specify which scanner to use e.g. --scanner=secrets, --scanner=secrets,sast (default [sast])
+      --skip-git-ignore                      Do not automatically skip files that match patterns in .gitignore
       --skip-path strings                    Specify the comma separated files and directories to skip. Supports * syntax, e.g. --skip-path users/*.go,users/admin.sql
       --skip-test                            Disable automatic skipping of test files (default true)
 

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-context-flag
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-context-flag
@@ -38,7 +38,7 @@ Scan Flags
       --parallel int                         Specify the amount of parallelism to use during the scan
       --quiet                                Suppress non-essential messages
       --scanner strings                      Specify which scanner to use e.g. --scanner=secrets, --scanner=secrets,sast (default [sast])
-      --skip-git-ignore                      Do not automatically skip files that match patterns in .gitignore
+      --skip-git-ignore                      Scan files even if their paths match patterns in .gitignore
       --skip-path strings                    Specify the comma separated files and directories to skip. Supports * syntax, e.g. --skip-path users/*.go,users/admin.sql
       --skip-test                            Disable automatic skipping of test files (default true)
 

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-context-flag
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-context-flag
@@ -38,6 +38,7 @@ Scan Flags
       --parallel int                         Specify the amount of parallelism to use during the scan
       --quiet                                Suppress non-essential messages
       --scanner strings                      Specify which scanner to use e.g. --scanner=secrets, --scanner=secrets,sast (default [sast])
+      --skip-git-ignore                      Do not automatically skip files that match patterns in .gitignore
       --skip-path strings                    Specify the comma separated files and directories to skip. Supports * syntax, e.g. --skip-path users/*.go,users/admin.sql
       --skip-test                            Disable automatic skipping of test files (default true)
 

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag-privacy
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag-privacy
@@ -38,7 +38,7 @@ Scan Flags
       --parallel int                         Specify the amount of parallelism to use during the scan
       --quiet                                Suppress non-essential messages
       --scanner strings                      Specify which scanner to use e.g. --scanner=secrets, --scanner=secrets,sast (default [sast])
-      --skip-git-ignore                      Do not automatically skip files that match patterns in .gitignore
+      --skip-git-ignore                      Scan files even if their paths match patterns in .gitignore
       --skip-path strings                    Specify the comma separated files and directories to skip. Supports * syntax, e.g. --skip-path users/*.go,users/admin.sql
       --skip-test                            Disable automatic skipping of test files (default true)
 

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag-privacy
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag-privacy
@@ -38,6 +38,7 @@ Scan Flags
       --parallel int                         Specify the amount of parallelism to use during the scan
       --quiet                                Suppress non-essential messages
       --scanner strings                      Specify which scanner to use e.g. --scanner=secrets, --scanner=secrets,sast (default [sast])
+      --skip-git-ignore                      Do not automatically skip files that match patterns in .gitignore
       --skip-path strings                    Specify the comma separated files and directories to skip. Supports * syntax, e.g. --skip-path users/*.go,users/admin.sql
       --skip-test                            Disable automatic skipping of test files (default true)
 

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag-security
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag-security
@@ -38,7 +38,7 @@ Scan Flags
       --parallel int                         Specify the amount of parallelism to use during the scan
       --quiet                                Suppress non-essential messages
       --scanner strings                      Specify which scanner to use e.g. --scanner=secrets, --scanner=secrets,sast (default [sast])
-      --skip-git-ignore                      Do not automatically skip files that match patterns in .gitignore
+      --skip-git-ignore                      Scan files even if their paths match patterns in .gitignore
       --skip-path strings                    Specify the comma separated files and directories to skip. Supports * syntax, e.g. --skip-path users/*.go,users/admin.sql
       --skip-test                            Disable automatic skipping of test files (default true)
 

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag-security
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-format-flag-security
@@ -38,6 +38,7 @@ Scan Flags
       --parallel int                         Specify the amount of parallelism to use during the scan
       --quiet                                Suppress non-essential messages
       --scanner strings                      Specify which scanner to use e.g. --scanner=secrets, --scanner=secrets,sast (default [sast])
+      --skip-git-ignore                      Do not automatically skip files that match patterns in .gitignore
       --skip-path strings                    Specify the comma separated files and directories to skip. Supports * syntax, e.g. --skip-path users/*.go,users/admin.sql
       --skip-test                            Disable automatic skipping of test files (default true)
 

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-report-flag
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-report-flag
@@ -38,7 +38,7 @@ Scan Flags
       --parallel int                         Specify the amount of parallelism to use during the scan
       --quiet                                Suppress non-essential messages
       --scanner strings                      Specify which scanner to use e.g. --scanner=secrets, --scanner=secrets,sast (default [sast])
-      --skip-git-ignore                      Do not automatically skip files that match patterns in .gitignore
+      --skip-git-ignore                      Scan files even if their paths match patterns in .gitignore
       --skip-path strings                    Specify the comma separated files and directories to skip. Supports * syntax, e.g. --skip-path users/*.go,users/admin.sql
       --skip-test                            Disable automatic skipping of test files (default true)
 

--- a/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-report-flag
+++ b/e2e/flags/.snapshots/TestReportFlagsShouldFail-invalid-report-flag
@@ -38,6 +38,7 @@ Scan Flags
       --parallel int                         Specify the amount of parallelism to use during the scan
       --quiet                                Suppress non-essential messages
       --scanner strings                      Specify which scanner to use e.g. --scanner=secrets, --scanner=secrets,sast (default [sast])
+      --skip-git-ignore                      Do not automatically skip files that match patterns in .gitignore
       --skip-path strings                    Specify the comma separated files and directories to skip. Supports * syntax, e.g. --skip-path users/*.go,users/admin.sql
       --skip-test                            Disable automatic skipping of test files (default true)
 

--- a/pkg/commands/process/orchestrator/worker/worker.go
+++ b/pkg/commands/process/orchestrator/worker/worker.go
@@ -44,7 +44,7 @@ func (worker *Worker) Setup(config config.Config) error {
 	worker.debug = config.Debug
 	worker.enabledScanners = config.Scan.Scanner
 	worker.skipTest = config.Scan.SkipTest
-	worker.skipGitIgnore = config.Scan.SkipTest
+	worker.skipGitIgnore = config.Scan.SkipGitIgnore
 
 	if slices.Contains(worker.enabledScanners, "sast") {
 		if err := worker.engine.Initialize(config.LogLevel); err != nil {

--- a/pkg/commands/process/orchestrator/worker/worker.go
+++ b/pkg/commands/process/orchestrator/worker/worker.go
@@ -37,12 +37,14 @@ type Worker struct {
 	enabledScanners []string
 	sastScanner     *scanner.Scanner
 	skipTest        bool
+	skipGitIgnore   bool
 }
 
 func (worker *Worker) Setup(config config.Config) error {
 	worker.debug = config.Debug
 	worker.enabledScanners = config.Scan.Scanner
 	worker.skipTest = config.Scan.SkipTest
+	worker.skipGitIgnore = config.Scan.SkipTest
 
 	if slices.Contains(worker.enabledScanners, "sast") {
 		if err := worker.engine.Initialize(config.LogLevel); err != nil {
@@ -95,6 +97,7 @@ func (worker *Worker) Scan(ctx context.Context, scanRequest work.ProcessRequest)
 		worker.enabledScanners,
 		worker.sastScanner,
 		worker.skipTest,
+		worker.skipGitIgnore,
 	)
 
 	if ctx.Err() != nil {

--- a/pkg/detectors/detectors.go
+++ b/pkg/detectors/detectors.go
@@ -141,6 +141,7 @@ func Extract(
 	enabledScanners []string,
 	sastScanner *scanner.Scanner,
 	skipTest bool,
+	skipGitIgnore bool,
 ) error {
 	return ExtractWithDetectors(
 		ctx,
@@ -151,6 +152,7 @@ func Extract(
 		Registrations(enabledScanners),
 		sastScanner,
 		skipTest,
+		skipGitIgnore,
 	)
 }
 
@@ -163,6 +165,7 @@ func ExtractWithDetectors(
 	allDetectors []InitializedDetector,
 	sastScanner *scanner.Scanner,
 	skipTest bool,
+	skipGitIgnore bool,
 ) error {
 
 	activeDetectors := make(map[InitializedDetector]activeDetector)
@@ -171,6 +174,7 @@ func ExtractWithDetectors(
 		rootDir,
 		[]string{filename},
 		skipTest,
+		skipGitIgnore,
 		func(dir *file.Path) (bool, error) {
 			for _, detector := range allDetectors {
 				active, isActive := activeDetectors[detector]

--- a/pkg/detectors/internal/testhelper/testhelper.go
+++ b/pkg/detectors/internal/testhelper/testhelper.go
@@ -54,7 +54,7 @@ func Extract(
 	}
 
 	for _, filename := range files {
-		err = detectors.ExtractWithDetectors(context.Background(), path, filename, &report, nil, registrations, nil, true)
+		err = detectors.ExtractWithDetectors(context.Background(), path, filename, &report, nil, registrations, nil, true, false)
 		if !assert.Nil(t, err) {
 			t.Errorf("report has errored %s", err)
 		}

--- a/pkg/flag/scan_flags.go
+++ b/pkg/flag/scan_flags.go
@@ -40,6 +40,12 @@ var (
 		Value:      true,
 		Usage:      "Disable automatic skipping of test files",
 	})
+	SkipGitIgnore = ScanFlagGroup.add(flagtypes.Flag{
+		Name:       "skip-git-ignore",
+		ConfigName: "scan.skip-git-ignore",
+		Value:      false,
+		Usage:      "Do not automatically skip files that match patterns in .gitignore",
+	})
 	DisableDomainResolutionFlag = ScanFlagGroup.add(flagtypes.Flag{
 		Name:       "disable-domain-resolution",
 		ConfigName: "scan.disable-domain-resolution",
@@ -169,6 +175,7 @@ func (scanFlagGroup) SetOptions(options *flagtypes.Options, args []string) error
 	options.ScanOptions = flagtypes.ScanOptions{
 		SkipPath:                getStringSlice(SkipPathFlag),
 		SkipTest:                getBool(SkipTestFlag),
+		SkipGitIgnore:           getBool(SkipGitIgnore),
 		DisableDomainResolution: getBool(DisableDomainResolutionFlag),
 		DomainResolutionTimeout: getDuration(DomainResolutionTimeoutFlag),
 		InternalDomains:         getStringSlice(InternalDomainsFlag),

--- a/pkg/flag/scan_flags.go
+++ b/pkg/flag/scan_flags.go
@@ -44,7 +44,7 @@ var (
 		Name:       "skip-git-ignore",
 		ConfigName: "scan.skip-git-ignore",
 		Value:      false,
-		Usage:      "Do not automatically skip files that match patterns in .gitignore",
+		Usage:      "Scan files even if their paths match patterns in .gitignore",
 	})
 	DisableDomainResolutionFlag = ScanFlagGroup.add(flagtypes.Flag{
 		Name:       "disable-domain-resolution",

--- a/pkg/flag/types/types.go
+++ b/pkg/flag/types/types.go
@@ -61,6 +61,7 @@ type Options struct {
 type ScanOptions struct {
 	Target                  string        `mapstructure:"target" json:"target" yaml:"target"`
 	SkipTest                bool          `mapstructure:"skip-test" json:"skip-test" yaml:"skip-test"`
+	SkipGitIgnore           bool          `mapstructure:"skip-git-ignore" json:"skip-git-ignore" yaml:"skip-git-ignore"`
 	SkipPath                []string      `mapstructure:"skip-path" json:"skip-path" yaml:"skip-path"`
 	DisableDomainResolution bool          `mapstructure:"disable-domain-resolution" json:"disable-domain-resolution" yaml:"disable-domain-resolution"`
 	DomainResolutionTimeout time.Duration `mapstructure:"domain-resolution-timeout" json:"domain-resolution-timeout" yaml:"domain-resolution-timeout"`

--- a/pkg/languages/testhelper/testhelper.go
+++ b/pkg/languages/testhelper/testhelper.go
@@ -141,6 +141,7 @@ func (runner *Runner) scanSingleFile(t *testing.T, testDataPath string, fileRela
 		[]string{"sast"},
 		runner.scanner,
 		false,
+		false,
 	); err != nil {
 		t.Fatalf("failed to do scan %s", err)
 	}

--- a/pkg/util/file/file.go
+++ b/pkg/util/file/file.go
@@ -117,10 +117,15 @@ func IterateFilesList(
 	rootDir string,
 	files []string,
 	skipTest bool,
+	skipGitIgnore bool,
 	allowDir AllowDirFunction,
 	visitFile VisitFileFunction,
 ) error {
-	gitIgnore := getGitIgnore(rootDir)
+	var gitIgnore *ignore.GitIgnore
+
+	if !skipGitIgnore {
+		gitIgnore = getGitIgnore(rootDir)
+	}
 
 	rootDir, err := filepath.Abs(rootDir)
 	if err != nil {


### PR DESCRIPTION
## Description
Address and edge case where files added before a git ignore is committed can exist in the project but not be scanned.

This option can also be used to make sure you scan every file present on disk, for example, when working with generated or built files that are not otherwise committed to source control.

