### PR TITLE
feat: Extend reflexive methods with additional string operations

### DIFF
--- a/pkg/languages/python/analyzer/analyzer.go
+++ b/pkg/languages/python/analyzer/analyzer.go
@@ -15,6 +15,16 @@ var reflexiveMethods = []string{
 	"format",
 	"replace",
 	"split",
+	"lower",
+	"upper",
+	"strip",
+	"lstrip", 
+	"rstrip",
+	"capitalize",
+	"title",
+	"swapcase",
+	"casefold",
+	"expandtabs",
 }
 
 type analyzer struct {

--- a/pkg/languages/python/detectors/.snapshots/TestPythonObjects-object_class
+++ b/pkg/languages/python/detectors/.snapshots/TestPythonObjects-object_class
@@ -319,6 +319,7 @@ children:
                                   id: 67
                                   range: 8:15 - 8:32
                                   dataflow_sources:
+                                    - 69
                                     - 75
                                   children:
                                     - type: attribute


### PR DESCRIPTION
## Description
This PR extends the `reflexiveMethods` list in the Python analyzer (`pkg/languages/python/analyzer/analyzer.go`) to include additional string transformation methods such as `lower`, `upper`, `strip`, `lstrip`, `rstrip`, `capitalize`, `title`, `swapcase`, `casefold`, and `expandtabs`. 

By doing this, the SAST engine will more accurately track user-controlled data through these transformations, resulting in improved detection of vulnerabilities (e.g., path traversal) even when user input is manipulated with these methods