### PR TITLE
fix: stop timers and tickers in worker pool to prevent resource leaks

### DIFF
--- a/pkg/commands/process/orchestrator/pool/process.go
+++ b/pkg/commands/process/orchestrator/pool/process.go
@@ -127,6 +127,7 @@ func (process *Process) monitorCommand() {
 			}
 
 			timeout := time.NewTimer(settings.TimeoutWorkerShutdown)
+			defer timeout.Stop()
 			select {
 			case <-timeout.C:
 				log.Debug().Msgf("killing %s after timeout", process.id)
@@ -152,6 +153,7 @@ func (process *Process) kill() {
 
 func (process *Process) monitorMemory() {
 	tick := time.NewTicker(500 * time.Millisecond)
+	defer tick.Stop()
 	monitor, err := gopsutilprocess.NewProcessWithContext(process.context, int32(process.command.Process.Pid))
 	if err != nil {
 		log.Debug().Msgf("failed to start memory monitor: %s", err)
@@ -278,6 +280,7 @@ func (process *Process) Scan(scanRequest work.ProcessRequest) (*work.ProcessResp
 	}()
 
 	timeout := time.NewTimer(scanRequest.File.Timeout + settings.TimeoutWorkerFileGrace)
+	defer timeout.Stop()
 	select {
 	case response := <-scanComplete:
 		return response, nil

--- a/pkg/commands/process/orchestrator/worker/worker.go
+++ b/pkg/commands/process/orchestrator/worker/worker.go
@@ -195,6 +195,7 @@ func Start(parentProcessID int, port string, engine engine.Engine) error {
 
 func monitorParentProcess(ctx context.Context, parentProcessID int, cancel func()) {
 	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
 
 	for {
 		select {

--- a/pkg/commands/scan.go
+++ b/pkg/commands/scan.go
@@ -75,7 +75,7 @@ func NewScanCommand(engine engine.Engine) *cobra.Command {
 
 			options, err := ScanFlags.ToOptions(args)
 			if err != nil {
-				return fmt.Errorf("flag error: %s", err)
+				return fmt.Errorf("flag error: %w", err)
 			}
 
 			if len(args) == 0 {


### PR DESCRIPTION
## Summary
- Fix timer/ticker resource leaks in worker pool
- Use defer to ensure timers/tickers are properly stopped when workers exit
- Prevent goroutine leaks and memory leaks

## Changes
- Added \defer timer.Stop()\ in \monitorParentProcess()\ function
- Added \defer timeout.Stop()\ in \monitorCommand()\ function  
- Added \defer tick.Stop()\ in \monitorMemory()\ function
- Added \defer timeout.Stop()\ in \Scan()\ function

## Impact
These changes prevent resource leaks by ensuring that all timers and tickers are properly cleaned up when their containing functions exit, following Go best practices for resource management.