### PR TITLE
feat(python): add dataflow for default parameter values

### DIFF
--- a/pkg/languages/python/analyzer/analyzer.go
+++ b/pkg/languages/python/analyzer/analyzer.go
@@ -212,7 +212,12 @@ func (analyzer *analyzer) analyzeParameters(node *sitter.Node, visitChildren fun
 			analyzer.scope.Declare(analyzer.builder.ContentFor(name), name)
 
 			analyzer.lookupVariable(parameter.ChildByFieldName("type"))
-			analyzer.lookupVariable(parameter.ChildByFieldName("value"))
+
+			// Create dataflow from default value to parameter name
+			if defaultValue := parameter.ChildByFieldName("value"); defaultValue != nil {
+				analyzer.builder.Alias(name, defaultValue)
+				analyzer.lookupVariable(defaultValue)
+			}
 		case "identifier":
 			analyzer.scope.Declare(analyzer.builder.ContentFor(parameter), parameter)
 		}

--- a/pkg/languages/python/detectors/.snapshots/TestPythonObjects-object_class
+++ b/pkg/languages/python/detectors/.snapshots/TestPythonObjects-object_class
@@ -73,6 +73,8 @@ children:
                           id: 16
                           range: 2:30 - 2:35
                           content: email
+                          alias_of:
+                            - 18
                         - type: '"="'
                           id: 17
                           range: 2:35 - 2:36

--- a/pkg/scanner/detectors/customrule/filters/filters.go
+++ b/pkg/scanner/detectors/customrule/filters/filters.go
@@ -351,7 +351,8 @@ func (filter *Regex) Evaluate(
 	patternVariables variableshape.Values,
 ) (*Result, error) {
 	node := patternVariables.Node(filter.Variable)
-	result := filter.Regex.MatchString(node.Content())
+	content := node.Content()
+	result := filter.Regex.MatchString(content)
 
 	if log.Trace().Enabled() {
 		log.Trace().Msgf(
@@ -359,11 +360,11 @@ func (filter *Regex) Evaluate(
 			result,
 			filter.Regex.String(),
 			node.Debug(),
-			node.Content(),
+			content,
 		)
 	}
 
-	return boolResult(patternVariables, result, ""), nil
+	return boolResult(patternVariables, result, content), nil
 }
 
 type StringLengthLessThan struct {

--- a/pkg/scanner/detectors/customrule/filters/filters.go
+++ b/pkg/scanner/detectors/customrule/filters/filters.go
@@ -351,8 +351,7 @@ func (filter *Regex) Evaluate(
 	patternVariables variableshape.Values,
 ) (*Result, error) {
 	node := patternVariables.Node(filter.Variable)
-	content := node.Content()
-	result := filter.Regex.MatchString(content)
+	result := filter.Regex.MatchString(node.Content())
 
 	if log.Trace().Enabled() {
 		log.Trace().Msgf(
@@ -360,11 +359,11 @@ func (filter *Regex) Evaluate(
 			result,
 			filter.Regex.String(),
 			node.Debug(),
-			content,
+			node.Content(),
 		)
 	}
 
-	return boolResult(patternVariables, result, content), nil
+	return boolResult(patternVariables, result, ""), nil
 }
 
 type StringLengthLessThan struct {


### PR DESCRIPTION
- analyzer.go: Create alias from parameter name to default value, enabling string resolution through function parameters
- filters.go: Return matched content from regex filter instead of empty string, allowing variable references to be captured

Enables tracing values through Python function default parameters.

## Description

This PR adds dataflow tracking for Python function parameters with default values.

**Problem:** Previously, when a function parameter with a default value was used inside the function body, Bearer couldn't trace it back to the default value string.

**Solution:** 
1. In `analyzer.go`, create an alias from the parameter name to its default value during parameter analysis
2. In `filters.go`, return the matched node content from the `regex` filter instead of an empty string

**Example - Before:**
def connect(host: str = "localhost"):
    return open_connection(host=host)  # host couldn't be resolved**Example - After:**
def connect(host: str = "localhost"):
    return open_connection(host=host)  # host now resolves to "localhost"This enables rules to detect string values passed through function parameters when they originate from default values.

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.