### PR TITLE
fix(python): handle return statements

### DIFF
--- a/pkg/languages/python/analyzer/analyzer.go
+++ b/pkg/languages/python/analyzer/analyzer.go
@@ -47,7 +47,7 @@ func (analyzer *analyzer) Analyze(node *sitter.Node, visitChildren func() error)
 		return analyzer.analyzeCall(node, visitChildren)
 	case "pair", "argument_list", "expression_statement", "list", "tuple", "unary_operator", "binary_operator":
 		return analyzer.analyzeGenericOperation(node, visitChildren)
-	case "parenthesized_expression", "interpolation":
+	case "parenthesized_expression", "interpolation", "return_statement":
 		return analyzer.analyzeGenericConstruct(node, visitChildren)
 	case "parameters":
 		return analyzer.analyzeParameters(node, visitChildren)


### PR DESCRIPTION
## Description

Handle `return_statement`s for Python as generic constructs

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.

