### PR TITLE
feat: add VisitNode function to builder

### DIFF
--- a/pkg/scanner/ast/ast.go
+++ b/pkg/scanner/ast/ast.go
@@ -112,6 +112,10 @@ func analyzeNode(
 		return nil
 	}
 
+	builder.SetVisitNode(func(child *sitter.Node) error {
+		return analyzeNode(ctx, ruleSet, builder, analyzer, child)
+	})
+
 	return analyzer.Analyze(node, visitChildren)
 }
 

--- a/pkg/scanner/ast/tree/builder.go
+++ b/pkg/scanner/ast/tree/builder.go
@@ -23,6 +23,11 @@ type Builder struct {
 	fieldNames          []string
 	ruleCount           int
 	stringFragmentTypes []string
+	// visitNode is set by the AST analysis loop before each Analyze call.
+	// It allows analyzers to visit individual child subtrees (rather than
+	// all children at once via visitChildren), enabling split visiting where
+	// different children need to be processed in different scopes.
+	visitNode func(node *sitter.Node) error
 }
 
 func NewBuilder(
@@ -63,6 +68,24 @@ func NewBuilder(
 
 func (builder *Builder) SitterRootNode() *sitter.Node {
 	return builder.sitterRootNode
+}
+
+// SetVisitNode is called by the AST analysis loop to provide a function that
+// visits a single child node's subtree. Analyzers can use VisitNode to control
+// child visit order — e.g. visiting a for-loop's iterator before declaring
+// pattern bindings, then visiting the body afterward.
+func (builder *Builder) SetVisitNode(fn func(node *sitter.Node) error) {
+	builder.visitNode = fn
+}
+
+// VisitNode visits a single child node's subtree using the function provided
+// by SetVisitNode. This enables split visiting where different children need
+// to be processed in different scopes (e.g. for-loop value vs body).
+func (builder *Builder) VisitNode(node *sitter.Node) error {
+	if node == nil || builder.visitNode == nil {
+		return nil
+	}
+	return builder.visitNode(node)
 }
 
 func (builder *Builder) LastChild(node *sitter.Node) *sitter.Node {


### PR DESCRIPTION
## Description
- Added `SetVisitNode` and `VisitNode` functions to the Builder, allowing analyzers to visit individual child subtrees instead of all-or-nothing visitChildren
- Set function in `analyzeNode` in ast.go before each Analyze call

This is to address a cyclic issue that can be seen when handling for-loops for some languages: 

> The root cause is that visitChildren is all-or-nothing — you either visit all children or none. What for-loops need is to visit the value in the outer scope, then declare bindings, then visit the body in the inner scope.

We keep the impact minimal here and do not use this `VisitNode` for bearer languages, although Java could benefit from it

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] I've added test coverage that shows my fix or feature works as expected.
- [ ] I've updated or added documentation if required.

