### PR TITLE
fix: add safe type assertions in scanner module to prevent panic

### DIFF
--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -89,7 +89,11 @@ func (scanner *Scanner) Scan(
 
 		for _, detection := range detections {
 			detectorType := detectors.Type(detection.RuleID)
-			data := detection.Data.(customruletypes.Data)
+			data, ok := detection.Data.(customruletypes.Data)
+			if !ok {
+				fmt.Printf("Warning: detection.Data is not of type customruletypes.Data, skipping\n")
+				continue
+			}
 
 			if len(data.Datatypes) == 0 {
 				report.AddDetection(reportdetections.TypeCustomRisk,
@@ -136,7 +140,11 @@ func reportDatatypeDetection(
 	datatypeDetection *detectortypes.Detection,
 	objectName string,
 ) {
-	data := datatypeDetection.Data.(datatype.Data)
+	data, ok := datatypeDetection.Data.(datatype.Data)
+	if !ok {
+		fmt.Printf("Warning: datatypeDetection.Data is not of type datatype.Data, skipping\n")
+		return
+	}
 
 	for _, property := range data.Properties {
 		detectionContent := detection.MatchNode.Content()


### PR DESCRIPTION
## Issue\nThe scanner module in pkg/scanner/scanner.go uses unsafe type assertions (lines 92 and 143) that can cause runtime panics if the actual type doesn't match the expected type.\n\n## Fix\n- Line 92: Changed data := detection.Data.(customruletypes.Data) to use comma-ok pattern with warning log and continue\n- Line 143: Changed data := datatypeDetection.Data.(datatype.Data) to use comma-ok pattern with warning log and return\n\n## Validation\n- Type assertions now use safe comma-ok pattern\n- Failed assertions log warnings and skip processing instead of panicking\n- No behavioral change for valid type matches