### PR TITLE
Use case-insensitive matching for Git error "Not a valid object name"

### DIFF
--- a/pkg/commands/process/gitrepository/context.go
+++ b/pkg/commands/process/gitrepository/context.go
@@ -199,7 +199,7 @@ func getBaseCommitHash(
 	log.Debug().Msg("finding merge base using local repository")
 	hash, err := git.GetMergeBase(rootDir, "origin/"+baseBranch, currentCommitHash)
 	if err != nil {
-		if !strings.Contains(err.Error(), "Not a valid object name") {
+		if !strings.Contains(strings.ToLower(err.Error()), "not a valid object name") {
 			return "", fmt.Errorf("invalid ref: %w", err)
 		}
 	}


### PR DESCRIPTION
Fixes #1902

Git is lowercasing the `fatal: Not a valid object name` error message
to follow its CodingGuidelines. This change makes the string matching
case-insensitive so it works with both the current and future Git versions.

See: https://lore.kernel.org/git/pull.2052.git.1771836302101.gitgitgadget@gmail.com