### PR TITLE
docs: update to .sources format

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,9 @@ brew update && brew upgrade bearer/tap/bearer
   <summary>Debian/Ubuntu</summary>
 
 ```shell
+sudo apt-get update && sudo apt-get install ca-certificates -y && sudo update-ca-certificates
 sudo apt-get install apt-transport-https
-echo "deb [trusted=yes] https://apt.fury.io/bearer/ /" | sudo tee -a /etc/apt/sources.list.d/fury.list
+echo -e "Types: deb\nURIs: https://apt.fury.io/bearer/\nSuites: /\nTrusted: yes" | sudo tee /etc/apt/sources.list.d/fury.sources
 sudo apt-get update
 sudo apt-get install bearer
 ```

--- a/docs/reference/installation.md
+++ b/docs/reference/installation.md
@@ -42,7 +42,7 @@ brew install bearer/tap/bearer
 ```bash
 sudo apt-get update && sudo apt-get install ca-certificates -y && sudo update-ca-certificates
 sudo apt-get install apt-transport-https
-echo "deb [trusted=yes] https://apt.fury.io/bearer/ /" | sudo tee -a /etc/apt/sources.list.d/fury.list
+echo -e "Types: deb\nURIs: https://apt.fury.io/bearer/\nSuites: /\nTrusted: yes" | sudo tee /etc/apt/sources.list.d/fury.sources
 sudo apt-get update
 sudo apt-get install bearer
 ```


### PR DESCRIPTION
## Description
Update the debian/ubuntu install instructions to use modern `.sources` format instead of `.list` for fury file

## Related
- #1857


## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.

